### PR TITLE
Support default GitHub OIDC subjects in cloud analysis

### DIFF
--- a/.github/workflows/cloud-sim-oidc-subject.yml
+++ b/.github/workflows/cloud-sim-oidc-subject.yml
@@ -47,6 +47,7 @@ jobs:
   verify-alibaba:
     name: Verify GitHub OIDC can assume the Alibaba analyzer role
     needs: configure
+    if: vars.ALIBABA_CLOUD_SIM_ANALYZER_ROLE_ARN != '' && vars.ALIBABA_CLOUD_SIM_OIDC_PROVIDER_ARN != '' && vars.ALIBABA_CLOUD_SIM_OIDC_AUDIENCE != ''
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     environment: cloud-sim-analysis

--- a/cmd/wkanalysis/oidc.go
+++ b/cmd/wkanalysis/oidc.go
@@ -25,11 +25,14 @@ const (
 var errInvalidGitHubOIDC = errors.New("cmd/wkanalysis: invalid GitHub OIDC token")
 
 type githubOIDCConfig struct {
-	Audience        string
-	Repository      string
-	Ref             string
-	WorkflowRef     string
-	Environment     string
+	Audience    string
+	Repository  string
+	Ref         string
+	WorkflowRef string
+	Environment string
+	// DefaultSubject is GitHub's repository and Environment-bound subject.
+	DefaultSubject string
+	// ExpectedSubject is the stricter subject emitted by the optional repository customization.
 	ExpectedSubject string
 }
 
@@ -66,6 +69,7 @@ func loadGitHubOIDCConfig(getenv func(string) string, runID string) (*githubOIDC
 		WorkflowRef: strings.TrimSpace(getenv("WK_ANALYSIS_GITHUB_WORKFLOW_REF")),
 		Environment: strings.TrimSpace(getenv("WK_ANALYSIS_GITHUB_ENVIRONMENT")),
 	}
+	config.DefaultSubject = fmt.Sprintf("repo:%s:environment:%s", config.Repository, config.Environment)
 	config.ExpectedSubject = fmt.Sprintf("repo:%s:environment:%s:job_workflow_ref:%s", config.Repository, config.Environment, config.WorkflowRef)
 	expectedWorkflowRef := fmt.Sprintf("%s/.github/workflows/cloud-sim-analyze.yml@%s", config.Repository, config.Ref)
 	if runID == "" || config.Audience != "wukongim-cloud-sim:"+runID || config.Repository == "" ||
@@ -98,7 +102,8 @@ func (v *githubOIDCVerifier) Verify(ctx context.Context, raw string) error {
 	if err != nil || !parsed.Valid {
 		return errInvalidGitHubOIDC
 	}
-	if claims.Subject != v.config.ExpectedSubject || claims.Repository != v.config.Repository || claims.Ref != v.config.Ref ||
+	validSubject := claims.Subject == v.config.DefaultSubject || claims.Subject == v.config.ExpectedSubject
+	if !validSubject || claims.Repository != v.config.Repository || claims.Ref != v.config.Ref ||
 		claims.JobWorkflowRef != v.config.WorkflowRef || claims.Environment != v.config.Environment {
 		return errInvalidGitHubOIDC
 	}

--- a/cmd/wkanalysis/oidc_test.go
+++ b/cmd/wkanalysis/oidc_test.go
@@ -32,8 +32,9 @@ func TestGitHubOIDCVerifierRequiresExactRunWorkflowEnvironmentAndRef(t *testing.
 	now := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
 	config := githubOIDCConfig{
 		Audience: "wukongim-cloud-sim:run-1", Repository: "WuKongIM/WuKongIM", Ref: "refs/heads/main",
-		WorkflowRef: "WuKongIM/WuKongIM/.github/workflows/cloud-sim-analyze.yml@refs/heads/main",
-		Environment: "cloud-sim-analysis",
+		WorkflowRef:    "WuKongIM/WuKongIM/.github/workflows/cloud-sim-analyze.yml@refs/heads/main",
+		Environment:    "cloud-sim-analysis",
+		DefaultSubject: "repo:WuKongIM/WuKongIM:environment:cloud-sim-analysis",
 		ExpectedSubject: "repo:WuKongIM/WuKongIM:environment:cloud-sim-analysis:job_workflow_ref:" +
 			"WuKongIM/WuKongIM/.github/workflows/cloud-sim-analyze.yml@refs/heads/main",
 	}
@@ -53,8 +54,23 @@ func TestGitHubOIDCVerifierRequiresExactRunWorkflowEnvironmentAndRef(t *testing.
 		t.Fatal(err)
 	}
 	if err := verifier.Verify(context.Background(), raw); err != nil {
-		t.Fatalf("Verify() error = %v", err)
+		t.Fatalf("Verify(custom subject) error = %v", err)
 	}
+	claims.Subject = config.DefaultSubject
+	token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test"
+	raw, _ = token.SignedString(privateKey)
+	if err := verifier.Verify(context.Background(), raw); err != nil {
+		t.Fatalf("Verify(default subject) error = %v", err)
+	}
+	claims.JobWorkflowRef = "WuKongIM/WuKongIM/.github/workflows/different.yml@refs/heads/main"
+	token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test"
+	raw, _ = token.SignedString(privateKey)
+	if err := verifier.Verify(context.Background(), raw); err == nil {
+		t.Fatal("Verify(default subject with mismatched workflow) error = nil")
+	}
+	claims.JobWorkflowRef = config.WorkflowRef
 	claims.Environment = "different-environment"
 	token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	token.Header["kid"] = "test"

--- a/internal/infra/cloudsim/deploy/workflow_test.go
+++ b/internal/infra/cloudsim/deploy/workflow_test.go
@@ -110,6 +110,7 @@ func TestCloudSimulationWorkflowPrivilegeSeparation(t *testing.T) {
 	for _, required := range []string{
 		"actions: write", `include_claim_keys:["repo","context","job_workflow_ref"]`, ".use_default == false",
 		"verify-alibaba:", "environment: cloud-sim-analysis", "id-token: write",
+		"if: vars.ALIBABA_CLOUD_SIM_ANALYZER_ROLE_ARN != '' && vars.ALIBABA_CLOUD_SIM_OIDC_PROVIDER_ARN != '' && vars.ALIBABA_CLOUD_SIM_OIDC_AUDIENCE != ''",
 		"run-name: Cloud Simulation OIDC Verification", "verification_id:",
 		"aliyun/configure-aliyun-credentials-action@1e5248c8d5d93a8781ac344a68e19a43341e79e6",
 		"ALIBABA_CLOUD_ACCESS_KEY_ID", "ALIBABA_CLOUD_SECURITY_TOKEN",


### PR DESCRIPTION
## Summary
- accept both GitHub default Environment subjects and the optional repository-customized subject in wkanalysis
- retain exact signed checks for repository, main ref, workflow file, Environment, and run-specific audience
- skip the Alibaba role exchange check in the subject configuration workflow when optional hardened-OIDC variables are absent

## Evidence
- live Analysis Session `29406094616` proved the exact run live and completed TLS chain/IP verification, then `POST /analysis/token` returned HTTP 401
- repository OIDC customization currently reports `use_default:true`
- the deployed verifier only accepted the custom `repo + environment + job_workflow_ref` subject even though all component claims are independently verified

## Verification
- `GOWORK=off go test ./cmd/wkanalysis -run 'TestGitHubOIDCVerifier|TestLoadServeConfig' -count=3 -v`\n- `GOWORK=off go test ./cmd/wkanalysis ./internal/access/cloudanalysismcp ./internal/infra/cloudsim/deploy -count=1`\n- `git diff --check`