### PR TITLE
fix cloud calibration evidence

### DIFF
--- a/.agents/skills/wukongim-cloud-analysis/SKILL.md
+++ b/.agents/skills/wukongim-cloud-analysis/SKILL.md
@@ -27,7 +27,7 @@ After a live result, read [references/tool-contract.md](references/tool-contract
 
 Call `cluster_snapshot`, then query the smallest useful metric set:
 
-1. target availability plus `simulator_cpu_percent`, `simulator_memory_percent`, TCP/source-port, network, and disk headroom;
+1. target availability plus `simulator_cpu_percent`, `simulator_memory_percent`, TCP/source-port, network, simulator disk headroom, and per-node data-disk bytes when storage growth matters;
 2. send, delivery, and append rates;
 3. append errors;
 4. gateway, runtime, storage-commit, and delivery-retry queue pressure.

--- a/.agents/skills/wukongim-cloud-analysis/references/tool-contract.md
+++ b/.agents/skills/wukongim-cloud-analysis/references/tool-contract.md
@@ -7,7 +7,7 @@ Use only the run-specific MCP configured by the local Analysis Session. Every in
 | Tool | Purpose | Key bounds |
 |---|---|---|
 | `run_inspect` | Prove exact run state and inventory | Always first |
-| `workload_inspect` | Parsed final wkbench threshold summary | Simulator-local `summary.md`, maximum 16 KiB; no raw reports, messages, or paths |
+| `workload_inspect` | Parsed final wkbench threshold summary and measured-run successful send count | Simulator-local `summary.md`, maximum 16 KiB; no raw reports, messages, or paths |
 | `cluster_snapshot` | Nodes and workqueues | Aggregate, bounded response |
 | `metrics_query_range` | Server-owned PromQL by `query_id` | Maximum 72 hours, 5,000 samples/series, step 1–900 seconds |
 | `logs_search` | Literal log search on one node | Sources `app` or `error`, maximum 200 lines |
@@ -52,6 +52,7 @@ diagnostics perturb only one node at a time.
 - `simulator_tcp_time_wait`
 - `simulator_network_bytes`
 - `simulator_disk_used_percent`
+- `node_data_disk_used_bytes`
 
 Use RFC3339 `start` and `end` plus integer `step_seconds`. Begin with a small query set and widen only when the result changes the diagnosis.
 

--- a/.github/cloud-sim/diagnosis.schema.json
+++ b/.github/cloud-sim/diagnosis.schema.json
@@ -53,13 +53,13 @@
         "type": "object", "additionalProperties": false,
         "required": ["tool", "node", "observed_at", "window", "complete", "state", "status", "note"],
         "properties": {
-          "tool": {"type": "string", "minLength": 1, "maxLength": 64},
+          "tool": {"type": "string", "minLength": 1, "maxLength": 64, "description": "Analysis MCP tool that produced this observation."},
           "node": {"type": "string", "minLength": 1, "maxLength": 64},
           "observed_at": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$"},
           "window": {"type": "string", "maxLength": 256},
           "complete": {"type": "boolean"},
-          "state": {"type": ["string", "null"], "enum": ["in_progress", "completed", null]},
-          "status": {"type": ["string", "null"], "enum": ["passed", "failed", null]},
+          "state": {"type": ["string", "null"], "enum": ["in_progress", "completed", null], "description": "Workload lifecycle state for workload_inspect; null for every other tool."},
+          "status": {"type": ["string", "null"], "enum": ["passed", "failed", null], "description": "Workload result for workload_inspect; null for every other tool."},
           "note": {"type": ["string", "null"], "maxLength": 500}
         }
       }

--- a/cmd/wkanalysis/config.go
+++ b/cmd/wkanalysis/config.go
@@ -222,6 +222,7 @@ func defaultMetricQueries() map[string]string {
 		"simulator_tcp_time_wait":     `node_sockstat_TCP_tw{job="hosts",role="sim"}`,
 		"simulator_network_bytes":     `sum by (instance) (rate(node_network_receive_bytes_total{job="hosts",role="sim",device!~"lo"}[1m]) + rate(node_network_transmit_bytes_total{job="hosts",role="sim",device!~"lo"}[1m]))`,
 		"simulator_disk_used_percent": `100 * (1 - (node_filesystem_avail_bytes{job="hosts",role="sim",mountpoint="/var/lib/wukongim-cloud"} / clamp_min(node_filesystem_size_bytes{job="hosts",role="sim",mountpoint="/var/lib/wukongim-cloud"}, 1)))`,
+		"node_data_disk_used_bytes":   `max by (instance, role) (node_filesystem_size_bytes{job="hosts",role=~"node-[123]",mountpoint="/var/lib/wukongim-cloud"} - node_filesystem_avail_bytes{job="hosts",role=~"node-[123]",mountpoint="/var/lib/wukongim-cloud"})`,
 	}
 }
 

