### PR TITLE
Fix cloud bootstrap leader health gate

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -220,6 +220,7 @@
 - Cloud Simulation cleanup reconstructs temporary ingress deadlines from provider security rules; sweeps preserve unexpired local Analysis Windows and close expired, malformed, or duplicate windows.
 - Cloud Simulation normal completion uses a non-diagnostic Finalization Schedule plus local `finalize.sh`: retry an explicit in-progress workload while the lease permits, run exact cleanup even after diagnosis/remediation failure, then require structured provider-confirmed empty inventory.
 - Cloud Simulation stability topology uses 256 physical hash slots mapped to 10 logical Slot Raft Groups; bootstrap gates both values separately.
+- Cloud Simulation Bootstrap Gate accepts a non-zero actual Slot Raft leader that belongs to the current voter set when quorum and peer sync are healthy; `PreferredLeader` mismatch is placement evidence, not a health failure.
 - Standard Cloud Simulation verdicts require a 48h/168h reviewed small, medium, or large profile plus empirical 30m storage calibration; shorter durations are diagnostic evidence only.
 - Any node OOM increment or WuKongIM process start-time change during a Cloud Simulation run invalidates performance and storage calibration; use an intentional phase-boundary profiling rerun for root-cause isolation, then a separate passive calibration after remediation.
 - Phase-ending process loss may occur after the last coarse scrape; query at 5-second steps through 90 seconds after the phase end, and compare heap `inuse_space` with `alloc_space` so transient allocation spikes are not mistaken for retained memory.

