### PR TITLE
在线状态通知webhook失败 配置重试次数不生效 DualStack废弃

### DIFF
--- a/config/wk.yaml
+++ b/config/wk.yaml
@@ -37,7 +37,7 @@ external: # 公网配置
 #  suffix: "@tmp" # 临时频道后缀 带有此后缀的频道将被认为是临时频道，临时频道不会被持久化
 #  cacheCount: 500 # 临时频道缓存数量
 #webhook: # 两者配其一即可 webhook配置 用于接收消息通知事件，详情请查看文档
-#  httpAddr: "" # webhook的http地址 通过此地址通知数据给第三方 地址为你提供的api接口地址
+#  httpAddr: "http://127.0.0.1:7778/webhook" # webhook的http地址 通过此地址通知数据给第三方 地址为你提供的api接口地址
 #  grpcAddr: "" #  webhook的grpc地址 当前httpAddr成为瓶颈的时候可以用grpc进行推送， 如果此地址有值 则不会再调用httpAddr配置的地址,格式为 ip:port，通讯协议请查看文档
 #  msgNotifyEventPushInterval: 500ms # 消息通知事件推送间隔，默认500毫秒发起一次推送
 #  msgNotifyEventRetryMaxCount: 5 # 消息通知事件消息推送失败最大重试次数 默认为5次，超过将丢弃

--- a/internal/server/webbhook.go
+++ b/internal/server/webbhook.go
@@ -336,7 +336,8 @@ func (w *Webhook) loopOnlineStatus() {
 	if !w.s.opts.WebhookOn() {
 		return
 	}
-	opLen := 0 // 最后一次操作在线状态数组的长度
+	opLen := 0    // 最后一次操作在线状态数组的长度
+	errCount := 0 // webhook请求失败重试次数
 	for {
 		if opLen == 0 {
 			w.onlinestatusLock.Lock()
@@ -363,8 +364,19 @@ func (w *Webhook) loopOnlineStatus() {
 			err = w.sendWebhookForHttp(EventOnlineStatus, jsonData)
 		}
 		if err != nil {
+			errCount++
 			w.Error("请求在线状态webhook失败！", zap.Error(err))
 			time.Sleep(time.Second * 1) // 如果报错就休息下
+
+			if errCount >= w.s.opts.Webhook.MsgNotifyEventRetryMaxCount {
+				w.Error("请求在线状态webhook通知超过最大次数！", zap.Int("MsgNotifyEventRetryMaxCount", w.s.opts.Webhook.MsgNotifyEventRetryMaxCount))
+				errCount = 0
+
+				w.onlinestatusLock.Lock()
+				w.onlinestatusList = w.onlinestatusList[opLen:]
+				opLen = 0
+				w.onlinestatusLock.Unlock()
+			}
 			continue
 		}
 

--- a/internal/server/webbhook.go
+++ b/internal/server/webbhook.go
@@ -71,7 +71,6 @@ func NewWebhook(s *Server) *Webhook {
 				DialContext: (&net.Dialer{
 					Timeout:   5 * time.Second,
 					KeepAlive: 5 * time.Second,
-					DualStack: true,
 				}).DialContext,
 				ForceAttemptHTTP2:     true,
 				MaxIdleConns:          200,


### PR DESCRIPTION
1. 修复配置文件中配置webhook失败请求重试次数msgNotifyEventRetryMaxCount无效的情况
2. go1.21中Dialer中DualStack已被废弃，默认是开启的该功能，已删除该参数