### PR TITLE
Fix Slot bootstrap election preference

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -154,7 +154,7 @@
 - Manager Slot inventory keeps control intent and live Raft status separate: `runtime.preferred_leader_id` is Controller intent; `runtime.leader_id`, voter membership, quorum, sync, and leader-match require live Raft evidence, while selected-node detail also uses `node_log.leader_id` and `node_log.role`. Missing evidence stays unknown/unreported.
 - Manager node-list Slot `leader_count` is also actual Slot Raft leadership from runtime status, not the Controller preferred leader count.
 - Production controller planning writes must go through Controller Raft proposals; direct Store writes are only for local tests or tools.
-- Bootstrap planning rotates `Task.TargetNode` across DesiredPeers by SlotID; cluster execution must observe exact voter membership and that target as the live Slot leader before completing the task, transferring from the observed current leader when needed.
+- Bootstrap planning rotates the preferred `Task.TargetNode` across DesiredPeers by SlotID. That voter campaigns first after initial membership applies, but Raft eligibility and quorum remain authoritative; bootstrap completes with exact voter membership and any live leader in that voter set, without a post-election forced transfer.
 - V2 UID authority targets must use distributed Slot identity `(hash slot, slot id, leader node, leader term, config epoch)` as the hard fence. Node-local `AuthorityEpoch` is diagnostic/order metadata only and must not be used as a cross-node hard fence.
 
 ### Controller Raft transport

--- a/pkg/cluster/FLOW.md
+++ b/pkg/cluster/FLOW.md
@@ -210,12 +210,14 @@ advancement, fenced commit, or fenced completion through the control task
 writer facade; they do not mutate Controller state directly. Task and
 generic control writes from non-leader Controller runtimes, including
 `PromoteControllerVoter`, are forwarded to the current Controller leader.
-Bootstrap execution completes only after all target peers report done, the
-observed voter set exactly matches `TargetPeers`, and the live Slot Raft leader
-equals the bootstrap `TargetNode`. If voter membership is converged under a
-different leader, every replica records the transfer expectation and only the
-observed current leader calls Slot Raft `TransferLeadership`; a later reconcile
-must observe the target leader before completing the Controller task.
+During initial Slot bootstrap, every target peer installs the same voter set.
+The `PreferredLeader` target asks only that local voter to campaign as soon as
+the initial membership is durably applied; ordinary Raft election timeouts stay
+active as the fallback. Raft vote eligibility, log freshness, and quorum remain
+authoritative. Bootstrap execution completes after all target peers report done,
+the observed voter set exactly matches `TargetPeers`, and the live Slot Raft
+leader belongs to that voter set. It does not force a post-election leadership
+transfer when the observed leader differs from the preference.
 Leader-transfer execution calls Slot Raft `TransferLeadership` from
 the current Slot leader and completes once the observed actual leader is any
 legal non-source Slot Raft leader; the requested `target_node` is preferred,

--- a/pkg/cluster/slots/manager.go
+++ b/pkg/cluster/slots/manager.go
@@ -24,9 +24,9 @@ func NewManager(cfg Config) *Manager {
 	return &Manager{localNode: cfg.LocalNode, runtime: cfg.Runtime, storage: cfg.Storage, stateMach: cfg.StateMachine, unassigned: make(map[uint32]struct{})}
 }
 
