### PR TITLE
fix: avoid Perl in cloud analysis fingerprinting

### DIFF
--- a/scripts/cloud-sim/analyze.sh
+++ b/scripts/cloud-sim/analyze.sh
@@ -407,11 +407,10 @@ else
 fi
 [[ "$expiry_epoch" =~ ^[0-9]+$ ]] || fail "invalid Analysis Token expiry"
 ((expiry_epoch > $(date -u +%s) + 60)) || fail "Analysis Token expired before local Codex started"
-if command -v sha256sum >/dev/null 2>&1; then
-  actual_ca_fingerprint="sha256:$(openssl x509 -in "$pinned_ca" -outform DER | sha256sum | awk '{print $1}')"
-else
-  actual_ca_fingerprint="sha256:$(openssl x509 -in "$pinned_ca" -outform DER | shasum -a 256 | awk '{print $1}')"
-fi
+# Keep fingerprint verification independent of platform hash wrappers. macOS
+# shasum is implemented by system Perl, which aborts when the caller inherited
+# a Linux-only locale such as C.UTF-8.
+actual_ca_fingerprint="sha256:$(openssl x509 -in "$pinned_ca" -outform DER | openssl dgst -sha256 | awk '{print $NF}')"
 [[ "$actual_ca_fingerprint" == "$expected_ca_fingerprint" ]] || fail "Analysis MCP CA fingerprint mismatch"
 
 analysis_token="$(openssl pkeyutl -decrypt -inkey "$private_key" \

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -285,21 +285,6 @@ func TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	hashCommandFound := false
-	for _, command := range []string{"sha256sum", "shasum"} {
-		source, err := exec.LookPath(command)
-		if err != nil {
-			continue
-		}
-		hashCommandFound = true
-		if err := os.Symlink(source, filepath.Join(bin, command)); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if !hashCommandFound {
-		t.Fatal("find required SHA-256 test command")
-	}
-
 	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
 		"run-live", "--repository", "example/project")
 	command.Dir = root
@@ -628,6 +613,10 @@ case "$1" in
     ;;
   pkeyutl) printf '%s' 'analysis-secret-token-0123456789abcdef' ;;
   x509) printf '%s' 'DERDATA' ;;
+  dgst)
+    cat >/dev/null
+    printf '%s\n' '494c9d9f353d3aa18a4ada2697e2a7bac90492022d9821ba0a5a6f4c3b15233a'
+    ;;
   *) exit 97 ;;
 esac
 `)
@@ -764,11 +753,7 @@ case "$1" in
         elif [[ "$WK_ANALYZE_SESSION_STATE" == insufficient_evidence ]]; then
           jq -n --arg request_id "$request_id" --arg message "${WK_ANALYZE_SESSION_MESSAGE:-Provider preflight could not establish a live identity-matched Simulation Run.}" '{schema:"wukongim/cloud-simulation-analysis-session/v1",state:"insufficient_evidence",run_id:"run-insufficient",request_id:$request_id,message:$message}' >"$destination/session.json"
         else
-		  if command -v sha256sum >/dev/null 2>&1; then
-		    fingerprint="sha256:$(printf '%s' DERDATA | sha256sum | awk '{print $1}')"
-		  else
-		    fingerprint="sha256:$(printf '%s' DERDATA | shasum -a 256 | awk '{print $1}')"
-		  fi
+		  fingerprint='sha256:494c9d9f353d3aa18a4ada2697e2a7bac90492022d9821ba0a5a6f4c3b15233a'
           jq -n --arg request_id "$request_id" --arg fingerprint "$fingerprint" '{schema:"wukongim/cloud-simulation-analysis-session/v1",state:"live",run_id:"run-live",request_id:$request_id,source_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",scenario_digest:"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",mcp_url:"https://198.51.100.20:19092/mcp",expires_at:"2099-07-14T01:00:00Z",ca_fingerprint:$fingerprint}' >"$destination/session.json"
           printf '%s' encrypted >"$destination/encrypted-token.bin"
           printf '%s' certificate >"$destination/pinned-ca.pem"


### PR DESCRIPTION
## Summary
- compute the pinned Analysis MCP CA fingerprint with OpenSSL directly
- avoid the macOS shasum/Perl locale crash before local Codex starts
- keep the scripted live-session test independent of platform SHA wrappers

## Verification
- bash -n scripts/cloud-sim/analyze.sh
- GOWORK=off go test ./scripts -run TestCloudSimulationAnalyze -count=1
- exact live Analysis Session 29668996520 completed after the prior failure point
- full repository unit gate ran; two unrelated timing tests failed once and passed on focused rerun