### PR TITLE
fix: duplicate init

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -243,10 +243,6 @@ func (s *Server) Start() error {
 		return err
 
 	}
-	err = s.tagManager.start()
-	if err != nil {
-		return err
-	}
 
 	err = s.store.Open()
 	if err != nil {


### PR DESCRIPTION
1. 重复启动tag manager任务