-// BootstrapOwner returns the deterministic node allowed to bootstrap assignment.
-func BootstrapOwner(assignment Assignment) uint64 {
-	if assignment.PreferredLeader != 0 {
+// BootstrapCampaignNode returns the initial voter that should campaign first.
+func BootstrapCampaignNode(assignment Assignment) uint64 {
+	if assignment.PreferredLeader != 0 && containsNode(assignment.DesiredPeers, assignment.PreferredLeader) {
 		return assignment.PreferredLeader
 	}
 	if len(assignment.DesiredPeers) == 0 {
@@ -35,6 +35,11 @@ func BootstrapOwner(assignment Assignment) uint64 {
 	peers := append([]uint64(nil), assignment.DesiredPeers...)
 	sort.Slice(peers, func(i, j int) bool { return peers[i] < peers[j] })
 	return peers[0]
+}
+
+// BootstrapOwner is deprecated; use BootstrapCampaignNode.
+func BootstrapOwner(assignment Assignment) uint64 {
+	return BootstrapCampaignNode(assignment)
 }
 
 // Ensure opens or bootstraps the local Slot state for assignment.
@@ -70,7 +75,11 @@ func (m *Manager) Ensure(ctx context.Context, assignment Assignment) error {
 	if !raft.IsEmptyHardState(initial.HardState) {
 		return m.runtime.OpenSlot(ctx, opts)
 	}
-	return m.runtime.BootstrapSlot(ctx, multiraft.BootstrapSlotRequest{Slot: opts, Voters: nodeIDs(assignment.DesiredPeers)})
+	return m.runtime.BootstrapSlot(ctx, multiraft.BootstrapSlotRequest{
+		Slot:     opts,
+		Voters:   nodeIDs(assignment.DesiredPeers),
+		Campaign: BootstrapCampaignNode(assignment) == m.localNode,
+	})
 }
 
 // OpenLearner opens local Slot runtime state for a staged learner target.

--- a/pkg/cluster/slots/slots_test.go
+++ b/pkg/cluster/slots/slots_test.go
@@ -10,17 +10,24 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
-func TestBootstrapOwnerUsesPreferredLeader(t *testing.T) {
+func TestBootstrapCampaignNodeUsesPreferredLeader(t *testing.T) {
 	assignment := Assignment{SlotID: 1, DesiredPeers: []uint64{1, 2, 3}, PreferredLeader: 2}
-	if got := BootstrapOwner(assignment); got != 2 {
-		t.Fatalf("BootstrapOwner() = %d, want 2", got)
+	if got := BootstrapCampaignNode(assignment); got != 2 {
+		t.Fatalf("BootstrapCampaignNode() = %d, want 2", got)
 	}
 }
 
-func TestBootstrapOwnerFallsBackToLowestPeer(t *testing.T) {
+func TestBootstrapCampaignNodeFallsBackToLowestPeer(t *testing.T) {
 	assignment := Assignment{SlotID: 1, DesiredPeers: []uint64{3, 1, 2}}
-	if got := BootstrapOwner(assignment); got != 1 {
-		t.Fatalf("BootstrapOwner() = %d, want 1", got)
+	if got := BootstrapCampaignNode(assignment); got != 1 {
+		t.Fatalf("BootstrapCampaignNode() = %d, want 1", got)
+	}
+}
+
+func TestBootstrapCampaignNodeIgnoresPreferredLeaderOutsideVoters(t *testing.T) {
+	assignment := Assignment{SlotID: 1, DesiredPeers: []uint64{3, 1, 2}, PreferredLeader: 9}
+	if got := BootstrapCampaignNode(assignment); got != 1 {
+		t.Fatalf("BootstrapCampaignNode() = %d, want fallback voter 1", got)
 	}
 }
 
@@ -32,6 +39,9 @@ func TestManagerBootstrapsOwnerWithEmptyState(t *testing.T) {
 	}
 	if runtime.bootstrapCalls != 1 || runtime.openCalls != 0 {
 		t.Fatalf("bootstrap=%d open=%d, want bootstrap=1 open=0", runtime.bootstrapCalls, runtime.openCalls)
+	}
+	if !runtime.lastCampaign {
+		t.Fatal("bootstrap campaign = false, want preferred node to campaign")
 	}
 }
 
@@ -46,6 +56,9 @@ func TestManagerAssignedPeerBootstrapsWithEmptyState(t *testing.T) {
 	}
 	if got, want := runtime.lastVoters, []multiraft.NodeID{1, 2, 3}; !equalNodeIDs(got, want) {
 		t.Fatalf("bootstrap voters = %#v, want %#v", got, want)
+	}
+	if runtime.lastCampaign {
+		t.Fatal("bootstrap campaign = true, want non-preferred node to wait for Raft election")
 	}
 }
 
@@ -110,6 +123,7 @@ type fakeRuntime struct {
 	bootstrapCalls int
 	openCalls      int
 	lastVoters     []multiraft.NodeID
+	lastCampaign   bool
 }
 
 func newFakeRuntime() *fakeRuntime { return &fakeRuntime{status: make(map[uint32]multiraft.Status)} }
@@ -120,6 +134,7 @@ func (r *fakeRuntime) OpenSlot(context.Context, multiraft.SlotOptions) error {
 func (r *fakeRuntime) BootstrapSlot(_ context.Context, req multiraft.BootstrapSlotRequest) error {
 	r.bootstrapCalls++
 	r.lastVoters = append([]multiraft.NodeID(nil), req.Voters...)
+	r.lastCampaign = req.Campaign
 	return nil
 }
 func (r *fakeRuntime) ChangeConfig(context.Context, multiraft.SlotID, multiraft.ConfigChange) (multiraft.Future, error) {

--- a/pkg/cluster/slots/types.go
+++ b/pkg/cluster/slots/types.go
@@ -12,7 +12,7 @@ type Assignment struct {
 	SlotID uint32
 	// DesiredPeers are node IDs that should host this Slot.
 	DesiredPeers []uint64
-	// PreferredLeader is the desired bootstrap owner when set.
+	// PreferredLeader is the voter that should campaign first during initial bootstrap.
 	PreferredLeader uint64
 	// HashSlots are logical hash slots currently owned by this physical Slot.
 	HashSlots []uint16

--- a/pkg/cluster/tasks/bootstrap.go
+++ b/pkg/cluster/tasks/bootstrap.go
@@ -22,14 +22,19 @@ type Writer interface {
 	ReportTaskProgress(context.Context, controller.TaskProgress) error
 }
 
+// BootstrapRuntime is the Slot Raft status surface needed to verify bootstrap convergence.
+type BootstrapRuntime interface {
+	Status(multiraft.SlotID) (multiraft.Status, error)
+}
+
 // BootstrapExecutorConfig wires a bootstrap task executor.
 type BootstrapExecutorConfig struct {
 	// LocalNode is this node's stable cluster identity.
 	LocalNode uint64
 	// Slots ensures local Slot runtime state.
 	Slots SlotManager
-	// Runtime observes local Slot Multi-Raft status and converges the target leader.
-	Runtime LeaderTransferRuntime
+	// Runtime observes local Slot Multi-Raft status after every participant has opened the group.
+	Runtime BootstrapRuntime
 	// Writer persists task progress through the Controller facade.
 	Writer Writer
 }
@@ -99,7 +104,7 @@ func (e *BootstrapExecutor) ensureLocal(ctx context.Context, table control.HashS
 	})
 }
 
-func (e *BootstrapExecutor) reconcileConvergence(ctx context.Context, task control.ReconcileTask) (bool, error) {
+func (e *BootstrapExecutor) reconcileConvergence(_ context.Context, task control.ReconcileTask) (bool, error) {
 	if e == nil || e.cfg.Runtime == nil {
 		return false, nil
 	}
@@ -127,22 +132,7 @@ func (e *BootstrapExecutor) reconcileConvergence(ctx context.Context, task contr
 			return false, nil
 		}
 	}
-	if task.TargetNode == 0 || !containsNode(targets, task.TargetNode) {
-		return false, nil
-	}
-	if uint64(status.LeaderID) == task.TargetNode {
-		return true, nil
-	}
-	if err := e.cfg.Runtime.ExpectLeaderTransfer(ctx, slotID, multiraft.NodeID(task.TargetNode)); err != nil {
-		return false, err
-	}
-	if uint64(status.LeaderID) != e.cfg.LocalNode {
-		return false, nil
-	}
-	if err := e.cfg.Runtime.TransferLeadership(ctx, slotID, multiraft.NodeID(task.TargetNode)); err != nil {
-		return false, err
-	}
-	return false, nil
+	return containsNode(targets, uint64(status.LeaderID)), nil
 }
 
 func findSlot(slots []control.SlotAssignment, slotID uint32) (control.SlotAssignment, bool) {

--- a/pkg/cluster/tasks/bootstrap_test.go
+++ b/pkg/cluster/tasks/bootstrap_test.go
@@ -29,7 +29,7 @@ func TestBootstrapExecutorReportsParticipantDoneAfterEnsure(t *testing.T) {
 	}
 }
 
-func TestBootstrapExecutorCompletesAfterAllParticipantsDoneAndTargetLeaderObserved(t *testing.T) {
+func TestBootstrapExecutorCompletesAfterAllParticipantsDoneAndLegalLeaderObserved(t *testing.T) {
 	manager := &fakeSlotManager{}
 	writer := &recordingWriter{}
 	status := &fakeStatusReader{status: multiraft.Status{SlotID: 1, LeaderID: 1, CurrentVoters: []multiraft.NodeID{1, 2, 3}}}
@@ -159,7 +159,25 @@ func TestBootstrapExecutorDoesNotCompleteWithoutObservedLeader(t *testing.T) {
 	}
 }
 
-func TestBootstrapExecutorTransfersObservedLeaderToTargetBeforeCompletion(t *testing.T) {
+func TestBootstrapExecutorDoesNotCompleteWithLeaderOutsideTargetVoters(t *testing.T) {
+	manager := &fakeSlotManager{}
+	writer := &recordingWriter{}
+	status := &fakeStatusReader{status: multiraft.Status{SlotID: 1, LeaderID: 9, CurrentVoters: []multiraft.NodeID{1, 2, 3}}}
+	snapshot := bootstrapSnapshot()
+	for i := range snapshot.Tasks[0].ParticipantProgress {
+		snapshot.Tasks[0].ParticipantProgress[i].Status = control.TaskParticipantStatusDone
+	}
+	executor := NewBootstrapExecutor(BootstrapExecutorConfig{LocalNode: 1, Slots: manager, Runtime: status, Writer: writer})
+
+	if err := executor.Reconcile(context.Background(), snapshot); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if len(writer.completed) != 0 {
+		t.Fatalf("completed = %#v, want none for leader outside target voters", writer.completed)
+	}
+}
+
+func TestBootstrapExecutorAcceptsRaftLeaderDifferentFromPreferredTarget(t *testing.T) {
 	manager := &fakeSlotManager{}
 	writer := &recordingWriter{}
 	runtime := &fakeStatusReader{status: multiraft.Status{SlotID: 1, LeaderID: 2, CurrentVoters: []multiraft.NodeID{1, 2, 3}}}
@@ -170,25 +188,17 @@ func TestBootstrapExecutorTransfersObservedLeaderToTargetBeforeCompletion(t *tes
 	executor := NewBootstrapExecutor(BootstrapExecutorConfig{LocalNode: 2, Slots: manager, Runtime: runtime, Writer: writer})
 
 	if err := executor.Reconcile(context.Background(), snapshot); err != nil {
-		t.Fatalf("first Reconcile() error = %v", err)
+		t.Fatalf("Reconcile() error = %v", err)
 	}
-	if runtime.expectCalls != 1 || runtime.transferCalls != 1 || runtime.lastTarget != 1 {
-		t.Fatalf("runtime expect=%d transfer=%d target=%d, want 1/1/1", runtime.expectCalls, runtime.transferCalls, runtime.lastTarget)
-	}
-	if len(writer.completed) != 0 {
-		t.Fatalf("completed = %#v, want none before target leadership is observed", writer.completed)
-	}
-
-	runtime.status.LeaderID = 1
-	if err := executor.Reconcile(context.Background(), snapshot); err != nil {
-		t.Fatalf("second Reconcile() error = %v", err)
+	if runtime.expectCalls != 0 || runtime.transferCalls != 0 {
+		t.Fatalf("runtime expect=%d transfer=%d, want no bootstrap leader transfer", runtime.expectCalls, runtime.transferCalls)
 	}
 	if len(writer.completed) != 1 || writer.completed[0].TaskID != "slot-1-bootstrap-1" {
-		t.Fatalf("completed = %#v, want target-leader convergence completion", writer.completed)
+		t.Fatalf("completed = %#v, want Raft-leader convergence completion", writer.completed)
 	}
 }
 
-func TestBootstrapExecutorFollowerDoesNotTransferMismatchedLeader(t *testing.T) {
+func TestBootstrapExecutorFollowerAcceptsRaftLeaderDifferentFromPreferredTarget(t *testing.T) {
 	manager := &fakeSlotManager{}
 	writer := &recordingWriter{}
 	runtime := &fakeStatusReader{status: multiraft.Status{SlotID: 1, LeaderID: 2, CurrentVoters: []multiraft.NodeID{1, 2, 3}}}
@@ -201,11 +211,11 @@ func TestBootstrapExecutorFollowerDoesNotTransferMismatchedLeader(t *testing.T) 
 	if err := executor.Reconcile(context.Background(), snapshot); err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
-	if runtime.expectCalls != 1 || runtime.transferCalls != 0 {
-		t.Fatalf("runtime expect=%d transfer=%d, want follower expectation without transfer", runtime.expectCalls, runtime.transferCalls)
+	if runtime.expectCalls != 0 || runtime.transferCalls != 0 {
+		t.Fatalf("runtime expect=%d transfer=%d, want no bootstrap leader transfer", runtime.expectCalls, runtime.transferCalls)
 	}
-	if len(writer.completed) != 0 {
-		t.Fatalf("completed = %#v, want none while target leader is not observed", writer.completed)
+	if len(writer.completed) != 1 {
+		t.Fatalf("completed = %#v, want task completion under legal Raft leader", writer.completed)
 	}
 }
 

--- a/pkg/controller/state/types.go
+++ b/pkg/controller/state/types.go
@@ -231,7 +231,7 @@ type SlotAssignment struct {
 	DesiredPeers []uint64 `json:"desired_peers"`
 	// ConfigEpoch changes whenever the desired assignment changes.
 	ConfigEpoch uint64 `json:"config_epoch"`
-	// PreferredLeader is the desired leader node for this slot when non-zero.
+	// PreferredLeader is the voter preferred for the initial Slot Raft election.
 	PreferredLeader uint64 `json:"preferred_leader,omitempty"`
 }
 

--- a/pkg/plugin/pluginhost/socket_test.go
+++ b/pkg/plugin/pluginhost/socket_test.go
@@ -2,6 +2,7 @@ package pluginhost
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -118,13 +119,6 @@ func TestWaitUnixSocketReadyCompletesConnackHandshake(t *testing.T) {
 
 	serveDone := make(chan error, 1)
 	go func() {
-		conn, err := listener.Accept()
-		if err != nil {
-			serveDone <- err
-			return
-		}
-		defer func() { _ = conn.Close() }()
-
 		body, err := (&wkrpcproto.Connack{Id: 1, Status: wkrpcproto.StatusOK}).Marshal()
 		if err != nil {
 			serveDone <- err
@@ -135,11 +129,23 @@ func TestWaitUnixSocketReadyCompletesConnackHandshake(t *testing.T) {
 			serveDone <- err
 			return
 		}
-		_, err = conn.Write(packet)
-		serveDone <- err
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					serveDone <- nil
+				} else {
+					serveDone <- err
+				}
+				return
+			}
+			_, _ = conn.Write(packet)
+			_ = conn.Close()
+		}
 	}()
 
 	require.NoError(t, waitUnixSocketReady(socketPath, time.Second))
+	require.NoError(t, listener.Close())
 	select {
 	case err := <-serveDone:
 		require.NoError(t, err)

--- a/pkg/slot/multiraft/api.go
+++ b/pkg/slot/multiraft/api.go
@@ -3,6 +3,7 @@ package multiraft
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 
 	raft "go.etcd.io/raft/v3"
@@ -77,6 +78,9 @@ func (r *Runtime) BootstrapSlot(ctx context.Context, req BootstrapSlotRequest) e
 	if err := validateSlotOptions(req.Slot); err != nil {
 		return err
 	}
+	if req.Campaign && !containsNodeID(req.Voters, r.opts.NodeID) {
+		return fmt.Errorf("%w: local campaign node %d is not an initial voter", ErrInvalidOptions, r.opts.NodeID)
+	}
 
 	g, err := newSlot(ctx, r.opts.NodeID, r.opts.Logger, r.opts.Raft, req.Slot, r.opts.Observer, r.apply)
 	if err != nil {
@@ -103,7 +107,7 @@ func (r *Runtime) BootstrapSlot(ctx context.Context, req BootstrapSlotRequest) e
 			r.mu.Unlock()
 			return err
 		}
-		if len(req.Voters) == 1 && req.Voters[0] == r.opts.NodeID {
+		if req.Campaign || (len(req.Voters) == 1 && req.Voters[0] == r.opts.NodeID) {
 			g.requestCampaignAfterReady()
 		}
 	}
@@ -111,6 +115,15 @@ func (r *Runtime) BootstrapSlot(ctx context.Context, req BootstrapSlotRequest) e
 
 	r.scheduler.enqueue(req.Slot.ID)
 	return nil
+}
+
+func containsNodeID(nodeIDs []NodeID, target NodeID) bool {
+	for _, nodeID := range nodeIDs {
+		if nodeID == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Runtime) CloseSlot(ctx context.Context, slotID SlotID) error {

--- a/pkg/slot/multiraft/control_test.go
+++ b/pkg/slot/multiraft/control_test.go
@@ -60,6 +60,52 @@ func TestExpectLeaderTransferRejectsUnknownSlot(t *testing.T) {
 	}
 }
 
+func TestBootstrapSlotCampaignsAfterInitialMembershipIsReady(t *testing.T) {
+	transport := &recordingTransport{}
+	rt, err := New(Options{
+		NodeID:       1,
+		TickInterval: time.Hour,
+		Workers:      1,
+		Transport:    transport,
+		Raft: RaftOptions{
+			ElectionTick:  10,
+			HeartbeatTick: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rt.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	if err := rt.BootstrapSlot(context.Background(), BootstrapSlotRequest{
+		Slot:     newInternalSlotOptions(100),
+		Voters:   []NodeID{1, 2, 3},
+		Campaign: true,
+	}); err != nil {
+		t.Fatalf("BootstrapSlot() error = %v", err)
+	}
+
+	waitForCondition(t, func() bool {
+		return transport.countMessagesOfType(raftpb.MsgVote) > 0
+	})
+}
+
+func TestBootstrapSlotRejectsCampaignFromNonVoter(t *testing.T) {
+	rt := newStartedRuntimeWithTick(t, time.Hour)
+	err := rt.BootstrapSlot(context.Background(), BootstrapSlotRequest{
+		Slot:     newInternalSlotOptions(101),
+		Voters:   []NodeID{2, 3},
+		Campaign: true,
+	})
+	if !errors.Is(err, ErrInvalidOptions) {
+		t.Fatalf("BootstrapSlot() error = %v, want %v", err, ErrInvalidOptions)
+	}
+}
+
 func TestSelectLeaderTransferTransfereePrefersEligiblePreferred(t *testing.T) {
 	st := raft.Status{
 		BasicStatus: raft.BasicStatus{

--- a/pkg/slot/multiraft/types.go
+++ b/pkg/slot/multiraft/types.go
@@ -137,8 +137,11 @@ type SlotOptions struct {
 }
 
 type BootstrapSlotRequest struct {
-	Slot   SlotOptions
+	Slot SlotOptions
+	// Voters is the initial Raft voter set installed on every replica.
 	Voters []NodeID
+	// Campaign asks this local voter to campaign after the initial membership is durably applied.
+	Campaign bool
 }
 
 type Envelope struct {


### PR DESCRIPTION
## Summary

- let the preferred Slot voter campaign immediately after initial membership is durably applied
- keep the actual Raft-elected leader authoritative and stop forcing a post-bootstrap transfer
- make the Unix socket readiness test server honor the production retry contract
- align cluster flow and project knowledge documentation

## Root cause

Slot bootstrap ignored PreferredLeader during the initial Raft election, then the bootstrap executor forced leadership to Task.TargetNode after another voter had already won. Foreground writes could race that post-election transfer and fail with not-leader or dropped-proposal errors. The plugin readiness test accepted only one probe connection even though production readiness intentionally retries with new connections.

## Validation

- focused Slot, task, Multi-Raft, and pluginhost package tests
- original two failing Cluster tests repeated 20 times
- Unix socket Connack readiness test repeated 200 times
- full explicit repository unit gate: GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1