### PR TITLE
fix(wkbench): keep measured traffic errors within limits

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -213,6 +213,7 @@
 - Cloud Simulation CloudShell tool downloads are checksum-pinned, IPv4/HTTP 1.1, bounded, resumable under the user cache, and missing Go prefers the Alibaba Golang mirror; do not add an unverified GitHub Release proxy.
 - Cloud Simulation live Codex analysis uses `scripts/cloud-sim/analyze.sh` with local ChatGPT authentication; GitHub receives no OpenAI or Codex credential and hands off only a request-correlated RSA-OAEP-encrypted, run-scoped token.
 - Cloud Simulation workers must set an explicit bounded WKProto client capacity profile; omitting it activates the generic 8192-entry per-client queues and can exhaust simulator memory at stability scale.
+- Timed wkbench measurements record individual message-operation failures and continue; configured error-rate limits decide the verdict, while phase cancellation and harness failures remain fail-fast.
 - Cloud Simulation Codex tool subprocesses inherit no caller environment and run under strict filesystem/network permission profiles; Codex auth and the live Analysis Token stay in the parent Codex/MCP process, tools cannot read them, and model-authored diagnosis text never enters Draft PR metadata.
 - Cloud Simulation local analysis ignores project exec rules and rejects deployed `.codex/config.toml` or `.codex/hooks.json` before Codex starts so repository configuration cannot widen its permission profiles.
 - Cloud Simulation cleanup reconstructs temporary ingress deadlines from provider security rules; sweeps preserve unexpired local Analysis Windows and close expired, malformed, or duplicate windows.

--- a/internal/bench/FLOW.md
+++ b/internal/bench/FLOW.md
@@ -427,6 +427,12 @@ and briefly yields to foreground sendack/recv matchers when they are queued.
 
 Warmup, run, and cooldown execute all stored person and group workloads concurrently. Warmup uses a reduced rate but schedules at least one message per assigned channel so cold runtime metadata is activated before measured traffic starts. Warmup also raises per-message sendack/recv waits to at least the warmup duration, preventing cold bootstrap latency from being cut off by the shorter measured-run operation timeout. Run uses each traffic entry's own `rate_per_channel`, adjusted by split traffic partitions for large groups. Timed run windows stop scheduling new messages when the window expires and then wait only for already-started send operations to finish; overloaded attempts therefore report lower actual QPS instead of extending the measured window to drain the full original schedule. Cooldown waits for the configured drain period without new sends.
 
+Timed measured run windows record individual send, SENDACK, receive-verification,
+and RECVACK failures in workload metrics and continue scheduling. The declared
+error-rate limits own the final verdict; one message-level failure must not turn
+the worker into a `phase_hook_failed` harness result. Parent phase cancellation,
+warmup failures, and untimed direct operations remain fail-fast.
+
 ## Planner Flow
 
 `planner.Build` validates inputs, computes identity ranges, and creates a `model.Plan`. The total generated online identity pool is weighted across workers as `WorkerPlan.IdentityRange`; worker connect uses this range as the baseline online population. After the weighted ranges are final, the planner verifies each configured TCP source pool has at least `IdentityRange.Len()` candidates. Workers without an explicit pool are not assigned an inferred operating-system capacity.

--- a/internal/bench/worker/server_test.go
+++ b/internal/bench/worker/server_test.go
@@ -842,9 +842,12 @@ func TestBuildGroupWorkloadsAppliesTrafficAckTimeout(t *testing.T) {
 	workloads, err := buildGroupWorkloads(assignment, groupBundlesForTest(t, assignment), clients)
 	require.NoError(t, err)
 
-	require.Error(t, workloads[0].Run(context.Background()))
+	require.NoError(t, workloads[0].Run(context.Background()))
 	observed := <-clients["bench-u-0"].(*deadlineObservingPersonClient).observed
 	require.Less(t, observed, 100*time.Millisecond)
+	require.Equal(t, uint64(1), workloads[0].Metrics().CounterValue("group_send_error_total", metrics.Labels{
+		"phase": "run", "channel_type": "group", "profile": "huge-group", "traffic": "group-send",
+	}))
 }
 
 func TestConnectionAckTimeoutUsesLargestTrafficWindow(t *testing.T) {

--- a/internal/bench/workload/group.go
+++ b/internal/bench/workload/group.go
@@ -387,7 +387,11 @@ func (w *GroupWorkload) runFor(ctx context.Context, cfg GroupRunConfig) error {
 		}, func(ctx context.Context, localOffset int) error {
 			ch := w.channels[localOffset%len(w.channels)]
 			messageIndex := w.messageIndexForLocalOffset(ch, localOffset/len(w.channels))
-			return w.sendOneInPhase(ctx, phase, ch.ChannelIndex, messageIndex)
+			err := w.sendOneInPhase(ctx, phase, ch.ChannelIndex, messageIndex)
+			if shouldContinueMeasuredMessageError(ctx, cfg.Phase, err) {
+				return nil
+			}
+			return err
 		}, stats)
 		recordSchedulerStats(w.metrics, w.sendMetricLabels(phase), stats)
 		return err