--- a/cmd/wkanalysis/config_test.go
+++ b/cmd/wkanalysis/config_test.go
@@ -46,7 +46,8 @@ func TestLoadServeConfigBindsThreeNodeClusterAndTokenLease(t *testing.T) {
 		t.Fatalf("token=%s run=%s", cfg.gateway.MCPTokenExpiresAt, cfg.gateway.RunExpiresAt)
 	}
 	if cfg.gateway.MetricQueries["send_rate"] == "" || cfg.gateway.MetricQueries["runtime_queue_pressure"] == "" ||
-		cfg.gateway.MetricQueries["simulator_cpu_percent"] == "" || cfg.gateway.MetricQueries["simulator_memory_percent"] == "" {
+		cfg.gateway.MetricQueries["simulator_cpu_percent"] == "" || cfg.gateway.MetricQueries["simulator_memory_percent"] == "" ||
+		cfg.gateway.MetricQueries["node_data_disk_used_bytes"] == "" {
 		t.Fatalf("metric query IDs = %#v", cfg.gateway.MetricQueries)
 	}
 }

--- a/internal/access/cloudanalysismcp/FLOW.md
+++ b/internal/access/cloudanalysismcp/FLOW.md
@@ -14,8 +14,8 @@ HTTPS Streamable MCP request
 ```
 
 The MCP endpoint is stateless and JSON-response-only. `workload_inspect` exposes
-only the bounded, parsed wkbench final threshold summary and never raw report
-content or paths. The tool list contains no
+only the bounded, parsed wkbench final threshold summary plus the measured-run
+successful send count, and never raw report content or paths. The tool list contains no
 shell, file, URL, process, service restart, configuration write, cloud resource,
 or deletion operation. `trace_start` and `profile_capture` are annotated as
 active non-destructive diagnostics; all other tools are read-only and closed

--- a/internal/bench/FLOW.md
+++ b/internal/bench/FLOW.md
@@ -109,6 +109,9 @@ Reports additionally carry a `stability_verdict`: `passed`,
 `operator_modified`, or `insufficient_evidence`. Diagnostic durations cannot
 produce a standard passed verdict. Worker/harness evidence and external Cloud
 View purity classification take precedence over product-limit inference.
+The bounded final summary also records the successful send acknowledgement
+count from the measured `run` phase so storage calibration can use the exact
+workload denominator even when a run terminates early.
 
 Explicit TCP source pool errors are worker-local configuration or capacity
 failures and therefore resolve to `worker_failed`, never

--- a/internal/bench/report/report.go
+++ b/internal/bench/report/report.go
@@ -76,6 +76,8 @@ type StabilityClassification struct {
 
 // Summary contains run quality measurements used for limit checks.
 type Summary struct {
+	// SendSuccess is the successful send acknowledgement count during the measured run phase.
+	SendSuccess uint64 `json:"send_success"`
 	// ConnectErrorRate is failed connects divided by attempted connects.
 	ConnectErrorRate float64 `json:"connect_error_rate"`
 	// SendackErrorRate is failed send acknowledgements divided by attempted sends.
@@ -358,6 +360,7 @@ func SummaryFromMetrics(snapshot metrics.SnapshotData, workerFailed int) Summary
 	recvSuccess := counterSum(snapshot, "person_recv_success_total", "group_recv_success_total", "recv_verify_success_total")
 	recvErrors := counterSum(snapshot, "person_recv_error_total", "group_recv_error_total", "recv_verify_error_total")
 	return Summary{
+		SendSuccess:         counterSumWithPhase(snapshot, "run", "person_send_success_total", "group_send_success_total", "sendack_success_total"),
 		ConnectErrorRate:    connectErrorRate(connectErrors, connectSuccess, connectAttempts),
 		SendackErrorRate:    errorRate(sendErrors, sendSuccess),
 		RecvVerifyErrorRate: errorRate(recvErrors, recvSuccess),
@@ -542,6 +545,7 @@ func summaryMarkdown(rep Report) string {
 	fmt.Fprintf(&b, "- run_id: %s\n", rep.RunID)
 	fmt.Fprintf(&b, "- status: %s\n", rep.Status)
 	fmt.Fprintf(&b, "- exit_code: %d\n", rep.ExitCode)
+	fmt.Fprintf(&b, "- send_success: %d\n", rep.Summary.SendSuccess)
 	fmt.Fprintf(&b, "- sendack_error_rate: %.6f\n", rep.Summary.SendackErrorRate)
 	fmt.Fprintf(&b, "- connect_error_rate: %.6f\n", rep.Summary.ConnectErrorRate)
 	fmt.Fprintf(&b, "- recv_verify_error_rate: %.6f\n", rep.Summary.RecvVerifyErrorRate)

--- a/internal/bench/report/report_test.go
+++ b/internal/bench/report/report_test.go
@@ -113,6 +113,18 @@ func TestSummaryFromMetricsComputesRatesAndMaxWorkerP99(t *testing.T) {
 	}
 }
 
+func TestSummaryFromMetricsIncludesOnlyMeasuredRunSendSuccess(t *testing.T) {
+	summary := SummaryFromMetrics(metrics.SnapshotData{Counters: map[string]uint64{
+		"person_send_success_total{phase=warmup}": 100,
+		"person_send_success_total{phase=run}":    7,
+		"group_send_success_total{phase=run}":     3,
+	}}, 0)
+
+	if summary.SendSuccess != 10 {
+		t.Fatalf("send_success = %d, want run-phase 10", summary.SendSuccess)
+	}
+}
+
 func TestSummaryFromMetricsUsesOnlyRunPhaseForLatencyLimits(t *testing.T) {
 	summary := SummaryFromMetrics(metrics.SnapshotData{
 		Histograms: map[string]metrics.HistogramSummary{
@@ -181,9 +193,12 @@ func TestSendRunSummaryFromMetricsUsesOnlyRunPhase(t *testing.T) {
 }
 
 func TestSummaryMarkdownLabelsMaxWorkerPercentiles(t *testing.T) {
-	rep := Build(Input{RunID: "run-1", Summary: Summary{SendackMaxWorkerP99: 50 * time.Millisecond, RecvMaxWorkerP99: 70 * time.Millisecond}})
+	rep := Build(Input{RunID: "run-1", Summary: Summary{SendSuccess: 123, SendackMaxWorkerP99: 50 * time.Millisecond, RecvMaxWorkerP99: 70 * time.Millisecond}})
 
 	md := summaryMarkdown(rep)
+	if !strings.Contains(md, "send_success: 123") {
+		t.Fatalf("summary markdown should expose measured-run successful sends, got:\n%s", md)
+	}
 	if !strings.Contains(md, "sendack_max_worker_p99") || !strings.Contains(md, "recv_max_worker_p99") {
 		t.Fatalf("summary markdown should label max-worker percentiles, got:\n%s", md)
 	}

--- a/internal/infra/cloudanalysis/FLOW.md
+++ b/internal/infra/cloudanalysis/FLOW.md
@@ -22,3 +22,5 @@ Phase 1 can exercise a provider-backed inspector locally with
 `ProviderRunInspector`. That inspector requires a valid Run Locator and matches
 provider, region, account hash, repository, source SHA, scenario digest,
 creation time, and lease. A static inspector cannot claim a released run.
+The workload source strictly parses the bounded final `summary.md`, including
+the measured-run successful send count used as the storage-growth denominator.

--- a/internal/infra/cloudanalysis/workload_source.go
+++ b/internal/infra/cloudanalysis/workload_source.go
@@ -94,6 +94,10 @@ func decodeWorkloadSummary(reader io.Reader, expectedRunID string) (analysis.Wor
 	if err != nil || exitCode < 0 || exitCode > 6 || status != "passed" && status != "failed" || status == "passed" && exitCode != 0 || status == "failed" && exitCode == 0 {
 		return analysis.WorkloadInspection{}, errInvalidWorkloadSummary
 	}
+	sendSuccess, err := strconv.ParseUint(values["send_success"], 10, 64)
+	if err != nil {
+		return analysis.WorkloadInspection{}, errInvalidWorkloadSummary
+	}
 	connectRate, err := parseWorkloadRate(values["connect_error_rate"])
 	if err != nil {
 		return analysis.WorkloadInspection{}, err
@@ -121,6 +125,7 @@ func decodeWorkloadSummary(reader io.Reader, expectedRunID string) (analysis.Wor
 	return analysis.WorkloadInspection{
 		RunID: expectedRunID, State: "completed", Status: status, ExitCode: exitCode,
 		Summary: analysis.WorkloadSummary{
+			SendSuccess:      sendSuccess,
 			ConnectErrorRate: connectRate, SendackErrorRate: sendackRate, RecvVerifyErrorRate: recvRate,
 			WorkerFailed: workerFailed, SendackMaxWorkerP99: sendackP99, ReceiveMaxWorkerP99: recvP99,
 		},

--- a/internal/infra/cloudanalysis/workload_source_test.go
+++ b/internal/infra/cloudanalysis/workload_source_test.go
@@ -17,6 +17,7 @@ func TestWorkloadSummarySourceParsesBoundedFinalSummary(t *testing.T) {
 - run_id: run-1
 - status: passed
 - exit_code: 0
+- send_success: 123456
 - sendack_error_rate: 0.000001
 - connect_error_rate: 0.000002
 - recv_verify_error_rate: 0.000003
@@ -42,7 +43,7 @@ func TestWorkloadSummarySourceParsesBoundedFinalSummary(t *testing.T) {
 	if inspection.RunID != "run-1" || inspection.State != "completed" || inspection.Status != "passed" || inspection.ExitCode != 0 {
 		t.Fatalf("inspection = %+v", inspection)
 	}
-	if inspection.Summary.ConnectErrorRate != 0.000002 || inspection.Summary.SendackMaxWorkerP99 != "125ms" || inspection.Summary.ReceiveMaxWorkerP99 != "250ms" {
+	if inspection.Summary.SendSuccess != 123456 || inspection.Summary.ConnectErrorRate != 0.000002 || inspection.Summary.SendackMaxWorkerP99 != "125ms" || inspection.Summary.ReceiveMaxWorkerP99 != "250ms" {
 		t.Fatalf("summary = %+v", inspection.Summary)
 	}
 }
@@ -66,6 +67,7 @@ func TestWorkloadSummarySourceRejectsIdentityMismatchAndOversize(t *testing.T) {
 - run_id: other-run
 - status: failed
 - exit_code: 2
+- send_success: 42
 - sendack_error_rate: 0
 - connect_error_rate: 0
 - recv_verify_error_rate: 0

--- a/internal/usecase/cloudanalysis/FLOW.md
+++ b/internal/usecase/cloudanalysis/FLOW.md
@@ -16,7 +16,8 @@ MCP tool input
   -> JSON response-size gate
 ```
 
