### PR TITLE
Fix: time.Ticker 没有调用 Stop

### DIFF
--- a/internal/server/channel_reactor_sub.go
+++ b/internal/server/channel_reactor_sub.go
@@ -44,6 +44,7 @@ func (r *channelReactorSub) stop() {
 func (r *channelReactorSub) loop() {
 
 	tk := time.NewTicker(400 * time.Millisecond)
+	defer tk.Stop()
 
 	for !r.stopped.Load() {
 		r.readys()

--- a/internal/server/conversation.go
+++ b/internal/server/conversation.go
@@ -261,6 +261,7 @@ func (c *conversationWorker) stop() {
 func (c *conversationWorker) loopPropose() {
 
 	tk := time.NewTicker(time.Minute * 5)
+	defer tk.Stop()
 
 	for {
 		select {

--- a/internal/server/node.go
+++ b/internal/server/node.go
@@ -99,6 +99,8 @@ func (n *node) loopHandleReq() {
 
 func (n *node) loop() {
 	tk := time.NewTicker(time.Millisecond * 200)
+	defer tk.Stop()
+
 	for {
 		if n.hasReady() {
 			msgs := n.ready()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -133,6 +133,7 @@ func TestClusterSlotMigrate(t *testing.T) {
 	assert.Nil(t, err)
 
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {
@@ -184,6 +185,7 @@ func TestClusterSlotMigrateForFollowToLeader(t *testing.T) {
 	assert.Nil(t, err)
 
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {
@@ -233,6 +235,7 @@ func TestClusterNodeJoin(t *testing.T) {
 	defer s3.StopNoErr()
 
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {

--- a/internal/server/task_migrate.go
+++ b/internal/server/task_migrate.go
@@ -63,6 +63,7 @@ func (m *MigrateTask) Run() {
 func (m *MigrateTask) run() {
 
 	tk := time.NewTicker(5 * time.Second)
+	defer tk.Stop()
 
 	for !m.stop {
 		m.currentTryCount++

--- a/internal/server/test.go
+++ b/internal/server/test.go
@@ -157,6 +157,7 @@ func TestStartServer(t testing.TB, ss ...*Server) {
 // MustWaitNodeOffline 必须等待某个节点离线
 func (s *Server) MustWaitNodeOffline(nodeId uint64) {
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {

--- a/internal/server/user_reactor_sub.go
+++ b/internal/server/user_reactor_sub.go
@@ -49,6 +49,7 @@ func (u *userReactorSub) stop() {
 
 func (u *userReactorSub) loop() {
 	tk := time.NewTicker(time.Millisecond * 200)
+	defer tk.Stop()
 	for {
 		u.readys()
 		select {

--- a/internal/server/webhook.go
+++ b/internal/server/webhook.go
@@ -192,6 +192,7 @@ func (w *webhook) notifyOfflineMsg(msg ReactorChannelMessage, subscribers []stri
 func (w *webhook) notifyQueueLoop() {
 	errorSleepTime := time.Second * 1 // 发生错误后sleep时间
 	ticker := time.NewTicker(w.s.opts.Webhook.MsgNotifyEventPushInterval)
+	defer ticker.Stop()
 	errMessageIDMap := make(map[int64]int) // 记录错误的消息ID value为错误次数
 	if w.s.opts.WebhookOn() {
 		for {

--- a/pkg/cluster/clusterevent/event_loop.go
+++ b/pkg/cluster/clusterevent/event_loop.go
@@ -11,6 +11,7 @@ import (
 
 func (s *Server) loop() {
 	tk := time.NewTicker(time.Millisecond * 250)
+	defer tk.Stop()
 
 	for !s.stopped.Load() {
 		err := s.checkClusterConfig()

--- a/pkg/cluster/clusterserver/server_wait.go
+++ b/pkg/cluster/clusterserver/server_wait.go
@@ -7,6 +7,7 @@ import (
 
 func (s *Server) MustWaitAllSlotsReady() {
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {
@@ -36,6 +37,7 @@ func (s *Server) MustWaitAllSlotsReady() {
 // 等待所有节点提交apiServerAddr
 func (s *Server) MustWaitAllApiServerAddrReady() {
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {
@@ -64,6 +66,7 @@ func (s *Server) MustWaitAllApiServerAddrReady() {
 
 func (s *Server) MustWaitAllNodeOnline() {
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	for {

--- a/pkg/cluster/replica/replica_test.go
+++ b/pkg/cluster/replica/replica_test.go
@@ -307,6 +307,7 @@ func TestElection(t *testing.T) {
 	electionWait.Add(1)
 	go func() {
 		tk := time.NewTicker(time.Millisecond * 10)
+		defer tk.Stop()
 		for {
 			rd := r.Ready()
 			for _, m := range rd.Messages {
@@ -372,6 +373,7 @@ func TestElectionTreeNode(t *testing.T) {
 func loopReady(t *testing.T, ctx context.Context, rs ...*Replica) {
 
 	tk := time.NewTicker(time.Millisecond * 10)
+	defer tk.Stop()
 	for {
 		for _, r := range rs {
 			rd := r.Ready()

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -68,6 +68,7 @@ func (s *Server) WaitJoin(timeout time.Duration) error {
 	defer cancel()
 
 	tick := time.NewTicker(time.Millisecond * 200)
+	defer tick.Stop()
 
 	for {
 		select {
@@ -99,6 +100,7 @@ func (s *Server) loopJoin() {
 	}
 
 	tick := time.NewTicker(time.Second * 5)
+	defer tick.Stop()
 	for {
 		select {
 		case <-tick.C:

--- a/pkg/keylock/keylock.go
+++ b/pkg/keylock/keylock.go
@@ -89,6 +89,7 @@ func (l *KeyLock) StopCleanLoop() {
 // 清理循环
 func (l *KeyLock) cleanLoop() {
 	ticker := time.NewTicker(l.cleanInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:

--- a/pkg/wkutil/data_pipeline.go
+++ b/pkg/wkutil/data_pipeline.go
@@ -60,6 +60,7 @@ func (d *DataPipeline) Start() {
 
 func (d *DataPipeline) run() {
 	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
 	var err error
 	defer d.onStop()
 	for {


### PR DESCRIPTION
根据官方文档描述，使用 ticker 后最好立即跟着 Stop 调用，防止内存泄露。

> // NewTicker returns a new [Ticker] containing a channel that will send
// the current time on the channel after each tick. The period of the
// ticks is specified by the duration argument. The ticker will adjust
// the time interval or drop ticks to make up for slow receivers.
// The duration d must be greater than zero; if not, NewTicker will
// panic.
//
// Before Go 1.23, the garbage collector did not recover
// tickers that had not yet expired or been stopped, so code often
// immediately deferred t.Stop after calling NewTicker, to make
// the ticker recoverable when it was no longer needed.
// As of Go 1.23, the garbage collector can recover unreferenced
// tickers, even if they haven't been stopped.
// The Stop method is no longer necessary to help the garbage collector.
// (Code may of course still want to call Stop to stop the ticker for other reasons.)
func NewTicker(d Duration) *Ticker {