### PR TITLE
Fix Alibaba simulator secondary IP readiness

### DIFF
--- a/internal/infra/cloudsim/alibaba/openapi.go
+++ b/internal/infra/cloudsim/alibaba/openapi.go
@@ -863,7 +863,7 @@ func (a *OpenAPI) CreateHost(ctx context.Context, request HostRequest) (_ []Asse
 		SetTag(runInstanceTags(request.Tags))
 	response, err := a.ecs.RunInstances(runRequest)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("run spot instance: %w", err)
 	}
 	var instanceID string
 	if response.Body != nil && response.Body.InstanceIdSets != nil && len(response.Body.InstanceIdSets.InstanceIdSet) == 1 {
@@ -889,7 +889,7 @@ func (a *OpenAPI) CreateHost(ctx context.Context, request HostRequest) (_ []Asse
 		SetClientToken(clientToken(request.Tags[cloudsim.TagRunID], request.Role+"-data")).
 		SetTag(createDiskTags(request.Tags)))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create data disk: %w", err)
 	}
 	if diskResponse.Body != nil {
 		diskID = deref(diskResponse.Body.DiskId)
@@ -898,31 +898,33 @@ func (a *OpenAPI) CreateHost(ctx context.Context, request HostRequest) (_ []Asse
 		return nil, ErrAmbiguousInventory
 	}
 	if err = a.waitDiskAvailable(ctx, request.Region, diskID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("wait for data disk availability: %w", err)
 	}
 	if err = a.waitInstanceAttachable(ctx, request.Region, instanceID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("wait for disk-attachable instance: %w", err)
 	}
 	if err = a.attachDisk(ctx, request.Region, instanceID, diskID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("attach data disk: %w", err)
 	}
 	diskAttached = true
 	if len(request.SecondaryPrivateIPv4) != 0 {
 		networkInterfaceID, interfaceErr := a.primaryNetworkInterfaceID(ctx, request.Region, instanceID)
 		if interfaceErr != nil {
-			return nil, interfaceErr
+			return nil, fmt.Errorf("discover primary network interface: %w", interfaceErr)
 		}
 		addresses := make([]*string, 0, len(request.SecondaryPrivateIPv4))
 		for _, address := range request.SecondaryPrivateIPv4 {
 			addresses = append(addresses, dara.String(address))
 		}
-		_, assignErr := a.ecs.AssignPrivateIpAddresses((&ecs.AssignPrivateIpAddressesRequest{}).
-			SetRegionId(request.Region).
-			SetNetworkInterfaceId(networkInterfaceID).
-			SetPrivateIpAddress(addresses).
-			SetClientToken(clientToken(request.Tags[cloudsim.TagRunID], request.Role+"-source-ips")))
-		if assignErr != nil {
-			return nil, assignErr
+		if assignErr := a.assignPrivateIPAddresses(
+			ctx,
+			request.Region,
+			instanceID,
+			networkInterfaceID,
+			addresses,
+			clientToken(request.Tags[cloudsim.TagRunID], request.Role+"-source-ips"),
+		); assignErr != nil {
+			return nil, fmt.Errorf("assign simulator secondary private addresses: %w", assignErr)
 		}
 	}
 	deadline := time.Now().Add(a.waitTimeout)
@@ -1056,14 +1058,17 @@ func (a *OpenAPI) primaryNetworkInterfaceID(ctx context.Context, region, instanc
 						NetworkInterfaces struct {
 							NetworkInterface []struct {
 								NetworkInterfaceID string `json:"NetworkInterfaceId"`
+								Type               string `json:"Type"`
 							} `json:"NetworkInterface"`
 						} `json:"NetworkInterfaces"`
 					} `json:"Instance"`
 				} `json:"Instances"`
 			}
 			if decodeErr := decodeSDKBody(response.Body, &body); decodeErr == nil && len(body.Instances.Instance) == 1 && len(body.Instances.Instance[0].NetworkInterfaces.NetworkInterface) > 0 {
-				if id := body.Instances.Instance[0].NetworkInterfaces.NetworkInterface[0].NetworkInterfaceID; id != "" {
-					return id, nil
+				for _, networkInterface := range body.Instances.Instance[0].NetworkInterfaces.NetworkInterface {
+					if networkInterface.Type == "Primary" && networkInterface.NetworkInterfaceID != "" {
+						return networkInterface.NetworkInterfaceID, nil
+					}
 				}
 			}
 		}
