### PR TITLE
fix: bound conversation active pressure flushes

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -40,6 +40,7 @@
 - `ActiveAt` is a best-effort hint: updates may be batched, throttled, dropped, and merged from the kind-aware conversation active cache during `ListConversationActiveView`.
 - Legacy `UserConversation*` and `CMDConversation*` APIs in `pkg/db/meta` are source compatibility shims only; they must map to the unified kind-aware conversation table.
 - Conversation active flush attempts must carry a bounded context because Slot proposal futures rely on caller deadlines for stale or uncommitted proposals.
+- Conversation active dirty flushes must be serialized across scheduled, cache-pressure, and hash-slot drains; concurrent full-cache snapshots multiply memory by admission concurrency.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -8,9 +8,17 @@ Current flow:
 
 1. Channel append or another authority-owned caller submits an `ActiveBatch`.
 2. The manager merges rows by `(uid, kind, channel_id, channel_type)`.
-3. Dirty rows flush through `ActiveStore.TouchConversationActiveAt`.
-4. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
-5. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
+3. Dirty flushes are serialized from cache snapshot through durable completion,
+   then write through `ActiveStore.TouchConversationActiveAt`.
+4. Cache-pressure admission rechecks capacity after it owns the flush lane, flushes
+   dirty rows, and evicts only clean rows before retrying admission.
+5. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
+6. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
+
+Serialization covers scheduled, cache-pressure, and hash-slot-scoped flushes. It
+prevents concurrent admissions at the row cap from each retaining a duplicate
+whole-cache snapshot while preserving version fencing for updates that arrive
+during durable I/O.
 
 Cache observations report aggregate row/dirty counts plus fixed kind-aware
 normal/CMD counts maintained incrementally on cache mutation. Observation does

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -48,6 +48,8 @@ type flushEntry struct {
 type Manager struct {
 	// mu protects cache and all per-UID conversation rows.
 	mu sync.RWMutex
+	// flushMu serializes dirty snapshots through durable completion to bound concurrent snapshot memory.
+	flushMu sync.Mutex
 	// nowMS supplies ActiveAtMS when an admitted batch does not provide one.
 	nowMS func() int64
 	// store reads and persists durable active rows for cache/store merging.
@@ -277,7 +279,17 @@ func (m *Manager) spillForPressure(ctx context.Context, newRows int) error {
 	if m.store == nil {
 		return ErrCachePressure
 	}
-	if _, err := m.flushDirty(ctx, 0); err != nil {
+
+	m.flushMu.Lock()
+	defer m.flushMu.Unlock()
+
+	m.mu.RLock()
+	needsSpill := m.cacheWouldExceedLocked(newRows)
+	m.mu.RUnlock()
+	if !needsSpill {
+		return nil
+	}
+	if _, err := m.flushDirtySerialized(ctx, 0); err != nil {
 		return err
 	}
 
@@ -332,6 +344,9 @@ func (m *Manager) FlushHashSlot(ctx context.Context, hashSlot uint16, limit int)
 	if m.store == nil {
 		return FlushResult{}, ErrStoreRequired
 	}
+	m.flushMu.Lock()
+	defer m.flushMu.Unlock()
+
 	startedAt := time.Now()
 	return m.flushDirtyEntries(ctx, startedAt, m.dirtyFlushEntriesForHashSlot(hashSlot, limit))
 }
@@ -340,6 +355,13 @@ func (m *Manager) flushDirty(ctx context.Context, limit int) (FlushResult, error
 	if m.store == nil {
 		return FlushResult{}, ErrStoreRequired
 	}
+	m.flushMu.Lock()
+	defer m.flushMu.Unlock()
+
+	return m.flushDirtySerialized(ctx, limit)
+}
+
+func (m *Manager) flushDirtySerialized(ctx context.Context, limit int) (FlushResult, error) {
 	startedAt := time.Now()
 
 	return m.flushDirtyEntries(ctx, startedAt, m.dirtyFlushEntries(limit))

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -3,8 +3,10 @@ package conversationactive
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -897,6 +899,82 @@ func TestAdmitUnderCachePressureSpillsDirtyRows(t *testing.T) {
 	}
 }
 
+func TestConcurrentCachePressureDoesNotDuplicateFullFlush(t *testing.T) {
+	const (
+		maxRows = 64
+		workers = 8
+	)
+	ctx := context.Background()
+	store := &blockingActiveStore{
+		entered: make(chan int, workers),
+		release: make(chan struct{}),
+	}
+	releaseStore := sync.OnceFunc(func() { close(store.release) })
+	defer releaseStore()
+	m := NewManager(Options{Store: store, MaxCachedRows: maxRows})
+	initial := make([]ActivePatch, 0, maxRows)
+	for i := 0; i < maxRows; i++ {
+		initial = append(initial, ActivePatch{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         fmt.Sprintf("existing-%d", i),
+			ChannelID:   "room",
+			ChannelType: 2,
+			ActiveAtMS:  1000,
+		})
+	}
+	if err := m.MarkActive(ctx, initial); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+
+	start := make(chan struct{})
+	ready := sync.WaitGroup{}
+	ready.Add(workers)
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		go func(worker int) {
+			ready.Done()
+			<-start
+			errs <- m.MarkActive(ctx, []ActivePatch{{
+				Kind:        metadb.ConversationKindNormal,
+				UID:         fmt.Sprintf("new-%d", worker),
+				ChannelID:   "room",
+				ChannelType: 2,
+				ActiveAtMS:  2000,
+			}})
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+
+	select {
+	case selected := <-store.entered:
+		if selected != maxRows {
+			t.Fatalf("first pressure flush selected %d rows, want %d", selected, maxRows)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first pressure flush did not reach the store")
+	}
+
+	duplicateFullFlush := false
+	select {
+	case selected := <-store.entered:
+		duplicateFullFlush = selected == maxRows
+	case <-time.After(200 * time.Millisecond):
+	}
+	releaseStore()
+	for i := 0; i < workers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("MarkActive(concurrent pressure) error = %v", err)
+		}
+	}
+	if duplicateFullFlush {
+		t.Fatal("concurrent cache pressure duplicated the same full-cache flush snapshot")
+	}
+	if got := store.maxConcurrentCalls(); got != 1 {
+		t.Fatalf("maximum concurrent store flushes = %d, want 1", got)
+	}
+}
+
 type recordingActiveStore struct {
 	rows      []metadb.ConversationState
 	primary   map[metadb.ConversationStateKey]metadb.ConversationState
@@ -910,6 +988,38 @@ type recordingActiveStore struct {
 	touchErr  error
 	touchHook func()
 	touches   [][]metadb.ConversationActivePatch
+}
+
+type blockingActiveStore struct {
+	recordingActiveStore
+	mu            sync.Mutex
+	entered       chan int
+	release       chan struct{}
+	concurrent    int
+	maxConcurrent int
+}
+
+func (s *blockingActiveStore) TouchConversationActiveAt(_ context.Context, patches []metadb.ConversationActivePatch) error {
+	s.mu.Lock()
+	s.concurrent++
+	if s.concurrent > s.maxConcurrent {
+		s.maxConcurrent = s.concurrent
+	}
+	s.mu.Unlock()
+
+	s.entered <- len(patches)
+	<-s.release
+
+	s.mu.Lock()
+	s.concurrent--
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *blockingActiveStore) maxConcurrentCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxConcurrent
 }
 
 type recordingConversationActiveObserver struct {


### PR DESCRIPTION
## Summary

- serialize conversation-active dirty snapshots through durable completion
- recheck cache pressure after acquiring the flush lane
- add a concurrent pressure regression and document the runtime invariant

## Root cause

In cloud Medium run `gh-29664328663-1`, node 2 reached the 100,000-row active-conversation cache cap during warmup. Concurrent recipient workers each entered pressure spill, copied the same full dirty cache, and retained those snapshots while durable flushes were in flight. In 15 seconds the live heap grew by about 10.5 GB and live objects by about 16 million before host OOM. A deterministic regression reproduced duplicate full-cache flushes before this fix.

The post-restart PullBatch storm was excluded as the first-kill cause: only 1,907 successful PullBatch calls occurred before the original OOM.

## Verification

- `GOWORK=off go test ./internal/runtime/conversationactive -count=1`
- `GOWORK=off go test -race ./internal/runtime/conversationactive -count=1`
- `GOWORK=off go test ./internal/app -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- concurrent pressure regression passed 20 consecutive runs

The invalid diagnostic run was cleaned by workflow `29665716917`; release verification returned `state=released`, and cleanup enforced `resources.length == 0`.