### PR TITLE
fix: 修复集群模式下节点转发请求未携带token导致401

### DIFF
--- a/internal/api/user.go
+++ b/internal/api/user.go
@@ -145,7 +145,8 @@ func (u *user) getOnlineStatus(c *wkhttp.Context) {
 	}
 
 	var conns []*OnlinestatusResp
-	conns, err = u.getOnlineConnsForCluster(uids)
+	headers := c.CopyRequestHeader(c.Request)
+	conns, err = u.getOnlineConnsForCluster(uids, headers)
 	if err != nil {
 		u.Error("获取在线状态失败！", zap.Error(err))
 		c.ResponseError(err)
@@ -155,7 +156,7 @@ func (u *user) getOnlineStatus(c *wkhttp.Context) {
 	c.JSON(http.StatusOK, conns)
 }
 
-func (u *user) getOnlineConnsForCluster(uids []string) ([]*OnlinestatusResp, error) {
+func (u *user) getOnlineConnsForCluster(uids []string, headers map[string]string) ([]*OnlinestatusResp, error) {
 	uidInPeerMap := make(map[uint64][]string)
 	localUids := make([]string, 0)
 	for _, uid := range uids {
@@ -188,7 +189,7 @@ func (u *user) getOnlineConnsForCluster(uids []string) ([]*OnlinestatusResp, err
 		for nodeId, uidList := range uidInPeerMap {
 			wg.Add(1)
 			go func(pid uint64, uidArr []string) {
-				results, err := u.requestOnlineStatus(pid, uidArr)
+				results, err := u.requestOnlineStatus(pid, uidArr, headers)
 				if err != nil {
 					reqErr = err
 				} else {
@@ -208,7 +209,7 @@ func (u *user) getOnlineConnsForCluster(uids []string) ([]*OnlinestatusResp, err
 	return conns, nil
 }
 
-func (u *user) requestOnlineStatus(nodeId uint64, uids []string) ([]*OnlinestatusResp, error) {
+func (u *user) requestOnlineStatus(nodeId uint64, uids []string, headers map[string]string) ([]*OnlinestatusResp, error) {
 
 	nodeInfo := service.Cluster.NodeInfoById(nodeId) // 获取频道的领导节点
 	if nodeInfo == nil {
@@ -216,7 +217,7 @@ func (u *user) requestOnlineStatus(nodeId uint64, uids []string) ([]*Onlinestatu
 		return nil, errors.New("节点信息不存在")
 	}
 	reqURL := fmt.Sprintf("%s/user/onlinestatus", nodeInfo.ApiServerAddr)
-	resp, err := network.Post(reqURL, []byte(wkutil.ToJSON(uids)), nil)
+	resp, err := network.Post(reqURL, []byte(wkutil.ToJSON(uids)), headers)
 	if err != nil {
 		u.Error("获取在线用户状态失败！", zap.Error(err), zap.String("reqURL", reqURL))
 		return nil, err
@@ -425,6 +426,7 @@ func (u *user) systemUidsAdd(c *wkhttp.Context) {
 
 	// 将系统账号添加到各个节点的缓存内
 	nodes := service.Cluster.Nodes()
+	headers := c.CopyRequestHeader(c.Request)
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), options.G.Cluster.ReqTimeout)
 	defer cancel()
@@ -438,7 +440,7 @@ func (u *user) systemUidsAdd(c *wkhttp.Context) {
 		}
 		requestGroup.Go(func(n *types.Node) func() error {
 			return func() error {
-				return u.requestSystemUidsAddToCache(n, req.UIDs)
+				return u.requestSystemUidsAddToCache(n, req.UIDs, headers)
 			}
 		}(node))
 	}
@@ -454,11 +456,11 @@ func (u *user) systemUidsAdd(c *wkhttp.Context) {
 
 }
 
-func (u *user) requestSystemUidsAddToCache(nodeInfo *types.Node, uids []string) error {
+func (u *user) requestSystemUidsAddToCache(nodeInfo *types.Node, uids []string, headers map[string]string) error {
 	reqURL := fmt.Sprintf("%s/user/systemuids_add_to_cache", nodeInfo.ApiServerAddr)
 	resp, err := network.Post(reqURL, []byte(wkutil.ToJSON(map[string]interface{}{
 		"uids": uids,
-	})), nil)
+	})), headers)
 	if err != nil {
 		u.Error("添加系统账号到缓存失败！", zap.Error(err), zap.String("reqURL", reqURL))
 		return err
@@ -521,6 +523,7 @@ func (u *user) systemUidsRemove(c *wkhttp.Context) {
 
 	// 将系统账号从各个节点的缓存内移除
 	nodes := service.Cluster.Nodes()
+	headers := c.CopyRequestHeader(c.Request)
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), options.G.Cluster.ReqTimeout)
 	defer cancel()
@@ -534,7 +537,7 @@ func (u *user) systemUidsRemove(c *wkhttp.Context) {
 		}
 		requestGroup.Go(func(n *types.Node) func() error {
 			return func() error {
-				return u.requestSystemUidsRemoveFromCache(n, req.UIDs)
+				return u.requestSystemUidsRemoveFromCache(n, req.UIDs, headers)
 			}
 		}(node))
 	}
@@ -549,11 +552,11 @@ func (u *user) systemUidsRemove(c *wkhttp.Context) {
 	c.ResponseOK()
 }
 
-func (u *user) requestSystemUidsRemoveFromCache(nodeInfo *types.Node, uids []string) error {
+func (u *user) requestSystemUidsRemoveFromCache(nodeInfo *types.Node, uids []string, headers map[string]string) error {
 	reqURL := fmt.Sprintf("%s/user/systemuids_remove_from_cache", nodeInfo.ApiServerAddr)
 	resp, err := network.Post(reqURL, []byte(wkutil.ToJSON(map[string]interface{}{
 		"uids": uids,
-	})), nil)
+	})), headers)
 	if err != nil {
 		u.Error("移除系统账号从缓存失败！", zap.Error(err), zap.String("reqURL", reqURL))
 		return err


### PR DESCRIPTION
## Summary

- 集群模式下，`/user/onlinestatus`、`/user/systemuids_add_to_cache`、`/user/systemuids_remove_from_cache` 三个接口在节点间转发时使用 `network.Post(url, body, nil)` 丢失了请求头中的 `token`，导致目标节点的 ManagerToken 中间件校验失败返回 401
- 修复方式：在 handler 入口通过 `c.CopyRequestHeader` 提取 headers，传递给 `requestXxx` 函数，再传入 `network.Post`

## 受影响接口

| 接口 | 说明 |
|------|------|
| `POST /user/onlinestatus` | 获取用户在线状态 |
| `POST /user/systemuids_add_to_cache` | 添加系统账号到缓存 |
| `POST /user/systemuids_remove_from_cache` | 从缓存移除系统账号 |

## Test plan

- [ ] 配置 `ManagerToken`，部署多节点集群
- [ ] 请求 `/user/onlinestatus` 查询分布在不同节点上的用户，验证不再出现 401
- [ ] 调用 `/user/systemuids_add` 和 `/user/systemuids_remove`，验证跨节点缓存同步正常