### PR TITLE
fix wkbench group membership churn

### DIFF
--- a/internal/access/api/FLOW.md
+++ b/internal/access/api/FLOW.md
@@ -17,7 +17,8 @@ usecase. `/conversation/list` and `/conversation/sync` requests forward to the
 conversation usecase and keep ordering, cursor rules, sync candidate selection,
 and message reads out of the HTTP layer. When the composition root provides a
 benchmark data writer,
-`/bench/v1/channels` and `/bench/v1/channels/subscribers` forward setup
+`/bench/v1/channels`, `/bench/v1/channels/subscribers`, and
+`/bench/v1/channels/subscribers/remove` forward setup or churn membership
 mutations through that writer; for `cmd/wukongim` delivery benchmarks the
 writer persists real cluster Slot metadata.
 When `bench.api_token` is configured, every `/bench/v1/*` request must carry
@@ -52,6 +53,7 @@ POST /bench/v1/channel-runtime/evict
 POST /bench/v1/users/tokens
 POST /bench/v1/channels
 POST /bench/v1/channels/subscribers
+POST /bench/v1/channels/subscribers/remove
 POST /message/send
 POST /message/event
 POST /message/sync
@@ -218,11 +220,12 @@ acknowledgments for black-box `wkbench` compatibility. The current
 `wukongim` gateway does not enable token authentication, so this route does
 not prove user-token persistence.
 
-`/bench/v1/channels` and `/bench/v1/channels/subscribers` require a benchmark
-data writer from the composition root. Without that writer, capabilities do not
+The bench channel and subscriber mutation routes require a benchmark data
+writer from the composition root. Without that writer, capabilities do not
 advertise channel mutation support and mutation requests fail closed with
-`501`. With a writer, they inject real channel metadata and subscriber rows
-through the composition root. Subscriber reset requests remain unsupported.
+`501`. With a writer, they inject real channel metadata and add or remove
+subscriber rows through the composition root. Subscriber reset requests remain
+unsupported.
 
 `/bench/v1/presence/snapshot` is a read-only diagnostic route. It reports
 owner-local route counts and authority-side virtual route counts for wkbench

