### PR TITLE
fix: discover local Go for cloud analysis

### DIFF
--- a/scripts/cloud-sim/analyze.sh
+++ b/scripts/cloud-sim/analyze.sh
@@ -48,6 +48,8 @@ fail() {
   exit 1
 }
 
+# ensure_go_on_path keeps an existing Go first, then prepends GOROOT or a
+# common installation directory without discarding the caller's PATH.
 ensure_go_on_path() {
   if command -v go >/dev/null 2>&1; then
     return 0

--- a/scripts/cloud-sim/analyze.sh
+++ b/scripts/cloud-sim/analyze.sh
@@ -48,6 +48,35 @@ fail() {
   exit 1
 }
 
+ensure_go_on_path() {
+  if command -v go >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local candidate
+  if [[ -n "${GOROOT:-}" ]]; then
+    candidate="$GOROOT/bin/go"
+    if [[ -x "$candidate" ]]; then
+      PATH="$(dirname "$candidate"):$PATH"
+      export PATH
+      return 0
+    fi
+  fi
+
+  for candidate in \
+    /usr/local/go/bin/go \
+    /opt/homebrew/bin/go \
+    /opt/homebrew/opt/go/libexec/bin/go \
+    /usr/local/bin/go; do
+    if [[ -x "$candidate" ]]; then
+      PATH="$(dirname "$candidate"):$PATH"
+      export PATH
+      return 0
+    fi
+  done
+  return 1
+}
+
 toml_string() {
   jq -Rn --arg value "$1" '$value'
 }
@@ -295,7 +324,8 @@ case "$session_state" in
   live) session_open=true ;;
 esac
 
