### PR TITLE
fix: 修复webhook中离线消息通知问题，#265 问题1

### DIFF
--- a/internal/channel/handler/event_distribute.go
+++ b/internal/channel/handler/event_distribute.go
@@ -124,14 +124,14 @@ func (h *Handler) distributeByTag(leaderId uint64, tag *types.Tag, channelId str
 			if options.G.IsSystemUid(uid) {
 				continue
 			}
-			if !h.isOnline(uid) {
-				continue
-			}
 			if !h.masterDeviceIsOnline(uid) {
 				if offlineUids == nil {
 					offlineUids = make([]string, 0, len(node.Uids))
 				}
 				offlineUids = append(offlineUids, uid)
+			}
+			if !h.isOnline(uid) {
+				continue
 			}
 
 			for _, event := range events {


### PR DESCRIPTION
修复指定用户不在线时，webhook离线消息中的toUids中没有的问题（#265 问题1）