-Metrics select server-owned query IDs rather than accepting PromQL. Logs and
+Metrics select server-owned query IDs rather than accepting PromQL, including
+per-node data-disk used bytes for bounded storage-growth calibration. Logs and
 diagnostics use fixed private API selectors and opaque cursors. Active
 diagnostics are serialized across expiring trace rules and all profile kinds,
 so only one node is perturbed at a time. Profiles select only `cpu`, `heap`, or

--- a/internal/usecase/cloudanalysis/types.go
+++ b/internal/usecase/cloudanalysis/types.go
@@ -166,6 +166,8 @@ type WorkloadInspection struct {
 
 // WorkloadSummary contains bounded load-generator quality measurements.
 type WorkloadSummary struct {
+	// SendSuccess is the successful send acknowledgement count during the measured run phase.
+	SendSuccess uint64 `json:"send_success"`
 	// ConnectErrorRate is the final failed-connection fraction across workers.
 	ConnectErrorRate float64 `json:"connect_error_rate"`
 	// SendackErrorRate is the final failed-SENDACK fraction across workers.

--- a/scripts/cloud-sim/analyze.sh
+++ b/scripts/cloud-sim/analyze.sh
@@ -447,6 +447,16 @@ set -e
 ((codex_status != 142)) || fail "local Codex diagnosis exceeded the Analysis Token deadline"
 ((codex_status == 0)) || fail "local Codex diagnosis failed"
 
+# State and status describe the workload lifecycle only. Structured output can
+# still populate these nullable fields for other observations, so canonicalize
+# the inapplicable values before closing the live Analysis Session and running
+# the stricter repository semantic validator.
+diagnosis_canonical="$analysis_temp/diagnosis-canonical.json"
+jq '(.observation_references[] | select(.tool != "workload_inspect") | .state) = null |
+    (.observation_references[] | select(.tool != "workload_inspect") | .status) = null' \
+  "$diagnosis_json" >"$diagnosis_canonical"
+mv "$diagnosis_canonical" "$diagnosis_json"
+
 analysis_token=""
 dispatch_session_operation close >/dev/null
 session_open=false

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -187,6 +187,57 @@ func TestCloudSimulationAnalyzeUsesEncryptedSessionAndLocalChatGPT(t *testing.T)
 	}
 }
 
