### PR TITLE
Pin SSH identity across Alibaba ProxyJump

### DIFF
--- a/.github/workflows/cloud-sim-provision.yml
+++ b/.github/workflows/cloud-sim-provision.yml
@@ -360,28 +360,35 @@ jobs:
           NODE3_PRIVATE: ${{ steps.create.outputs.node3_private }}
         run: |
           set -euo pipefail
-          ssh_opts=(-i bootstrap-key -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
+          WK_CLOUD_SIM_PUBLIC_IP="$SIM_PUBLIC" \
+          WK_CLOUD_NODE1_IP="$NODE1_PRIVATE" \
+          WK_CLOUD_NODE2_IP="$NODE2_PRIVATE" \
+          WK_CLOUD_NODE3_IP="$NODE3_PRIVATE" \
+          WK_CLOUD_SSH_KEY="$PWD/bootstrap-key" \
+          WK_CLOUD_SSH_CONFIG="$PWD/cloud-sim-ssh-config" \
+            ./scripts/cloud-sim/write-ssh-config.sh
+          ssh_opts=(-F cloud-sim-ssh-config)
           for attempt in $(seq 1 30); do
-            if ssh "${ssh_opts[@]}" "wukong@${SIM_PUBLIC}" true; then break; fi
+            if ssh "${ssh_opts[@]}" wukong-sim-jump true; then break; fi
             test "$attempt" -lt 30
             sleep 5
           done
           tar -czf node-secrets.tar.gz -C secrets-node .
           tar -czf sim-secrets.tar.gz -C secrets .
-          scp "${ssh_opts[@]}" artifact/deployment-bundle.tar.gz sim-secrets.tar.gz "wukong@${SIM_PUBLIC}:/home/wukong/"
+          scp "${ssh_opts[@]}" artifact/deployment-bundle.tar.gz sim-secrets.tar.gz wukong-sim-jump:/home/wukong/
           for pair in "node-1:${NODE1_PRIVATE}" "node-2:${NODE2_PRIVATE}" "node-3:${NODE3_PRIVATE}"; do
             role="${pair%%:*}"; address="${pair#*:}"
-            scp "${ssh_opts[@]}" -o "ProxyJump=wukong@${SIM_PUBLIC}" artifact/deployment-bundle.tar.gz node-secrets.tar.gz "wukong@${address}:/home/wukong/"
-            ssh "${ssh_opts[@]}" -o "ProxyJump=wukong@${SIM_PUBLIC}" "wukong@${address}" \
+            scp "${ssh_opts[@]}" artifact/deployment-bundle.tar.gz node-secrets.tar.gz "${address}:/home/wukong/"
+            ssh "${ssh_opts[@]}" "$address" \
               "rm -rf /home/wukong/bundle /home/wukong/run-secrets && mkdir /home/wukong/bundle /home/wukong/run-secrets && tar -xzf /home/wukong/deployment-bundle.tar.gz -C /home/wukong/bundle && tar -xzf /home/wukong/node-secrets.tar.gz -C /home/wukong/run-secrets"
-            data_device="$(ssh "${ssh_opts[@]}" -o "ProxyJump=wukong@${SIM_PUBLIC}" "wukong@${address}" 'root_source=$(findmnt -no SOURCE /); root_parent=$(lsblk -no PKNAME "$root_source" | head -1); lsblk -dpno NAME,TYPE | awk -v root="/dev/$root_parent" '\''$2=="disk" && $1!=root {print $1; exit}'\''')"
-            ssh "${ssh_opts[@]}" -o "ProxyJump=wukong@${SIM_PUBLIC}" "wukong@${address}" \
+            data_device="$(ssh "${ssh_opts[@]}" "$address" 'root_source=$(findmnt -no SOURCE /); root_parent=$(lsblk -no PKNAME "$root_source" | head -1); lsblk -dpno NAME,TYPE | awk -v root="/dev/$root_parent" '\''$2=="disk" && $1!=root {print $1; exit}'\''')"
+            ssh "${ssh_opts[@]}" "$address" \
               "sudo /home/wukong/bundle/bin/wkcloudhost install --bundle /home/wukong/bundle --role '$role' --env-dir /home/wukong/run-secrets --data-device '$data_device' --authorized-keys ''"
           done
-          ssh "${ssh_opts[@]}" "wukong@${SIM_PUBLIC}" \
+          ssh "${ssh_opts[@]}" wukong-sim-jump \
             "rm -rf /home/wukong/bundle /home/wukong/run-secrets && mkdir /home/wukong/bundle /home/wukong/run-secrets && tar -xzf /home/wukong/deployment-bundle.tar.gz -C /home/wukong/bundle && tar -xzf /home/wukong/sim-secrets.tar.gz -C /home/wukong/run-secrets"
-          sim_data_device="$(ssh "${ssh_opts[@]}" "wukong@${SIM_PUBLIC}" 'root_source=$(findmnt -no SOURCE /); root_parent=$(lsblk -no PKNAME "$root_source" | head -1); lsblk -dpno NAME,TYPE | awk -v root="/dev/$root_parent" '\''$2=="disk" && $1!=root {print $1; exit}'\''')"
-          ssh "${ssh_opts[@]}" "wukong@${SIM_PUBLIC}" \
+          sim_data_device="$(ssh "${ssh_opts[@]}" wukong-sim-jump 'root_source=$(findmnt -no SOURCE /); root_parent=$(lsblk -no PKNAME "$root_source" | head -1); lsblk -dpno NAME,TYPE | awk -v root="/dev/$root_parent" '\''$2=="disk" && $1!=root {print $1; exit}'\''')"
+          ssh "${ssh_opts[@]}" wukong-sim-jump \
             "sudo /home/wukong/bundle/bin/wkcloudhost install --bundle /home/wukong/bundle --role sim --env-dir /home/wukong/run-secrets --data-device '$sim_data_device' --authorized-keys ''"
 
       - name: Prove Bootstrap Gate
@@ -453,11 +460,18 @@ jobs:
           NODE2_PRIVATE: ${{ steps.create.outputs.node2_private }}
           NODE3_PRIVATE: ${{ steps.create.outputs.node3_private }}
         run: |
-          ssh_opts=(-i bootstrap-key -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new)
+          WK_CLOUD_SIM_PUBLIC_IP="$SIM_PUBLIC" \
+          WK_CLOUD_NODE1_IP="$NODE1_PRIVATE" \
+          WK_CLOUD_NODE2_IP="$NODE2_PRIVATE" \
+          WK_CLOUD_NODE3_IP="$NODE3_PRIVATE" \
+          WK_CLOUD_SSH_KEY="$PWD/bootstrap-key" \
+          WK_CLOUD_SSH_CONFIG="$PWD/cloud-sim-ssh-config" \
+            ./scripts/cloud-sim/write-ssh-config.sh
+          ssh_opts=(-F cloud-sim-ssh-config -o ConnectTimeout=5)
           for address in "$NODE1_PRIVATE" "$NODE2_PRIVATE" "$NODE3_PRIVATE"; do
-            ssh "${ssh_opts[@]}" -o "ProxyJump=wukong@${SIM_PUBLIC}" "wukong@${address}" 'sudo rm -f /home/wukong/.ssh/authorized_keys' || true
+            ssh "${ssh_opts[@]}" "$address" 'sudo rm -f /home/wukong/.ssh/authorized_keys' || true
           done
-          ssh "${ssh_opts[@]}" "wukong@${SIM_PUBLIC}" 'sudo rm -f /home/wukong/.ssh/authorized_keys' || true
+          ssh "${ssh_opts[@]}" wukong-sim-jump 'sudo rm -f /home/wukong/.ssh/authorized_keys' || true
       - name: Close deployment ingress
         if: always() && steps.create.outcome == 'success'
         shell: bash

--- a/scripts/cloud-sim/collect-bootstrap-gate.sh
+++ b/scripts/cloud-sim/collect-bootstrap-gate.sh
@@ -10,16 +10,20 @@ set -euo pipefail
 : "${WK_CLOUD_GATE_OUTPUT:?required}"
 : "${WK_ANALYSIS_MANAGER_PASSWORD:?required}"
 
-ssh_common=(-i "$WK_CLOUD_SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new)
+ssh_config="$(mktemp)"
+trap 'rm -f "$ssh_config"' EXIT
+WK_CLOUD_SSH_CONFIG="$ssh_config" \
+  "$(dirname "$0")/write-ssh-config.sh"
+ssh_common=(-F "$ssh_config")
 
 ssh_sim() {
-  ssh "${ssh_common[@]}" "wukong@${WK_CLOUD_SIM_PUBLIC_IP}" "$@"
+  ssh "${ssh_common[@]}" wukong-sim-jump "$@"
 }
 
 ssh_node() {
   local address="$1"
   shift
-  ssh "${ssh_common[@]}" -o "ProxyJump=wukong@${WK_CLOUD_SIM_PUBLIC_IP}" "wukong@${address}" "$@"
+  ssh "${ssh_common[@]}" "$address" "$@"
 }
 
 bundle_digest() {

--- a/scripts/cloud-sim/write-ssh-config.sh
+++ b/scripts/cloud-sim/write-ssh-config.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${WK_CLOUD_SIM_PUBLIC_IP:?required}"
+: "${WK_CLOUD_NODE1_IP:?required}"
+: "${WK_CLOUD_NODE2_IP:?required}"
+: "${WK_CLOUD_NODE3_IP:?required}"
+: "${WK_CLOUD_SSH_KEY:?required}"
+: "${WK_CLOUD_SSH_CONFIG:?required}"
+
+for address in "$WK_CLOUD_SIM_PUBLIC_IP" "$WK_CLOUD_NODE1_IP" "$WK_CLOUD_NODE2_IP" "$WK_CLOUD_NODE3_IP"; do
+  [[ "$address" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || {
+    echo "invalid SSH host address: $address" >&2
+    exit 1
+  }
+done
+[[ -f "$WK_CLOUD_SSH_KEY" ]] || {
+  echo "SSH identity file not found: $WK_CLOUD_SSH_KEY" >&2
+  exit 1
+}
+
+key_dir="$(cd "$(dirname "$WK_CLOUD_SSH_KEY")" && pwd -P)"
+key_path="${key_dir}/$(basename "$WK_CLOUD_SSH_KEY")"
+output_dir="$(dirname "$WK_CLOUD_SSH_CONFIG")"
+[[ -d "$output_dir" ]] || {
+  echo "SSH config directory not found: $output_dir" >&2
+  exit 1
+}
+
+umask 077
+temporary="${WK_CLOUD_SSH_CONFIG}.tmp.$$"
+trap 'rm -f "$temporary"' EXIT
+cat >"$temporary" <<EOF
+Host wukong-sim-jump
+  HostName $WK_CLOUD_SIM_PUBLIC_IP
+  User wukong
+  IdentityFile "$key_path"
+  IdentitiesOnly yes
+  BatchMode yes
+  ConnectTimeout 10
+  StrictHostKeyChecking accept-new
+
+Host $WK_CLOUD_NODE1_IP $WK_CLOUD_NODE2_IP $WK_CLOUD_NODE3_IP
+  User wukong
+  IdentityFile "$key_path"
+  IdentitiesOnly yes
+  BatchMode yes
+  ConnectTimeout 10
+  StrictHostKeyChecking accept-new
+  ProxyJump wukong-sim-jump
+EOF
+chmod 0600 "$temporary"
+mv "$temporary" "$WK_CLOUD_SSH_CONFIG"
+trap - EXIT

--- a/scripts/cloud_sim_ssh_config_test.go
+++ b/scripts/cloud_sim_ssh_config_test.go
@@ -1,0 +1,111 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCloudSimulationSSHConfigPinsJumpAndTargetIdentity(t *testing.T) {
+	_, current, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filepath.Dir(current))
+	temporary := t.TempDir()
+	keyPath := filepath.Join(temporary, "bootstrap identity")
+	configPath := filepath.Join(temporary, "ssh-config")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	canonicalKeyPath, err := filepath.EvalSymlinks(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts/cloud-sim/write-ssh-config.sh"))
+	command.Env = append(os.Environ(),
+		"WK_CLOUD_SIM_PUBLIC_IP=203.0.113.20",
+		"WK_CLOUD_NODE1_IP=10.42.0.11",
+		"WK_CLOUD_NODE2_IP=10.42.0.12",
+		"WK_CLOUD_NODE3_IP=10.42.0.13",
+		"WK_CLOUD_SSH_KEY="+keyPath,
+		"WK_CLOUD_SSH_CONFIG="+configPath,
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("write SSH config: %v\n%s", err, output)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{
+		"Host wukong-sim-jump",
+		"HostName 203.0.113.20",
+		`IdentityFile "` + canonicalKeyPath + `"`,
+		"IdentitiesOnly yes",
+		"Host 10.42.0.11 10.42.0.12 10.42.0.13",
+		"ProxyJump wukong-sim-jump",
+	} {
+		if !strings.Contains(string(content), fragment) {
+			t.Fatalf("SSH config missing %q:\n%s", fragment, content)
+		}
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("SSH config mode = %o, want 600", got)
+	}
+
+	for _, test := range []struct {
+		host      string
+		hostname  string
+		proxyJump string
+	}{
+		{host: "wukong-sim-jump", hostname: "203.0.113.20"},
+		{host: "10.42.0.11", hostname: "10.42.0.11", proxyJump: "wukong-sim-jump"},
+	} {
+		resolved := exec.CommandContext(t.Context(), "ssh", "-G", "-F", configPath, test.host)
+		output, err := resolved.CombinedOutput()
+		if err != nil {
+			t.Fatalf("resolve SSH config for %s: %v\n%s", test.host, err, output)
+		}
+		for _, setting := range []string{
+			"hostname " + test.hostname,
+			"user wukong",
+			"identityfile " + canonicalKeyPath,
+			"identitiesonly yes",
+		} {
+			if !strings.Contains(string(output), setting+"\n") {
+				t.Fatalf("resolved SSH config for %s missing %q:\n%s", test.host, setting, output)
+			}
+		}
+		if test.proxyJump != "" && !strings.Contains(string(output), "proxyjump "+test.proxyJump+"\n") {
+			t.Fatalf("resolved SSH config for %s missing proxy jump %q:\n%s", test.host, test.proxyJump, output)
+		}
+	}
+}
+
+func TestCloudSimulationSSHConfigRejectsConfigInjection(t *testing.T) {
+	_, current, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filepath.Dir(current))
+	temporary := t.TempDir()
+	keyPath := filepath.Join(temporary, "key")
+	if err := os.WriteFile(keyPath, []byte("test-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts/cloud-sim/write-ssh-config.sh"))
+	command.Env = append(os.Environ(),
+		"WK_CLOUD_SIM_PUBLIC_IP=203.0.113.20\nProxyCommand evil",
+		"WK_CLOUD_NODE1_IP=10.42.0.11",
+		"WK_CLOUD_NODE2_IP=10.42.0.12",
+		"WK_CLOUD_NODE3_IP=10.42.0.13",
+		"WK_CLOUD_SSH_KEY="+keyPath,
+		"WK_CLOUD_SSH_CONFIG="+filepath.Join(temporary, "ssh-config"),
+	)
+	if err := command.Run(); err == nil {
+		t.Fatal("SSH config accepted a non-IPv4 host value")
+	}
+}

--- a/scripts/cloud_sim_workflows_test.go
+++ b/scripts/cloud_sim_workflows_test.go
@@ -206,6 +206,9 @@ func TestCloudSimulationWorkflowsPersistAndReuseDiscoveredProviderConfig(t *test
 		"ref: ${{ github.sha }}",
 		"go build -trimpath -o wkcloudsim ./cmd/wkcloudsim",
 		"discover-config --region \"$ALIBABA_REGION\" >provider.json",
+		"./scripts/cloud-sim/write-ssh-config.sh",
+		"ssh_opts=(-F cloud-sim-ssh-config)",
+		"ssh_opts=(-F cloud-sim-ssh-config -o ConnectTimeout=5)",
 		"name: cloud-sim-provider-config--${{ needs.build.outputs.run_id }}--${{ inputs.region }}--${{ steps.provider_config.outputs.account_hash_hex }}",
 		"retention-days: 90",
 	} {
@@ -218,6 +221,9 @@ func TestCloudSimulationWorkflowsPersistAndReuseDiscoveredProviderConfig(t *test
 	}
 	if strings.Contains(provision, "bundle/bin/wkcloudsim --provider") {
 		t.Fatal("provision workflow uses the selected deployment revision as its cloud control plane")
+	}
+	if strings.Contains(provision, `ProxyJump=wukong@${SIM_PUBLIC}`) {
+		t.Fatal("provision workflow uses a ProxyJump whose connection does not pin the bootstrap identity")
 	}
 
 	cleanup := read("cloud-sim-cleanup.yml")


### PR DESCRIPTION
## Summary
- render a run-scoped OpenSSH config that pins the bootstrap identity for both the public simulator jump host and all private cluster nodes
- reuse that config for bundle transfer, bootstrap-gate collection, and ephemeral-key revocation
- reject host-value config injection and verify the effective OpenSSH configuration with `ssh -G`

## Evidence
- real run `gh-29401143630-1` reached direct simulator SSH, then failed on the first private-node ProxyJump because the jump connection did not inherit `-i bootstrap-key`
- exact cleanup run `29401636344` confirmed the failed simulation was released with zero resources

## Verification
- `GOWORK=off go test ./scripts -run 'TestCloudSimulationSSHConfig|TestCloudSimulationWorkflowsPersist' -count=3 -v`\n- `GOWORK=off go test ./scripts ./internal/infra/cloudsim/deploy -count=1`\n- `bash -n scripts/cloud-sim/write-ssh-config.sh scripts/cloud-sim/collect-bootstrap-gate.sh`\n- `git diff --check`