### PR TITLE
fix: isolate SEND from post-commit pressure

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -21,6 +21,8 @@
 - `internal` presence stores owner-local `OwnerRoute` projections for authority/touch; concrete gateway session handles must stay out of authority routes and live only in owner-local session records used for conflict close actions.
 - `internal/runtime/delivery` is the no-gateway/no-cluster benchmark boundary for online fanout, owner push batching, and recipient-owner recvack tracking.
 - `internal` webhook delivery is a node-local best-effort post-commit side effect with bounded queues and finite retry. Large offline fanout should use batch observer/chunking, and webhook failure must not affect SENDACK, durable append, conversation active admission, or owner delivery.
+- Channelappend post-commit pool admission and per-channel backlog must stay bounded and independent from foreground append admission; saturation is observed and dropped so best-effort conversation/delivery work cannot pin writer-advance workers, delay durable SEND/SENDACK, or return `ErrChannelBusy` for an otherwise admissible send.
+- Conversation-active cache churn must evict clean rows before entering the serialized dirty-flush lane; a full clean cache must not turn every new-channel admission into a global flush-lane operation.
 
 ## Gateway Runtime
 

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -389,6 +389,13 @@ count with a minimum of four. `ChannelAppend.AdvancePoolSize` is the direct ants
 pool capacity used to activate channelappend writer state machines.
 `ChannelAppend.EffectPoolSize` is the direct ants pool capacity used separately
 by foreground channelappend append effects and post-append recipient effects.
+The post-append pool uses non-blocking saturated admission and drops the
+already-best-effort effect through the scheduler-failure observation instead of
+blocking a channel writer advance worker; the foreground append pool keeps its
+blocking worker admission semantics. Each channel also keeps the post-commit
+backlog separately bounded from foreground append admission; a full side-effect
+backlog records and drops the newest already-durable envelope without returning
+`ErrChannelBusy` to a later SEND.
 Prepare runs inline on the writer advance path; append remains the foreground
 durable path that determines SEND/SENDACK throughput.
 `ChannelAppend.RecipientAuthorityDispatchConcurrency` defaults to a bounded

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -198,9 +198,11 @@ sampled recipient, target, and dispatch context so route-resolution failures
 can be distinguished from conversation active admission and delivery enqueue
 failures in logs. Each channel keeps only one committed envelope in flight at a
 time, and concurrency inside that envelope is limited to recipient authority
-targets. Unprocessed and in-flight commit backlog still participates in the
-channel high-watermark, but failed best-effort work is dropped promptly to
-avoid retaining unbounded payloads.
+targets. Foreground append admission and the post-commit backlog use separate
+bounds derived from `ChannelBacklogHighWatermark`. When the best-effort bound
+is full, the newest already-durable envelope is reported as an admission-phase
+post-commit failure and dropped; it never turns a later foreground SEND into
+`ErrChannelBusy`.
 
 When a PersistAfter enqueuer is configured, each successful durable committed
 envelope is cloned into the configured side-effect sinks from the same
@@ -296,8 +298,11 @@ Pending append, append in-flight, and post-commit backlog counters are updated
 by the writer as items move between queues. Append effects run on a foreground
 append pool, while post-commit and realtime recipient effects run on an
 isolated post-commit pool so best-effort side effects cannot occupy durable
-append workers. The writer pressure observer reports the local writer group
-aggregate rather than a per-channel event loop. When the observer supports ants
+append workers. Post-commit pool admission is bounded and non-blocking: a full
+pool produces the normal scheduler failure observation and drops that committed
+envelope, so saturated best-effort work cannot pin writer-advance workers or
+delay later durable appends. The writer pressure observer reports the local
+writer group aggregate rather than a per-channel event loop. When the observer supports ants
 pool samples, the group also emits direct ants/v2 running/capacity/waiting
 observations for the advance, append_effect, and post_commit pools; benchmark
 scripts use these samples for the per-node peak `used/cap` ants pool summary.

