### PR TITLE
fix cluster readiness and gateway auth races

### DIFF
--- a/pkg/channel/reactor/append_batch_test.go
+++ b/pkg/channel/reactor/append_batch_test.go
@@ -840,13 +840,14 @@ func TestAppendCancellationSweepSendsOverdueResumeHint(t *testing.T) {
 	meta.MinISR = 2
 	r := NewReactor(ReactorConfig{
 		ID: 0, LocalNode: 1, Store: factory, Pools: pools, MailboxSize: 16,
-		AppendBatchMaxRecords: 1, PullHintRetryInterval: time.Millisecond,
+		AppendBatchMaxRecords: 1, PullHintRetryInterval: time.Hour,
 	})
 	require.NoError(t, applyMetaDirect(t, r, meta))
 	rc := r.channels[meta.Key]
 	follower := rc.lifecycle.followers[2]
 	require.NotNil(t, follower)
-	follower.lastPullAt = time.Now()
+	now := time.Now()
+	follower.lastPullAt = now
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -859,9 +860,9 @@ func TestAppendCancellationSweepSendsOverdueResumeHint(t *testing.T) {
 	requireFuturePending(t, future)
 
 	require.Equal(t, 0, tr.pullHintCount(2))
-	follower.hint.retryAt = time.Now().Add(-time.Millisecond)
+	follower.hint.retryAt = now.Add(time.Hour)
 
-	r.sweepAppendCancellationsForChannel(rc)
+	r.sweepAppendCancellationsForChannelAt(rc, now.Add(time.Hour+time.Millisecond))
 
 	require.Eventually(t, func() bool {
 		return tr.pullHintCount(2) == 1 && tr.lastPullHintVersion(2) == rc.lifecycle.version

--- a/pkg/cluster/integration_test.go
+++ b/pkg/cluster/integration_test.go
@@ -85,7 +85,7 @@ func TestClusterThreeNodeDefaultChannelsReplicateQuorumAppend(t *testing.T) {
 	startNodes(t, nodes...)
 	t.Cleanup(func() { stopNodes(t, nodes...) })
 	waitClusterReady(t, nodes...)
-	waitRouteKeyLeaderReady(t, nodes[0], channelID.ID)
+	waitNodeWriteReady(t, nodes[0])
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -216,6 +216,23 @@ func waitClusterReady(t testing.TB, nodes ...*Node) {
 	if err := WaitClusterReady(ctx, nodes...); err != nil {
 		t.Fatalf("WaitClusterReady() error = %v", err)
 	}
+}
+
+// waitNodeWriteReady proves that the routed Slot runtime can commit a bounded metadata write.
+func waitNodeWriteReady(t testing.TB, node *Node) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		lastErr = node.ProbeWriteReady(ctx)
+		cancel()
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("ProbeWriteReady(node=%d) error = %v", node.NodeID(), lastErr)
 }
 
 func waitRouteLeader(t testing.TB, node *Node, hashSlot uint16, want uint64) {

--- a/pkg/gateway/FLOW.md
+++ b/pkg/gateway/FLOW.md
@@ -282,10 +282,11 @@ WKProto CONNECT:
   ⑤ 若 Handler 实现 SessionActivator，调用 OnSessionActivate
      - access/gateway 在这里调用 presence.Activate
      - 可返回 Connack override
-  ⑥ 写出 CONNACK；非 success 时关闭连接
+  ⑥ success CONNACK 写出前原子进入 authenticated + open-pending gate；非 success 时不进入该状态并在写出后关闭连接
+     - 客户端并发观察到 success CONNACK 并立即发送的业务 frame 会等待 open gate，不会被误判为 auth pending 协议违规，也不会早于 OnSessionOpen 进入 handler
      - 若激活已成功但 success CONNACK 写出失败，或写出前发现连接已关闭/正在关闭，调用 SessionActivationRollbacker 回滚激活，再关闭物理连接
-  ⑦ success CONNACK 写出后标记 authenticated，清理 authPending，并 dispatch OnSessionOpen
-  ⑧ 认证完成后到达的业务 frame 必须等待 OnSessionOpen 返回后，才记录 OnFrameIn 并进入 handler；认证 pending 期间到达的业务 frame 已在步骤 ② 按 policy_violation 关闭
+  ⑦ success CONNACK 写出后 dispatch OnSessionOpen，返回后释放 open gate
+  ⑧ 认证完成后到达的业务 frame 必须等待 OnSessionOpen 返回后，才记录 OnFrameIn 并进入 handler；认证结果尚未进入 success gate 时到达的业务 frame 仍在步骤 ② 按 policy_violation 关闭
 ```
 
 认证失败会尽量先写出对应 CONNACK，再关闭连接；CONNECT 同批尾帧、认证 pending 期间的重复帧或非 CONNECT 首帧属于协议违规，直接关闭连接。`Observer.OnAuth` 会携带 `status` 与低基数 `failure` 类别；Authenticator error、SessionActivator error 和 async auth 队列满会使用不同 failure class，队列满的 failure class 为 `auth_queue_full`，关闭原因为 `async_auth_queue_full`，方便区分客户端侧同为 SystemError 的失败来源。认证成功后的 `RequestContext` 会在 session close / gateway stop 时取消，用例层可用它中止正在进行的发送。

--- a/pkg/gateway/core/async_auth_test.go
+++ b/pkg/gateway/core/async_auth_test.go
@@ -372,6 +372,50 @@ func TestServerAsyncAuthRollsBackWhenConnackWriteSucceedsButSessionClosesBeforeO
 	}
 }
 
+func TestServerAsyncAuthAcceptsFrameVisibleDuringSuccessConnackWrite(t *testing.T) {
+	handler := asyncAuthNoopHandler{}
+	srv := &Server{
+		options: gatewaytypes.Options{
+			Authenticator: gatewaytypes.AuthenticatorFunc(func(*gatewaytypes.Context, *frame.ConnectPacket) (*gatewaytypes.AuthResult, error) {
+				return &gatewaytypes.AuthResult{Connack: &frame.ConnackPacket{ReasonCode: frame.ReasonSuccess}}, nil
+			}),
+			Handler: handler,
+		},
+		dispatcher: newDispatcher(handler),
+	}
+	state := &sessionState{
+		server:   srv,
+		listener: &listenerRuntime{adapter: asyncAuthEncodeOnlyProtocol{}},
+		closedCh: make(chan struct{}),
+	}
+	state.requestContext, state.cancelRequestContext = context.WithCancel(context.Background())
+	state.session = session.New(session.Config{ID: 1})
+	state.setAuthRequired(true)
+	state.setAuthPending(true)
+
+	var handled bool
+	var handleErr error
+	state.conn = asyncAuthCloseOnWriteConn{onWrite: func() {
+		handled, handleErr = srv.handleAuthFrame(state, "", &frame.PingPacket{}, false)
+	}}
+
+	srv.runAuthTask(asyncAuthTask{
+		state:      state,
+		connect:    &frame.ConnectPacket{UID: "u1", DeviceID: "d-1", DeviceFlag: frame.APP},
+		enqueuedAt: time.Now(),
+	})
+
+	if handleErr != nil {
+		t.Fatalf("handle post-CONNACK frame error = %v", handleErr)
+	}
+	if handled {
+		t.Fatal("post-CONNACK frame was treated as an authentication frame")
+	}
+	if state.isClosed() {
+		t.Fatalf("session closed after post-CONNACK frame, reason=%q", state.closeReason())
+	}
+}
+
 func TestAsyncAuthReportsQueueAndAdmission(t *testing.T) {
 	observer := &recordingAsyncSendObserver{}
 	srv := &Server{options: gatewaytypes.Options{Observer: observer}}

--- a/pkg/gateway/core/server.go
+++ b/pkg/gateway/core/server.go
@@ -108,11 +108,14 @@ type sessionState struct {
 	// closeErrs preserves close errors until lifecycle callbacks are safe to emit.
 	closeErrs []error
 	// closeNotified prevents duplicate OnSessionError/OnSessionClose callbacks.
-	closeNotified  bool
-	closing        bool
-	authenticated  bool
-	authPending    bool
-	authRequired   bool
+	closeNotified bool
+	closing       bool
+	authenticated bool
+	authPending   bool
+	authRequired  bool
+	// openPending gates post-CONNACK frames while the successful authentication
+	// worker finishes the write and starts OnSessionOpen.
+	openPending    bool
 	openDispatched bool
 	openCompleted  bool
 	openDone       chan struct{}
@@ -817,6 +820,17 @@ func (s *Server) runAuthTask(task asyncAuthTask) {
 		suppressObservation = true
 		return
 	}
+	openAlreadyDispatched := state.openWasDispatched()
+	if connack.ReasonCode == frame.ReasonSuccess {
+		if openAlreadyDispatched {
+			state.setAuthenticated(true)
+			state.setAuthPending(false)
+		} else if !state.beginAuthenticatedOpen() {
+			s.rollbackActivatedSession(ctx, activated, connack, session.ErrSessionClosed)
+			suppressObservation = true
+			return
+		}
+	}
 	if writeErr := s.writeImmediateFrame(state, connack); writeErr != nil {
 		if connack.ReasonCode == frame.ReasonSuccess {
 			failure = authFailureConnackWriteError
@@ -831,19 +845,16 @@ func (s *Server) runAuthTask(task asyncAuthTask) {
 	}
 	status = authStatusOK
 	failure = authFailureNone
-	if !state.openWasDispatched() {
-		if !state.beginAuthenticatedOpen() {
-			s.rollbackActivatedSession(ctx, activated, connack, session.ErrSessionClosed)
-			suppressObservation = true
-			return
-		}
+	if state.isClosed() {
+		s.rollbackActivatedSession(ctx, activated, connack, session.ErrSessionClosed)
+		suppressObservation = true
+		return
+	}
+	if !openAlreadyDispatched {
 		if err := s.dispatchSessionOpen(state); err != nil {
 			s.handleHandlerError(state, err)
 			return
 		}
-	} else {
-		state.setAuthenticated(true)
-		state.setAuthPending(false)
 	}
 }
 
@@ -1788,12 +1799,12 @@ func (st *sessionState) beginAuthenticatedOpen() bool {
 
 	st.metaMu.Lock()
 	defer st.metaMu.Unlock()
-	if st.closing || st.authenticated || st.openDispatched {
+	if st.closing || st.authenticated || st.openPending || st.openDispatched {
 		return false
 	}
 	st.authenticated = true
 	st.authPending = false
-	st.openDispatched = true
+	st.openPending = true
 	st.openCompleted = false
 	if st.openDone == nil {
 		st.openDone = make(chan struct{})
@@ -1878,6 +1889,7 @@ func (st *sessionState) markOpenDispatched() {
 	}
 
 	st.metaMu.Lock()
+	st.openPending = false
 	st.openDispatched = true
 	if st.openDone == nil {
 		st.openDone = make(chan struct{})
@@ -1892,6 +1904,7 @@ func (st *sessionState) markOpenComplete() {
 
 	st.metaMu.Lock()
 	if !st.openCompleted {
+		st.openPending = false
 		st.openCompleted = true
 		if st.openDone != nil {
 			close(st.openDone)
@@ -1906,11 +1919,12 @@ func (st *sessionState) waitOpenComplete() {
 	}
 
 	st.metaMu.RLock()
+	openPending := st.openPending
 	openDispatched := st.openDispatched
 	openCompleted := st.openCompleted
 	openDone := st.openDone
 	st.metaMu.RUnlock()
-	if !openDispatched || openCompleted || openDone == nil {
+	if (!openPending && !openDispatched) || openCompleted || openDone == nil {
 		return
 	}
 


### PR DESCRIPTION
## Root causes

- The three-node Channel append test waited only for a non-zero route leader. That control-plane observation did not prove the Slot runtime could commit through a quorum, so the test could race initial Raft readiness and fail with no slot leader or proposal dropped.
- WKProto authentication wrote a success CONNACK before changing the session from auth-pending to authenticated. A client that immediately sent its next frame could be rejected as a protocol violation in that visibility window.

## Fix

- Gate the multi-node append assertion with ProbeWriteReady, which validates routed Slot status and commits a bounded metadata noop before the tested append.
- Enter an authenticated open-pending state before writing a success CONNACK. Frames visible concurrently wait for OnSessionOpen and write failures still close and roll back activation.
- Add a deterministic regression that injects a frame during the CONNACK write.
- Update pkg/gateway/FLOW.md to document the lifecycle ordering.

## Validation

- Cluster failing test: 10 consecutive passes.
- Gateway real TCP test: 30 consecutive passes.
- Deterministic auth race tests: 50 consecutive passes plus race detector.
- Full pkg/cluster and pkg/gateway package suites passed.
- Full explicit repository Go unit gate passed.