### PR TITLE
Run Bootstrap Gate TLS probe as service user

### DIFF
--- a/scripts/cloud-sim/collect-bootstrap-gate.sh
+++ b/scripts/cloud-sim/collect-bootstrap-gate.sh
@@ -88,7 +88,7 @@ prometheus_targets="$(ssh_sim "curl --fail --silent --show-error --max-time 10 '
 targets_want="$(jq -er '.data.activeTargets | length' <<<"$prometheus_targets")"
 targets_up="$(jq -er '[.data.activeTargets[] | select(.health == "up")] | length' <<<"$prometheus_targets")"
 
-ssh_sim "curl --fail --silent --show-error --max-time 10 --resolve '${WK_CLOUD_SIM_PUBLIC_IP}:19092:127.0.0.1' 'https://${WK_CLOUD_SIM_PUBLIC_IP}:19092/self-check' --cacert /etc/wukongim/tls/mcp-ca.pem >/dev/null"
+ssh_sim "sudo -u wukongim curl --fail --silent --show-error --max-time 10 --resolve '${WK_CLOUD_SIM_PUBLIC_IP}:19092:127.0.0.1' 'https://${WK_CLOUD_SIM_PUBLIC_IP}:19092/self-check' --cacert /etc/wukongim/tls/mcp-ca.pem >/dev/null"
 analysis_self_check=true
 ssh_sim "sudo -u wukongim bash -c 'set -a; source /etc/wukongim/sim.env; set +a; /opt/wukongim/bin/wkbench validate --target /etc/wukongim/target.yaml --workers /etc/wukongim/workers.yaml --scenario /etc/wukongim/scenario.yaml'"
 wkbench_validate=true

--- a/scripts/cloud_sim_workflows_test.go
+++ b/scripts/cloud_sim_workflows_test.go
@@ -246,3 +246,18 @@ func TestCloudSimulationWorkflowsPersistAndReuseDiscoveredProviderConfig(t *test
 		t.Fatal("analysis workflow still requires the setup-created provider config variable")
 	}
 }
+
+func TestCloudSimulationBootstrapGateReadsTLSAsServiceUser(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "scripts", "cloud-sim", "collect-bootstrap-gate.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, `ssh_sim "sudo -u wukongim curl`) {
+		t.Fatal("Bootstrap Gate TLS self-check does not read the service-owned CA as wukongim")
+	}
+	if strings.Contains(text, `ssh_sim "curl --fail --silent --show-error --max-time 10 --resolve`) {
+		t.Fatal("Bootstrap Gate TLS self-check reads the private service CA as the SSH deployment user")
+	}
+}


### PR DESCRIPTION
## Summary
- execute the Analysis MCP TLS self-check as the `wukongim` service user that owns the run-scoped CA
- keep the CA and private key permissions restricted instead of weakening filesystem access
- add a regression guard that rejects running the CA-backed probe as the SSH deployment user

## Evidence
- real run `gh-29402585668-1` successfully created all resources and installed all four hosts
- Bootstrap Gate then failed 11 consecutive times with `curl: (77) error setting certificate verify locations` for `/etc/wukongim/tls/mcp-ca.pem`
- the install path intentionally copies TLS material as mode 0600 and chowns it to `wukongim`; the probe ran as `wukong`

## Verification
- `GOWORK=off go test ./scripts -run 'TestCloudSimulationBootstrapGateReadsTLSAsServiceUser|TestCloudSimulationSSHConfig|TestCloudSimulationWorkflowsPersist' -count=3 -v`\n- `GOWORK=off go test ./scripts -count=1`\n- `bash -n scripts/cloud-sim/collect-bootstrap-gate.sh`\n- `git diff --check`