### PR TITLE
Fix Alibaba cloud simulation readiness and cleanup

### DIFF
--- a/internal/infra/cloudsim/alibaba/openapi.go
+++ b/internal/infra/cloudsim/alibaba/openapi.go
@@ -790,6 +790,12 @@ func (a *OpenAPI) CreateNetwork(ctx context.Context, request NetworkRequest) (_ 
 			_, _ = a.vpc.DeleteVSwitch((&vpc.DeleteVSwitchRequest{}).SetRegionId(request.Region).SetVSwitchId(vswitchID))
 		}
 	}()
+	if vswitchID == "" {
+		return nil, ErrAmbiguousInventory
+	}
+	if err = a.waitVSwitch(ctx, request.Region, vswitchID); err != nil {
+		return nil, err
+	}
 	securityResponse, err := a.ecs.CreateSecurityGroup((&ecs.CreateSecurityGroupRequest{}).
 		SetRegionId(request.Region).
 		SetVpcId(vpcID).
@@ -800,7 +806,7 @@ func (a *OpenAPI) CreateNetwork(ctx context.Context, request NetworkRequest) (_ 
 		return nil, err
 	}
 	securityGroupID := deref(securityResponse.Body.SecurityGroupId)
-	if securityGroupID == "" || vswitchID == "" {
+	if securityGroupID == "" {
 		return nil, ErrAmbiguousInventory
 	}
 	defer func() {
@@ -1332,6 +1338,36 @@ func (a *OpenAPI) waitVpc(ctx context.Context, region, vpcID string) error {
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("wait for VPC %s: %w", vpcID, err)
+		}
+		if err := waitContext(ctx, a.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// waitVSwitch blocks host provisioning until Alibaba reports the asynchronous
+// vSwitch creation as usable by RunInstances.
+func (a *OpenAPI) waitVSwitch(ctx context.Context, region, vswitchID string) error {
+	deadline := time.Now().Add(a.waitTimeout)
+	lastStatus := ""
+	var lastErr error
+	for {
+		response, err := a.vpc.DescribeVSwitchAttributes((&vpc.DescribeVSwitchAttributesRequest{}).
+			SetRegionId(region).
+			SetVSwitchId(vswitchID))
+		if err == nil && response != nil && response.Body != nil {
+			lastStatus = deref(response.Body.Status)
+			if lastStatus == "Available" {
+				return nil
+			}
+		} else if err != nil {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("wait for vSwitch %s to become Available: %w", vswitchID, lastErr)
+			}
+			return fmt.Errorf("wait for vSwitch %s: status %q did not become Available before timeout", vswitchID, lastStatus)
 		}
 		if err := waitContext(ctx, a.pollInterval); err != nil {
 			return err

--- a/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
+++ b/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
@@ -6,11 +6,90 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
 	"github.com/alibabacloud-go/tea/dara"
 )
+
+func TestCreateNetworkWaitsForVSwitchBeforeCreatingSecurityGroup(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		actions        []string
+		vSwitchQueries int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		action := request.Header.Get("x-acs-action")
+		mu.Lock()
+		actions = append(actions, action)
+		if action == "DescribeVSwitchAttributes" {
+			vSwitchQueries++
+		}
+		query := vSwitchQueries
+		mu.Unlock()
+
+		response.Header().Set("Content-Type", "application/json")
+		switch action {
+		case "CreateVpc":
+			_, _ = response.Write([]byte(`{"RequestId":"request-1","VpcId":"vpc-1"}`))
+		case "DescribeVpcAttribute":
+			_, _ = response.Write([]byte(`{"RequestId":"request-2","VpcId":"vpc-1","Status":"Available"}`))
+		case "CreateVSwitch":
+			_, _ = response.Write([]byte(`{"RequestId":"request-3","VSwitchId":"vsw-1"}`))
+		case "DescribeVSwitchAttributes":
+			status := "Pending"
+			if query > 1 {
+				status = "Available"
+			}
+			_, _ = response.Write([]byte(`{"RequestId":"request-4","VSwitchId":"vsw-1","Status":"` + status + `"}`))
+		case "CreateSecurityGroup":
+			_, _ = response.Write([]byte(`{"RequestId":"request-5","SecurityGroupId":"sg-1"}`))
+		case "AuthorizeSecurityGroup":
+			_, _ = response.Write([]byte(`{"RequestId":"request-6"}`))
+		default:
+			http.Error(response, "unexpected action "+action, http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	api, err := newOpenAPI(&openapiutil.Config{
+		AccessKeyId:     dara.String("test-access-key-id"),
+		AccessKeySecret: dara.String("test-access-key-secret"),
+		RegionId:        dara.String("cn-hangzhou"),
+		Endpoint:        dara.String(strings.TrimPrefix(server.URL, "http://")),
+		Protocol:        dara.String("http"),
+	})
+	if err != nil {
+		t.Fatalf("newOpenAPI() error = %v", err)
+	}
+	api.pollInterval = 0
+	api.waitTimeout = time.Second
+
+	assets, err := api.CreateNetwork(context.Background(), NetworkRequest{
+		Region: "cn-hangzhou", ZoneID: "cn-hangzhou-a",
+		VPCIPv4CIDR: "10.42.0.0/16", VSwitchIPv4CIDR: "10.42.0.0/24",
+		Tags: map[string]string{"wukongim:run-id": "run-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateNetwork() error = %v", err)
+	}
+	if len(assets) != 3 {
+		t.Fatalf("CreateNetwork() assets = %v, want three assets", assets)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{
+		"CreateVpc", "DescribeVpcAttribute", "CreateVSwitch",
+		"DescribeVSwitchAttributes", "DescribeVSwitchAttributes",
+		"CreateSecurityGroup", "AuthorizeSecurityGroup",
+	}
+	if !reflect.DeepEqual(actions, want) {
+		t.Fatalf("Alibaba actions = %v, want %v", actions, want)
+	}
+}
 
 func TestNewOpenAPIFromEnvironmentAcceptsCredentialModes(t *testing.T) {
 	tests := []struct {

--- a/scripts/cloud-sim/resolve-exact-provider-config.sh
+++ b/scripts/cloud-sim/resolve-exact-provider-config.sh
@@ -16,8 +16,11 @@ trap 'rm -rf "$temporary"' EXIT
 gh api --paginate -X GET "repos/${GITHUB_REPOSITORY}/actions/artifacts" -f per_page=100 \
   --jq '.artifacts[] | select(.expired == false and (.name | startswith("cloud-sim-provider-config"))) | [.id,.name] | @tsv' \
   >"$temporary/provider-artifacts.tsv"
-if artifact_id="$("$script_dir/select-exact-provider-config-artifact.sh" "$run_id" \
+artifact_region=""
+artifact_account_id_hash=""
+if selection="$("$script_dir/select-exact-provider-config-artifact.sh" "$run_id" \
   <"$temporary/provider-artifacts.tsv" 2>"$temporary/selector-error")"; then
+  IFS=$'\t' read -r artifact_id artifact_region artifact_account_id_hash <<<"$selection"
   gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" >"$temporary/provider-config.zip"
   mkdir "$temporary/provider-config"
   unzip -q "$temporary/provider-config.zip" -d "$temporary/provider-config"
@@ -31,18 +34,39 @@ fi
 
 jq -e '.region | type == "string" and test("^[a-z0-9-]+$")' "$destination" >/dev/null
 jq -e '.account_id_hash | test("^sha256:[0-9a-f]{64}$")' "$destination" >/dev/null
+if [[ -n "$artifact_region" ]]; then
+  test "$(jq -er .region "$destination")" = "$artifact_region"
+  test "$(jq -er .account_id_hash "$destination")" = "$artifact_account_id_hash"
+fi
 expected_region="${EXPECTED_REGION:-}"
 expected_account_id_hash="${EXPECTED_ACCOUNT_ID_HASH:-}"
 if [[ -z "$expected_region" && -z "$expected_account_id_hash" ]]; then
   locator_name="cloud-sim-locator-${run_id}"
   locators="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/artifacts" -f name="$locator_name" -f per_page=2)"
-  locator_id="$(jq -er '[.artifacts[] | select(.expired == false)] | select(length == 1) | .[0].id' <<<"$locators")"
-  gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${locator_id}/zip" >"$temporary/locator.zip"
-  mkdir "$temporary/locator"
-  unzip -q "$temporary/locator.zip" -d "$temporary/locator"
-  test "$(jq -er .run_id "$temporary/locator/run-locator.json")" = "$run_id"
-  expected_region="$(jq -er '.region | select(test("^[a-z0-9-]+$"))' "$temporary/locator/run-locator.json")"
-  expected_account_id_hash="$(jq -er '.account_id_hash | select(test("^sha256:[0-9a-f]{64}$"))' "$temporary/locator/run-locator.json")"
+  locator_count="$(jq -er '[.artifacts[] | select(.expired == false)] | length' <<<"$locators")"
+  case "$locator_count" in
+    0)
+      if [[ -z "$artifact_region" || -z "$artifact_account_id_hash" ]]; then
+        echo "no trusted provider binding or run locator exists for Simulation Run $run_id" >&2
+        exit 1
+      fi
+      expected_region="$artifact_region"
+      expected_account_id_hash="$artifact_account_id_hash"
+      ;;
+    1)
+      locator_id="$(jq -er '[.artifacts[] | select(.expired == false)][0].id' <<<"$locators")"
+      gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${locator_id}/zip" >"$temporary/locator.zip"
+      mkdir "$temporary/locator"
+      unzip -q "$temporary/locator.zip" -d "$temporary/locator"
+      test "$(jq -er .run_id "$temporary/locator/run-locator.json")" = "$run_id"
+      expected_region="$(jq -er '.region | select(test("^[a-z0-9-]+$"))' "$temporary/locator/run-locator.json")"
+      expected_account_id_hash="$(jq -er '.account_id_hash | select(test("^sha256:[0-9a-f]{64}$"))' "$temporary/locator/run-locator.json")"
+      ;;
+    *)
+      echo "multiple run locators exist for Simulation Run $run_id" >&2
+      exit 1
+      ;;
+  esac
 elif [[ -z "$expected_region" || -z "$expected_account_id_hash" ]]; then
   echo "expected provider region and account hash must be supplied together" >&2
   exit 1

--- a/scripts/cloud-sim/select-exact-provider-config-artifact.sh
+++ b/scripts/cloud-sim/select-exact-provider-config-artifact.sh
@@ -22,6 +22,8 @@ awk -F '\t' -v run_id="$run_id" '
     }
     if (matches) {
       selected[++selected_count] = $1
+      selected_region[selected_count] = parts[1]
+      selected_account_hash[selected_count] = parts[2]
     }
   }
   END {
@@ -29,6 +31,6 @@ awk -F '\t' -v run_id="$run_id" '
       print "No unique provider config exists for exact Simulation Run " run_id "." > "/dev/stderr"
       exit 1
     }
-    print selected[1]
+    printf "%s\t%s\tsha256:%s\n", selected[1], selected_region[1], selected_account_hash[1]
   }
 '

--- a/scripts/cloud_sim_workflows_test.go
+++ b/scripts/cloud_sim_workflows_test.go
@@ -102,7 +102,7 @@ func TestResolveAlibabaCredentialMode(t *testing.T) {
 	}
 }
 
-func TestExactProviderConfigResolverAlwaysBindsRunLocator(t *testing.T) {
+func TestExactProviderConfigResolverBindsArtifactAndOptionalLocator(t *testing.T) {
 	path := filepath.Join(repoRoot(t), "scripts", "cloud-sim", "resolve-exact-provider-config.sh")
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -110,8 +110,14 @@ func TestExactProviderConfigResolverAlwaysBindsRunLocator(t *testing.T) {
 	}
 	text := string(content)
 	for _, fragment := range []string{
+		`IFS=$'\t' read -r artifact_id artifact_region artifact_account_id_hash`,
+		`test "$(jq -er .region "$destination")" = "$artifact_region"`,
+		`test "$(jq -er .account_id_hash "$destination")" = "$artifact_account_id_hash"`,
 		`locator_name="cloud-sim-locator-${run_id}"`,
 		`test "$(jq -er .run_id "$temporary/locator/run-locator.json")" = "$run_id"`,
+		`case "$locator_count" in`,
+		`0)`,
+		`1)`,
 		`test "$(jq -er .region "$destination")" = "$expected_region"`,
 		`test "$(jq -er .account_id_hash "$destination")" = "$expected_account_id_hash"`,
 	} {
@@ -159,14 +165,15 @@ func TestSelectExactProviderConfigArtifactAcceptsBindingAwareName(t *testing.T) 
 	if err != nil {
 		t.Fatalf("select exact provider config: %v", err)
 	}
-	if got, want := string(output), "101\n"; got != want {
-		t.Fatalf("selected artifact ID = %q, want %q", got, want)
+	boundSelection := "101\tcn-hangzhou\tsha256:" + hash + "\n"
+	if got, want := string(output), boundSelection; got != want {
+		t.Fatalf("selected artifact binding = %q, want %q", got, want)
 	}
 
 	command = exec.CommandContext(t.Context(), "bash", selector, "gh-101-1")
 	command.Stdin = strings.NewReader(input + "99\tcloud-sim-provider-config-gh-101-1\n")
 	output, err = command.Output()
-	if err != nil || string(output) != "101\n" {
+	if err != nil || string(output) != boundSelection {
 		t.Fatalf("unbound artifact affected exact selection: output=%q err=%v", output, err)
 	}
 


### PR DESCRIPTION
## What changed

- wait for a newly created Alibaba vSwitch to become Available before creating dependent infrastructure
- retain the trusted region and account hash encoded in the exact provider-config artifact name
- allow exact cleanup before locator publication while still failing closed on missing or ambiguous bindings
- add real Alibaba SDK HTTP regression coverage and workflow contract tests

## Root cause

Alibaba vSwitch creation is asynchronous, but provisioning called RunInstances immediately after CreateVSwitch. Failed provisioning also never published a run locator, while exact cleanup required that locator even though the unique provider artifact was already bound to the run, region, and account.

## Validation

- GOWORK=off /usr/local/go/bin/go test ./internal/infra/cloudsim/alibaba ./cmd/wkcloudsim ./scripts -count=1
- GOWORK=off /usr/local/go/bin/go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1
- bash -n scripts/cloud-sim/select-exact-provider-config-artifact.sh scripts/cloud-sim/resolve-exact-provider-config.sh
- git diff --check