--- a/internal/infra/cloudsim/deploy/gate.go
+++ b/internal/infra/cloudsim/deploy/gate.go
@@ -18,7 +18,8 @@ type BootstrapSnapshot struct {
 	HashSlotCount int `json:"hash_slot_count"`
 	// SlotGroupCount is the number of logical Slot Raft Groups that own hash slots.
 	SlotGroupCount int `json:"slot_group_count"`
-	// HealthySlotLeaders is the count of slots with a healthy current leader.
+	// HealthySlotLeaders is the count of slots whose actual leader is a current voter with ready quorum and matched peers.
+	// A PreferredLeader mismatch is observable placement drift, not a Raft health failure.
 	HealthySlotLeaders int `json:"healthy_slot_leaders"`
 	// HealthySlotReplicas is the count of slots with the required voter set.
 	HealthySlotReplicas int `json:"healthy_slot_replicas"`

--- a/internal/usecase/cloudsim/FLOW.md
+++ b/internal/usecase/cloudsim/FLOW.md
@@ -40,7 +40,12 @@ the resulting size into the provider config before quote and creation. Large
 
 The immutable node bundle configures 256 physical hash slots owned by 10
 logical Slot Raft Groups. Bootstrap evidence records and gates both counts; the
-healthy leader/replica totals remain aggregated across all 256 hash slots.
+healthy leader/replica totals remain aggregated across all 256 hash slots. A
+healthy Slot leader is the non-zero actual Raft leader contained in the current
+voter set while quorum is ready and runtime peers match the assignment.
+`PreferredLeader` mismatch remains observable placement drift and is not a
+Bootstrap Gate failure because Raft eligibility and the elected leader are
+authoritative.
 Prometheus uses a 15-second interval with 72h retention for runs through 48h
 and 192h retention for 168h.
 

--- a/scripts/cloud-sim/bootstrap-slot-health.jq
+++ b/scripts/cloud-sim/bootstrap-slot-health.jq
@@ -1,0 +1,18 @@
+def has_legal_leader:
+  (.runtime.leader_id // 0) as $leader_id
+  | ($leader_id != 0 and ((.runtime.current_voters // []) | index($leader_id)) != null);
+
+{
+  healthy_slot_leaders: (
+    [.items[]
+      | select(.state.quorum == "ready" and .state.sync == "matched" and has_legal_leader)
+      | (.hash_slots.count // 0)]
+    | add // 0
+  ),
+  healthy_slot_replicas: (
+    [.items[]
+      | select(.state.quorum == "ready" and .state.sync == "matched" and ((.runtime.current_voters // []) | length) == 3)
+      | (.hash_slots.count // 0)]
+    | add // 0
+  )
+}

--- a/scripts/cloud-sim/collect-bootstrap-gate.sh
+++ b/scripts/cloud-sim/collect-bootstrap-gate.sh
@@ -99,8 +99,9 @@ tasks_json="$(ssh_sim "curl --fail --silent --show-error --max-time 10 -H 'Autho
 member_count="$(jq -er '[.items[] | select(.membership.join_state == "active" and .health.runtime_ready == true)] | length' <<<"$nodes_json")"
 slot_group_count="$(jq -er '.items | length' <<<"$slots_json")"
 hash_slot_count="$(jq -er '[.items[].hash_slots.count // 0] | add // 0' <<<"$slots_json")"
-healthy_slot_leaders="$(jq -er '[.items[] | select(.state.quorum == "ready" and .state.sync == "matched" and .state.leader_match == true) | .hash_slots.count // 0] | add // 0' <<<"$slots_json")"
-healthy_slot_replicas="$(jq -er '[.items[] | select(.state.quorum == "ready" and .state.sync == "matched" and (.runtime.current_voters | length) == 3) | .hash_slots.count // 0] | add // 0' <<<"$slots_json")"
+slot_health="$(jq -cer -f "$(dirname "$0")/bootstrap-slot-health.jq" <<<"$slots_json")"
+healthy_slot_leaders="$(jq -er '.healthy_slot_leaders' <<<"$slot_health")"
+healthy_slot_replicas="$(jq -er '.healthy_slot_replicas' <<<"$slot_health")"
 pending_tasks="$(jq -er '.total' <<<"$tasks_json")"
 
 prometheus_targets="$(ssh_sim "curl --fail --silent --show-error --max-time 10 'http://127.0.0.1:9090/api/v1/targets?state=active'")"

--- a/scripts/cloud_sim_bootstrap_gate_test.go
+++ b/scripts/cloud_sim_bootstrap_gate_test.go
@@ -1,0 +1,77 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCloudSimulationBootstrapSlotHealthUsesLegalActualLeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantLeaders  int
+		wantReplicas int
+	}{
+		{
+			name: "preferred mismatch remains healthy when actual leader is a voter",
+			input: `{"items":[
+				{"hash_slots":{"count":128},"state":{"quorum":"ready","sync":"matched","leader_match":true},"runtime":{"leader_id":1,"current_voters":[1,2,3]}},
+				{"hash_slots":{"count":128},"state":{"quorum":"ready","sync":"matched","leader_match":false},"runtime":{"leader_id":2,"current_voters":[1,2,3]}}
+			]}`,
+			wantLeaders:  256,
+			wantReplicas: 256,
+		},
+		{
+			name: "missing or non-voter leader is unhealthy",
+			input: `{"items":[
+				{"hash_slots":{"count":64},"state":{"quorum":"ready","sync":"matched"},"runtime":{"leader_id":0,"current_voters":[1,2,3]}},
+				{"hash_slots":{"count":64},"state":{"quorum":"ready","sync":"matched"},"runtime":{"leader_id":4,"current_voters":[1,2,3]}},
+				{"hash_slots":{"count":64},"state":{"quorum":"quorum_lost","sync":"matched"},"runtime":{"leader_id":1,"current_voters":[1,2,3]}},
+				{"hash_slots":{"count":64},"state":{"quorum":"ready","sync":"peer_mismatch"},"runtime":{"leader_id":1,"current_voters":[1,2,3]}}
+			]}`,
+			wantLeaders:  0,
+			wantReplicas: 128,
+		},
+	}
+
+	program := filepath.Join(repoRoot(t), "scripts", "cloud-sim", "bootstrap-slot-health.jq")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.Command("jq", "-c", "-f", program)
+			command.Stdin = strings.NewReader(test.input)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("evaluate slot health: %v\n%s", err, output)
+			}
+			var got struct {
+				HealthySlotLeaders  int `json:"healthy_slot_leaders"`
+				HealthySlotReplicas int `json:"healthy_slot_replicas"`
+			}
+			if err := json.Unmarshal(output, &got); err != nil {
+				t.Fatalf("decode slot health: %v\n%s", err, output)
+			}
+			if got.HealthySlotLeaders != test.wantLeaders || got.HealthySlotReplicas != test.wantReplicas {
+				t.Fatalf("slot health = leaders %d, replicas %d; want leaders %d, replicas %d", got.HealthySlotLeaders, got.HealthySlotReplicas, test.wantLeaders, test.wantReplicas)
+			}
+		})
+	}
+}
+
+func TestCloudSimulationBootstrapCollectorDoesNotGatePreferredLeaderMatch(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "scripts", "cloud-sim", "collect-bootstrap-gate.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, `bootstrap-slot-health.jq`) {
+		t.Fatal("Bootstrap Gate collector does not use the tested Slot health evaluator")
+	}
+	if strings.Contains(text, `leader_match == true`) {
+		t.Fatal("Bootstrap Gate still treats PreferredLeader match as a hard health invariant")
+	}
+}


### PR DESCRIPTION
## What changed

- evaluate Slot leader health from the actual Raft leader and current voter set
- keep PreferredLeader mismatch as observable placement drift instead of a Bootstrap Gate failure
- add executable jq fixtures covering preferred mismatch, missing leaders, and non-voter leaders
- document the Gate invariant in FLOW and project knowledge

## Root cause

The cloud Bootstrap Gate counted a Slot group as healthy only when the actual Raft leader equaled PreferredLeader. After a legal fallback election, quorum, peer sync, and all three voters were healthy, but 128 of 256 hash slots were rejected solely because leader_match was false. This contradicted the Raft contract: PreferredLeader influences an eligible election, while the actual elected voter remains authoritative.

## Impact

Cloud Simulation can proceed when every Slot group has ready quorum, matched peers, three voters, and a non-zero actual leader in the voter set. Missing leaders and leaders outside the voter set still fail closed.

## Validation

- bash -n scripts/cloud-sim/collect-bootstrap-gate.sh
- GOWORK=off go test ./scripts -run TestCloudSimulationBootstrap -count=1
- GOWORK=off go test ./internal/infra/cloudsim/deploy -run TestBootstrapGate -count=1
- LC_ALL=C LANG=C GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1