@@ -1073,6 +1078,90 @@ func (a *OpenAPI) primaryNetworkInterfaceID(ctx context.Context, region, instanc
 		if err := waitContext(ctx, a.pollInterval); err != nil {
 			return "", err
 		}
+	}
+}
+
+// assignPrivateIPAddresses waits for both sides of the primary ENI attachment
+// and retries only idempotent control-plane errors that can converge.
+func (a *OpenAPI) assignPrivateIPAddresses(ctx context.Context, region, instanceID, networkInterfaceID string, addresses []*string, token string) error {
+	deadline := time.Now().Add(a.waitTimeout)
+	for {
+		if err := a.waitInstanceAttachable(ctx, region, instanceID); err != nil {
+			return err
+		}
+		if err := a.waitNetworkInterfaceAssignable(ctx, region, instanceID, networkInterfaceID); err != nil {
+			return err
+		}
+		_, err := a.ecs.AssignPrivateIpAddresses((&ecs.AssignPrivateIpAddressesRequest{}).
+			SetRegionId(region).
+			SetNetworkInterfaceId(networkInterfaceID).
+			SetPrivateIpAddress(addresses).
+			SetClientToken(token))
+		if err == nil {
+			return nil
+		}
+		if !retryablePrivateIPAssignmentError(err) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("assign private addresses to network interface %s after readiness retries: %w", networkInterfaceID, err)
+		}
+		if err := waitContext(ctx, a.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func (a *OpenAPI) waitNetworkInterfaceAssignable(ctx context.Context, region, instanceID, networkInterfaceID string) error {
+	deadline := time.Now().Add(a.waitTimeout)
+	lastErr := error(ErrAmbiguousInventory)
+	for {
+		response, err := a.ecs.DescribeNetworkInterfaces((&ecs.DescribeNetworkInterfacesRequest{}).
+			SetRegionId(region).
+			SetNetworkInterfaceId([]*string{dara.String(networkInterfaceID)}))
+		if err == nil {
+			var body struct {
+				NetworkInterfaceSets struct {
+					NetworkInterfaceSet []struct {
+						NetworkInterfaceID string `json:"NetworkInterfaceId"`
+						InstanceID         string `json:"InstanceId"`
+						Status             string `json:"Status"`
+					} `json:"NetworkInterfaceSet"`
+				} `json:"NetworkInterfaceSets"`
+			}
+			if decodeErr := decodeSDKBody(response.Body, &body); decodeErr == nil {
+				if len(body.NetworkInterfaceSets.NetworkInterfaceSet) == 1 {
+					networkInterface := body.NetworkInterfaceSets.NetworkInterfaceSet[0]
+					if networkInterface.NetworkInterfaceID == networkInterfaceID &&
+						networkInterface.InstanceID == instanceID &&
+						networkInterface.Status == "InUse" {
+						return nil
+					}
+				}
+				lastErr = ErrAmbiguousInventory
+			} else {
+				lastErr = decodeErr
+			}
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wait for assignable network interface %s: %w", networkInterfaceID, lastErr)
+		}
+		if err := waitContext(ctx, a.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func retryablePrivateIPAssignmentError(err error) bool {
+	switch sdkErrorCode(err) {
+	case "UnknownError", "InternalError", "Throttling", "Operation.Conflict",
+		"InvalidOperation.InvalidEcsState", "InvalidOperation.InvalidEniState",
+		"InvalidStatus.InstanceIsMigrating":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1619,10 +1708,17 @@ func ignoreIncorrectDiskStatus(err error) error {
 }
 
 func sdkErrorHasCode(err error, code string) bool {
+	return sdkErrorCode(err) == code
+}
+
+func sdkErrorCode(err error) string {
 	var teaErr *tea.SDKError
 	if errors.As(err, &teaErr) {
-		return deref(teaErr.Code) == code
+		return deref(teaErr.Code)
 	}
 	var sdkErr *dara.SDKError
-	return errors.As(err, &sdkErr) && deref(sdkErr.Code) == code
+	if errors.As(err, &sdkErr) {
+		return deref(sdkErr.Code)
+	}
+	return ""
 }

--- a/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
+++ b/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
@@ -100,6 +100,96 @@ func TestCreateHostRetriesAttachWhileInstanceStatusConverges(t *testing.T) {
 	}
 }
 
+func TestCreateHostRetriesSecondaryIPAssignmentAfterTransientUnknownError(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		assignCalls int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		_ = request.ParseForm()
+		action := request.Header.Get("x-acs-action")
+		response.Header().Set("Content-Type", "application/json")
+		switch action {
+		case "RunInstances":
+			_, _ = response.Write([]byte(`{"RequestId":"request-1","InstanceIdSets":{"InstanceIdSet":["i-sim"]}}`))
+		case "CreateDisk":
+			_, _ = response.Write([]byte(`{"RequestId":"request-2","DiskId":"d-sim"}`))
+		case "DescribeDisks":
+			if request.Form.Get("DiskIds") != "" {
+				_, _ = response.Write([]byte(`{"RequestId":"request-3","Disks":{"Disk":[{"DiskId":"d-sim","Status":"Available"}]}}`))
+				return
+			}
+			_, _ = response.Write([]byte(`{"RequestId":"request-9","TotalCount":1,"Disks":{"Disk":[{"DiskId":"d-sim","InstanceId":"i-sim","Tags":{"Tag":[{"TagKey":"wukongim-resource-role","TagValue":"sim"}]}}]}}`))
+		case "DescribeInstances":
+			if request.Form.Get("InstanceIds") != "" {
+				_, _ = response.Write([]byte(`{"RequestId":"request-4","Instances":{"Instance":[{"InstanceId":"i-sim","Status":"Running","NetworkInterfaces":{"NetworkInterface":[{"NetworkInterfaceId":"eni-sim","Type":"Primary"}]}}]}}`))
+				return
+			}
+			_, _ = response.Write([]byte(`{"RequestId":"request-8","TotalCount":1,"Instances":{"Instance":[{"InstanceId":"i-sim","VpcAttributes":{"PrivateIpAddress":{"IpAddress":["10.42.0.20"]}},"Tags":{"Tag":[{"TagKey":"wukongim-resource-role","TagValue":"sim"}]}}]}}`))
+		case "DescribeNetworkInterfaces":
+			_, _ = response.Write([]byte(`{"RequestId":"request-5","TotalCount":1,"NetworkInterfaceSets":{"NetworkInterfaceSet":[{"NetworkInterfaceId":"eni-sim","InstanceId":"i-sim","Status":"InUse"}]}}`))
+		case "AttachDisk":
+			_, _ = response.Write([]byte(`{"RequestId":"request-6"}`))
+		case "AssignPrivateIpAddresses":
+			mu.Lock()
+			assignCalls++
+			call := assignCalls
+			mu.Unlock()
+			if call == 1 {
+				response.WriteHeader(http.StatusBadRequest)
+				_, _ = response.Write([]byte(`{"RequestId":"request-7","Code":"UnknownError","Message":"The request processing has failed due to some unknown error."}`))
+				return
+			}
+			_, _ = response.Write([]byte(`{"RequestId":"request-7-retry","AssignedPrivateIpAddressesSet":{"NetworkInterfaceId":"eni-sim","PrivateIpSet":{"PrivateIpAddress":["10.42.0.21","10.42.0.22"]}}}`))
+		case "DescribeSecurityGroups", "DescribeVpcs", "DescribeVSwitches", "DescribeEipAddresses":
+			_, _ = response.Write([]byte(`{"RequestId":"request-10","TotalCount":0}`))
+		case "DeleteInstance", "DeleteDisk":
+			_, _ = response.Write([]byte(`{"RequestId":"rollback"}`))
+		default:
+			http.Error(response, "unexpected action "+action, http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	api, err := newOpenAPI(&openapiutil.Config{
+		AccessKeyId:     dara.String("test-access-key-id"),
+		AccessKeySecret: dara.String("test-access-key-secret"),
+		RegionId:        dara.String("cn-hangzhou"),
+		Endpoint:        dara.String(strings.TrimPrefix(server.URL, "http://")),
+		Protocol:        dara.String("http"),
+	})
+	if err != nil {
+		t.Fatalf("newOpenAPI() error = %v", err)
+	}
+	api.pollInterval = 0
+	api.waitTimeout = time.Second
+
+	assets, err := api.CreateHost(context.Background(), HostRequest{
+		Region: "cn-hangzhou", ZoneID: "cn-hangzhou-a", Role: "sim",
+		ImageID: "aliyun_3_x64_20G_alibase_20260101.vhd", InstanceType: "ecs.c7.large",
+		VSwitchID: "vsw-1", SecurityGroupID: "sg-1", PrivateIPv4: "10.42.0.20",
+		SecondaryPrivateIPv4: []string{"10.42.0.21", "10.42.0.22"}, PrivateIPv4PrefixBits: 24,
+		SystemDiskCategory: "cloud_essd", SystemDiskSizeGiB: 40,
+		DataDiskCategory: "cloud_essd", DataDiskSizeGiB: 40,
+		AutoReleaseAt: time.Now().Add(3 * time.Hour), SSHPublicKey: "ssh-ed25519 AAAATEST run",
+		Tags: map[string]string{
+			cloudsim.TagManagedBy: cloudsim.ManagedByValue,
+			cloudsim.TagRunID:     "run-1", cloudsim.TagResourceRole: "sim",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateHost() error = %v", err)
+	}
+	if len(assets) != 2 || assets[0].Role != "sim" || assets[1].Role != "sim" {
+		t.Fatalf("CreateHost() assets = %#v, want sim compute and disk", assets)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if assignCalls != 2 {
+		t.Fatalf("AssignPrivateIpAddresses calls = %d, want one bounded retry", assignCalls)
+	}
+}
+
 func TestCreateNetworkWaitsForVSwitchBeforeCreatingSecurityGroup(t *testing.T) {
 	var (
 		mu             sync.Mutex


### PR DESCRIPTION
## Summary
- wait until the simulator primary ENI is attached and assignable before adding secondary private IPs
- retry only bounded, idempotent Alibaba control-plane convergence errors with the same client token
- add per-operation context to host provisioning errors and a real SDK transport regression test

## Evidence
- real run `gh-29398660976-1` failed only on the simulator with Alibaba `400 UnknownError`; the three hosts without secondary IP assignment succeeded
- the new SDK test failed against the old behavior and passes after the fix
- `GOWORK=off go test ./internal/infra/cloudsim/alibaba ./cmd/wkcloudsim -count=3`
- repository gate passed except one unrelated `pkg/cluster` timing failure; isolated `pkg/cluster` rerun passed
- exact cleanup run `29399060269` verified released state with zero residual resources