### PR TITLE
Wait for Alibaba host address inventory

### DIFF
--- a/internal/infra/cloudsim/alibaba/openapi.go
+++ b/internal/infra/cloudsim/alibaba/openapi.go
@@ -928,21 +928,36 @@ func (a *OpenAPI) CreateHost(ctx context.Context, request HostRequest) (_ []Asse
 		}
 	}
 	deadline := time.Now().Add(a.waitTimeout)
+	lastErr := error(ErrAmbiguousInventory)
 	for {
 		assets, listErr := a.ListAssets(ctx, ListAssetsRequest{Region: request.Region, RunID: request.Tags[cloudsim.TagRunID]})
 		if listErr == nil {
-			selected := make([]Asset, 0, 2)
+			var compute Asset
+			var disk Asset
+			computeFound := false
+			diskFound := false
 			for _, asset := range assets {
-				if asset.Role == request.Role && (asset.ID == instanceID || asset.Kind == "disk") {
-					selected = append(selected, asset)
+				if asset.Role != request.Role {
+					continue
+				}
+				if asset.Kind == "compute" && asset.ID == instanceID && asset.PrivateAddress == request.PrivateIPv4 {
+					compute = asset
+					computeFound = true
+				}
+				if asset.Kind == "disk" && asset.ID == diskID && asset.AttachedTo == instanceID {
+					disk = asset
+					diskFound = true
 				}
 			}
-			if len(selected) == 2 {
-				return selected, nil
+			if computeFound && diskFound {
+				return []Asset{compute, disk}, nil
 			}
+			lastErr = ErrAmbiguousInventory
+		} else {
+			lastErr = listErr
 		}
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("discover host %s assets: %w", request.Role, listErr)
+			return nil, fmt.Errorf("discover converged host %s assets: %w", request.Role, lastErr)
 		}
 		if err := waitContext(ctx, a.pollInterval); err != nil {
 			return nil, err

--- a/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
+++ b/internal/infra/cloudsim/alibaba/openapi_credentials_test.go
@@ -102,8 +102,9 @@ func TestCreateHostRetriesAttachWhileInstanceStatusConverges(t *testing.T) {
 
 func TestCreateHostRetriesSecondaryIPAssignmentAfterTransientUnknownError(t *testing.T) {
 	var (
-		mu          sync.Mutex
-		assignCalls int
+		mu             sync.Mutex
+		assignCalls    int
+		inventoryCalls int
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		_ = request.ParseForm()
@@ -123,6 +124,14 @@ func TestCreateHostRetriesSecondaryIPAssignmentAfterTransientUnknownError(t *tes
 		case "DescribeInstances":
 			if request.Form.Get("InstanceIds") != "" {
 				_, _ = response.Write([]byte(`{"RequestId":"request-4","Instances":{"Instance":[{"InstanceId":"i-sim","Status":"Running","NetworkInterfaces":{"NetworkInterface":[{"NetworkInterfaceId":"eni-sim","Type":"Primary"}]}}]}}`))
+				return
+			}
+			mu.Lock()
+			inventoryCalls++
+			inventoryCall := inventoryCalls
+			mu.Unlock()
+			if inventoryCall == 1 {
+				_, _ = response.Write([]byte(`{"RequestId":"request-8-converging","TotalCount":1,"Instances":{"Instance":[{"InstanceId":"i-sim","VpcAttributes":{"PrivateIpAddress":{"IpAddress":[]}},"Tags":{"Tag":[{"TagKey":"wukongim-resource-role","TagValue":"sim"}]}}]}}`))
 				return
 			}
 			_, _ = response.Write([]byte(`{"RequestId":"request-8","TotalCount":1,"Instances":{"Instance":[{"InstanceId":"i-sim","VpcAttributes":{"PrivateIpAddress":{"IpAddress":["10.42.0.20"]}},"Tags":{"Tag":[{"TagKey":"wukongim-resource-role","TagValue":"sim"}]}}]}}`))
@@ -180,13 +189,16 @@ func TestCreateHostRetriesSecondaryIPAssignmentAfterTransientUnknownError(t *tes
 	if err != nil {
 		t.Fatalf("CreateHost() error = %v", err)
 	}
-	if len(assets) != 2 || assets[0].Role != "sim" || assets[1].Role != "sim" {
+	if len(assets) != 2 || assets[0].Role != "sim" || assets[1].Role != "sim" || assets[0].PrivateAddress != "10.42.0.20" {
 		t.Fatalf("CreateHost() assets = %#v, want sim compute and disk", assets)
 	}
 	mu.Lock()
 	defer mu.Unlock()
 	if assignCalls != 2 {
 		t.Fatalf("AssignPrivateIpAddresses calls = %d, want one bounded retry", assignCalls)
+	}
+	if inventoryCalls != 2 {
+		t.Fatalf("host inventory calls = %d, want address-converging retry", inventoryCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- require the exact compute ID and expected private address before host creation returns
- require the exact data disk to report attachment to that instance
- retain the last inventory error for an actionable convergence timeout

## Evidence
- real run `gh-29400216646-1` completed cloud creation but the workflow silently failed while extracting an absent private address
- the SDK regression test reproduces an initially empty private address and fails with the old behavior
- fixed regression passed 10 times
- `GOWORK=off go test ./internal/infra/cloudsim/alibaba ./cmd/wkcloudsim -count=3`
- exact cleanup run `29400588990` verified released state with zero residual resources