@@ -401,7 +405,9 @@ func (w *GroupWorkload) runFor(ctx context.Context, cfg GroupRunConfig) error {
 		ch := w.channels[localOffset%len(w.channels)]
 		messageIndex := w.messageIndexForLocalOffset(ch, localOffset/len(w.channels))
 		if err := w.sendOneInPhase(ctx, phase, ch.ChannelIndex, messageIndex); err != nil {
-			return err
+			if !shouldContinueMeasuredMessageError(ctx, cfg.Phase, err) {
+				return err
+			}
 		}
 		if interval > 0 {
 			if err := w.cfg.sleep(ctx, interval); err != nil {

--- a/internal/bench/workload/group_test.go
+++ b/internal/bench/workload/group_test.go
@@ -382,6 +382,35 @@ func TestGroupWorkloadSendOneRejectsSendackWithoutExpectedClientMsgNo(t *testing
 	require.Contains(t, err.Error(), "sendack not received")
 }
 
+func TestGroupWorkloadMeasuredRunKeepsGoingAfterOperationError(t *testing.T) {
+	sender := newRecordingPersonClient()
+	sender.autoSendack = true
+	sender.readErrors = append(sender.readErrors, context.DeadlineExceeded)
+	workload, err := NewGroupWorkload(GroupConfig{
+		RunID:           "run-a",
+		ProfileName:     "group-profile",
+		TrafficName:     "group-send",
+		ClientMsgPrefix: "bench-msg",
+		RunDuration:     50 * time.Millisecond,
+		LocalRate:       model.Rate{PerSecond: 100},
+		MaxConcurrency:  4,
+		Channels: []GroupChannel{{
+			ChannelIndex:  0,
+			ChannelID:     "run-a-group-profile-0",
+			OnlineMembers: []string{"u-0"},
+		}},
+		Metrics: metrics.NewRegistry(),
+	}, map[string]PersonClient{"u-0": sender})
+	require.NoError(t, err)
+
+	require.NoError(t, workload.Run(context.Background()))
+
+	labels := groupSendLabels("run", "group-profile", "group-send")
+	require.Len(t, sender.sentFrames, 5)
+	require.Equal(t, uint64(1), workload.Metrics().CounterValue("group_send_error_total", labels))
+	require.Equal(t, uint64(4), workload.Metrics().CounterValue("group_send_success_total", labels))
+}
+
 func TestGroupWorkloadPipelinesSendackOperationsPerWrappedClient(t *testing.T) {
 	raw := newSerialSendackClient()
 	clients := WrapPersonClientsForConcurrentReads(map[string]PersonClient{"u-0": raw})

--- a/internal/bench/workload/person.go
+++ b/internal/bench/workload/person.go
@@ -299,7 +299,11 @@ func (w *PersonWorkload) runFor(ctx context.Context, cfg PersonRunConfig) error 
 			return pair.SenderUID
 		}, func(ctx context.Context, messageOffset int) error {
 			pair := w.pairs[messageOffset%len(w.pairs)]
-			return w.sendPairInPhase(ctx, pair, phase, messageOffset)
+			err := w.sendPairInPhase(ctx, pair, phase, messageOffset)
+			if shouldContinueMeasuredMessageError(ctx, cfg.Phase, err) {
+				return nil
+			}
+			return err
 		}, stats)
 		recordSchedulerStats(w.metrics, w.sendMetricLabels(phase), stats)
 		return err
@@ -312,7 +316,9 @@ func (w *PersonWorkload) runFor(ctx context.Context, cfg PersonRunConfig) error 
 		}
 		pair := w.pairs[messageOffset%len(w.pairs)]
 		if err := w.sendPairInPhase(ctx, pair, phase, messageOffset); err != nil {
-			return err
+			if !shouldContinueMeasuredMessageError(ctx, cfg.Phase, err) {
+				return err
+			}
 		}
 		if interval > 0 {
 			if err := w.cfg.sleep(ctx, interval); err != nil {

--- a/internal/bench/workload/person_test.go
+++ b/internal/bench/workload/person_test.go
@@ -1009,6 +1009,33 @@ func TestPersonWorkloadRunHonorsRateDurationPerChannel(t *testing.T) {
 	require.Equal(t, uint64(4), workload.Metrics().CounterValue("person_send_success_total", personSendLabels("run", "profile-a", "traffic-a")))
 }
 
+func TestPersonWorkloadMeasuredRunKeepsGoingAfterOperationError(t *testing.T) {
+	sender := newRecordingPersonClient()
+	sender.autoSendack = true
+	sender.readErrors = append(sender.readErrors, context.DeadlineExceeded)
+	workload, err := NewPersonWorkload(PersonConfig{
+		RunID:           "run-a",
+		ProfileName:     "profile-a",
+		TrafficName:     "traffic-a",
+		ClientMsgPrefix: "bench-msg",
+		RunDuration:     50 * time.Millisecond,
+		Rate:            model.Rate{PerSecond: 100},
+		MaxConcurrency:  4,
+		Pairs: []PersonPair{
+			{ChannelIndex: 0, SenderUID: "u1", RecipientUID: "u2"},
+		},
+		Metrics: metrics.NewRegistry(),
+	}, map[string]PersonClient{"u1": sender, "u2": newRecordingPersonClient()})
+	require.NoError(t, err)
+
+	require.NoError(t, workload.Run(context.Background()))
+
+	labels := personSendLabels("run", "profile-a", "traffic-a")
+	require.Len(t, sender.sentFrames, 5)
+	require.Equal(t, uint64(1), workload.Metrics().CounterValue("person_send_error_total", labels))
+	require.Equal(t, uint64(4), workload.Metrics().CounterValue("person_send_success_total", labels))
+}
+
 func TestPersonWorkloadWarmupTouchesEveryPairAtLeastOnce(t *testing.T) {
 	clients := map[string]*recordingPersonClient{
 		"u1": newRecordingPersonClient(),

--- a/internal/bench/workload/phase_error.go
+++ b/internal/bench/workload/phase_error.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"context"
 	"errors"
+	"strings"
 )
 
 func shouldRecordPhaseOperationError(ctx context.Context, err error) bool {
@@ -17,4 +18,16 @@ func shouldRecordPhaseOperationError(ctx context.Context, err error) bool {
 		return true
 	}
 	return !errors.Is(err, ctxErr)
+}
+
+// shouldContinueMeasuredMessageError keeps one message-level failure from
+// invalidating a timed measurement whose declared error-rate limits own the verdict.
+func shouldContinueMeasuredMessageError(ctx context.Context, phase string, err error) bool {
+	if err == nil || phase != "run" && !strings.HasPrefix(phase, "run-window-") {
+		return false
+	}
+	if ctx == nil || ctx.Err() == nil {
+		return true
+	}
+	return !errors.Is(err, ctx.Err())
 }


### PR DESCRIPTION
## Summary

- keep timed Person and Group workload windows running after individual message-operation failures
- preserve fail-fast behavior for parent cancellation, warmup, and untimed direct operations
- let declared send/receive error-rate limits determine the benchmark verdict
- add deterministic regression coverage for both concurrent measured traffic paths

## Root cause

Cloud calibration run `gh-29633375786-1` completed only 4m8s of its planned 30m measured phase and reported `phase_hook_failed` after 124,115 successful messages. Targets stayed up and simulator memory peaked at 47.07%, while the only hard violation was `max_worker_failed=1`.

The workload scheduler returned the first message-level SENDACK/RECV error from a timed measurement. The worker converted that normal, rate-limited measurement error into a fatal phase-hook failure before the configured `max_sendack_error_rate` or `max_recv_verify_error_rate` limits could evaluate the run.

## Impact

A single transient message failure no longer invalidates a long stability run as a harness failure. The error remains counted in workload metrics, and excessive failures still fail the declared error-rate gates.

## Validation

- red/green: `GOWORK=off go test ./internal/bench/workload -run "^(TestPersonWorkloadMeasuredRunKeepsGoingAfterOperationError|TestGroupWorkloadMeasuredRunKeepsGoingAfterOperationError)$" -count=20`
- `GOWORK=off go test ./internal/bench/worker -run "^TestBuildGroupWorkloadsAppliesTrafficAckTimeout$" -count=20`
- `GOWORK=off go test ./internal/bench/... ./pkg/bench/model ./pkg/client -count=1`
- `git diff --check`