### PR TITLE
fix Alibaba VPC inventory pagination

### DIFF
--- a/internal/infra/cloudsim/alibaba/openapi.go
+++ b/internal/infra/cloudsim/alibaba/openapi.go
@@ -30,6 +30,7 @@ const (
 	defaultSDKWaitTimeout  = 3 * time.Minute
 	maxDiscoveryPages      = 20
 	discoveryPageSize      = 100
+	vpcInventoryPageSize   = 50
 )
 
 type linuxImageCandidate struct {
@@ -569,7 +570,7 @@ func (a *OpenAPI) ListAssets(ctx context.Context, request ListAssetsRequest) ([]
 
 	vpcs, err := collectPages(ctx, func(page int32) ([]listedVPC, int, error) {
 		response, listErr := a.vpc.DescribeVpcs((&vpc.DescribeVpcsRequest{}).
-			SetRegionId(request.Region).SetPageNumber(page).SetPageSize(100).SetTag(describeVPCTags(selector)))
+			SetRegionId(request.Region).SetPageNumber(page).SetPageSize(vpcInventoryPageSize).SetTag(describeVPCTags(selector)))
 		if listErr != nil {
 			return nil, 0, listErr
 		}
@@ -594,7 +595,7 @@ func (a *OpenAPI) ListAssets(ctx context.Context, request ListAssetsRequest) ([]
 
 	vswitches, err := collectPages(ctx, func(page int32) ([]listedVSwitch, int, error) {
 		response, listErr := a.vpc.DescribeVSwitches((&vpc.DescribeVSwitchesRequest{}).
-			SetRegionId(request.Region).SetPageNumber(page).SetPageSize(100).SetTag(describeVSwitchTags(selector)))
+			SetRegionId(request.Region).SetPageNumber(page).SetPageSize(vpcInventoryPageSize).SetTag(describeVSwitchTags(selector)))
 		if listErr != nil {
 			return nil, 0, listErr
 		}

--- a/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
+++ b/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
@@ -102,6 +102,63 @@ func TestEligibleSpotZonesUsesAlibabaSDKRequestRuntime(t *testing.T) {
 	}
 }
 
+func TestListAssetsUsesAlibabaAPIPageLimits(t *testing.T) {
+	type observedRequest struct {
+		action   string
+		pageSize string
+	}
+	requests := make(chan observedRequest, 6)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		_ = request.ParseForm()
+		requests <- observedRequest{
+			action:   request.Header.Get("x-acs-action"),
+			pageSize: request.Form.Get("PageSize"),
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"RequestId":"request-1","PageNumber":1,"TotalCount":0}`))
+	}))
+	t.Cleanup(server.Close)
+
+	api, err := newOpenAPI(&openapiutil.Config{
+		AccessKeyId:     dara.String("test-access-key-id"),
+		AccessKeySecret: dara.String("test-access-key-secret"),
+		RegionId:        dara.String("cn-hangzhou"),
+		Endpoint:        dara.String(strings.TrimPrefix(server.URL, "http://")),
+		Protocol:        dara.String("http"),
+	})
+	if err != nil {
+		t.Fatalf("newOpenAPI() error = %v", err)
+	}
+
+	assets, err := api.ListAssets(context.Background(), ListAssetsRequest{Region: "cn-hangzhou", RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("ListAssets() error = %v", err)
+	}
+	if len(assets) != 0 {
+		t.Fatalf("ListAssets() = %v, want empty inventory", assets)
+	}
+
+	wantPageSizes := map[string]string{
+		"DescribeInstances":      "100",
+		"DescribeDisks":          "100",
+		"DescribeSecurityGroups": "100",
+		"DescribeVpcs":           "50",
+		"DescribeVSwitches":      "50",
+		"DescribeEipAddresses":   "100",
+	}
+	for range wantPageSizes {
+		observed := <-requests
+		want, exists := wantPageSizes[observed.action]
+		if !exists {
+			t.Fatalf("unexpected Alibaba action %q", observed.action)
+		}
+		if observed.pageSize != want {
+			t.Fatalf("%s PageSize = %q, want %q", observed.action, observed.pageSize, want)
+		}
+		delete(wantPageSizes, observed.action)
+	}
+}
+
 func TestDiscoverLatestLinuxImageReadsEveryPage(t *testing.T) {
 	var pages []int32
 	imageID, err := discoverLatestLinuxImage(context.Background(), func(_ context.Context, pageNumber, pageSize int32) ([]linuxImageCandidate, int32, error) {


### PR DESCRIPTION
## What changed

- use the Alibaba VPC API maximum page size of 50 for `DescribeVpcs` and `DescribeVSwitches`
- keep the valid page size of 100 for ECS inventory and `DescribeEipAddresses`
- add a real SDK request regression test covering every resource inventory action

## Root cause

The cloud simulation safety inventory used `PageSize=100` uniformly. Alibaba accepts 100 for ECS and EIP inventory, but `DescribeVpcs` and `DescribeVSwitches` allow at most 50. The provision workflow therefore stopped during its pre-mutation inventory check.

## Impact

The account-wide safety inventory can complete before quote and resource creation. No lifecycle, selection, tagging, or cleanup semantics change.

## Validation

- `GOWORK=off go test ./internal/infra/cloudsim/alibaba -run '^TestListAssetsUsesAlibabaAPIPageLimits$' -count=1`
- `GOWORK=off go test ./internal/infra/cloudsim/alibaba ./cmd/wkcloudsim -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check`
