### PR TITLE
fix Alibaba SDK request runtime options

### DIFF
--- a/internal/infra/cloudsim/alibaba/openapi.go
+++ b/internal/infra/cloudsim/alibaba/openapi.go
@@ -125,7 +125,7 @@ func (a *OpenAPI) EligibleSpotZones(ctx context.Context, region string) ([]strin
 		SetRegionId(region).
 		SetInstanceChargeType("PostPaid").
 		SetSpotStrategy("SpotAsPriceGo").
-		SetVerbose(true), nil)
+		SetVerbose(true), &dara.RuntimeOptions{})
 	if err != nil || response.Body == nil || response.Body.Zones == nil {
 		return nil, errors.Join(ErrInvalidConfig, err)
 	}
@@ -164,7 +164,7 @@ func (a *OpenAPI) LatestLinuxImage(ctx context.Context, region string) (string, 
 			SetStatus("Available").
 			SetIsSupportCloudinit(true).
 			SetPageNumber(pageNumber).
-			SetPageSize(pageSize), nil)
+			SetPageSize(pageSize), &dara.RuntimeOptions{})
 		if err != nil || response.Body == nil || response.Body.Images == nil {
 			return nil, 0, errors.Join(ErrInvalidConfig, err)
 		}
@@ -236,7 +236,7 @@ func (a *OpenAPI) InstanceTypes(ctx context.Context, _ string, cpu, memory int32
 		if nextToken != "" {
 			request.SetNextToken(nextToken)
 		}
-		response, err := a.ecs.DescribeInstanceTypesWithContext(ctx, request, nil)
+		response, err := a.ecs.DescribeInstanceTypesWithContext(ctx, request, &dara.RuntimeOptions{})
 		if err != nil || response.Body == nil || response.Body.InstanceTypes == nil {
 			return nil, errors.Join(ErrInvalidConfig, err)
 		}
@@ -395,7 +395,7 @@ func (a *OpenAPI) availableInstanceTypes(ctx context.Context, region, zoneID, in
 	if instanceType != "" {
 		request.SetInstanceType(instanceType)
 	}
-	response, err := a.ecs.DescribeAvailableResourceWithContext(ctx, request, nil)
+	response, err := a.ecs.DescribeAvailableResourceWithContext(ctx, request, &dara.RuntimeOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
+++ b/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
@@ -2,8 +2,14 @@ package alibaba
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+
+	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
+	"github.com/alibabacloud-go/tea/dara"
 )
 
 func TestNewOpenAPIFromEnvironmentAcceptsCredentialModes(t *testing.T) {
@@ -54,6 +60,45 @@ func TestNewOpenAPIFromEnvironmentRejectsMissingRegion(t *testing.T) {
 
 	if _, err := NewOpenAPIFromEnvironment(""); err == nil {
 		t.Fatal("NewOpenAPIFromEnvironment() error = nil, want error")
+	}
+}
+
+func TestEligibleSpotZonesUsesAlibabaSDKRequestRuntime(t *testing.T) {
+	actions := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		actions <- request.Header.Get("x-acs-action")
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{
+			"RequestId":"request-1",
+			"Zones":{"Zone":[{
+				"ZoneId":"cn-hangzhou-a",
+				"ZoneType":"AvailabilityZone",
+				"AvailableDiskCategories":{"DiskCategories":["cloud_essd"]}
+			}]}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	api, err := newOpenAPI(&openapiutil.Config{
+		AccessKeyId:     dara.String("test-access-key-id"),
+		AccessKeySecret: dara.String("test-access-key-secret"),
+		RegionId:        dara.String("cn-hangzhou"),
+		Endpoint:        dara.String(strings.TrimPrefix(server.URL, "http://")),
+		Protocol:        dara.String("http"),
+	})
+	if err != nil {
+		t.Fatalf("newOpenAPI() error = %v", err)
+	}
+
+	zones, err := api.EligibleSpotZones(context.Background(), "cn-hangzhou")
+	if err != nil {
+		t.Fatalf("EligibleSpotZones() error = %v", err)
+	}
+	if !reflect.DeepEqual(zones, []string{"cn-hangzhou-a"}) {
+		t.Fatalf("EligibleSpotZones() = %v, want [cn-hangzhou-a]", zones)
+	}
+	if action := <-actions; action != "DescribeZones" {
+		t.Fatalf("Action = %q, want DescribeZones", action)
 	}
 }
 


### PR DESCRIPTION
## What changed

- pass non-nil Alibaba SDK `RuntimeOptions` to all context-aware ECS discovery calls
- add a regression test that sends a signed `DescribeZones` request through the real SDK to a local HTTP server

## Root cause

The Alibaba Darabonba SDK dereferences `RuntimeOptions` inside `DoRequestWithCtx`. The cloud simulation adapter passed `nil`, so the provision workflow panicked before any billable resources were created.

## Impact

AccessKey-based cloud simulation discovery can proceed to the Alibaba API instead of crashing locally. Resource selection and provisioning semantics are unchanged.

## Validation

- `GOWORK=off go test ./internal/infra/cloudsim/alibaba -run '^TestEligibleSpotZonesUsesAlibabaSDKRequestRuntime$' -count=1`
- `GOWORK=off go test ./internal/infra/cloudsim/alibaba ./cmd/wkcloudsim -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check`
