### PR TITLE
chore(cloudsim): raise default cost ceiling to 70 CNY

### DIFF
--- a/.github/workflows/cloud-sim-provision.yml
+++ b/.github/workflows/cloud-sim-provision.yml
@@ -50,7 +50,7 @@ on:
       max_total_cost:
         description: Hard maximum total cost in CNY
         required: true
-        default: "50"
+        default: "70"
         type: string
       storage_calibration_run_id:
         description: Completed 30m calibration Run Identity; required for 48h and 168h

--- a/scripts/cloud-sim/setup.sh
+++ b/scripts/cloud-sim/setup.sh
@@ -608,7 +608,7 @@ Recommended inputs:
   infrastructure_preset=small
   duration=30m
   analysis_grace=30m
-  max_total_cost=50
+  max_total_cost=70
 
 After Provision prints a Run Identity, finalize it with your ChatGPT login:
   ./scripts/cloud-sim/finalize.sh <run_id> --allow-fix-pr

--- a/scripts/cloud_sim_workflows_test.go
+++ b/scripts/cloud_sim_workflows_test.go
@@ -44,6 +44,25 @@ func TestCloudSimulationWorkflowsPreferAccessKeyAndRetainOIDCFallback(t *testing
 	}
 }
 
+func TestCloudSimulationDefaultCostCeilingIsSeventyCNY(t *testing.T) {
+	root := repoRoot(t)
+	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "cloud-sim-provision.yml"))
+	if err != nil {
+		t.Fatalf("read provision workflow: %v", err)
+	}
+	if !strings.Contains(string(workflow), "max_total_cost:\n        description: Hard maximum total cost in CNY\n        required: true\n        default: \"70\"") {
+		t.Fatal("provision workflow default max_total_cost is not 70 CNY")
+	}
+
+	setup, err := os.ReadFile(filepath.Join(root, "scripts", "cloud-sim", "setup.sh"))
+	if err != nil {
+		t.Fatalf("read setup script: %v", err)
+	}
+	if !strings.Contains(string(setup), "max_total_cost=70") {
+		t.Fatal("setup recommendation does not use the 70 CNY default cost ceiling")
+	}
+}
+
 func TestResolveAlibabaCredentialMode(t *testing.T) {
 	script := filepath.Join(repoRoot(t), "scripts", "cloud-sim", "resolve-alibaba-credential-mode.sh")
 	tests := []struct {


### PR DESCRIPTION
## Summary

- raise the Cloud Simulation Provision default hard cost ceiling from 50 CNY to 70 CNY
- keep the `setup.sh` recommended input aligned with the workflow default
- add a contract test that prevents the two defaults from drifting

The cost ceiling remains an explicit hard guard. This change does not create cloud resources.

## Tests

- `GOWORK=off go test ./scripts -run 'TestCloudSimulationDefaultCostCeilingIsSeventyCNY$' -count=1 -v`
- `GOWORK=off go test ./scripts -count=1` (186.6s)

## Review

- Standards: no findings
- Spec: no findings