-for command in codex go git perl; do
+ensure_go_on_path || fail "go is required"
+for command in codex git perl; do
   command -v "$command" >/dev/null 2>&1 || fail "$command is required"
 done
 login_status="$(codex login status 2>&1 || true)"

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -210,6 +210,27 @@ func TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH(t *testing.T) {
 			continue
 		}
 		if _, err := os.Stat(filepath.Join(entry, "go")); err == nil {
+			commands, err := os.ReadDir(entry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, command := range commands {
+				if command.Name() == "go" {
+					continue
+				}
+				source := filepath.Join(entry, command.Name())
+				info, err := os.Stat(source)
+				if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+					continue
+				}
+				target := filepath.Join(bin, command.Name())
+				if _, err := os.Lstat(target); err == nil {
+					continue
+				}
+				if err := os.Symlink(source, target); err != nil {
+					t.Fatal(err)
+				}
+			}
 			continue
 		}
 		pathEntries = append(pathEntries, entry)

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -204,43 +204,43 @@ func TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH(t *testing.T) {
 	if err := os.Rename(filepath.Join(bin, "go"), filepath.Join(goRoot, "bin", "go")); err != nil {
 		t.Fatal(err)
 	}
-	pathEntries := []string{bin}
-	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
-		if entry == "" {
+	preservedCommands := []string{
+		"awk", "base64", "bash", "cat", "chmod", "cp", "date", "dirname", "env", "grep",
+		"jq", "mkdir", "mktemp", "mv", "perl", "rm", "sleep", "sort", "tr",
+	}
+	for _, command := range preservedCommands {
+		source, err := exec.LookPath(command)
+		if err != nil {
+			t.Fatalf("find required test command %s: %v", command, err)
+		}
+		target := filepath.Join(bin, command)
+		if _, err := os.Lstat(target); err == nil {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(entry, "go")); err == nil {
-			commands, err := os.ReadDir(entry)
-			if err != nil {
-				t.Fatal(err)
-			}
-			for _, command := range commands {
-				if command.Name() == "go" {
-					continue
-				}
-				source := filepath.Join(entry, command.Name())
-				info, err := os.Stat(source)
-				if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
-					continue
-				}
-				target := filepath.Join(bin, command.Name())
-				if _, err := os.Lstat(target); err == nil {
-					continue
-				}
-				if err := os.Symlink(source, target); err != nil {
-					t.Fatal(err)
-				}
-			}
+		if err := os.Symlink(source, target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hashCommandFound := false
+	for _, command := range []string{"sha256sum", "shasum"} {
+		source, err := exec.LookPath(command)
+		if err != nil {
 			continue
 		}
-		pathEntries = append(pathEntries, entry)
+		hashCommandFound = true
+		if err := os.Symlink(source, filepath.Join(bin, command)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !hashCommandFound {
+		t.Fatal("find required SHA-256 test command")
 	}
 
 	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
 		"run-live", "--repository", "example/project")
 	command.Dir = root
 	command.Env = append(os.Environ(),
-		"PATH="+strings.Join(pathEntries, string(os.PathListSeparator)),
+		"PATH="+bin,
 		"GOROOT="+goRoot,
 		"WK_ANALYZE_CALL_LOG="+callLog,
 		"WK_ANALYZE_STATE_DIR="+stateDir,
@@ -693,7 +693,11 @@ case "$1" in
         elif [[ "$WK_ANALYZE_SESSION_STATE" == insufficient_evidence ]]; then
           jq -n --arg request_id "$request_id" --arg message "${WK_ANALYZE_SESSION_MESSAGE:-Provider preflight could not establish a live identity-matched Simulation Run.}" '{schema:"wukongim/cloud-simulation-analysis-session/v1",state:"insufficient_evidence",run_id:"run-insufficient",request_id:$request_id,message:$message}' >"$destination/session.json"
         else
-          fingerprint="sha256:$(printf '%s' DERDATA | sha256sum | awk '{print $1}')"
+		  if command -v sha256sum >/dev/null 2>&1; then
+		    fingerprint="sha256:$(printf '%s' DERDATA | sha256sum | awk '{print $1}')"
+		  else
+		    fingerprint="sha256:$(printf '%s' DERDATA | shasum -a 256 | awk '{print $1}')"
+		  fi
           jq -n --arg request_id "$request_id" --arg fingerprint "$fingerprint" '{schema:"wukongim/cloud-simulation-analysis-session/v1",state:"live",run_id:"run-live",request_id:$request_id,source_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",scenario_digest:"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",mcp_url:"https://198.51.100.20:19092/mcp",expires_at:"2099-07-14T01:00:00Z",ca_fingerprint:$fingerprint}' >"$destination/session.json"
           printf '%s' encrypted >"$destination/encrypted-token.bin"
           printf '%s' certificate >"$destination/pinned-ca.pem"

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -187,6 +187,58 @@ func TestCloudSimulationAnalyzeUsesEncryptedSessionAndLocalChatGPT(t *testing.T)
 	}
 }
 
+func TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH(t *testing.T) {
+	root := repoRoot(t)
+	temp := t.TempDir()
+	bin := filepath.Join(temp, "bin")
+	goRoot := filepath.Join(temp, "go-root")
+	stateDir := filepath.Join(temp, "state")
+	callLog := filepath.Join(temp, "calls.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(goRoot, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAnalyzeFakes(t, bin)
+	if err := os.Rename(filepath.Join(bin, "go"), filepath.Join(goRoot, "bin", "go")); err != nil {
+		t.Fatal(err)
+	}
+	pathEntries := []string{bin}
+	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
+		if entry == "" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(entry, "go")); err == nil {
+			continue
+		}
+		pathEntries = append(pathEntries, entry)
+	}
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+		"run-live", "--repository", "example/project")
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+strings.Join(pathEntries, string(os.PathListSeparator)),
+		"GOROOT="+goRoot,
+		"WK_ANALYZE_CALL_LOG="+callLog,
+		"WK_ANALYZE_STATE_DIR="+stateDir,
+		"WK_ANALYZE_SESSION_STATE=live",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		calls, _ := os.ReadFile(callLog)
+		t.Fatalf("analyze with GOROOT Go outside PATH: %v\n%s\ncalls:\n%s", err, output, calls)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "go run ./cmd/wkclouddiagnosis validate") {
+		t.Fatalf("analysis did not use the discovered Go toolchain:\n%s", calls)
+	}
+}
+
 func TestCloudSimulationAnalyzeKeepsValidDiagnosisSuccessfulWhenRemediationFails(t *testing.T) {
 	root := repoRoot(t)
 	temp := t.TempDir()


### PR DESCRIPTION
## Summary

- discover an installed Go toolchain when the local Codex shell omits it from `PATH`
- prefer `GOROOT/bin/go`, then common macOS/Linux installation paths
- preserve the provider-confirmed `released` early exit before local tool discovery
- add a CLI-boundary regression test that proves the discovered toolchain runs diagnosis validation

## Root cause

The first real minimum Canary successfully provisioned four Alibaba Cloud spot hosts, deployed the three-node cluster plus sim node, passed Bootstrap Gate, ran the workload, and cleaned up all exact Run resources. Local analysis then failed before Codex diagnosis because `analyze.sh` required `command -v go`, while the Codex shell did not include `/usr/local/go/bin` in `PATH` even though Go 1.23.4 was installed there.

Initial evidence:

- Provision: https://github.com/WuKongIM/WuKongIM/actions/runs/29443572316
- Live Analysis Session: https://github.com/WuKongIM/WuKongIM/actions/runs/29446405490
- Exact cleanup: https://github.com/WuKongIM/WuKongIM/actions/runs/29446571879
- Provider-backed release verification: https://github.com/WuKongIM/WuKongIM/actions/runs/29446885225

The finalizer still destroyed the exact Run after analysis failed, and the second provider-backed session confirmed that no live resources remained.

## Validation

- `GOWORK=off /usr/local/go/bin/go test ./scripts -run '^TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH$' -count=1`
- Linux-equivalent synthetic `PATH` where Go and all system tools share one directory
- `GOWORK=off /usr/local/go/bin/go test ./scripts -run 'TestCloudSimulation(Analyze|Finalize)' -count=1`
- `GOWORK=off /usr/local/go/bin/go test ./scripts/... -count=1`
- `GOWORK=off /usr/local/go/bin/go vet ./scripts`
- `bash -n scripts/cloud-sim/analyze.sh scripts/cloud-sim/finalize.sh`
- `git diff --check`
- GitHub Actions CI: https://github.com/WuKongIM/WuKongIM/actions/runs/29448333091

## Live cloud revalidation

The fix was revalidated end to end with a second 30-minute minimum Canary:

- Provision and Bootstrap Gate: https://github.com/WuKongIM/WuKongIM/actions/runs/29448686207
- Encrypted live Analysis Session: https://github.com/WuKongIM/WuKongIM/actions/runs/29451372755
- Exact cleanup: https://github.com/WuKongIM/WuKongIM/actions/runs/29451756647
- Provider-backed zero-inventory verification: https://github.com/WuKongIM/WuKongIM/actions/runs/29452002364

The local launcher automatically discovered Go and reached ChatGPT-authenticated Codex plus the run-scoped WuKongIM Analysis MCP. The schema-validated diagnosis was `insufficient_evidence`, not a product defect: the workload passed and the primary metrics were healthy, while the manager workqueue snapshot was unavailable and the node-3 application log reader returned HTTP 503. No automatic remediation PR was eligible. The finalizer closed analysis access, destroyed the exact Run, and confirmed an empty provider inventory.

Keep this PR unmerged until human review; automatic merge is prohibited for this path.
