### PR TITLE
fix: bound conversation cache pressure spills

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -43,6 +43,7 @@
 - Legacy `UserConversation*` and `CMDConversation*` APIs in `pkg/db/meta` are source compatibility shims only; they must map to the unified kind-aware conversation table.
 - Conversation active flush attempts must carry a bounded context because Slot proposal futures rely on caller deadlines for stale or uncommitted proposals.
 - Conversation active dirty flushes must be serialized across scheduled, cache-pressure, and hash-slot drains; concurrent full-cache snapshots multiply memory by admission concurrency.
+- Conversation active cache pressure must flush and evict only a bounded batch with reusable headroom; synchronously flushing the whole dirty cache blocks authority RPCs and amplifies writes at high cardinality.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -336,7 +336,7 @@ type ConversationConfig struct {
 	AuthorityFlushInterval time.Duration
 	// AuthorityFlushTimeout bounds one authority active-row flush attempt.
 	AuthorityFlushTimeout time.Duration
-	// AuthorityFlushBatchRows bounds dirty authority active rows flushed in one tick.
+	// AuthorityFlushBatchRows bounds dirty authority active rows flushed in one tick or cache-pressure spill.
 	AuthorityFlushBatchRows int
 	// AuthorityAdmitBatchRows limits active rows in one authority admission batch.
 	AuthorityAdmitBatchRows int

--- a/internal/app/conversation_authority.go
+++ b/internal/app/conversation_authority.go
@@ -40,7 +40,7 @@ type conversationAuthorityOptions struct {
 	AdmissionConcurrency int
 	// ActiveCooldown skips receiver-only active_at flushes newer than the durable row by less than this duration.
 	ActiveCooldown time.Duration
-	// FlushBatchRows bounds dirty rows flushed per authority handoff iteration.
+	// FlushBatchRows bounds dirty rows per scheduled flush, pressure spill, and authority handoff iteration.
 	FlushBatchRows int
 	// CurrentRouteTarget returns the locally visible authority target for one hash slot.
 	CurrentRouteTarget func(uint16) (conversationusecase.RouteTarget, bool)
@@ -209,10 +209,11 @@ func newConversationAuthority(opts conversationAuthorityOptions) *conversationAu
 		activeObserver = observer
 	}
 	authority.active = conversationactive.NewManager(conversationactive.Options{
-		Store:          conversationActiveStoreAdapter{authority: authority},
-		ActiveCooldown: opts.ActiveCooldown,
-		MaxCachedRows:  opts.MaxRows,
-		Observer:       activeObserver,
+		Store:             conversationActiveStoreAdapter{authority: authority},
+		ActiveCooldown:    opts.ActiveCooldown,
+		MaxCachedRows:     opts.MaxRows,
+		PressureSpillRows: opts.FlushBatchRows,
+		Observer:          activeObserver,
 	})
 	return authority
 }

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -12,14 +12,16 @@ Current flow:
    then write through `ActiveStore.TouchConversationActiveAt`.
 4. Cache-pressure admission first evicts already-clean rows while holding the
    cache lock. Only an insufficient clean working set enters the serialized
-   flush lane to persist dirty rows before retrying admission.
+   flush lane, where the larger of required admission capacity and configured
+   headroom is persisted and evicted. Spill size follows bounded admission work
+   instead of scaling to the whole dirty cache.
 5. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
 6. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
 
 Serialization covers scheduled, cache-pressure, and hash-slot-scoped flushes. It