+func TestCloudSimulationAnalyzeClearsNonWorkloadObservationState(t *testing.T) {
+	root := repoRoot(t)
+	temp := t.TempDir()
+	bin := filepath.Join(temp, "bin")
+	stateDir := filepath.Join(temp, "state")
+	callLog := filepath.Join(temp, "calls.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAnalyzeFakes(t, bin)
+	if err := os.WriteFile(filepath.Join(temp, "diagnosis-mode"), []byte("nonworkload-state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resultFile := filepath.Join(temp, "analysis-result.json")
+	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+		"run-live", "--repository", "example/project", "--result-file", resultFile)
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"WK_ANALYZE_CALL_LOG="+callLog,
+		"WK_ANALYZE_STATE_DIR="+stateDir,
+		"WK_ANALYZE_SESSION_STATE=live",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		calls, _ := os.ReadFile(callLog)
+		t.Fatalf("analyze: %v\n%s\ncalls:\n%s", err, output, calls)
+	}
+	result, err := os.ReadFile(resultFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var outcome struct {
+		Diagnosis struct {
+			Observations []struct {
+				Tool   string  `json:"tool"`
+				State  *string `json:"state"`
+				Status *string `json:"status"`
+			} `json:"observation_references"`
+		} `json:"diagnosis"`
+	}
+	if err := json.Unmarshal(result, &outcome); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, result)
+	}
+	for _, observation := range outcome.Diagnosis.Observations {
+		if observation.Tool == "run_inspect" && (observation.State != nil || observation.Status != nil) {
+			t.Fatalf("run_inspect state/status must be null after canonicalization: %+v", observation)
+		}
+	}
+}
+
 func TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH(t *testing.T) {
 	root := repoRoot(t)
 	temp := t.TempDir()
@@ -625,6 +676,9 @@ cat >"$output" <<'JSON'
 JSON
 if [[ "$mode" == mismatch ]]; then
   jq '.run_identity.source_sha = "cccccccccccccccccccccccccccccccccccccccc"' "$output" >"$output.tmp"
+  mv "$output.tmp" "$output"
+elif [[ "$mode" == nonworkload-state ]]; then
+  jq '.observation_references += [{"tool":"run_inspect","node":"run","observed_at":"2026-07-14T00:30:00Z","window":"point-in-time","complete":true,"state":"in_progress","status":"passed","note":null}]' "$output" >"$output.tmp"
   mv "$output.tmp" "$output"
 fi
 `)


### PR DESCRIPTION
## What changed

- canonicalize non-workload diagnosis observation state/status before the strict repository validator runs
- expose measured-run successful SENDACK count through wkbench summary and workload_inspect
- add an allowlisted per-node data-disk used-bytes Prometheus query
- align the Analysis skill, tool contract, JSON schema descriptions, and FLOW documentation
- add regressions for the exact diagnosis failure and storage-calibration evidence

## Why

The cloud-small calibration diagnosis produced state on a run_inspect observation. The structured output schema allowed it, but the Go semantic validator correctly rejected non-workload lifecycle state after the live Analysis Session had already closed. The same run also showed that storage calibration required manual Prometheus recovery because workload_inspect did not expose the successful measured-run message count and the allowlist did not expose node data-disk bytes.

## Impact

A future 30-minute calibration can obtain both inputs for worst-node retained bytes per successful message through the bounded Analysis MCP. Invalid model output is normalized only for inapplicable nullable fields; the strict diagnosis validator remains unchanged.

## Validation

- `GOWORK=off go test ./internal/bench/coordinator ./internal/bench/report ./internal/usecase/cloudanalysis ./internal/access/cloudanalysismcp ./internal/infra/cloudanalysis ./cmd/wkclouddiagnosis ./cmd/wkanalysis -count=1`
- `GOWORK=off go test ./scripts -run '^TestCloudSimulationAnalyze' -count=1`
- original invalid diagnosis remains rejected; canonicalized diagnosis passes
- `bash -n scripts/cloud-sim/analyze.sh`
- `jq -e . .github/cloud-sim/diagnosis.schema.json`
- `git diff --check`