--- a/internal/access/api/server.go
+++ b/internal/access/api/server.go
@@ -64,6 +64,7 @@ type DiagnosticsReader interface {
 type BenchData interface {
 	UpsertChannels(context.Context, []BenchChannelMutation) (int, error)
 	AddSubscribers(context.Context, []BenchSubscriberMutation) (int, error)
+	RemoveSubscribers(context.Context, []BenchSubscriberMutation) (int, error)
 }
 
 // LegacyRouteAddresses contains legacy client gateway addresses returned by /route APIs.
@@ -204,13 +205,13 @@ type BenchChannelMutation struct {
 	AllowStranger bool
 }
 
-// BenchSubscriberMutation describes one benchmark channel subscriber append.
+// BenchSubscriberMutation describes one benchmark channel subscriber add or removal.
 type BenchSubscriberMutation struct {
 	// ChannelID identifies the benchmark channel.
 	ChannelID string
 	// ChannelType is the WuKong channel type for ChannelID.
 	ChannelType uint8
-	// Subscribers are user IDs appended to the benchmark channel subscriber set.
+	// Subscribers are user IDs mutated in the benchmark channel subscriber set.
 	Subscribers []string
 }
 
@@ -506,6 +507,7 @@ func (s *Server) registerRoutes() {
 	bench.POST("/users/tokens", s.handleBenchTokens)
 	bench.POST("/channels", s.handleBenchChannels)
 	bench.POST("/channels/subscribers", s.handleBenchSubscribers)
+	bench.POST("/channels/subscribers/remove", s.handleBenchSubscriberRemovals)
 }
 
 // registerDemoRoutes mounts the embedded chat Demo below the product API.
@@ -603,10 +605,11 @@ type capabilitiesResponse struct {
 }
 
 type capabilitiesSupports struct {
-	UsersTokensBatch        bool `json:"users_tokens_batch"`
-	ChannelsBatch           bool `json:"channels_batch"`
-	ChannelSubscribersBatch bool `json:"channel_subscribers_batch"`
-	Snapshot                bool `json:"snapshot"`
+	UsersTokensBatch               bool `json:"users_tokens_batch"`
+	ChannelsBatch                  bool `json:"channels_batch"`
+	ChannelSubscribersBatch        bool `json:"channel_subscribers_batch"`
+	ChannelSubscriberRemovalsBatch bool `json:"channel_subscriber_removals_batch"`
+	Snapshot                       bool `json:"snapshot"`
 	// PresenceSnapshot indicates support for connection-route presence snapshots.
 	PresenceSnapshot bool `json:"presence_snapshot"`
 	// ChannelRuntimeSnapshot indicates support for local channel runtime snapshots.
@@ -632,17 +635,18 @@ func (s *Server) handleBenchCapabilities(c *gin.Context) {
 		Enabled: true,
 		Version: versionV1,
 		Supports: capabilitiesSupports{
-			UsersTokensBatch:        true,
-			ChannelsBatch:           s.benchData != nil,
-			ChannelSubscribersBatch: s.benchData != nil,
-			Snapshot:                true,
-			PresenceSnapshot:        s.benchPresence != nil,
-			ChannelRuntimeSnapshot:  s.benchRuntime != nil,
-			ChannelRuntimeProbe:     s.benchRuntime != nil,
-			ChannelRuntimeEvict:     s.benchRuntime != nil,
-			ChannelRuntimeFaults:    false,
-			ChannelRuntimeActivate:  false,
-			ChannelTypes:            []string{"group"},
+			UsersTokensBatch:               true,
+			ChannelsBatch:                  s.benchData != nil,
+			ChannelSubscribersBatch:        s.benchData != nil,
+			ChannelSubscriberRemovalsBatch: s.benchData != nil,
+			Snapshot:                       true,
+			PresenceSnapshot:               s.benchPresence != nil,
+			ChannelRuntimeSnapshot:         s.benchRuntime != nil,
+			ChannelRuntimeProbe:            s.benchRuntime != nil,
+			ChannelRuntimeEvict:            s.benchRuntime != nil,
+			ChannelRuntimeFaults:           false,
+			ChannelRuntimeActivate:         false,
+			ChannelTypes:                   []string{"group"},
 		},
 		Limits: capabilitiesLimits{
 			MaxBatchSize:    s.benchMaxBatchSize,
@@ -808,6 +812,14 @@ type subscriberItem struct {
 }
 
 func (s *Server) handleBenchSubscribers(c *gin.Context) {
+	s.handleBenchSubscriberMutation(c, false)
+}
+
+func (s *Server) handleBenchSubscriberRemovals(c *gin.Context) {
+	s.handleBenchSubscriberMutation(c, true)
+}
+
+func (s *Server) handleBenchSubscriberMutation(c *gin.Context, remove bool) {
 	if s.benchData == nil {
 		writeBenchError(c, http.StatusNotImplemented, "bench subscriber data writer is not configured")
 		return
@@ -834,9 +846,16 @@ func (s *Server) handleBenchSubscribers(c *gin.Context) {
 			Subscribers: append([]string(nil), item.Subscribers...),
 		})
 	}
-	acceptedSubscribers, err := s.benchData.AddSubscribers(c.Request.Context(), mutations)
+	operation := "subscribers_add"
+	var err error
+	if remove {
+		operation = "subscribers_remove"
+		acceptedSubscribers, err = s.benchData.RemoveSubscribers(c.Request.Context(), mutations)
+	} else {
+		acceptedSubscribers, err = s.benchData.AddSubscribers(c.Request.Context(), mutations)
+	}
 	if err != nil {
-		s.logBenchFailure(c, "internal.access.api.bench_subscribers_failed", "subscribers_add", err,
+		s.logBenchFailure(c, "internal.access.api.bench_subscribers_failed", operation, err,
 			wklog.String("runID", req.RunID),
 			wklog.String("batchID", req.BatchID),
 			wklog.Int("items", len(mutations)),
@@ -844,8 +863,12 @@ func (s *Server) handleBenchSubscribers(c *gin.Context) {
 		writeBenchError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.addCount("accepted_subscriber_items", len(req.Items))
-	s.addCount("accepted_subscribers", acceptedSubscribers)
+	countPrefix := "accepted_subscriber"
+	if remove {
+		countPrefix = "removed_subscriber"
+	}
+	s.addCount(countPrefix+"_items", len(req.Items))
+	s.addCount(countPrefix+"s", acceptedSubscribers)
 	c.JSON(http.StatusOK, subscribersResponse{
 		RunID:               req.RunID,
 		BatchID:             req.BatchID,

--- a/internal/access/api/server_test.go
+++ b/internal/access/api/server_test.go
@@ -43,7 +43,7 @@ func TestServerServesHealthReadyAndBenchTargetSurface(t *testing.T) {
 	if !caps.Supports.UsersTokensBatch || !caps.Supports.Snapshot {
 		t.Fatalf("capabilities supports = %+v, want token and snapshot features", caps.Supports)
 	}
-	if caps.Supports.ChannelsBatch || caps.Supports.ChannelSubscribersBatch {
+	if caps.Supports.ChannelsBatch || caps.Supports.ChannelSubscribersBatch || caps.Supports.ChannelSubscriberRemovalsBatch {
 		t.Fatalf("capabilities supports = %+v, want channel mutations disabled without bench data writer", caps.Supports)
 	}
 	if caps.Supports.ChannelRuntimeSnapshot || caps.Supports.ChannelRuntimeProbe || caps.Supports.ChannelRuntimeEvict || caps.Supports.ChannelRuntimeFaults || caps.Supports.ChannelRuntimeActivate {
@@ -152,6 +152,11 @@ func TestBenchChannelMutationsRequireConfiguredBenchData(t *testing.T) {
 		"batch_id":"subs-1",
 		"items":[{"channel_id":"g1","channel_type":2,"subscribers":["u1"]}]
 	}`, http.StatusNotImplemented)
+	postJSON(t, httpSrv.URL+"/bench/v1/channels/subscribers/remove", `{
+		"run_id":"run-1",
+		"batch_id":"subs-remove-1",
+		"items":[{"channel_id":"g1","channel_type":2,"subscribers":["u1"]}]
+	}`, http.StatusNotImplemented)
 }
 
 func TestBenchMutationRoutesWriteConfiguredBenchData(t *testing.T) {
@@ -162,9 +167,15 @@ func TestBenchMutationRoutesWriteConfiguredBenchData(t *testing.T) {
 	})
 	httpSrv := httptest.NewServer(srv.Handler())
 	t.Cleanup(httpSrv.Close)
+	var caps capabilitiesResponse
+	resp, err := http.Get(httpSrv.URL + "/bench/v1/capabilities")
+	decodeJSON(t, resp, err, &caps)
+	if !caps.Supports.ChannelSubscribersBatch || !caps.Supports.ChannelSubscriberRemovalsBatch {
+		t.Fatalf("capabilities supports = %+v, want subscriber add and removal batches", caps.Supports)
+	}
 
 	var channelResp mutationResponse
-	resp, err := http.Post(httpSrv.URL+"/bench/v1/channels", "application/json", bytes.NewBufferString(`{
+	resp, err = http.Post(httpSrv.URL+"/bench/v1/channels", "application/json", bytes.NewBufferString(`{
 		"run_id":"run-1",
 		"batch_id":"channels-1",
 		"channels":[{"channel_id":"g1","channel_type":2,"allow_stranger":true}]
@@ -197,10 +208,19 @@ func TestBenchMutationRoutesWriteConfiguredBenchData(t *testing.T) {
 		len(writer.subscribers[0].Subscribers) != 2 || writer.subscribers[0].Subscribers[0] != "u1" || writer.subscribers[0].Subscribers[1] != "u2" {
 		t.Fatalf("first subscriber mutation = %#v, want g1 subscribers", writer.subscribers[0])
 	}
+	resp, err = http.Post(httpSrv.URL+"/bench/v1/channels/subscribers/remove", "application/json", bytes.NewBufferString(`{
+		"run_id":"run-1",
+		"batch_id":"subs-remove-1",
+		"items":[{"channel_id":"g1","channel_type":2,"subscribers":["u1"]}]
+	}`))
+	decodeJSON(t, resp, err, &got)
+	if got.Accepted != 1 || got.AcceptedSubscribers != 1 || len(writer.removedSubscribers) != 1 || writer.removedSubscribers[0].Subscribers[0] != "u1" {
+		t.Fatalf("subscriber removal = response %#v mutations %#v, want one removed subscriber", got, writer.removedSubscribers)
+	}
 	var snap snapshotResponse
 	resp, err = http.Get(httpSrv.URL + "/bench/v1/snapshot")
 	decodeJSON(t, resp, err, &snap)
-	if snap.Counts["accepted_channels"] != 1 || snap.Counts["accepted_subscriber_items"] != 2 || snap.Counts["accepted_subscribers"] != 3 {
+	if snap.Counts["accepted_channels"] != 1 || snap.Counts["accepted_subscriber_items"] != 2 || snap.Counts["accepted_subscribers"] != 3 || snap.Counts["removed_subscriber_items"] != 1 || snap.Counts["removed_subscribers"] != 1 {
 		t.Fatalf("snapshot counts = %#v, want bench writer counts", snap.Counts)
 	}
 }
@@ -475,6 +495,7 @@ type fakeBenchData struct {
 	acceptedSubscribers int
 	channels            []BenchChannelMutation
 	subscribers         []BenchSubscriberMutation
+	removedSubscribers  []BenchSubscriberMutation
 	err                 error
 }
 
@@ -492,6 +513,18 @@ func (f *fakeBenchData) AddSubscribers(_ context.Context, mutations []BenchSubsc
 		return 0, f.err
 	}
 	return f.acceptedSubscribers, nil
+}
+
+func (f *fakeBenchData) RemoveSubscribers(_ context.Context, mutations []BenchSubscriberMutation) (int, error) {
+	f.removedSubscribers = append(f.removedSubscribers, mutations...)
+	if f.err != nil {
+		return 0, f.err
+	}
+	accepted := 0
+	for _, mutation := range mutations {
+		accepted += len(mutation.Subscribers)
+	}
+	return accepted, nil
 }
 
 func (f *fakePresenceBenchController) Snapshot(context.Context) (model.PresenceSnapshot, error) {

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -445,11 +445,12 @@ batch key routing, the app recipient resolver resolves each subscriber page's
 unique UIDs through one batch route lookup before grouping. When delivery is
 enabled, the app wires a bounded
 recipient delivery worker that drains those batches and runs the delivery-only
-channelappend recipient processor outside the authority writer. `/bench/v1/channels` and
-`/bench/v1/channels/subscribers` write real channel metadata and subscriber rows
-through Slot proposals. The benchmark data writer uses bounded concurrency for
-independent channel/subscriber mutations while preserving subscriber mutation
-order within the same channel. Scoped UID delivery bypasses subscriber scan and
+channelappend recipient processor outside the authority writer. `/bench/v1/channels`,
+`/bench/v1/channels/subscribers`, and `/bench/v1/channels/subscribers/remove`
+write real channel metadata or add/remove subscriber rows through Slot proposals.
+The benchmark data writer uses bounded concurrency for independent
+channel/subscriber mutations while preserving subscriber mutation order within
+the same channel. Scoped UID delivery bypasses subscriber scan and
 flows through recipient authority grouping, presence resolution, and the local
 or RPC owner pusher after the recipient delivery worker accepts the batch.
 The app maps the worker's serialized execution-pressure observation into

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4432,6 +4432,17 @@ func TestDeliveryMetaStoreWritesBenchDataAndFiltersSubscriberPages(t *testing.T)
 	if acceptedSubscribers != 2 || len(node.added) != 2 || node.added[0].version != 1 || node.added[1].version != 2 {
 		t.Fatalf("added = %#v accepted=%d, want ordered subscriber mutation versions 1 and 2", node.added, acceptedSubscribers)
 	}
+	removedSubscribers, err := store.RemoveSubscribers(context.Background(), []accessapi.BenchSubscriberMutation{{
+		ChannelID:   "g1",
+		ChannelType: frame.ChannelTypeGroup,
+		Subscribers: []string{slotThreeUID},
+	}})
+	if err != nil {
+		t.Fatalf("RemoveSubscribers() error = %v", err)
+	}
+	if removedSubscribers != 1 || len(node.removed) != 1 || node.removed[0].version != 3 || node.removed[0].uids[0] != slotThreeUID {
+		t.Fatalf("removed = %#v accepted=%d, want one subscriber at mutation version 3", node.removed, removedSubscribers)
+	}
 
 	page, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{
 		ChannelID:   "g1",
@@ -7178,6 +7189,7 @@ type recordingDeliveryMetaNode struct {
 	snapshot          clusterpkg.Snapshot
 	upserted          []metadb.Channel
 	added             []recordedSubscriberMutation
+	removed           []recordedSubscriberMutation
 	membershipUpserts []recordedMembershipProjection
 	membershipDeletes []recordedMembershipProjection
 	subscribers       map[string][]string
@@ -7519,7 +7531,7 @@ func (n *recordingDeliveryMetaNode) AddChannelSubscribers(_ context.Context, cha
 func (n *recordingDeliveryMetaNode) RemoveChannelSubscribers(_ context.Context, channelID string, channelType int64, uids []string, version uint64) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	n.added = append(n.added, recordedSubscriberMutation{
+	n.removed = append(n.removed, recordedSubscriberMutation{
 		channelID:   channelID,
 		channelType: channelType,
 		uids:        append([]string(nil), uids...),

--- a/internal/app/delivery_meta.go
+++ b/internal/app/delivery_meta.go
@@ -21,6 +21,7 @@ type deliveryMetaNode interface {
 	Snapshot() cluster.Snapshot
 	UpsertChannelMetadata(context.Context, metadb.Channel) error
 	AddChannelSubscribers(context.Context, string, int64, []string, uint64) error
+	RemoveChannelSubscribers(context.Context, string, int64, []string, uint64) error
 	ListChannelSubscribersPage(context.Context, string, int64, string, int) ([]string, string, bool, error)
 }
 
@@ -77,6 +78,15 @@ type deliveryMetaSubscriberCacheEntry struct {
 }
 
 func (s *deliveryMetaStore) AddSubscribers(ctx context.Context, mutations []accessapi.BenchSubscriberMutation) (int, error) {
+	return s.mutateSubscribers(ctx, mutations, false)
+}
+
+// RemoveSubscribers deletes benchmark subscribers through the same ordered mutation path as additions.
+func (s *deliveryMetaStore) RemoveSubscribers(ctx context.Context, mutations []accessapi.BenchSubscriberMutation) (int, error) {
+	return s.mutateSubscribers(ctx, mutations, true)
+}
+
+func (s *deliveryMetaStore) mutateSubscribers(ctx context.Context, mutations []accessapi.BenchSubscriberMutation, remove bool) (int, error) {
 	if s == nil || s.node == nil {
 		return 0, nil
 	}
@@ -96,7 +106,13 @@ func (s *deliveryMetaStore) AddSubscribers(ctx context.Context, mutations []acce
 			accepted := 0
 			for _, mutation := range group {
 				version := s.version.Add(1)
-				if err := s.node.AddChannelSubscribers(ctx, mutation.ChannelID, int64(mutation.ChannelType), append([]string(nil), mutation.Subscribers...), version); err != nil {
+				var err error
+				if remove {
+					err = s.node.RemoveChannelSubscribers(ctx, mutation.ChannelID, int64(mutation.ChannelType), append([]string(nil), mutation.Subscribers...), version)
+				} else {
+					err = s.node.AddChannelSubscribers(ctx, mutation.ChannelID, int64(mutation.ChannelType), append([]string(nil), mutation.Subscribers...), version)
+				}
+				if err != nil {
 					return accepted, err
 				}
 				accepted += len(mutation.Subscribers)

--- a/internal/bench/FLOW.md
+++ b/internal/bench/FLOW.md
@@ -28,8 +28,11 @@ that cannot emit at least one message per required active-channel window.
 During measured scheduled churn, the worker runs traffic in bounded windows.
 At each boundary it archives the completed workload metrics, reconnects the
 same-UID share, replaces the identity-swap share from deterministic offline
-lanes, refreshes bench tokens, and rebuilds person/group workloads before
-traffic resumes. `OnlineIdentityIndexes` is worker-local runtime mapping state;
+lanes, refreshes bench tokens, adds replacement UIDs to every affected group,
+removes the replaced UIDs, and rebuilds person/group workloads before traffic
+resumes. The add-before-remove order prevents a replacement sender from
+temporarily losing membership, while removal keeps long-running group sizes
+bounded. `OnlineIdentityIndexes` is worker-local runtime mapping state;
 an empty mapping preserves the initial plan. Each measured window gets a unique
 message identity namespace while report metrics normalize it back to the stable
 `run` phase. Churn never requests history sync.
@@ -491,6 +494,7 @@ For split traffic, message indexes are partitioned by `TrafficPartitionCount` an
 - `POST /bench/v1/users/tokens`
 - `POST /bench/v1/channels`
 - `POST /bench/v1/channels/subscribers`
+- `POST /bench/v1/channels/subscribers/remove`
 
 The server-side implementation lives outside this package. Keep request/response types in `pkg/bench/model` aligned with the bench API surface and avoid depending on internal server usecases from wkbench code.
 

--- a/internal/bench/target/client.go
+++ b/internal/bench/target/client.go
@@ -209,6 +209,11 @@ func (c *Client) AddSubscribers(ctx context.Context, req model.BatchSubscribersR
 	return c.postAny(ctx, "/bench/v1/channels/subscribers", req)
 }
 
+// RemoveSubscribers posts a spec-shaped batch subscriber removal request.
+func (c *Client) RemoveSubscribers(ctx context.Context, req model.BatchSubscribersRequest) error {
+	return c.postAny(ctx, "/bench/v1/channels/subscribers/remove", req)
+}
+
 func (c *Client) getAny(ctx context.Context, path string, out any) error {
 	addrs := c.addrs()
 	if len(addrs) == 0 {

--- a/internal/bench/target/client_test.go
+++ b/internal/bench/target/client_test.go
@@ -524,6 +524,20 @@ func TestAddSubscribersPostsToFirstHealthyAPIAddress(t *testing.T) {
 	require.Equal(t, 1, hits["first"])
 }
 
+func TestRemoveSubscribersPostsToRemovalEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/bench/v1/channels/subscribers/remove", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{APIAddrs: []string{server.URL}})
+	require.NoError(t, client.RemoveSubscribers(context.Background(), model.BatchSubscribersRequest{
+		RunID: "run", BatchID: "remove-1",
+		Items: []model.SubscriberItem{{ChannelID: "g1", ChannelType: 2, Subscribers: []string{"u1"}}},
+	}))
+}
+
 func TestMutationsFallBackToNextAPIAddress(t *testing.T) {
 	firstHits := 0
 	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/bench/worker/churn_membership_test.go
+++ b/internal/bench/worker/churn_membership_test.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/pkg/bench/model"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareChurnGroupSubscribersSwapsMappedIdentity(t *testing.T) {
+	type request struct {
+		path string
+		body model.BatchSubscribersRequest
+	}
+	requests := make([]request, 0, 2)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body model.BatchSubscribersRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		requests = append(requests, request{path: r.URL.Path, body: body})
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	assignment := Assignment{
+		RunID:    "run-churn-group",
+		WorkerID: "worker-a",
+		Target: model.Target{
+			BenchAPI: model.BenchAPIConfig{Addrs: []string{target.URL}},
+		},
+		Scenario: model.Scenario{
+			Identity: model.IdentityConfig{TotalUsers: 4, UIDPrefix: "bench-u"},
+			Online:   model.OnlineConfig{TotalUsers: 2},
+			Channels: model.ChannelsConfig{Profiles: []model.ChannelProfile{{
+				Name: "group-a", ChannelType: model.ChannelTypeGroup, Count: 1,
+				Members: model.MembersConfig{Count: 2},
+			}}},
+		},
+		Plan: model.WorkerPlan{
+			WorkerID:              "worker-a",
+			IdentityRange:         model.Range{Start: 0, End: 2},
+			OnlineIdentityIndexes: []int{0, 3},
+			Profiles: map[string]model.ProfileShard{"group-a": {
+				Name: "group-a", ChannelType: model.ChannelTypeGroup,
+				ChannelRange: model.Range{Start: 0, End: 1}, MemberRange: model.Range{Start: 0, End: 2},
+			}},
+		},
+	}
+	replacements := []churnReplacement{{oldUID: "bench-u-1", user: connectionUserForIdentityIndex(assignment.Scenario.Identity, 3)}}
+
+	require.NoError(t, prepareChurnGroupSubscriberSwaps(context.Background(), assignment, 1, replacements))
+	require.Len(t, requests, 2)
+	require.Equal(t, "/bench/v1/channels/subscribers", requests[0].path)
+	require.Equal(t, "/bench/v1/channels/subscribers/remove", requests[1].path)
+	require.Equal(t, []model.SubscriberItem{{
+		ChannelID: "run-churn-group-group-a-0", ChannelType: frame.ChannelTypeGroup, Subscribers: []string{"bench-u-3"},
+	}}, requests[0].body.Items)
+	require.Equal(t, []model.SubscriberItem{{
+		ChannelID: "run-churn-group-group-a-0", ChannelType: frame.ChannelTypeGroup, Subscribers: []string{"bench-u-1"},
+	}}, requests[1].body.Items)
+	require.Contains(t, requests[0].body.BatchID, "churn-subs-add-worker-a-1")
+	require.Contains(t, requests[1].body.BatchID, "churn-subs-remove-worker-a-1")
+}

--- a/internal/bench/worker/person_runner.go
+++ b/internal/bench/worker/person_runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/WuKongIM/WuKongIM/internal/bench/metrics"
 	benchworkload "github.com/WuKongIM/WuKongIM/internal/bench/workload"
 	"github.com/WuKongIM/WuKongIM/pkg/bench/model"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 )
 
 var errTargetUnavailable = errors.New("target unavailable")
@@ -463,6 +464,9 @@ func (r *defaultWorkloadRunner) applyScheduledChurn(ctx context.Context, assignm
 		}
 		assignment.Plan.OnlineIdentityIndexes[item.offset] = item.identityIndex
 	}
+	if err := prepareChurnGroupSubscriberSwaps(ctx, *assignment, cycle, replacements); err != nil {
+		return err
+	}
 
 	r.archiveCurrentWorkloadMetrics()
 	if err := r.rebuildTrafficFromManager(*assignment, manager); err != nil {
@@ -817,6 +821,83 @@ func prepareChurnTokens(ctx context.Context, assignment Assignment, cycle int, r
 	}
 	if err := groupPrepareClient(assignment.Target).UpsertTokens(ctx, request); err != nil {
 		return fmt.Errorf("prepare churn tokens: %w", err)
+	}
+	return nil
+}
+
+// prepareChurnGroupSubscriberSwaps keeps durable group membership aligned with identity-swap connections.
+func prepareChurnGroupSubscriberSwaps(ctx context.Context, assignment Assignment, cycle int, replacements []churnReplacement) error {
+	if len(replacements) == 0 {
+		return nil
+	}
+	replacementByUID := make(map[string]churnReplacement, len(replacements))
+	for _, replacement := range replacements {
+		replacementByUID[replacement.user.UID] = replacement
+	}
+	profiles := scenarioProfilesByName(assignment.Scenario)
+	itemsByChannel := make(map[string]model.SubscriberItem)
+	for _, profileName := range sortedProfileNames(assignment.Plan.Profiles) {
+		shard := assignment.Plan.Profiles[profileName]
+		if shard.ChannelType != model.ChannelTypeGroup {
+			continue
+		}
+		profile, ok := profiles[profileName]
+		if !ok {
+			return fmt.Errorf("prepare churn group subscribers: profile %q missing from scenario", profileName)
+		}
+		channels := groupChannelsForShard(assignment.RunID, shard, profile, assignment.Scenario.Identity, assignment.Scenario.Online.TotalUsers, assignment.Plan)
+		for _, channel := range channels {
+			item := model.SubscriberItem{ChannelID: channel.ChannelID, ChannelType: frame.ChannelTypeGroup}
+			for _, uid := range channel.OnlineMembers {
+				if _, ok := replacementByUID[uid]; ok {
+					item.Subscribers = append(item.Subscribers, uid)
+				}
+			}
+			if len(item.Subscribers) > 0 {
+				itemsByChannel[channel.ChannelID] = item
+			}
+		}
+	}
+	if len(itemsByChannel) == 0 {
+		return nil
+	}
+	channelIDs := make([]string, 0, len(itemsByChannel))
+	for channelID := range itemsByChannel {
+		channelIDs = append(channelIDs, channelID)
+	}
+	sort.Strings(channelIDs)
+	addItems := make([]model.SubscriberItem, 0, len(channelIDs))
+	removeItems := make([]model.SubscriberItem, 0, len(channelIDs))
+	for _, channelID := range channelIDs {
+		addItem := itemsByChannel[channelID]
+		removeItem := model.SubscriberItem{ChannelID: addItem.ChannelID, ChannelType: addItem.ChannelType, Subscribers: make([]string, 0, len(addItem.Subscribers))}
+		for _, uid := range addItem.Subscribers {
+			removeItem.Subscribers = append(removeItem.Subscribers, replacementByUID[uid].oldUID)
+		}
+		addItems = append(addItems, addItem)
+		removeItems = append(removeItems, removeItem)
+	}
+	client := groupPrepareClient(assignment.Target)
+	if err := mutateChurnGroupSubscribers(ctx, client.AddSubscribers, assignment, cycle, "add", addItems); err != nil {
+		return fmt.Errorf("prepare churn group subscribers: add replacements: %w", err)
+	}
+	if err := mutateChurnGroupSubscribers(ctx, client.RemoveSubscribers, assignment, cycle, "remove", removeItems); err != nil {
+		return fmt.Errorf("prepare churn group subscribers: remove replaced users: %w", err)
+	}
+	return nil
+}
+
+func mutateChurnGroupSubscribers(ctx context.Context, mutate func(context.Context, model.BatchSubscribersRequest) error, assignment Assignment, cycle int, operation string, items []model.SubscriberItem) error {
+	const batchSize = 1000
+	for start := 0; start < len(items); start += batchSize {
+		end := min(start+batchSize, len(items))
+		if err := mutate(ctx, model.BatchSubscribersRequest{
+			RunID:   assignment.RunID,
+			BatchID: fmt.Sprintf("%s-churn-subs-%s-%s-%d-%d-%d", assignment.RunID, operation, assignment.WorkerID, cycle, start, end),
+			Items:   append([]model.SubscriberItem(nil), items[start:end]...),
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bench/model/FLOW.md
+++ b/pkg/bench/model/FLOW.md
@@ -44,7 +44,9 @@ and is omitted from the initial deterministic plan.
 `OnlineConfig.Churn` is explicit about interval, churn ratio, same-user share,
 identity-swap share, and history-sync policy. Long stability profiles require
 the shares to sum to one, at least one full offline identity lane for swaps,
-and `history_sync: false`.
+and `history_sync: false`. Bench capabilities separately advertise batched
+subscriber adds and removals so identity-swap workers can keep group membership
+aligned without growing long-run group cardinality.
 
 `ShardConfig.HashSlotSpread` is a group-profile contract: `HashSlotCount` must
 be positive and equal the profile channel count. It means channel index `n`

--- a/pkg/bench/model/bench_api.go
+++ b/pkg/bench/model/bench_api.go
@@ -20,6 +20,8 @@ type BenchCapabilitiesSupports struct {
 	ChannelsBatch bool `json:"channels_batch"`
 	// ChannelSubscribersBatch indicates support for batch subscriber appends.
 	ChannelSubscribersBatch bool `json:"channel_subscribers_batch"`
+	// ChannelSubscriberRemovalsBatch indicates support for batch subscriber removals.
+	ChannelSubscriberRemovalsBatch bool `json:"channel_subscriber_removals_batch"`
 	// Snapshot indicates support for lightweight bench setup snapshots.
 	Snapshot bool `json:"snapshot"`
 	// PresenceSnapshot indicates support for connection-route presence snapshots.
@@ -284,7 +286,7 @@ type ChannelItem struct {
 	AllowStranger bool `json:"allow_stranger,omitempty"`
 }
 
-// BatchSubscribersRequest appends benchmark subscribers in one batch.
+// BatchSubscribersRequest mutates benchmark subscribers in one batch.
 type BatchSubscribersRequest struct {
 	// RunID identifies the benchmark run that owns this batch.
 	RunID string `json:"run_id"`
@@ -294,7 +296,7 @@ type BatchSubscribersRequest struct {
 	Items []SubscriberItem `json:"items"`
 }
 
-// SubscriberItem carries subscribers to append for one group channel.
+// SubscriberItem carries subscribers to add or remove for one group channel.
 type SubscriberItem struct {
 	// ChannelID is the benchmark channel identifier.
 	ChannelID string `json:"channel_id"`
@@ -302,6 +304,6 @@ type SubscriberItem struct {
 	ChannelType uint8 `json:"channel_type"`
 	// Reset requests subscriber replacement; bench/v1 currently rejects true.
 	Reset bool `json:"reset,omitempty"`
-	// Subscribers are user IDs appended to the channel subscriber list.
+	// Subscribers are user IDs mutated in the channel subscriber list.
 	Subscribers []string `json:"subscribers"`
 }

--- a/test/e2e/message/AGENTS.md
+++ b/test/e2e/message/AGENTS.md
@@ -20,6 +20,7 @@ This domain covers black-box message and conversation behavior for
 | `cmd_sync` | Prove unified normal/CMD conversation projection isolation, `/message/sync` delivery, and `/message/syncack` draining in a single-node cluster. | `GOWORK=off go test -tags=e2e ./test/e2e/message/cmd_sync -count=1 -timeout 2m` |
 | `message_retention` | Prove a static three-node `cmd/wukongim` cluster forwards manager retention requests to the channel leader, physically cleans retained local message rows when enabled, and consistently hides retained message sequences after leader restart. | `GOWORK=off go test -tags=e2e ./test/e2e/message/message_retention -count=1 -timeout 2m -p=1` |
 | `channel_failover` | Prove a static three-node `cmd/wukongim` cluster preserves Channel quorum-acknowledged messages after one data node stops, fails over affected channel leaders, and fails closed for new placement while a required replica is unavailable. | `GOWORK=off go test -tags=e2e ./test/e2e/message/channel_failover -count=1 -timeout 3m -p=1` |
+| `bench_churn` | Prove wkbench identity-swap churn updates real group membership before the replacement UID sends in the next traffic window. | `GOWORK=off go test -tags=e2e ./test/e2e/message/bench_churn -count=1 -timeout 2m` |
 
 ## Maintenance Rules
 

--- a/test/e2e/message/bench_churn/AGENTS.md
+++ b/test/e2e/message/bench_churn/AGENTS.md
@@ -1,0 +1,14 @@
+# bench_churn AGENTS
+
+This scenario proves that wkbench identity-swap churn keeps group membership
+aligned with the replacement connection.
+
+Run it with:
+
+```sh
+GOWORK=off go test -tags=e2e ./test/e2e/message/bench_churn -count=1 -timeout 2m
+```
+
+The test must use a real `cmd/wukongim` subprocess and real WKProto sessions.
+Keep the identity pool and group small; this is a correctness regression, not a
+load test.

--- a/test/e2e/message/bench_churn/bench_churn_test.go
+++ b/test/e2e/message/bench_churn/bench_churn_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+package bench_churn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/internal/bench/planner"
+	"github.com/WuKongIM/WuKongIM/internal/bench/worker"
+	"github.com/WuKongIM/WuKongIM/pkg/bench/model"
+	"github.com/WuKongIM/WuKongIM/test/e2e/suite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentitySwapKeepsReplacementUserInGroup(t *testing.T) {
+	node := suite.New(t).StartSingleNodeCluster(suite.WithNodeConfigOverrides(1, map[string]string{
+		"WK_BENCH_API_ENABLE":         "true",
+		"WK_BENCH_API_MAX_BATCH_SIZE": "100",
+	}))
+	scenario := model.Scenario{
+		Version: "wkbench/v1",
+		Run: model.RunConfig{
+			ID: "e2e-bench-churn", Duration: 2 * time.Second, FailFast: true,
+		},
+		Identity: model.IdentityConfig{
+			TotalUsers: 4, UIDPrefix: "churn-u", DevicePrefix: "churn-d", ClientMsgPrefix: "churn-msg",
+			Token: model.TokenConfig{Mode: "bench_api"},
+		},
+		Online: model.OnlineConfig{
+			TotalUsers: 2, ConnectRate: model.Rate{PerSecond: 100}, GatewayBalance: "round_robin",
+			Churn: model.ChurnConfig{
+				Enabled: true, Interval: time.Second, Ratio: 0.5, SameUserRatio: 0, IdentitySwapRatio: 1,
+			},
+		},
+		Channels: model.ChannelsConfig{Profiles: []model.ChannelProfile{{
+			Name: "group-a", ChannelType: model.ChannelTypeGroup, Count: 1,
+			Members: model.MembersConfig{Count: 2, Pick: "deterministic_hash", Overlap: "disallowed"},
+			Online:  model.ChannelOnlineConfig{MemberRatio: 1},
+			Shard:   model.ShardConfig{Mode: "hash"},
+			Prepare: model.ChannelPrepareConfig{SubscribersBatchSize: 100},
+		}}},
+		Messages: model.MessagesConfig{
+			Payload: model.PayloadConfig{SizeBytes: 32, Mode: "deterministic"},
+			Traffic: []model.TrafficConfig{{
+				Name: "group-send", ChannelRef: "group-a", RatePerChannel: model.Rate{PerSecond: 10},
+				Concurrency: 4, AckTimeout: 3 * time.Second, SenderPick: "round_robin",
+				Verify: model.VerifyConfig{Recv: model.RecvVerifyConfig{Mode: "none"}},
+			}},
+		},
+	}
+	workerConfig := model.Worker{ID: "worker-a", Weight: 1}
+	plan, err := planner.Build(scenario, []model.Worker{workerConfig})
+	require.NoError(t, err)
+	assignment := worker.Assignment{
+		RunID: scenario.Run.ID, WorkerID: workerConfig.ID,
+		Target: model.Target{
+			API:      model.TargetAPIConfig{Addrs: []string{"http://" + node.APIAddr()}},
+			BenchAPI: model.BenchAPIConfig{Enabled: true, Addrs: []string{"http://" + node.APIAddr()}},
+			Gateway:  model.TargetGatewayConfig{TCP: model.TargetGatewayTCPConfig{Addrs: []string{node.GatewayAddr()}}},
+		},
+		Scenario: scenario,
+		Plan:     plan.Workers[workerConfig.ID],
+	}
+
+	runner := worker.NewDefaultWorkloadRunner(nil)
+	runner.(worker.AssignmentStarter).BeginAssignment(assignment)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, runner.Prepare(ctx, assignment))
+	require.NoError(t, runner.Connect(ctx, assignment))
+	require.NoError(t, runner.Run(ctx, assignment))
+	require.Equal(t, uint64(1), runner.(worker.MetricsReporter).MetricsSnapshot().Counters["churn_window_total"])
+	require.NoError(t, runner.Cooldown(ctx, assignment))
+}


### PR DESCRIPTION
## What changed

- add a benchmark-only batch subscriber removal route and cluster-backed implementation
- update identity-swap churn to add replacement UIDs before removing replaced UIDs
- add focused unit coverage and a real `cmd/wukongim` + WKProto e2e regression
- align the affected FLOW and e2e scenario documentation

## Root cause

Scheduled identity churn replaced the connected UID and rebuilt group workloads with the new UID, but the durable group subscriber set still contained the old UID. The next measured window therefore received `ReasonSubscriberNotExist`. Appending replacements without removals would also grow group cardinality throughout long stability runs.

## Validation

- focused related unit packages all pass
- targeted race checks for worker, API, and app pass
- real cloud-small-shaped 1000-session local probe passes after reproducing the original failure
- `GOWORK=off go test -tags=e2e ./test/e2e/message/bench_churn -count=1 -timeout 2m` passes