-prevents concurrent admissions at the row cap from each retaining a duplicate
-whole-cache snapshot while preserving version fencing for updates that arrive
-during durable I/O.
+prevents concurrent admissions at the row cap from duplicating a pressure
+snapshot while preserving version fencing for updates that arrive during
+durable I/O.
 
 Cache observations report aggregate row/dirty counts plus fixed kind-aware
 normal/CMD counts maintained incrementally on cache mutation. Observation does

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -9,6 +9,8 @@ import (
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
 
+const defaultPressureSpillRows = 128
+
 type conversationKey struct {
 	kind        metadb.ConversationKind
 	channelID   string
@@ -58,6 +60,8 @@ type Manager struct {
 	activeCooldown time.Duration
 	// maxCachedRows bounds cached rows across all UIDs; zero means unbounded.
 	maxCachedRows int
+	// pressureSpillRows sets the reusable headroom for one synchronous cache-pressure flush and eviction.
+	pressureSpillRows int
 	// observer receives cache and flush observations.
 	observer Observer
 	// totalRows tracks cached active rows across all UID maps.
@@ -88,11 +92,16 @@ func NewManager(opts Options) *Manager {
 			return time.Now().UnixMilli()
 		}
 	}
+	pressureSpillRows := opts.PressureSpillRows
+	if pressureSpillRows <= 0 {
+		pressureSpillRows = defaultPressureSpillRows
+	}
 	return &Manager{
 		nowMS:               nowMS,
 		store:               opts.Store,
 		activeCooldown:      opts.ActiveCooldown,
 		maxCachedRows:       opts.MaxCachedRows,
+		pressureSpillRows:   pressureSpillRows,
 		observer:            opts.Observer,
 		rowsByKind:          make(map[metadb.ConversationKind]int),
 		dirtyRowsByKind:     make(map[metadb.ConversationKind]int),
@@ -288,23 +297,30 @@ func (m *Manager) spillForPressure(ctx context.Context, newRows int) error {
 	defer m.flushMu.Unlock()
 
 	m.mu.RLock()
-	needsSpill := m.cacheWouldExceedLocked(newRows)
+	over := m.totalRows + newRows - m.maxCachedRows
 	m.mu.RUnlock()
-	if !needsSpill {
+	if over <= 0 {
 		return nil
 	}
-	if _, err := m.flushDirtySerialized(ctx, 0); err != nil {
+	spillRows := m.pressureSpillRows
+	if over > spillRows {
+		spillRows = over
+	}
+	if _, err := m.flushDirtySerialized(ctx, spillRows); err != nil {
 		return err
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	over := m.totalRows + newRows - m.maxCachedRows
+	over = m.totalRows + newRows - m.maxCachedRows
 	if over <= 0 {
 		return nil
 	}
-	if evicted := m.evictCleanRowsLocked(over); evicted < over {
+	if over > spillRows {
+		spillRows = over
+	}
+	if evicted := m.evictCleanRowsLocked(spillRows); evicted < over {
 		return ErrCachePressure
 	}
 	return nil

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -944,10 +944,76 @@ func TestAdmitUnderCachePressureEvictsCleanRowsWithoutFlush(t *testing.T) {
 	}
 }
 
-func TestConcurrentCachePressureDoesNotDuplicateFullFlush(t *testing.T) {
+func TestCachePressureSpillIsBoundedAndCreatesHeadroom(t *testing.T) {
 	const (
-		maxRows = 64
-		workers = 8
+		maxRows           = 16
+		pressureSpillRows = 4
+	)
+	ctx := context.Background()
+	store := &recordingActiveStore{}
+	observer := &recordingConversationActiveObserver{}
+	m := NewManager(Options{
+		Store:             store,
+		MaxCachedRows:     maxRows,
+		PressureSpillRows: pressureSpillRows,
+		Observer:          observer,
+	})
+	initial := make([]ActivePatch, 0, maxRows)
+	for i := 0; i < maxRows; i++ {
+		initial = append(initial, ActivePatch{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         fmt.Sprintf("existing-%d", i),
+			ChannelID:   "room",
+			ChannelType: 2,
+			ActiveAtMS:  1000,
+		})
+	}
+	if err := m.MarkActive(ctx, initial); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "new-0",
+		ChannelID:   "room",
+		ChannelType: 2,
+		ActiveAtMS:  2000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(first pressure) error = %v", err)
+	}
+	if len(store.touches) != 1 || len(store.touches[0]) != pressureSpillRows {
+		t.Fatalf("first pressure touches = %+v, want one bounded %d-row spill", store.touches, pressureSpillRows)
+	}
+	cache := observer.lastCache(t)
+	if cache.Rows != maxRows-pressureSpillRows+1 {
+		t.Fatalf("cache rows after spill = %d, want %d rows with reusable headroom", cache.Rows, maxRows-pressureSpillRows+1)
+	}
+
+	for i := 1; i < pressureSpillRows; i++ {
+		if err := m.MarkActive(ctx, []ActivePatch{{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         fmt.Sprintf("new-%d", i),
+			ChannelID:   "room",
+			ChannelType: 2,
+			ActiveAtMS:  2000,
+		}}); err != nil {
+			t.Fatalf("MarkActive(headroom %d) error = %v", i, err)
+		}
+	}
+	if len(store.touches) != 1 {
+		t.Fatalf("touch calls after consuming headroom = %d, want 1", len(store.touches))
+	}
+	cache = observer.lastCache(t)
+	if cache.Rows != maxRows {
+		t.Fatalf("cache rows after consuming headroom = %d, want %d", cache.Rows, maxRows)
+	}
+}
+
+func TestConcurrentCachePressureDoesNotDuplicateBoundedSpill(t *testing.T) {
+	const (
+		maxRows           = 64
+		pressureSpillRows = 8
+		workers           = 8
 	)
 	ctx := context.Background()
 	store := &blockingActiveStore{
@@ -956,7 +1022,7 @@ func TestConcurrentCachePressureDoesNotDuplicateFullFlush(t *testing.T) {
 	}
 	releaseStore := sync.OnceFunc(func() { close(store.release) })
 	defer releaseStore()
-	m := NewManager(Options{Store: store, MaxCachedRows: maxRows})
+	m := NewManager(Options{Store: store, MaxCachedRows: maxRows, PressureSpillRows: pressureSpillRows})
 	initial := make([]ActivePatch, 0, maxRows)
 	for i := 0; i < maxRows; i++ {
 		initial = append(initial, ActivePatch{
@@ -993,17 +1059,17 @@ func TestConcurrentCachePressureDoesNotDuplicateFullFlush(t *testing.T) {
 
 	select {
 	case selected := <-store.entered:
-		if selected != maxRows {
-			t.Fatalf("first pressure flush selected %d rows, want %d", selected, maxRows)
+		if selected != pressureSpillRows {
+			t.Fatalf("first pressure flush selected %d rows, want bounded %d", selected, pressureSpillRows)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("first pressure flush did not reach the store")
 	}
 
-	duplicateFullFlush := false
+	duplicateSpill := false
 	select {
 	case selected := <-store.entered:
-		duplicateFullFlush = selected == maxRows
+		duplicateSpill = selected == pressureSpillRows
 	case <-time.After(200 * time.Millisecond):
 	}
 	releaseStore()
@@ -1012,8 +1078,8 @@ func TestConcurrentCachePressureDoesNotDuplicateFullFlush(t *testing.T) {
 			t.Fatalf("MarkActive(concurrent pressure) error = %v", err)
 		}
 	}
-	if duplicateFullFlush {
-		t.Fatal("concurrent cache pressure duplicated the same full-cache flush snapshot")
+	if duplicateSpill {
+		t.Fatal("concurrent cache pressure duplicated the same bounded flush snapshot")
 	}
 	if got := store.maxConcurrentCalls(); got != 1 {
 		t.Fatalf("maximum concurrent store flushes = %d, want 1", got)

--- a/internal/runtime/conversationactive/types.go
+++ b/internal/runtime/conversationactive/types.go
@@ -24,6 +24,8 @@ type Options struct {
 	ActiveCooldown time.Duration
 	// MaxCachedRows bounds in-memory active rows across all users; zero disables the bound.
 	MaxCachedRows int
+	// PressureSpillRows sets reusable headroom for a cache-pressure spill; a larger immediate admission requirement takes precedence.
+	PressureSpillRows int
 	// Observer receives low-cardinality cache and flush observations.
 	Observer Observer
 }


### PR DESCRIPTION
## Summary
- persist and evict only bounded conversation-active rows under cache pressure
- create reusable cache headroom instead of flushing the entire dirty working set
- wire the existing authority flush batch size into pressure spills and document the invariant

## Root cause evidence
The Cloud Medium run reached the 100,000-row authority cache bound. Cache-pressure admission synchronously flushed every dirty row, producing multi-second flush P99 and filling the conversation authority service queue while ingress fell far below target.

## Verification
- GOWORK=off go test -race ./internal/runtime/conversationactive -run Test... -count=1
- GOWORK=off go test ./internal/runtime/conversationactive ./internal/app -count=1
- GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1