--- a/internal/runtime/channelappend/commit.go
+++ b/internal/runtime/channelappend/commit.go
@@ -113,6 +113,13 @@ func commitScheduleErrorCompletion(effect commitEffect, scheduleErr error) commi
 	return commitErrorCompletion(effect, effectScheduleError(effectStagePostCommit, scheduleErr), PostCommitFailureDetail{Phase: "scheduler"})
 }
 
+// postCommitAdmissionFailure records an already-durable envelope that could
+// not enter the separately bounded best-effort backlog.
+func postCommitAdmissionFailure(event CommittedEnvelope) PostCommitFailureObservation {
+	err := fmt.Errorf("%w: post-commit backlog admission: %w", ErrCommitEffectFailed, ErrBackpressured)
+	return PostCommitFailureDetail{Phase: "admission"}.toObservation(event, 0, errorClass(err), err)
+}
+
 func commitErrorCompletion(effect commitEffect, err error, detail PostCommitFailureDetail) commitCompletedEvent {
 	completion := commitCompletedEvent{
 		key:     effect.key,

--- a/internal/runtime/channelappend/commit_test.go
+++ b/internal/runtime/channelappend/commit_test.go
@@ -510,13 +510,15 @@ func TestLargeGroupSubscribersRemainPagedPerCommittedMessage(t *testing.T) {
 	}
 }
 
-func TestBlockedCommitBacklogBackpressuresLaterSubmit(t *testing.T) {
+func TestBlockedCommitBacklogDropsBestEffortWorkWithoutBackpressuringLaterSubmit(t *testing.T) {
 	enqueuer := newBlockingRecipientDeliveryEnqueuerForCommitTest()
 	t.Cleanup(enqueuer.release)
+	observer := &recordingPostCommitFailureObserverForTest{}
 	group := newStartedTestGroup(t, Options{
 		LocalNodeID:                 1,
 		MessageID:                   newSequenceIDsForPrepare(1200),
 		Appender:                    newRecordingAppenderForAppendTest(),
+		Observer:                    observer,
 		RecipientAuthorityResolver:  staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
 		RecipientDeliveryEnqueuer:   enqueuer,
 		RecipientBatchSize:          16,
@@ -539,9 +541,16 @@ func TestBlockedCommitBacklogBackpressuresLaterSubmit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second SubmitLocal() error = %v", err)
 	}
-	results := waitFutureForTest(t, secondFuture)
-	if !errors.Is(results[0].Err, ErrChannelBusy) {
-		t.Fatalf("second result error = %v, want ErrChannelBusy from commit backlog pressure", results[0].Err)
+	requireAppendSuccess(t, waitFutureForTest(t, secondFuture), 0, 1201, 2)
+	observer.waitFailures(t, 1)
+	observer.mu.Lock()
+	failure := observer.failures[0]
+	observer.mu.Unlock()
+	if failure.MessageID != 1201 || failure.Phase != "admission" || failure.Result != channelAppendResultBackpressured {
+		t.Fatalf("post-commit failure = %#v, want bounded admission drop for message 1201", failure)
+	}
+	if calls := enqueuer.callCount(); calls != 1 {
+		t.Fatalf("recipient delivery calls = %d, want only the already in-flight post-commit effect", calls)
 	}
 }
 

--- a/internal/runtime/channelappend/group.go
+++ b/internal/runtime/channelappend/group.go
@@ -37,7 +37,7 @@ func New(opts Options) *Group {
 	limits := stateLimitsFromOptions(opts)
 	advancePool := newWorkerPool(opts.AdvancePoolSize)
 	appendPool := newWorkerPool(opts.EffectPoolSize)
-	postCommitPool := newWorkerPool(opts.EffectPoolSize)
+	postCommitPool := newNonblockingWorkerPool(opts.EffectPoolSize)
 	runtimeCtx, runtimeCancel := context.WithCancel(context.Background())
 	group := &Group{
 		opts:           opts,

--- a/internal/runtime/channelappend/options.go
+++ b/internal/runtime/channelappend/options.go
@@ -368,7 +368,7 @@ type Options struct {
 	AdvancePoolSize int
 	// AdmissionCapacityPerShard bounds admitted-but-incomplete items per shard. Values <= 0 use a conservative bounded default.
 	AdmissionCapacityPerShard int
-	// ChannelBacklogHighWatermark is reserved for per-channel admission pressure. Values <= 0 use a bounded default.
+	// ChannelBacklogHighWatermark independently bounds per-channel foreground append admission and best-effort post-commit backlog. Values <= 0 use a bounded default.
 	ChannelBacklogHighWatermark int
 	// AppendInflightBatchesPerChannel bounds same-channel append batches in flight. Values <= 0 use the runtime default.
 	AppendInflightBatchesPerChannel int
@@ -493,7 +493,8 @@ func commitPortsFromOptions(opts Options) commitPorts {
 
 func stateLimitsFromOptions(opts Options) channelStateLimits {
 	return channelStateLimits{
-		pendingItemHighWatermark: opts.ChannelBacklogHighWatermark,
-		appendInflightLimit:      opts.AppendInflightBatchesPerChannel,
+		pendingItemHighWatermark:       opts.ChannelBacklogHighWatermark,
+		postCommitBacklogHighWatermark: opts.ChannelBacklogHighWatermark,
+		appendInflightLimit:            opts.AppendInflightBatchesPerChannel,
 	}
 }

--- a/internal/runtime/channelappend/pool.go
+++ b/internal/runtime/channelappend/pool.go
@@ -12,10 +12,20 @@ type workerPool struct {
 }
 
 func newWorkerPool(size int) *workerPool {
+	return newWorkerPoolWithAdmission(size, false)
+}
+
+// newNonblockingWorkerPool creates a bounded pool whose saturated admission
+// returns an error instead of pinning the caller until a worker becomes free.
+func newNonblockingWorkerPool(size int) *workerPool {
+	return newWorkerPoolWithAdmission(size, true)
+}
+
+func newWorkerPoolWithAdmission(size int, nonblocking bool) *workerPool {
 	if size <= 0 {
 		size = 1
 	}
-	pool, err := ants.NewPool(size, ants.WithNonblocking(false), ants.WithDisablePurge(true))
+	pool, err := ants.NewPool(size, ants.WithNonblocking(nonblocking), ants.WithDisablePurge(true))
 	if err != nil {
 		panic("channelappend: create worker pool: " + err.Error())
 	}

--- a/internal/runtime/channelappend/pressure_test.go
+++ b/internal/runtime/channelappend/pressure_test.go
@@ -150,6 +150,59 @@ func TestPostCommitEffectDoesNotBlockDurableAppendPool(t *testing.T) {
 	waitCommitBacklogForTest(t, group, postCommitTarget.ChannelID, 0)
 }
 
+func TestPostCommitSaturationDoesNotBlockForegroundAppend(t *testing.T) {
+	delivery := newBlockingRecipientDeliveryEnqueuerForCommitTest()
+	group := newStartedTestGroup(t, Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(10),
+		Appender:                   newRecordingAppenderForAppendTest(),
+		AdvancePoolSize:            1,
+		EffectPoolSize:             1,
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  delivery,
+		RecipientBatchSize:         16,
+	})
+	t.Cleanup(delivery.release)
+
+	firstTarget := localTargetForAppendTest("post-commit-first")
+	firstItem := appendSendItemForTest("u1", firstTarget.ChannelID.ID, "first")
+	firstItem.Command.MessageScopedUIDs = []string{"u2"}
+	first, err := group.SubmitLocal(context.Background(), firstTarget, []SendBatchItem{firstItem})
+	if err != nil {
+		t.Fatalf("SubmitLocal(first) error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, first), 0, 10, 1)
+	delivery.waitStarted(t)
+
+	secondTarget := localTargetForAppendTest("post-commit-second")
+	secondItem := appendSendItemForTest("u1", secondTarget.ChannelID.ID, "second")
+	secondItem.Command.MessageScopedUIDs = []string{"u2"}
+	second, err := group.SubmitLocal(context.Background(), secondTarget, []SendBatchItem{secondItem})
+	if err != nil {
+		t.Fatalf("SubmitLocal(second) error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, second), 0, 11, 2)
+
+	deadline := time.Now().Add(time.Second)
+	for group.postCommitPool.waiting() == 0 && commitBacklogForTest(group, secondTarget.ChannelID) > 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("second post-commit effect neither waited nor completed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	foregroundTarget := localTargetForAppendTest("foreground")
+	foregroundItem := appendSendItemForTest("u1", foregroundTarget.ChannelID.ID, "foreground")
+	foregroundItem.Command.MessageScopedUIDs = []string{"u2"}
+	foregroundResult := receiveSubmitResult(t, submitNoWaitForAppendTest(group, foregroundTarget, foregroundItem))
+	if foregroundResult.err != nil {
+		t.Fatalf("SubmitLocal(foreground) error = %v", foregroundResult.err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, foregroundResult.future), 0, 12, 3)
+	waitCommitBacklogForTest(t, group, secondTarget.ChannelID, 0)
+	waitCommitBacklogForTest(t, group, foregroundTarget.ChannelID, 0)
+}
+
 func TestGroupDisablesWriterPressureMetricsWithoutObserver(t *testing.T) {
 	group := New(Options{
 		LocalNodeID:         1,

--- a/internal/runtime/channelappend/state.go
+++ b/internal/runtime/channelappend/state.go
@@ -9,13 +9,14 @@ const (
 type channelState struct {
 	target AuthorityTarget
 
-	pendingItemHighWatermark int
-	appendInflightLimit      int
-	pendingItems             []preparedSend
-	appendInflight           int
-	appendInflightItems      int
-	nextAppendSeq            uint64
-	nextAppendDrainSeq       uint64
+	pendingItemHighWatermark       int
+	postCommitBacklogHighWatermark int
+	appendInflightLimit            int
+	pendingItems                   []preparedSend
+	appendInflight                 int
+	appendInflightItems            int
+	nextAppendSeq                  uint64
+	nextAppendDrainSeq             uint64
 	// readyAppendCompletion stores the next in-order append completion without allocating the out-of-order map.
 	readyAppendCompletion appendCompletedEvent
 	// hasReadyAppendCompletion reports whether readyAppendCompletion is populated.
@@ -33,8 +34,9 @@ type channelState struct {
 }
 
 type channelStateLimits struct {
-	pendingItemHighWatermark int
-	appendInflightLimit      int
+	pendingItemHighWatermark       int
+	postCommitBacklogHighWatermark int
+	appendInflightLimit            int
 }
 
 // subscriberCache is a versioned non-large channel subscriber snapshot.
@@ -49,9 +51,10 @@ type subscriberCache struct {
 
 func newChannelState(target AuthorityTarget, limits channelStateLimits) *channelState {
 	return &channelState{
-		target:                   target,
-		pendingItemHighWatermark: limits.pendingItemHighWatermark,
-		appendInflightLimit:      limits.appendInflightLimit,
+		target:                         target,
+		pendingItemHighWatermark:       limits.pendingItemHighWatermark,
+		postCommitBacklogHighWatermark: limits.postCommitBacklogHighWatermark,
+		appendInflightLimit:            limits.appendInflightLimit,
 	}
 }
 
@@ -119,7 +122,7 @@ func (s *channelState) canAdmit(count int) bool {
 	if s.pendingItemHighWatermark <= 0 {
 		return true
 	}
-	return len(s.pendingItems)+s.appendInflightItems+s.commitBacklog()+count <= s.pendingItemHighWatermark
+	return len(s.pendingItems)+s.appendInflightItems+count <= s.pendingItemHighWatermark
 }
 
 func (s *channelState) nextAppendBatch() (uint64, []preparedSend, bool) {
@@ -197,8 +200,15 @@ func (s *channelState) popNextAppendCompletion() (appendCompletedEvent, bool) {
 	return event, true
 }
 
-func (s *channelState) enqueueCommitted(event CommittedEnvelope) {
+// enqueueCommitted admits best-effort post-commit work through a bound that is
+// independent from foreground append admission. A saturated side-effect lane
+// drops the newest envelope instead of rejecting a durable SEND.
+func (s *channelState) enqueueCommitted(event CommittedEnvelope) bool {
+	if s.postCommitBacklogHighWatermark > 0 && s.commitBacklog() >= s.postCommitBacklogHighWatermark {
+		return false
+	}
 	s.committed = append(s.committed, event)
+	return true
 }
 
 func (s *channelState) nextCommitEffect(key string, out *commitEffect) bool {

--- a/internal/runtime/channelappend/state_test.go
+++ b/internal/runtime/channelappend/state_test.go
@@ -12,8 +12,9 @@ func TestNewChannelStateCapturesAuthorityIdentityAndLimits(t *testing.T) {
 	}
 
 	state := newChannelState(target, channelStateLimits{
-		pendingItemHighWatermark: 8,
-		appendInflightLimit:      2,
+		pendingItemHighWatermark:       8,
+		postCommitBacklogHighWatermark: 8,
+		appendInflightLimit:            2,
 	})
 
 	if state.target != target {
@@ -21,6 +22,9 @@ func TestNewChannelStateCapturesAuthorityIdentityAndLimits(t *testing.T) {
 	}
 	if state.pendingItemHighWatermark != 8 {
 		t.Fatalf("pendingItemHighWatermark = %d, want 8", state.pendingItemHighWatermark)
+	}
+	if state.postCommitBacklogHighWatermark != 8 {
+		t.Fatalf("postCommitBacklogHighWatermark = %d, want 8", state.postCommitBacklogHighWatermark)
 	}
 	if state.appendInflightLimit != 2 {
 		t.Fatalf("appendInflightLimit = %d, want 2", state.appendInflightLimit)

--- a/internal/runtime/channelappend/writer.go
+++ b/internal/runtime/channelappend/writer.go
@@ -399,6 +399,7 @@ func (w *channelWriter) runRealtimeDispatch(dispatch realtimeDispatch) {
 
 func (w *channelWriter) applyAppendCompletion(event appendCompletedEvent) {
 	var dispatch []appendCompletionDispatchItem
+	var postCommitFailures []PostCommitFailureObservation
 	w.mu.Lock()
 	w.state.recordAppendCompletion(event)
 	for {
@@ -414,14 +415,26 @@ func (w *channelWriter) applyAppendCompletion(event appendCompletedEvent) {
 				completion.traceErr == nil &&
 				completion.result.Err == nil &&
 				completion.result.Result.Reason == ReasonSuccess {
-				w.state.enqueueCommitted(committedEnvelopeForAppend(completion.item, completion.appended))
-				w.ports.metrics.addPostCommitBacklog(1)
+				envelope := committedEnvelopeForAppend(completion.item, completion.appended)
+				if w.state.enqueueCommitted(envelope) {
+					w.ports.metrics.addPostCommitBacklog(1)
+				} else {
+					postCommitFailures = append(postCommitFailures, postCommitAdmissionFailure(envelope))
+				}
 			}
 			dispatch = append(dispatch, appendCompletionDispatchItem{completion: completion, duration: next.duration})
 		}
 	}
 	w.ports.metrics.observePressure()
 	w.mu.Unlock()
+	for _, failure := range postCommitFailures {
+		observeEffect(w.ports.append.observer, EffectObservation{
+			Stage:  effectStagePostCommit,
+			Result: failure.Result,
+			Items:  1,
+		})
+		observePostCommitFailure(w.ports.append.observer, failure)
+	}
 	for _, item := range dispatch {
 		w.dispatchAppendItemCompletion(item.completion, item.duration)
 	}
@@ -450,11 +463,14 @@ func (w *channelWriter) nextCommitLocked(out *commitEffect) bool {
 
 func (w *channelWriter) runCommit(effect *commitEffect) {
 	snapshot := *effect
-	_ = w.ports.postCommitPool.submit(func() {
+	if err := w.ports.postCommitPool.submit(func() {
 		completion := snapshot.run(w.ports.runtimeCtx, w.ports.commit)
 		w.applyCommitCompletion(completion)
 		w.rescheduleIfNeeded()
-	})
+	}); err != nil {
+		w.applyCommitCompletion(commitScheduleErrorCompletion(snapshot, err))
+		w.rescheduleIfNeeded()
+	}
 }
 
 func (w *channelWriter) applyCommitCompletion(event commitCompletedEvent) {

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -10,8 +10,9 @@ Current flow:
 2. The manager merges rows by `(uid, kind, channel_id, channel_type)`.
 3. Dirty flushes are serialized from cache snapshot through durable completion,
    then write through `ActiveStore.TouchConversationActiveAt`.
-4. Cache-pressure admission rechecks capacity after it owns the flush lane, flushes
-   dirty rows, and evicts only clean rows before retrying admission.
+4. Cache-pressure admission first evicts already-clean rows while holding the
+   cache lock. Only an insufficient clean working set enters the serialized
+   flush lane to persist dirty rows before retrying admission.
 5. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
 6. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
 

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -174,6 +174,14 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 	for {
 		m.mu.Lock()
 		newRows := m.countNewRowsLocked(patches)
+		if m.cacheWouldExceedLocked(newRows) {
+			if newRows > m.maxCachedRows {
+				m.mu.Unlock()
+				return ErrCachePressure
+			}
+			over := m.totalRows + newRows - m.maxCachedRows
+			m.evictCleanRowsLocked(over)
+		}
 		if !m.cacheWouldExceedLocked(newRows) {
 			for _, patch := range patches {
 				if patch.UID == "" {
@@ -184,10 +192,6 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 			m.mu.Unlock()
 			m.observeCache()
 			return nil
-		}
-		if newRows > m.maxCachedRows {
-			m.mu.Unlock()
-			return ErrCachePressure
 		}
 		m.mu.Unlock()
 

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -899,6 +899,51 @@ func TestAdmitUnderCachePressureSpillsDirtyRows(t *testing.T) {
 	}
 }
 
+func TestAdmitUnderCachePressureEvictsCleanRowsWithoutFlush(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingActiveStore{}
+	observer := &recordingConversationActiveObserver{}
+	m := NewManager(Options{Store: store, MaxCachedRows: 2, Observer: observer})
+	if err := m.MarkActive(ctx, []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "old-1", ChannelType: 2, ActiveAtMS: 1000},
+		{Kind: metadb.ConversationKindNormal, UID: "u2", ChannelID: "old-2", ChannelType: 2, ActiveAtMS: 1000},
+	}); err != nil {
+		t.Fatalf("MarkActive(old) error = %v", err)
+	}
+	if _, err := m.Flush(ctx, 0); err != nil {
+		t.Fatalf("Flush(old) error = %v", err)
+	}
+	flushObservations := len(observer.flush)
+	store.touches = nil
+
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u3",
+		ChannelID:   "new",
+		ChannelType: 2,
+		ActiveAtMS:  2000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(new) error = %v", err)
+	}
+
+	if len(observer.flush) != flushObservations {
+		t.Fatalf("flush observations = %d, want unchanged %d when clean rows can be evicted", len(observer.flush), flushObservations)
+	}
+	if len(store.touches) != 0 {
+		t.Fatalf("touches = %+v, want no durable flush for clean-row eviction", store.touches)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u3", "new", 2); !ok {
+		t.Fatal("new row was not cached")
+	}
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("DirtyCountForTest() = %d, want only new dirty row", got)
+	}
+	cache := observer.lastCache(t)
+	if cache.Rows != 2 || cache.DirtyRows != 1 {
+		t.Fatalf("cache observation = %+v, want rows=2 dirty=1", cache)
+	}
+}
+
 func TestConcurrentCachePressureDoesNotDuplicateFullFlush(t *testing.T) {
 	const (
 		maxRows = 64

--- a/pkg/metrics/gateway.go
+++ b/pkg/metrics/gateway.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var gatewayFrameDurationBuckets = []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5}
+var gatewayFrameDurationBuckets = []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
 var gatewayAsyncSendBatchRecordBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
 var gatewayAsyncSendBatchByteBuckets = []float64{64, 256, 1024, 4096, 16384, 65536, 262144, 524288, 1048576, 4194304}
 

--- a/pkg/metrics/registry_test.go
+++ b/pkg/metrics/registry_test.go
@@ -157,6 +157,11 @@ func TestGatewayMetricsTrackConnectionAndTraffic(t *testing.T) {
 	}).GetCounter().GetValue())
 }
 
+func TestLatencyHistogramBucketsCoverSevereStalls(t *testing.T) {
+	require.Equal(t, float64(30), gatewayFrameDurationBuckets[len(gatewayFrameDurationBuckets)-1])
+	require.Equal(t, float64(30), runtimePressureDurationBuckets[len(runtimePressureDurationBuckets)-1])
+}
+
 func TestClusterMonitorGaugesStayAbsentUntilObserved(t *testing.T) {
 	reg := New(1, "node-1")
 

--- a/pkg/metrics/runtime_pressure.go
+++ b/pkg/metrics/runtime_pressure.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var runtimePressureDurationBuckets = []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5}
+var runtimePressureDurationBuckets = []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
 
 // RuntimePressureQueueObservation captures current pressure gauges for a bounded runtime queue.
 type RuntimePressureQueueObservation struct {


### PR DESCRIPTION
## Root cause

Cloud-medium run `gh-29684956096-1` showed gateway entry P99 rising from about 18 ms to the 2.5 s histogram ceiling while node-2 `conversation authority` saturated at 128/128 workers and 3872/4096 queued tasks. The simulator, processes, gateway queue, storage queue, and append path remained healthy.

Two product feedback loops caused the stall:

- A full conversation-active cache entered the global serialized flush lane even when clean rows could be evicted.
- Best-effort post-commit scheduling/backlog could block writer advance and counted against foreground per-channel admission, returning `ErrChannelBusy` after durable capacity was still available.

## Fix

- Evict clean conversation rows before serialized dirty spill.
- Use bounded non-blocking post-commit pool admission and complete scheduler failures without leaking backlog.
- Bound per-channel post-commit backlog independently from foreground append admission; drop and observe the newest best-effort envelope instead of failing SEND/SENDACK.
- Extend gateway/runtime latency histogram ceilings from 2.5 s to 30 s so severe stalls are measurable.
- Update FLOW and project knowledge.

## Verification

- Exact hot-channel red test failed before the fix with `ErrChannelBusy`, then passed 5 consecutive runs.
- Post-commit pool saturation regression passed 5 consecutive runs.
- Clean-cache pressure regression passed 5 consecutive runs.
- `GOWORK=off go test ./internal/runtime/channelappend ./internal/runtime/conversationactive ./pkg/metrics ./internal/app -count=1`
- Earlier in the same worktree: `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`

Cloud revalidation is required after merge.