### PR TITLE
fix conversation pressure isolation

### DIFF
--- a/cmd/wukongim/wukongim-node1.toml.example
+++ b/cmd/wukongim/wukongim-node1.toml.example
@@ -119,7 +119,8 @@ authority_list_db_window_max = 1000
 authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
-authority_flush_batch_rows = 512
+# Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
+authority_flush_batch_rows = 128
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/cmd/wukongim/wukongim-node2.toml.example
+++ b/cmd/wukongim/wukongim-node2.toml.example
@@ -119,7 +119,8 @@ authority_list_db_window_max = 1000
 authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
-authority_flush_batch_rows = 512
+# Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
+authority_flush_batch_rows = 128
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/cmd/wukongim/wukongim-node3.toml.example
+++ b/cmd/wukongim/wukongim-node3.toml.example
@@ -119,7 +119,8 @@ authority_list_db_window_max = 1000
 authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
-authority_flush_batch_rows = 512
+# Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
+authority_flush_batch_rows = 128
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/cmd/wukongim/wukongim.toml.example
+++ b/cmd/wukongim/wukongim.toml.example
@@ -140,7 +140,8 @@ authority_list_db_window_max = 1000
 authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
-authority_flush_batch_rows = 512
+# Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
+authority_flush_batch_rows = 128
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -22,7 +22,7 @@
 - `internal/runtime/delivery` is the no-gateway/no-cluster benchmark boundary for online fanout, owner push batching, and recipient-owner recvack tracking.
 - `internal` webhook delivery is a node-local best-effort post-commit side effect with bounded queues and finite retry. Large offline fanout should use batch observer/chunking, and webhook failure must not affect SENDACK, durable append, conversation active admission, or owner delivery.
 - Channelappend post-commit pool admission and per-channel backlog must stay bounded and independent from foreground append admission; saturation is observed and dropped so best-effort conversation/delivery work cannot pin writer-advance workers, delay durable SEND/SENDACK, or return `ErrChannelBusy` for an otherwise admissible send.
-- Conversation-active cache churn must evict clean rows before entering the serialized dirty-flush lane; a full clean cache must not turn every new-channel admission into a global flush-lane operation.
+- Conversation-active cache churn may evict clean rows during memory-only admission; dirty persistence stays exclusively on periodic, pressure-woken, or handoff flush workers.
 
 ## Gateway Runtime
 
@@ -42,8 +42,9 @@
 - `ActiveAt` is a best-effort hint: updates may be batched, throttled, dropped, and merged from the kind-aware conversation active cache during `ListConversationActiveView`.
 - Legacy `UserConversation*` and `CMDConversation*` APIs in `pkg/db/meta` are source compatibility shims only; they must map to the unified kind-aware conversation table.
 - Conversation active flush attempts must carry a bounded context because Slot proposal futures rely on caller deadlines for stale or uncommitted proposals.
-- Conversation active dirty flushes must be serialized across scheduled, cache-pressure, and hash-slot drains; concurrent full-cache snapshots multiply memory by admission concurrency.
-- Conversation active cache pressure must flush and evict only a bounded batch with reusable headroom; synchronously flushing the whole dirty cache blocks authority RPCs and amplifies writes at high cardinality.
+- Conversation active admission is memory-only: it may evict clean rows or return cache pressure, but it must never perform durable I/O or wait for the serialized flush lane.
+- Conversation active pressure uses one coalesced async worker wakeup, bounded flush attempts, and 80%/70% high/dirty-low watermarks; clean rows below the dirty watermark are the reusable eviction reserve.
+- Conversation active projection failure is observed independently and must not block recipient delivery, later large-channel pages, or subscriber snapshot caching.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -413,18 +413,19 @@ script summarizes these in `channelappend_metrics_summary.tsv` and
 by the single-writer invariant even when different channels run through
 different shards or workers.
 The foreground SEND path waits only for channel-authority durable append;
-subscriber scan, conversation active-batch admission, recipient authority
-grouping, and delivery enqueue all run after SENDACK from the authority
-writer's best-effort post-commit pipeline. The recipient delivery worker later
+subscriber scan, recipient authority grouping, delivery enqueue, and the
+independent conversation active projection all run after SENDACK from the
+authority writer's best-effort post-commit pipeline. The recipient delivery worker later
 drains accepted batches, resolves online routes, and pushes owner-node delivery
 commands. Post-commit persistence and restart replay are not part of
 channelappend. Post-commit enqueue failures are logged with the failing phase and
 route/dispatch context, counted through effect metrics, and dropped after the
 routed helper's bounded retry window; they do not change channel durability or
 the already-successful SENDACK decision. Conversation active-batch admission
-performs only a short bounded fresh-route retry in the routed client; failures
-surface as the `conversation_active` post-commit phase before online delivery
-is enqueued.
+performs only a short bounded fresh-route retry in the routed client. Delivery
+is enqueued first; active projection failures surface independently as the
+`conversation_active` post-commit phase and do not stop online delivery or later
+large-channel pages.
 Runtime fanout failures are counted with normalized delivery error classes.
 Retryable fanout failures enter
 a bounded in-memory retry scheduler with a small fixed attempt cap; retry queue
@@ -440,17 +441,15 @@ errors and short append results.
 The channel append commit pipeline scopes unscoped person-channel events to the
 two channel participants. For non-person unscoped channels it pages durable
 subscribers through the app delivery metadata source, an explicitly supplied
-subscriber source, or the cluster Slot metadata source. After each recipient
-set is formed, channelappend admits a kind-aware
-`conversationactive.ActiveBatch` through the shared
-`ConversationAuthorityClient`; channelappend chooses normal versus CMD kind
-from the committed envelope, and active admission still runs when online
-delivery is disabled.
-Recipients are then grouped by exact UID hash-slot authority target including
-Slot leader term and Slot config epoch for delivery; when cluster exposes
+subscriber source, or the cluster Slot metadata source. When cluster exposes
 batch key routing, the app recipient resolver resolves each subscriber page's
-unique UIDs through one batch route lookup before grouping. When delivery is
-enabled, the app wires a bounded
+unique UIDs through one batch route lookup. After each recipient set is formed,
+channelappend groups recipients by exact UID hash-slot authority
+target including Slot leader term and Slot config epoch, then enqueues delivery.
+It next admits an independent kind-aware `conversationactive.ActiveBatch`
+through the shared `ConversationAuthorityClient`; channelappend chooses normal
+versus CMD kind from the committed envelope, and active admission still runs
+when online delivery is disabled. When delivery is enabled, the app wires a bounded
 recipient delivery worker that drains those batches and runs the delivery-only
 channelappend recipient processor outside the authority writer. `/bench/v1/channels`,
 `/bench/v1/channels/subscribers`, and `/bench/v1/channels/subscribers/remove`
@@ -612,8 +611,9 @@ Conversation active rows remain working-set hints: delayed or dropped
 post-commit work does not change message durability or SENDACK success. The
 runtime/conversationactive.Manager coalesces active rows, serves list reads by
 merging cached rows with UID-owned DB active rows, and flushes durable active
-touch patches through the conversation active flush worker, handoff drain, or
-cache pressure. The app conversation authority keeps route target fencing,
+touch patches through the conversation active flush worker or handoff drain.
+Cache pressure only sends a nonblocking wakeup to that worker; admission never
+performs durable I/O. The app conversation authority keeps route target fencing,
 lifecycle handoff, observer mapping, and usecase/RPC type adaptation.
 
 SEND with channel authority routing enabled:
@@ -632,9 +632,9 @@ gateway/API send
   -> SENDACK returns to sender
   -> authority writer post-commit effect:
        scope person recipients or page subscribers
-       ConversationAuthorityClient.AdmitActiveBatch for the expanded recipient set
        group recipients by UID authority target, including Slot leader term and config epoch, for delivery
        enqueue recipient delivery batch when delivery is enabled
+       ConversationAuthorityClient.AdmitActiveBatch as an independent projection
        drop the in-memory post-commit envelope after one enqueue attempt
 ```
 
@@ -659,7 +659,8 @@ Start(ctx)
   -> seed join loop Start(ctx): retry JoinNode against stable-order seeds when seed-join config is present
   -> wait for cluster write routing when the cluster runtime exposes route snapshots; the gate also runs the cluster write probe, which proves Slot metadata writes and Channel runtime placement data-node candidates before gateway SEND admission
   -> conversation authority route lifecycle Start(ctx): watch route authorities and seed current targets
-  -> conversation active flush worker Start(ctx): periodically persist dirty active rows
+  -> conversation active flush worker Start(ctx): persist dirty active rows
+     periodically or on a coalesced cache-pressure wakeup
   -> presence touch worker Start(ctx)
   -> plugin runtime Start(ctx): open the host RPC socket, scan local plugins, and start enabled processes
   -> plugin PersistAfter worker Start(ctx): accept durable commit side effects before channel append opens
@@ -783,13 +784,22 @@ touch summary but does not run or observe expiry.
 ## Conversation Active Flush Worker
 
 ```text
-periodic flush
+periodic tick or coalesced cache-pressure wakeup
   -> derive an AuthorityFlushTimeout-bounded attempt context
   -> conversationAuthority.FlushActiveRows(attemptCtx, AuthorityFlushBatchRows)
   -> runtime/conversationactive.Manager selects dirty rows with version fencing
   -> batch-read durable conversation rows for receiver-only cooldown filtering
   -> skip receiver-only ActiveAt updates inside AuthorityActiveCooldown
   -> store.TouchConversationActiveAtBatch persists remaining ActiveAt/ReadSeq/UpdatedAt
+  -> after a successful pressure-cycle attempt, requeue one wakeup while dirty
+     rows remain above the 70% low watermark
+
+cache admission
+  -> at 80% total occupancy with dirty rows above the 70% low watermark, start
+     one pressure cycle
+  -> if clean-row eviction cannot satisfy the hard cache bound, reject
+     atomically with cache_pressure
+  -> never call the store or wait for an in-flight flush
 
 Stop(ctx)
   -> channelappend has already closed admission and drained accepted post-commit effects
@@ -801,7 +811,9 @@ Stop(ctx)
 The flush worker does not construct conversation rows and does not read message
 payloads. It only persists dirty active rows already admitted into the
 conversationactive cache, keeping cache visibility immediate while bounding
-eventual durable lag.
+eventual durable lag. The capacity-1 pressure channel and single worker goroutine
+coalesce concurrent wakeups; every attempt remains bounded by
+`AuthorityFlushBatchRows` and `AuthorityFlushTimeout`.
 
 ## Conversation Authority Handoff
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -324,7 +324,7 @@ type ConversationConfig struct {
 	MaxLastMessageConcurrency int
 	// AuthorityCacheMaxRowsPerUID is retained for config compatibility; the runtime-backed authority currently does not enforce a per-UID cache bound.
 	AuthorityCacheMaxRowsPerUID int
-	// AuthorityCacheMaxRows bounds all unflushed authority cache rows on this node.
+	// AuthorityCacheMaxRows bounds all cached authority active rows on this node, including clean eviction reserves.
 	AuthorityCacheMaxRows int
 	// AuthorityListDBWindowMax is retained for config compatibility; the runtime-backed authority currently owns its active-view DB window internally.
 	AuthorityListDBWindowMax int
@@ -336,7 +336,7 @@ type ConversationConfig struct {
 	AuthorityFlushInterval time.Duration
 	// AuthorityFlushTimeout bounds one authority active-row flush attempt.
 	AuthorityFlushTimeout time.Duration
-	// AuthorityFlushBatchRows bounds dirty authority active rows flushed in one tick or cache-pressure spill.
+	// AuthorityFlushBatchRows bounds dirty authority active rows flushed by one periodic, pressure-woken, or handoff attempt.
 	AuthorityFlushBatchRows int
 	// AuthorityAdmitBatchRows limits active rows in one authority admission batch.
 	AuthorityAdmitBatchRows int

--- a/internal/app/conversation_active_flush.go
+++ b/internal/app/conversation_active_flush.go
@@ -23,6 +23,8 @@ type conversationActiveFlushWorkerOptions struct {
 	FlushTimeout time.Duration
 	// BatchRows bounds dirty active rows flushed in one tick.
 	BatchRows int
+	// PressureSignals receives coalesced dirty-cache pressure wakeups.
+	PressureSignals <-chan struct{}
 	// Logger records periodic flush failures.
 	Logger wklog.Logger
 }
@@ -107,11 +109,18 @@ func (w *conversationActiveFlushWorker) tick(ctx context.Context) {
 	defer w.wg.Done()
 	ticker := time.NewTicker(w.opts.FlushInterval)
 	defer ticker.Stop()
+	pressureSignals := w.opts.PressureSignals
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			_, _ = w.flushOnce(ctx, false)
+		case _, ok := <-pressureSignals:
+			if !ok {
+				pressureSignals = nil
+				continue
+			}
 			_, _ = w.flushOnce(ctx, false)
 		}
 	}

--- a/internal/app/conversation_active_flush_test.go
+++ b/internal/app/conversation_active_flush_test.go
@@ -41,6 +41,35 @@ func TestConversationActiveFlushWorkerFlushesPeriodicallyAndOnStop(t *testing.T)
 	}
 }
 
+func TestConversationActiveFlushWorkerWakesOnCachePressure(t *testing.T) {
+	flusher := &pressureAwareConversationActiveFlusher{
+		recordingConversationActiveFlusher: &recordingConversationActiveFlusher{firstFlush: make(chan struct{})},
+		pressure:                           make(chan struct{}, 1),
+	}
+	worker := newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
+		Authority:       flusher,
+		FlushInterval:   time.Hour,
+		BatchRows:       7,
+		PressureSignals: flusher.pressure,
+	})
+
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	flusher.pressure <- struct{}{}
+	select {
+	case <-flusher.firstFlush:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cache-pressure flush")
+	}
+	if err := worker.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if got := flusher.batchRows(); len(got) < 2 || got[0] != 7 {
+		t.Fatalf("flush batches = %#v, want immediate pressure flush bounded by 7 plus final drain", got)
+	}
+}
+
 func TestConversationActiveFlushWorkerStopReturnsFinalFlushError(t *testing.T) {
 	flushErr := errors.New("store unavailable")
 	worker := newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
@@ -142,6 +171,11 @@ type recordingConversationActiveFlusher struct {
 	err        error
 	results    []conversationactive.FlushResult
 	batches    []int
+}
+
+type pressureAwareConversationActiveFlusher struct {
+	*recordingConversationActiveFlusher
+	pressure chan struct{}
 }
 
 func (f *recordingConversationActiveFlusher) FlushActiveRows(_ context.Context, batchRows int) (conversationactive.FlushResult, error) {

--- a/internal/app/conversation_authority.go
+++ b/internal/app/conversation_authority.go
@@ -40,8 +40,10 @@ type conversationAuthorityOptions struct {
 	AdmissionConcurrency int
 	// ActiveCooldown skips receiver-only active_at flushes newer than the durable row by less than this duration.
 	ActiveCooldown time.Duration
-	// FlushBatchRows bounds dirty rows per scheduled flush, pressure spill, and authority handoff iteration.
+	// FlushBatchRows bounds dirty rows per periodic, pressure-woken, and authority handoff flush attempt.
 	FlushBatchRows int
+	// PressureNotify receives nonblocking dirty-cache pressure wakeups for the app flush worker.
+	PressureNotify chan<- struct{}
 	// CurrentRouteTarget returns the locally visible authority target for one hash slot.
 	CurrentRouteTarget func(uint16) (conversationusecase.RouteTarget, bool)
 	// Observer receives low-cardinality authority cache/list/handoff observations.
@@ -209,11 +211,11 @@ func newConversationAuthority(opts conversationAuthorityOptions) *conversationAu
 		activeObserver = observer
 	}
 	authority.active = conversationactive.NewManager(conversationactive.Options{
-		Store:             conversationActiveStoreAdapter{authority: authority},
-		ActiveCooldown:    opts.ActiveCooldown,
-		MaxCachedRows:     opts.MaxRows,
-		PressureSpillRows: opts.FlushBatchRows,
-		Observer:          activeObserver,
+		Store:          conversationActiveStoreAdapter{authority: authority},
+		ActiveCooldown: opts.ActiveCooldown,
+		MaxCachedRows:  opts.MaxRows,
+		PressureNotify: opts.PressureNotify,
+		Observer:       activeObserver,
 	})
 	return authority
 }

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -287,6 +287,7 @@ func (a *App) wireConversationAuthority() {
 		authorityNode, hasAuthorityNode := a.cluster.(clusterinfra.ConversationAuthorityNode)
 		authorityStore, hasAuthorityStore := a.cluster.(conversationAuthorityStore)
 		if hasAuthorityNode && hasAuthorityStore {
+			pressureSignals := make(chan struct{}, 1)
 			authority := newConversationAuthority(conversationAuthorityOptions{
 				LocalNodeID:          authorityNode.NodeID(),
 				Store:                authorityStore,
@@ -297,6 +298,7 @@ func (a *App) wireConversationAuthority() {
 				AdmissionConcurrency: a.cfg.Conversation.AuthorityAdmitConcurrency,
 				ActiveCooldown:       a.cfg.Conversation.AuthorityActiveCooldown,
 				FlushBatchRows:       a.cfg.Conversation.AuthorityFlushBatchRows,
+				PressureNotify:       pressureSignals,
 				CurrentRouteTarget:   a.currentConversationAuthorityRouteTarget,
 				Observer:             a.conversationAuthorityObserver(),
 			})
@@ -305,11 +307,12 @@ func (a *App) wireConversationAuthority() {
 			a.conversationAuthorityClient = client
 			if a.conversationActiveWorker == nil {
 				a.conversationActiveWorker = newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
-					Authority:     authority,
-					FlushInterval: a.cfg.Conversation.AuthorityFlushInterval,
-					FlushTimeout:  a.cfg.Conversation.AuthorityFlushTimeout,
-					BatchRows:     a.cfg.Conversation.AuthorityFlushBatchRows,
-					Logger:        a.logger.Named("conversation_active_flush"),
+					Authority:       authority,
+					FlushInterval:   a.cfg.Conversation.AuthorityFlushInterval,
+					FlushTimeout:    a.cfg.Conversation.AuthorityFlushTimeout,
+					BatchRows:       a.cfg.Conversation.AuthorityFlushBatchRows,
+					PressureSignals: pressureSignals,
+					Logger:          a.logger.Named("conversation_active_flush"),
 				})
 			}
 			if a.conversationRouteLifecycle == nil {

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -189,11 +189,13 @@ The committed envelope owns one payload copy when it enters the async
 post-commit backlog; later state and recipient dispatch steps pass that
 immutable envelope by reference through the delivery worker and owner-push
 planning. Concrete owner push adapters copy or serialize at their boundary.
-Success prunes the payload-bearing envelope from the backlog. Failure is logged
-through `PostCommitFailureObserver`, counted through effect metrics, and then
-the envelope is dropped without retry so one bad active-admission, recipient
-route, or delivery enqueue side effect cannot block later messages on the same
-channel. The failure observation carries a precise post-commit phase plus
+Success prunes the payload-bearing envelope from the backlog. Recipient route or
+delivery enqueue failure is logged through `PostCommitFailureObserver`, counted
+through effect metrics, and then the envelope is dropped without retry so one
+bad recipient side effect cannot block later messages on the same channel.
+Conversation-active projection failures are recorded independently and do not
+turn a successful delivery enqueue into a failed item completion. Failure
+observations carry a precise post-commit phase plus
 sampled recipient, target, and dispatch context so route-resolution failures
 can be distinguished from conversation active admission and delivery enqueue
 failures in logs. Each channel keeps only one committed envelope in flight at a
@@ -244,24 +246,25 @@ cursor different from the previous cursor; otherwise dispatch fails before that
 page's recipients are admitted or dispatched, avoiding partial side effects for
 the invalid page before the envelope is dropped.
 
-After each recipient set is formed, channelappend admits one
-`conversationactive.ActiveBatch` before enqueueing recipient delivery batches.
+After each recipient set is formed, channelappend first resolves the fenced
+recipient authority targets and enqueues recipient delivery batches, then admits
+one independent `conversationactive.ActiveBatch` projection.
 The batch carries an explicit `metadb.ConversationKind`: normal for ordinary
 channel commits, CMD for one-shot sync commits or command-channel ids. It also
 carries `SenderUID` from the committed event, channel identity, message
 sequence, activity timestamp, and the expanded recipient UIDs. Receiver entries
 leave `IsSender` unset; the active worker advances the sender read sequence
-from `SenderUID` semantics. This active admission still runs when online
+from `SenderUID` semantics. Active admission still runs when online
 delivery enqueueing is disabled or no `RecipientDeliveryEnqueuer` is
 configured. If active admission fails, the post-commit failure phase is
-`conversation_active` and recipient delivery is not enqueued for that recipient
-set.
+`conversation_active`, while accepted delivery, later large-channel pages, and
+a successfully loaded non-large subscriber snapshot continue independently.
 
 Recipient delivery is an enqueue contract. When delivery enqueueing is
 configured, recipient batches are grouped by the full fenced recipient
-authority target, including Slot leader term and Slot config epoch, after
-active admission succeeds. UID authority resolution is performed once per
-unique trimmed UID and uses the optional batch resolver when available; invalid
+authority target, including Slot leader term and Slot config epoch. UID
+authority resolution is performed once per unique trimmed UID and uses the
+optional batch resolver when available; invalid
 or missing targets map to route-not-ready before enqueueing.
 Different recipient authority targets may enqueue concurrently up to
 `RecipientAuthorityDispatchConcurrency`; batches for the same target are enqueued

--- a/internal/runtime/channelappend/commit.go
+++ b/internal/runtime/channelappend/commit.go
@@ -36,10 +36,12 @@ type commitEffect struct {
 }
 
 type commitCompletedEvent struct {
-	key             string
-	seq             uint64
-	attempt         int
-	items           []commitCompletedItem
+	key     string
+	seq     uint64
+	attempt int
+	items   []commitCompletedItem
+	// failures contains observation-only side-effect failures that must not change item completion.
+	failures        []commitCompletedItem
 	subscriberCache subscriberCache
 }
 
@@ -62,7 +64,15 @@ func (e commitEffect) run(runtimeCtx context.Context, ports commitPorts) commitC
 		seq:             e.seq,
 		attempt:         e.attempt,
 		items:           make([]commitCompletedItem, 0, len(e.events)),
+		failures:        make([]commitCompletedItem, 0, len(e.events)),
 		subscriberCache: e.subscriberCache,
+	}
+	recordResult := func(itemResult string) {
+		if result == channelAppendResultOK {
+			result = itemResult
+		} else if result != itemResult {
+			result = channelAppendResultMixed
+		}
 	}
 	cache := e.subscriberCache
 	for _, event := range e.events {
@@ -72,13 +82,19 @@ func (e commitEffect) run(runtimeCtx context.Context, ports commitPorts) commitC
 			continue
 		}
 		dispatch, err := dispatchCommittedRecipientsForTarget(runtimeCtx, e.target, event, cache, ports)
+		if dispatch.activeErr != nil {
+			itemResult := errorClass(dispatch.activeErr)
+			recordResult(itemResult)
+			completion.failures = append(completion.failures, commitCompletedItem{
+				err:    fmt.Errorf("%w: %w", ErrCommitEffectFailed, dispatch.activeErr),
+				result: itemResult,
+				event:  event,
+				detail: postCommitFailureDetailFromError(dispatch.activeErr),
+			})
+		}
 		if err != nil {
 			itemResult := errorClass(err)
-			if result == channelAppendResultOK {
-				result = itemResult
-			} else if result != itemResult {
-				result = channelAppendResultMixed
-			}
+			recordResult(itemResult)
 			detail := postCommitFailureDetailFromError(err)
 			completion.items = append(completion.items, commitCompletedItem{
 				err:    fmt.Errorf("%w: %w", ErrCommitEffectFailed, err),

--- a/internal/runtime/channelappend/commit_test.go
+++ b/internal/runtime/channelappend/commit_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/WuKongIM/WuKongIM/internal/contracts/authority"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/conversationactive"
 	runtimechannelid "github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
 )
 
@@ -43,6 +44,74 @@ func TestCommitEffectDoesNotRequirePersistAfterForNoPostCommitWork(t *testing.T)
 
 	if got := len(completion.items); got != 1 {
 		t.Fatalf("completion items = %d, want 1", got)
+	}
+}
+
+func TestCommitEffectSeparatesActiveProjectionFailureFromDeliveryCompletion(t *testing.T) {
+	activeErr := errors.New("active unavailable")
+	delivery := &scriptedRecipientDeliveryEnqueuerForCommitTest{}
+	effect := commitEffect{
+		key:    "room",
+		seq:    1,
+		target: localTargetForAppendTest("room"),
+		events: []CommittedEnvelope{{
+			MessageID:         10,
+			MessageSeq:        4,
+			ChannelID:         "room",
+			ChannelType:       2,
+			FromUID:           "sender",
+			MessageScopedUIDs: []string{"u2"},
+		}},
+	}
+
+	completion := effect.run(context.Background(), commitPorts{
+		activeAdmitter:             &recordingActiveAdmitterForRecipientTest{err: activeErr},
+		recipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		deliveryEnqueuer:           delivery,
+		recipientBatchSize:         16,
+	})
+
+	if got := delivery.callCount(); got != 1 {
+		t.Fatalf("recipient delivery calls = %d, want 1", got)
+	}
+	if len(completion.items) != 1 || completion.items[0].err != nil || completion.items[0].checkpointSeq != 4 {
+		t.Fatalf("delivery completion items = %#v, want successful checkpoint", completion.items)
+	}
+	if len(completion.failures) != 1 || !errors.Is(completion.failures[0].err, activeErr) {
+		t.Fatalf("independent active failures = %#v, want %v", completion.failures, activeErr)
+	}
+	if detail := completion.failures[0].detail; detail.Phase != "conversation_active" || detail.UID != "u2" {
+		t.Fatalf("active failure detail = %#v, want conversation_active for u2", detail)
+	}
+}
+
+func TestCommitEffectDoesNotLetActiveFailureReclassifyDeliveryFailure(t *testing.T) {
+	effect := commitEffect{
+		key:    "room",
+		seq:    1,
+		target: localTargetForAppendTest("room"),
+		events: []CommittedEnvelope{{
+			MessageID:         10,
+			MessageSeq:        4,
+			ChannelID:         "room",
+			ChannelType:       2,
+			FromUID:           "sender",
+			MessageScopedUIDs: []string{"u2"},
+		}},
+	}
+
+	completion := effect.run(context.Background(), commitPorts{
+		activeAdmitter:             &recordingActiveAdmitterForRecipientTest{err: context.DeadlineExceeded},
+		recipientAuthorityResolver: failingRecipientAuthorityResolverForRecipientTest{err: ErrRouteNotReady},
+		deliveryEnqueuer:           &scriptedRecipientDeliveryEnqueuerForCommitTest{},
+		recipientBatchSize:         16,
+	})
+
+	if len(completion.items) != 1 || completion.items[0].result != channelAppendResultRouteNotReady {
+		t.Fatalf("delivery completion = %#v, want route_not_ready", completion.items)
+	}
+	if len(completion.failures) != 1 || completion.failures[0].result != channelAppendResultTimeout {
+		t.Fatalf("active failures = %#v, want independent timeout", completion.failures)
 	}
 }
 
@@ -255,6 +324,93 @@ func TestCommitEffectFailureDropsAndAdvancesWithoutRetry(t *testing.T) {
 	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
 }
 
+func TestActiveProjectionFailureIsObservedWithoutStoppingRecipientDelivery(t *testing.T) {
+	activeErr := errors.New("active unavailable")
+	enqueuer := &scriptedRecipientDeliveryEnqueuerForCommitTest{}
+	observer := &recordingPostCommitFailureObserverForTest{}
+	group := newStartedTestGroup(t, Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(1005),
+		Appender:                   newRecordingAppenderForAppendTest(),
+		ConversationActiveAdmitter: &recordingActiveAdmitterForRecipientTest{err: activeErr},
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  enqueuer,
+		RecipientBatchSize:         16,
+		Observer:                   observer,
+	})
+	target := localTargetForAppendTest("room")
+	item := appendSendItemForTest("u1", "room", "payload")
+	item.Command.MessageScopedUIDs = []string{"u2"}
+
+	future, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{item})
+	if err != nil {
+		t.Fatalf("SubmitLocal() error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, future), 0, 1005, 1)
+	enqueuer.waitCalls(t, 1)
+	observer.waitFailures(t, 1)
+	observer.mu.Lock()
+	failure := observer.failures[0]
+	observer.mu.Unlock()
+	if failure.MessageID != 1005 || failure.Phase != "conversation_active" || failure.Result != channelAppendResultOther {
+		t.Fatalf("active projection failure = %#v, want independent conversation_active observation", failure)
+	}
+	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+}
+
+func TestActiveProjectionFailureDoesNotGateLargeRecipientDelivery(t *testing.T) {
+	active := newBlockingActiveAdmitterForCommitTest(errors.New("active unavailable"))
+	t.Cleanup(active.releaseAdmission)
+	source := &recordingSubscriberSourceForRecipientTest{pages: []SubscriberPage{
+		{Recipients: []Recipient{{UID: "u2"}}, Cursor: "next"},
+		{Recipients: []Recipient{{UID: "u3"}}, Done: true},
+	}}
+	enqueuer := &scriptedRecipientDeliveryEnqueuerForCommitTest{}
+	observer := &recordingPostCommitFailureObserverForTest{}
+	group := newStartedTestGroup(t, Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(1006),
+		Appender:                   newRecordingAppenderForAppendTest(),
+		Subscribers:                source,
+		ConversationActiveAdmitter: active,
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  enqueuer,
+		RecipientBatchSize:         16,
+		SubscriberScanPageSize:     1,
+		Observer:                   observer,
+	})
+	target := localTargetForAppendTest("room")
+	target.Large = true
+
+	future, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{
+		appendSendItemForTest("u1", "room", "payload"),
+	})
+	if err != nil {
+		t.Fatalf("SubmitLocal() error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, future), 0, 1006, 1)
+	enqueuer.waitCalls(t, 1)
+	select {
+	case <-active.started:
+	case <-time.After(time.Second):
+		t.Fatal("active projection did not start after first-page delivery")
+	}
+	if got := enqueuer.callCount(); got != 1 {
+		t.Fatalf("delivery calls before releasing active projection = %d, want first page only", got)
+	}
+
+	active.releaseAdmission()
+	enqueuer.waitCalls(t, 2)
+	observer.waitFailures(t, 1)
+	if source.calls != 2 {
+		t.Fatalf("subscriber page calls = %d, want both pages after active failure", source.calls)
+	}
+	if got := enqueuer.recipientUIDs(); !reflect.DeepEqual(got, []string{"u2", "u3"}) {
+		t.Fatalf("recipient delivery uids = %#v, want both pages", got)
+	}
+	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+}
+
 func TestPersistAfterDurableAppendSchedulesPostCommitAndDrainsBacklog(t *testing.T) {
 	persistAfter := &recordingPersistAfterEnqueuerForCommitTest{}
 	observer := &recordingCommitObserverForPersistAfterTest{}
@@ -371,6 +527,8 @@ func TestCommitEffectFailuresDropThenAdvance(t *testing.T) {
 }
 
 func TestNonLargeGroupSubscriberSnapshotCachedInChannelState(t *testing.T) {
+	activeErr := errors.New("active unavailable")
+	observer := &recordingPostCommitFailureObserverForTest{}
 	source := &recordingSubscriberSourceForRecipientTest{
 		pages: []SubscriberPage{{Recipients: []Recipient{{UID: "u2"}, {UID: "u3"}}, Done: true}},
 	}
@@ -380,10 +538,12 @@ func TestNonLargeGroupSubscriberSnapshotCachedInChannelState(t *testing.T) {
 		MessageID:                  newSequenceIDsForPrepare(1150),
 		Appender:                   newRecordingAppenderForAppendTest(),
 		Subscribers:                source,
+		ConversationActiveAdmitter: &recordingActiveAdmitterForRecipientTest{err: activeErr},
 		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
 		RecipientDeliveryEnqueuer:  enqueuer,
 		RecipientBatchSize:         16,
 		SubscriberScanPageSize:     1,
+		Observer:                   observer,
 	})
 	target := localTargetForAppendTest("room")
 	target.SubscriberMutationVersion = 7
@@ -399,8 +559,9 @@ func TestNonLargeGroupSubscriberSnapshotCachedInChannelState(t *testing.T) {
 	requireAppendSuccess(t, waitFutureForTest(t, future), 1, 1151, 2)
 
 	enqueuer.waitCalls(t, 2)
+	observer.waitFailures(t, 2)
 	if source.calls != 1 {
-		t.Fatalf("subscriber source calls = %d, want one cached non-large snapshot load", source.calls)
+		t.Fatalf("subscriber source calls = %d, want one cached snapshot load despite active failures", source.calls)
 	}
 	if got := enqueuer.recipientUIDs(); !reflect.DeepEqual(got, []string{"u2", "u3", "u2", "u3"}) {
 		t.Fatalf("recipient uids = %#v, want cached subscribers dispatched for both messages", got)
@@ -779,6 +940,32 @@ func TestNoPersistRequestScopedDispatchesRealtimeWithoutSubscriberScan(t *testin
 
 type staticRecipientAuthorityResolverForCommitTest struct {
 	nodeID uint64
+}
+
+type blockingActiveAdmitterForCommitTest struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+	err         error
+}
+
+func newBlockingActiveAdmitterForCommitTest(err error) *blockingActiveAdmitterForCommitTest {
+	return &blockingActiveAdmitterForCommitTest{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     err,
+	}
+}
+
+func (a *blockingActiveAdmitterForCommitTest) AdmitActiveBatch(_ context.Context, _ conversationactive.ActiveBatch) error {
+	a.startedOnce.Do(func() { close(a.started) })
+	<-a.release
+	return a.err
+}
+
+func (a *blockingActiveAdmitterForCommitTest) releaseAdmission() {
+	a.releaseOnce.Do(func() { close(a.release) })
 }
 
 type recordingEffectObserverForCommitTest struct {

--- a/internal/runtime/channelappend/recipient.go
+++ b/internal/runtime/channelappend/recipient.go
@@ -14,7 +14,15 @@ import (
 const subscriberSnapshotLoadLimit = 1 << 30
 
 type recipientDispatchResult struct {
+	// subscriberCache carries a successfully loaded non-large recipient snapshot.
 	subscriberCache subscriberCache
+	// activeErr reports an independent conversation projection failure without failing delivery.
+	activeErr error
+}
+
+type recipientSetDispatchResult struct {
+	// activeErr reports the best-effort conversation projection outcome for this recipient set.
+	activeErr error
 }
 
 func dispatchCommittedRecipients(ctx context.Context, event CommittedEnvelope, ports commitPorts) error {
@@ -35,31 +43,34 @@ func dispatchCommittedRecipientsForTarget(ctx context.Context, target AuthorityT
 		return recipientDispatchResult{}, withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "context"})
 	}
 	if len(event.MessageScopedUIDs) > 0 {
-		return recipientDispatchResult{}, dispatchRecipientSet(ctx, event, recipientsFromUIDs(event.MessageScopedUIDs), ports)
+		result, err := dispatchRecipientSetResult(ctx, event, recipientsFromUIDs(event.MessageScopedUIDs), ports)
+		return recipientDispatchResult{activeErr: result.activeErr}, err
 	}
 	if event.ChannelType == channelTypePerson {
 		left, right, err := runtimechannelid.DecodePersonChannel(event.ChannelID)
 		if err != nil {
 			return recipientDispatchResult{}, withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "person_channel_decode"})
 		}
-		return recipientDispatchResult{}, dispatchRecipientSet(ctx, event, []Recipient{{UID: left}, {UID: right}}, ports)
+		result, dispatchErr := dispatchRecipientSetResult(ctx, event, []Recipient{{UID: left}, {UID: right}}, ports)
+		return recipientDispatchResult{activeErr: result.activeErr}, dispatchErr
 	}
 	if target.Large {
-		return recipientDispatchResult{}, dispatchSubscriberPages(ctx, event, ports)
+		return dispatchSubscriberPages(ctx, event, ports)
 	}
 	return dispatchSubscriberSnapshot(ctx, target, event, cache, ports)
 }
 
-func dispatchSubscriberPages(ctx context.Context, event CommittedEnvelope, ports commitPorts) error {
+func dispatchSubscriberPages(ctx context.Context, event CommittedEnvelope, ports commitPorts) (recipientDispatchResult, error) {
 	if ports.subscribers == nil {
-		return nil
+		return recipientDispatchResult{}, nil
 	}
 	pageSize := boundedPositive(ports.subscriberPageSize, defaultSubscriberScanPageSize)
 	cursor := ""
+	var result recipientDispatchResult
 	for {
 		previousCursor := cursor
 		if err := contextErr(ctx); err != nil {
-			return withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "context"})
+			return result, withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "context"})
 		}
 		page, err := ports.subscribers.NextSubscriberPage(ctx, SubscriberPageRequest{
 			ChannelID: ChannelID{ID: event.ChannelID, Type: event.ChannelType},
@@ -67,19 +78,23 @@ func dispatchSubscriberPages(ctx context.Context, event CommittedEnvelope, ports
 			Limit:     pageSize,
 		})
 		if err != nil {
-			return withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "subscriber_page"})
+			return result, withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "subscriber_page"})
 		}
 		if !page.Done && (page.Cursor == "" || page.Cursor == previousCursor) {
-			return withPostCommitFailureDetail(ErrInvalidSubscriberCursor, PostCommitFailureDetail{
+			return result, withPostCommitFailureDetail(ErrInvalidSubscriberCursor, PostCommitFailureDetail{
 				Phase:          "subscriber_cursor",
 				RecipientCount: len(page.Recipients),
 			})
 		}
-		if err := dispatchRecipientSet(ctx, event, page.Recipients, ports); err != nil {
-			return err
+		pageResult, dispatchErr := dispatchRecipientSetResult(ctx, event, page.Recipients, ports)
+		if result.activeErr == nil {
+			result.activeErr = pageResult.activeErr
+		}
+		if dispatchErr != nil {
+			return result, dispatchErr
 		}
 		if page.Done {
-			return nil
+			return result, nil
 		}
 		cursor = page.Cursor
 	}
@@ -90,7 +105,8 @@ func dispatchSubscriberSnapshot(ctx context.Context, target AuthorityTarget, eve
 		return recipientDispatchResult{}, nil
 	}
 	if cache.matches(target) {
-		return recipientDispatchResult{}, dispatchRecipientSet(ctx, event, cache.recipients, ports)
+		result, err := dispatchRecipientSetResult(ctx, event, cache.recipients, ports)
+		return recipientDispatchResult{subscriberCache: cache, activeErr: result.activeErr}, err
 	}
 	if err := contextErr(ctx); err != nil {
 		return recipientDispatchResult{}, withPostCommitFailureDetail(err, PostCommitFailureDetail{Phase: "context"})
@@ -113,25 +129,33 @@ func dispatchSubscriberSnapshot(ctx context.Context, target AuthorityTarget, eve
 		mutationVersion: target.SubscriberMutationVersion,
 		recipients:      append([]Recipient(nil), page.Recipients...),
 	}
-	if err := dispatchRecipientSet(ctx, event, page.Recipients, ports); err != nil {
-		return recipientDispatchResult{}, err
+	dispatch, err := dispatchRecipientSetResult(ctx, event, page.Recipients, ports)
+	if err != nil {
+		return recipientDispatchResult{activeErr: dispatch.activeErr}, err
 	}
-	return recipientDispatchResult{subscriberCache: nextCache}, nil
+	return recipientDispatchResult{subscriberCache: nextCache, activeErr: dispatch.activeErr}, nil
 }
 
 func dispatchRecipientSet(ctx context.Context, event CommittedEnvelope, recipients []Recipient, ports commitPorts) error {
+	_, err := dispatchRecipientSetResult(ctx, event, recipients, ports)
+	return err
+}
+
+func dispatchRecipientSetResult(ctx context.Context, event CommittedEnvelope, recipients []Recipient, ports commitPorts) (recipientSetDispatchResult, error) {
 	enqueuer := effectiveRecipientDeliveryEnqueuer(ports)
 	if len(recipients) == 0 || (ports.activeAdmitter == nil && enqueuer == nil) {
-		return nil
+		return recipientSetDispatchResult{}, nil
 	}
-	batchSize := boundedPositive(ports.recipientBatchSize, defaultRecipientBatchSize)
 	recipients, uids := normalizeRecipientsForAuthorityResolution(recipients)
 	if len(recipients) == 0 {
-		return nil
+		return recipientSetDispatchResult{}, nil
 	}
-	if err := admitConversationActiveBatch(ctx, event, recipients, uids, ports.activeAdmitter); err != nil {
-		return err
-	}
+	deliveryErr := dispatchRecipientDelivery(ctx, event, recipients, uids, ports, enqueuer)
+	activeErr := admitConversationActiveBatch(ctx, event, recipients, uids, ports.activeAdmitter)
+	return recipientSetDispatchResult{activeErr: activeErr}, deliveryErr
+}
+
+func dispatchRecipientDelivery(ctx context.Context, event CommittedEnvelope, recipients []Recipient, uids []string, ports commitPorts, enqueuer RecipientDeliveryEnqueuer) error {
 	if enqueuer == nil {
 		return nil
 	}
@@ -164,6 +188,7 @@ func dispatchRecipientSet(ctx context.Context, event CommittedEnvelope, recipien
 		}
 		grouped[target] = append(grouped[target], recipient)
 	}
+	batchSize := boundedPositive(ports.recipientBatchSize, defaultRecipientBatchSize)
 	concurrency := boundedPositive(ports.recipientDispatchConcurrency, 1)
 	if concurrency <= 1 || len(order) <= 1 {
 		for _, target := range order {

--- a/internal/runtime/channelappend/recipient_test.go
+++ b/internal/runtime/channelappend/recipient_test.go
@@ -44,7 +44,7 @@ func TestScopedUIDsBypassSubscriberScan(t *testing.T) {
 	}
 }
 
-func TestActiveBatchAdmittedBeforeRecipientEnqueuer(t *testing.T) {
+func TestRecipientDeliveryDoesNotWaitForActiveBatchAdmission(t *testing.T) {
 	steps := &orderedStepsForDeliveryTest{}
 	active := &recordingActiveAdmitterForRecipientTest{steps: steps}
 	enqueuer := &recordingRecipientEnqueuerForRecipientTest{steps: steps}
@@ -69,8 +69,8 @@ func TestActiveBatchAdmittedBeforeRecipientEnqueuer(t *testing.T) {
 		t.Fatalf("dispatchCommittedRecipients() error = %v", err)
 	}
 
-	if got := steps.snapshot(); !reflect.DeepEqual(got, []string{"active", "delivery"}) {
-		t.Fatalf("steps = %#v, want active before delivery", got)
+	if got := steps.snapshot(); !reflect.DeepEqual(got, []string{"delivery", "active"}) {
+		t.Fatalf("steps = %#v, want delivery before active projection", got)
 	}
 	if len(active.batches) != 1 {
 		t.Fatalf("active batches = %d, want 1", len(active.batches))
@@ -176,12 +176,15 @@ func TestRecipientProcessorAdmitsCMDConversationKind(t *testing.T) {
 	}
 }
 
-func TestActiveBatchFailureStopsRecipientEnqueuer(t *testing.T) {
+func TestActiveBatchFailureDoesNotStopRecipientEnqueuer(t *testing.T) {
 	activeErr := errors.New("active unavailable")
 	active := &recordingActiveAdmitterForRecipientTest{err: activeErr}
 	enqueuer := &recordingRecipientEnqueuerForRecipientTest{}
 
-	err := dispatchCommittedRecipients(context.Background(), CommittedEnvelope{
+	dispatch, err := dispatchCommittedRecipientsForTarget(context.Background(), AuthorityTarget{
+		ChannelID: ChannelID{ID: "g1", Type: 2},
+		Large:     true,
+	}, CommittedEnvelope{
 		MessageID:         1,
 		MessageSeq:        7,
 		ChannelID:         "g1",
@@ -189,21 +192,122 @@ func TestActiveBatchFailureStopsRecipientEnqueuer(t *testing.T) {
 		FromUID:           "sender",
 		ServerTimestampMS: 99,
 		MessageScopedUIDs: []string{"u2"},
-	}, commitPorts{
+	}, subscriberCache{}, commitPorts{
 		activeAdmitter:             active,
 		recipientAuthorityResolver: staticRecipientAuthorityResolverForRecipientTest{nodeID: 7},
 		deliveryEnqueuer:           enqueuer,
 		recipientBatchSize:         16,
 	})
-	if !errors.Is(err, activeErr) {
-		t.Fatalf("dispatchCommittedRecipients() error = %v, want active error", err)
+	if err != nil {
+		t.Fatalf("dispatchCommittedRecipientsForTarget() delivery error = %v, want nil", err)
 	}
-	detail := postCommitFailureDetailFromError(err)
+	if !errors.Is(dispatch.activeErr, activeErr) {
+		t.Fatalf("active projection error = %v, want %v", dispatch.activeErr, activeErr)
+	}
+	detail := postCommitFailureDetailFromError(dispatch.activeErr)
 	if detail.Phase != "conversation_active" || detail.UID != "u2" || detail.RecipientCount != 1 {
 		t.Fatalf("post-commit failure detail = %#v, want conversation_active detail", detail)
 	}
-	if got := enqueuer.callCount(); got != 0 {
-		t.Fatalf("enqueuer calls = %d, want 0 after active failure", got)
+	if got := enqueuer.callCount(); got != 1 {
+		t.Fatalf("enqueuer calls = %d, want 1 despite active failure", got)
+	}
+}
+
+func TestActiveBatchFailureDoesNotStopLargeSubscriberPages(t *testing.T) {
+	activeErr := errors.New("active unavailable")
+	active := &recordingActiveAdmitterForRecipientTest{err: activeErr}
+	enqueuer := &recordingRecipientEnqueuerForRecipientTest{}
+	source := &recordingSubscriberSourceForRecipientTest{pages: []SubscriberPage{
+		{Recipients: []Recipient{{UID: "u2"}}, Cursor: "next"},
+		{Recipients: []Recipient{{UID: "u3"}}, Done: true},
+	}}
+
+	dispatch, err := dispatchCommittedRecipientsForTarget(context.Background(), AuthorityTarget{
+		ChannelID: ChannelID{ID: "g1", Type: 2},
+		Large:     true,
+	}, CommittedEnvelope{
+		MessageID:   1,
+		MessageSeq:  7,
+		ChannelID:   "g1",
+		ChannelType: 2,
+		FromUID:     "sender",
+	}, subscriberCache{}, commitPorts{
+		activeAdmitter:             active,
+		subscribers:                source,
+		recipientAuthorityResolver: staticRecipientAuthorityResolverForRecipientTest{nodeID: 7},
+		deliveryEnqueuer:           enqueuer,
+		recipientBatchSize:         16,
+		subscriberPageSize:         1,
+	})
+	if err != nil {
+		t.Fatalf("dispatchCommittedRecipientsForTarget() delivery error = %v, want nil", err)
+	}
+	if !errors.Is(dispatch.activeErr, activeErr) {
+		t.Fatalf("active projection error = %v, want %v", dispatch.activeErr, activeErr)
+	}
+	if source.calls != 2 {
+		t.Fatalf("subscriber page calls = %d, want all 2 pages", source.calls)
+	}
+	if got := enqueuer.allUIDs(); !reflect.DeepEqual(got, []string{"u2", "u3"}) {
+		t.Fatalf("enqueued recipients = %#v, want all large-channel pages", got)
+	}
+}
+
+func TestActiveBatchFailureStillCommitsSubscriberSnapshot(t *testing.T) {
+	activeErr := errors.New("active unavailable")
+	target := AuthorityTarget{
+		ChannelID:                 ChannelID{ID: "g1", Type: 2},
+		SubscriberMutationVersion: 9,
+	}
+	dispatch, err := dispatchCommittedRecipientsForTarget(context.Background(), target, CommittedEnvelope{
+		MessageID:   1,
+		MessageSeq:  7,
+		ChannelID:   "g1",
+		ChannelType: 2,
+		FromUID:     "sender",
+	}, subscriberCache{}, commitPorts{
+		activeAdmitter: &recordingActiveAdmitterForRecipientTest{err: activeErr},
+		subscribers: &recordingSubscriberSourceForRecipientTest{pages: []SubscriberPage{{
+			Recipients: []Recipient{{UID: "u2"}},
+			Done:       true,
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("dispatchCommittedRecipientsForTarget() delivery error = %v, want nil", err)
+	}
+	if !errors.Is(dispatch.activeErr, activeErr) {
+		t.Fatalf("active projection error = %v, want %v", dispatch.activeErr, activeErr)
+	}
+	if !dispatch.subscriberCache.matches(target) {
+		t.Fatalf("subscriber cache = %#v, want ready version %d despite active failure", dispatch.subscriberCache, target.SubscriberMutationVersion)
+	}
+}
+
+func TestSubscriberSnapshotDoubleFailurePreservesIndependentActiveError(t *testing.T) {
+	target := AuthorityTarget{
+		ChannelID:                 ChannelID{ID: "g1", Type: 2},
+		SubscriberMutationVersion: 9,
+	}
+	dispatch, err := dispatchCommittedRecipientsForTarget(context.Background(), target, CommittedEnvelope{
+		MessageID:   1,
+		MessageSeq:  7,
+		ChannelID:   "g1",
+		ChannelType: 2,
+		FromUID:     "sender",
+	}, subscriberCache{}, commitPorts{
+		activeAdmitter:             &recordingActiveAdmitterForRecipientTest{err: context.DeadlineExceeded},
+		subscribers:                &recordingSubscriberSourceForRecipientTest{pages: []SubscriberPage{{Recipients: []Recipient{{UID: "u2"}}, Done: true}}},
+		recipientAuthorityResolver: failingRecipientAuthorityResolverForRecipientTest{err: ErrRouteNotReady},
+		deliveryEnqueuer:           &recordingRecipientEnqueuerForRecipientTest{},
+	})
+	if !errors.Is(err, ErrRouteNotReady) {
+		t.Fatalf("delivery error = %v, want %v", err, ErrRouteNotReady)
+	}
+	if !errors.Is(dispatch.activeErr, context.DeadlineExceeded) {
+		t.Fatalf("active projection error = %v, want deadline exceeded", dispatch.activeErr)
+	}
+	if dispatch.subscriberCache.ready {
+		t.Fatal("subscriber cache committed despite delivery failure")
 	}
 }
 

--- a/internal/runtime/channelappend/writer.go
+++ b/internal/runtime/channelappend/writer.go
@@ -474,7 +474,7 @@ func (w *channelWriter) runCommit(effect *commitEffect) {
 }
 
 func (w *channelWriter) applyCommitCompletion(event commitCompletedEvent) {
-	var failures []commitCompletedItem
+	failures := append([]commitCompletedItem(nil), event.failures...)
 	w.mu.Lock()
 	backlogBefore := w.state.commitBacklog()
 	if len(event.items) > 0 {

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -8,20 +8,24 @@ Current flow:
 
 1. Channel append or another authority-owned caller submits an `ActiveBatch`.
 2. The manager merges rows by `(uid, kind, channel_id, channel_type)`.
-3. Dirty flushes are serialized from cache snapshot through durable completion,
-   then write through `ActiveStore.TouchConversationActiveAt`.
-4. Cache-pressure admission first evicts already-clean rows while holding the
-   cache lock. Only an insufficient clean working set enters the serialized
-   flush lane, where the larger of required admission capacity and configured
-   headroom is persisted and evicted. Spill size follows bounded admission work
-   instead of scaling to the whole dirty cache.
-5. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
-6. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
+3. Admission mutates cache state only. It may evict already-clean rows while
+   holding the cache lock, but it never reads or writes `ActiveStore` and never
+   waits for the serialized durable flush lane. If a new row still exceeds the
+   hard bound, the whole admission is rejected with `ErrCachePressure`.
+4. At 80% total cache occupancy with more than 70% of configured capacity still
+   dirty, the manager starts a pressure-drain cycle by sending one nonblocking,
+   coalesced wakeup to the app flush worker. A full dirty cache uses the same
+   wakeup and rejection path.
+5. Each pressure wake persists at most the configured flush batch through
+   `ActiveStore.TouchConversationActiveAt`. Successful attempts requeue one
+   wakeup while dirty rows remain above the 70% low watermark. Retained clean
+   rows form an immediately evictable reserve for later admissions.
+6. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
+7. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
 
-Serialization covers scheduled, cache-pressure, and hash-slot-scoped flushes. It
-prevents concurrent admissions at the row cap from duplicating a pressure
-snapshot while preserving version fencing for updates that arrive during
-durable I/O.
+Only periodic, pressure-woken, and hash-slot-scoped durable flush attempts enter
+the serialized flush lane. Version fencing preserves updates that arrive during
+durable I/O; admission remains independent from that lane.
 
 Cache observations report aggregate row/dirty counts plus fixed kind-aware
 normal/CMD counts maintained incrementally on cache mutation. Observation does

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -3,13 +3,17 @@ package conversationactive
 import (
 	"container/heap"
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
 
-const defaultPressureSpillRows = 128
+const (
+	pressureHighWatermarkPercent = 80
+	pressureLowWatermarkPercent  = 70
+)
 
 type conversationKey struct {
 	kind        metadb.ConversationKind
@@ -60,8 +64,14 @@ type Manager struct {
 	activeCooldown time.Duration
 	// maxCachedRows bounds cached rows across all UIDs; zero means unbounded.
 	maxCachedRows int
-	// pressureSpillRows sets the reusable headroom for one synchronous cache-pressure flush and eviction.
-	pressureSpillRows int
+	// pressureHighRows starts proactive asynchronous flushing at this cache size.
+	pressureHighRows int
+	// pressureLowDirtyRows stops a pressure-triggered flush cycle while retaining clean rows as an eviction reserve.
+	pressureLowDirtyRows int
+	// pressureDraining reports that the asynchronous worker is draining a high-pressure cache.
+	pressureDraining bool
+	// pressureNotify receives nonblocking cache-pressure wakeups owned by the app flush worker.
+	pressureNotify chan<- struct{}
 	// observer receives cache and flush observations.
 	observer Observer
 	// totalRows tracks cached active rows across all UID maps.
@@ -92,22 +102,21 @@ func NewManager(opts Options) *Manager {
 			return time.Now().UnixMilli()
 		}
 	}
-	pressureSpillRows := opts.PressureSpillRows
-	if pressureSpillRows <= 0 {
-		pressureSpillRows = defaultPressureSpillRows
-	}
+	pressureHighRows, pressureLowDirtyRows := pressureWatermarks(opts.MaxCachedRows)
 	return &Manager{
-		nowMS:               nowMS,
-		store:               opts.Store,
-		activeCooldown:      opts.ActiveCooldown,
-		maxCachedRows:       opts.MaxCachedRows,
-		pressureSpillRows:   pressureSpillRows,
-		observer:            opts.Observer,
-		rowsByKind:          make(map[metadb.ConversationKind]int),
-		dirtyRowsByKind:     make(map[metadb.ConversationKind]int),
-		dirtyActiveAtCounts: make(map[int64]int),
-		cache:               make(map[string]map[conversationKey]cacheEntry),
-		dirtyByHashSlot:     make(map[uint16]map[cacheAddress]struct{}),
+		nowMS:                nowMS,
+		store:                opts.Store,
+		activeCooldown:       opts.ActiveCooldown,
+		maxCachedRows:        opts.MaxCachedRows,
+		pressureHighRows:     pressureHighRows,
+		pressureLowDirtyRows: pressureLowDirtyRows,
+		pressureNotify:       opts.PressureNotify,
+		observer:             opts.Observer,
+		rowsByKind:           make(map[metadb.ConversationKind]int),
+		dirtyRowsByKind:      make(map[metadb.ConversationKind]int),
+		dirtyActiveAtCounts:  make(map[int64]int),
+		cache:                make(map[string]map[conversationKey]cacheEntry),
+		dirtyByHashSlot:      make(map[uint16]map[cacheAddress]struct{}),
 	}
 }
 
@@ -198,16 +207,76 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 				}
 				m.markActiveLocked(patch, hashSlot, hasHashSlot)
 			}
+			signalPressure := m.startPressureDrainLocked()
 			m.mu.Unlock()
+			if signalPressure {
+				m.signalPressure()
+			}
 			m.observeCache()
 			return nil
 		}
+		signalPressure := !m.pressureDraining
+		m.pressureDraining = true
 		m.mu.Unlock()
-
-		if err := m.spillForPressure(ctx, newRows); err != nil {
-			return err
+		if signalPressure {
+			m.signalPressure()
 		}
+		return ErrCachePressure
 	}
+}
+
+func (m *Manager) signalPressure() {
+	if m == nil || m.pressureNotify == nil {
+		return
+	}
+	select {
+	case m.pressureNotify <- struct{}{}:
+	default:
+	}
+}
+
+func (m *Manager) startPressureDrainLocked() bool {
+	if m.pressureDraining || m.maxCachedRows <= 0 || m.pressureHighRows <= 0 || m.totalRows < m.pressureHighRows || m.dirtyRows <= m.pressureLowDirtyRows {
+		return false
+	}
+	m.pressureDraining = true
+	return true
+}
+
+func (m *Manager) continuePressureDrain() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if !m.pressureDraining {
+		m.mu.Unlock()
+		return
+	}
+	if m.dirtyRows <= m.pressureLowDirtyRows {
+		m.pressureDraining = false
+		m.mu.Unlock()
+		return
+	}
+	m.mu.Unlock()
+	m.signalPressure()
+}
+
+func pressureWatermarks(maxRows int) (int, int) {
+	if maxRows <= 0 {
+		return 0, 0
+	}
+	high := maxRows * pressureHighWatermarkPercent / 100
+	if high <= 0 {
+		high = 1
+	}
+	low := maxRows * pressureLowWatermarkPercent / 100
+	if low >= high {
+		low = high - 1
+	}
+	if low < 0 {
+		low = 0
+	}
+	return high, low
 }
 
 func (m *Manager) markActiveLocked(patch ActivePatch, hashSlot uint16, hasHashSlot bool) {
@@ -288,44 +357,6 @@ func (m *Manager) cacheWouldExceedLocked(newRows int) bool {
 	return m.maxCachedRows > 0 && newRows > 0 && m.totalRows+newRows > m.maxCachedRows
 }
 
-func (m *Manager) spillForPressure(ctx context.Context, newRows int) error {
-	if m.store == nil {
-		return ErrCachePressure
-	}
-
-	m.flushMu.Lock()
-	defer m.flushMu.Unlock()
-
-	m.mu.RLock()
-	over := m.totalRows + newRows - m.maxCachedRows
-	m.mu.RUnlock()
-	if over <= 0 {
-		return nil
-	}
-	spillRows := m.pressureSpillRows
-	if over > spillRows {
-		spillRows = over
-	}
-	if _, err := m.flushDirtySerialized(ctx, spillRows); err != nil {
-		return err
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	over = m.totalRows + newRows - m.maxCachedRows
-	if over <= 0 {
-		return nil
-	}
-	if over > spillRows {
-		spillRows = over
-	}
-	if evicted := m.evictCleanRowsLocked(spillRows); evicted < over {
-		return ErrCachePressure
-	}
-	return nil
-}
-
 func (m *Manager) evictCleanRowsLocked(limit int) int {
 	if limit <= 0 {
 		return 0
@@ -389,6 +420,7 @@ func (m *Manager) flushDirtySerialized(ctx context.Context, limit int) (FlushRes
 
 func (m *Manager) flushDirtyEntries(ctx context.Context, startedAt time.Time, entries []flushEntry) (FlushResult, error) {
 	if len(entries) == 0 {
+		m.continuePressureDrain()
 		m.observeFlush(FlushObservation{Result: "no_dirty", Duration: positiveDuration(time.Since(startedAt))})
 		m.observeCache()
 		return FlushResult{}, nil
@@ -396,7 +428,7 @@ func (m *Manager) flushDirtyEntries(ctx context.Context, startedAt time.Time, en
 
 	flushEntries, skippedEntries, err := m.filterFlushEntries(ctx, entries)
 	if err != nil {
-		m.observeFlush(FlushObservation{Result: "error", Selected: len(entries), Duration: positiveDuration(time.Since(startedAt))})
+		m.observeFlush(FlushObservation{Result: flushErrorResult(err), Selected: len(entries), Duration: positiveDuration(time.Since(startedAt))})
 		m.observeCache()
 		return FlushResult{Selected: len(entries)}, err
 	}
@@ -407,16 +439,24 @@ func (m *Manager) flushDirtyEntries(ctx context.Context, startedAt time.Time, en
 	}
 	if len(patches) > 0 {
 		if err := m.store.TouchConversationActiveAt(ctx, patches); err != nil {
-			m.observeFlush(FlushObservation{Result: "error", Selected: len(entries), Duration: positiveDuration(time.Since(startedAt))})
+			m.observeFlush(FlushObservation{Result: flushErrorResult(err), Selected: len(entries), Duration: positiveDuration(time.Since(startedAt))})
 			m.observeCache()
 			return FlushResult{Selected: len(entries)}, err
 		}
 	}
 	m.clearSkippedDirty(skippedEntries)
 	m.clearFlushedDirty(flushEntries)
+	m.continuePressureDrain()
 	m.observeFlush(FlushObservation{Result: "ok", Selected: len(entries), Flushed: len(flushEntries), Duration: positiveDuration(time.Since(startedAt))})
 	m.observeCache()
 	return FlushResult{Selected: len(entries), Flushed: len(flushEntries)}, nil
+}
+
+func flushErrorResult(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return "timeout"
+	}
+	return "error"
 }
 
 func (m *Manager) filterFlushEntries(ctx context.Context, entries []flushEntry) ([]flushEntry, []flushEntry, error) {

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -802,6 +802,29 @@ func TestManagerObservesFlushFailureAndNoDirty(t *testing.T) {
 	}
 }
 
+func TestManagerObservesFlushDeadlineAsTimeout(t *testing.T) {
+	ctx := context.Background()
+	observer := &recordingConversationActiveObserver{}
+	store := &recordingActiveStore{touchErr: context.DeadlineExceeded}
+	m := NewManager(Options{Store: store, Observer: observer})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u1",
+		ChannelID:   "room-1",
+		ChannelType: 2,
+		ActiveAtMS:  1000,
+	}}); err != nil {
+		t.Fatalf("MarkActive() error = %v", err)
+	}
+
+	if _, err := m.Flush(ctx, 1); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Flush() error = %v, want deadline exceeded", err)
+	}
+	if flush := observer.lastFlush(t); flush.Result != "timeout" || flush.Selected != 1 {
+		t.Fatalf("flush observation = %+v, want timeout selected=1", flush)
+	}
+}
+
 func TestFlushFailureKeepsDirty(t *testing.T) {
 	ctx := context.Background()
 	touchErr := errors.New("touch failed")
@@ -858,7 +881,132 @@ func TestFlushDoesNotClearConcurrentDirtyUpdate(t *testing.T) {
 	}
 }
 
-func TestAdmitUnderCachePressureSpillsDirtyRows(t *testing.T) {
+func TestCachePressureAdmissionDoesNotPerformDurableIO(t *testing.T) {
+	ctx := context.Background()
+	storeErr := errors.New("durable store must not be called by admission")
+	store := &recordingActiveStore{touchErr: storeErr}
+	m := NewManager(Options{Store: store, ActiveCooldown: time.Hour, MaxCachedRows: 1})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u1",
+		ChannelID:   "old",
+		ChannelType: 2,
+		ActiveAtMS:  1000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(old) error = %v", err)
+	}
+
+	err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u2",
+		ChannelID:   "new",
+		ChannelType: 2,
+		ActiveAtMS:  2000,
+	}})
+	if !errors.Is(err, ErrCachePressure) {
+		t.Fatalf("MarkActive(pressure) error = %v, want %v", err, ErrCachePressure)
+	}
+	if len(store.touches) != 0 {
+		t.Fatalf("admission durable writes = %d, want 0", len(store.touches))
+	}
+	if len(store.batchKeys) != 0 {
+		t.Fatalf("admission durable reads = %d, want 0", len(store.batchKeys))
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "old", 2); !ok {
+		t.Fatal("existing dirty row was removed after rejected pressure admission")
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u2", "new", 2); ok {
+		t.Fatal("rejected pressure row was partially cached")
+	}
+}
+
+func TestCachePressureAdmissionSignalsAsyncFlush(t *testing.T) {
+	ctx := context.Background()
+	pressureSignals := make(chan struct{}, 1)
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 1, PressureNotify: pressureSignals})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u1",
+		ChannelID:   "old",
+		ChannelType: 2,
+		ActiveAtMS:  1000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(old) error = %v", err)
+	}
+
+	err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u2",
+		ChannelID:   "new",
+		ChannelType: 2,
+		ActiveAtMS:  2000,
+	}})
+	if !errors.Is(err, ErrCachePressure) {
+		t.Fatalf("MarkActive(pressure) error = %v, want %v", err, ErrCachePressure)
+	}
+	select {
+	case <-pressureSignals:
+	default:
+		t.Fatal("cache pressure admission did not signal the async flush worker")
+	}
+}
+
+func TestCachePressureAdmissionDoesNotWaitForInFlightFlush(t *testing.T) {
+	ctx := context.Background()
+	store := &blockingActiveStore{
+		entered: make(chan int, 1),
+		release: make(chan struct{}),
+	}
+	releaseStore := sync.OnceFunc(func() { close(store.release) })
+	defer releaseStore()
+	m := NewManager(Options{Store: store, MaxCachedRows: 1})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u1",
+		ChannelID:   "old",
+		ChannelType: 2,
+		ActiveAtMS:  1000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(old) error = %v", err)
+	}
+
+	flushDone := make(chan error, 1)
+	go func() {
+		_, err := m.Flush(ctx, 1)
+		flushDone <- err
+	}()
+	select {
+	case <-store.entered:
+	case <-time.After(time.Second):
+		t.Fatal("flush did not reach the blocking durable store")
+	}
+
+	admissionDone := make(chan error, 1)
+	go func() {
+		admissionDone <- m.MarkActive(ctx, []ActivePatch{{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         "u2",
+			ChannelID:   "new",
+			ChannelType: 2,
+			ActiveAtMS:  2000,
+		}})
+	}()
+	select {
+	case err := <-admissionDone:
+		if !errors.Is(err, ErrCachePressure) {
+			t.Fatalf("MarkActive(pressure) error = %v, want %v", err, ErrCachePressure)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("cache-pressure admission waited for the in-flight durable flush")
+	}
+
+	releaseStore()
+	if err := <-flushDone; err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+}
+
+func TestCachePressureAdmissionRecoversAfterAsyncFlush(t *testing.T) {
 	ctx := context.Background()
 	store := &recordingActiveStore{}
 	m := NewManager(Options{Store: store, MaxCachedRows: 1})
@@ -866,16 +1014,25 @@ func TestAdmitUnderCachePressureSpillsDirtyRows(t *testing.T) {
 		t.Fatalf("MarkActive(old) error = %v", err)
 	}
 
-	err := m.AdmitActiveBatch(ctx, ActiveBatch{
+	batch := ActiveBatch{
 		Kind:        metadb.ConversationKindNormal,
 		SenderUID:   "u1",
 		ChannelID:   "new",
 		ChannelType: 2,
 		MessageSeq:  10,
 		ActiveAtMS:  2000,
-	})
-	if err != nil {
-		t.Fatalf("AdmitActiveBatch() error = %v", err)
+	}
+	if err := m.AdmitActiveBatch(ctx, batch); !errors.Is(err, ErrCachePressure) {
+		t.Fatalf("AdmitActiveBatch(before flush) error = %v, want %v", err, ErrCachePressure)
+	}
+	if len(store.touches) != 0 {
+		t.Fatalf("admission durable writes = %d, want 0", len(store.touches))
+	}
+	if result, err := m.Flush(ctx, 1); err != nil || result.Flushed != 1 {
+		t.Fatalf("Flush() = %+v, %v, want one flushed row", result, err)
+	}
+	if err := m.AdmitActiveBatch(ctx, batch); err != nil {
+		t.Fatalf("AdmitActiveBatch(after flush) error = %v", err)
 	}
 
 	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "old", 2); ok {
@@ -944,19 +1101,17 @@ func TestAdmitUnderCachePressureEvictsCleanRowsWithoutFlush(t *testing.T) {
 	}
 }
 
-func TestCachePressureSpillIsBoundedAndCreatesHeadroom(t *testing.T) {
+func TestCachePressureFlushContinuesUntilDirtyLowWatermark(t *testing.T) {
 	const (
-		maxRows           = 16
-		pressureSpillRows = 4
+		maxRows = 10
 	)
 	ctx := context.Background()
 	store := &recordingActiveStore{}
-	observer := &recordingConversationActiveObserver{}
+	pressureSignals := make(chan struct{}, 1)
 	m := NewManager(Options{
-		Store:             store,
-		MaxCachedRows:     maxRows,
-		PressureSpillRows: pressureSpillRows,
-		Observer:          observer,
+		Store:          store,
+		MaxCachedRows:  maxRows,
+		PressureNotify: pressureSignals,
 	})
 	initial := make([]ActivePatch, 0, maxRows)
 	for i := 0; i < maxRows; i++ {
@@ -971,58 +1126,39 @@ func TestCachePressureSpillIsBoundedAndCreatesHeadroom(t *testing.T) {
 	if err := m.MarkActive(ctx, initial); err != nil {
 		t.Fatalf("MarkActive(initial) error = %v", err)
 	}
-
-	if err := m.MarkActive(ctx, []ActivePatch{{
-		Kind:        metadb.ConversationKindNormal,
-		UID:         "new-0",
-		ChannelID:   "room",
-		ChannelType: 2,
-		ActiveAtMS:  2000,
-	}}); err != nil {
-		t.Fatalf("MarkActive(first pressure) error = %v", err)
-	}
-	if len(store.touches) != 1 || len(store.touches[0]) != pressureSpillRows {
-		t.Fatalf("first pressure touches = %+v, want one bounded %d-row spill", store.touches, pressureSpillRows)
-	}
-	cache := observer.lastCache(t)
-	if cache.Rows != maxRows-pressureSpillRows+1 {
-		t.Fatalf("cache rows after spill = %d, want %d rows with reusable headroom", cache.Rows, maxRows-pressureSpillRows+1)
+	select {
+	case <-pressureSignals:
+	default:
+		t.Fatal("high watermark did not start an asynchronous pressure flush cycle")
 	}
 
-	for i := 1; i < pressureSpillRows; i++ {
-		if err := m.MarkActive(ctx, []ActivePatch{{
-			Kind:        metadb.ConversationKindNormal,
-			UID:         fmt.Sprintf("new-%d", i),
-			ChannelID:   "room",
-			ChannelType: 2,
-			ActiveAtMS:  2000,
-		}}); err != nil {
-			t.Fatalf("MarkActive(headroom %d) error = %v", i, err)
-		}
+	if result, err := m.Flush(ctx, 1); err != nil || result.Flushed != 1 {
+		t.Fatalf("Flush(first) = %+v, %v, want one bounded row", result, err)
 	}
-	if len(store.touches) != 1 {
-		t.Fatalf("touch calls after consuming headroom = %d, want 1", len(store.touches))
+	select {
+	case <-pressureSignals:
+	default:
+		t.Fatal("dirty rows above the low watermark did not continue the pressure flush cycle")
 	}
-	cache = observer.lastCache(t)
-	if cache.Rows != maxRows {
-		t.Fatalf("cache rows after consuming headroom = %d, want %d", cache.Rows, maxRows)
+	if result, err := m.Flush(ctx, 2); err != nil || result.Flushed != 2 {
+		t.Fatalf("Flush(to low watermark) = %+v, %v, want two bounded rows", result, err)
+	}
+	select {
+	case <-pressureSignals:
+		t.Fatal("pressure flush cycle continued after dirty rows reached the 70 percent low watermark")
+	default:
 	}
 }
 
-func TestConcurrentCachePressureDoesNotDuplicateBoundedSpill(t *testing.T) {
+func TestConcurrentCachePressureCoalescesAsyncFlushSignal(t *testing.T) {
 	const (
-		maxRows           = 64
-		pressureSpillRows = 8
-		workers           = 8
+		maxRows = 64
+		workers = 8
 	)
 	ctx := context.Background()
-	store := &blockingActiveStore{
-		entered: make(chan int, workers),
-		release: make(chan struct{}),
-	}
-	releaseStore := sync.OnceFunc(func() { close(store.release) })
-	defer releaseStore()
-	m := NewManager(Options{Store: store, MaxCachedRows: maxRows, PressureSpillRows: pressureSpillRows})
+	store := &recordingActiveStore{}
+	pressureSignals := make(chan struct{}, 1)
+	m := NewManager(Options{Store: store, MaxCachedRows: maxRows, PressureNotify: pressureSignals})
 	initial := make([]ActivePatch, 0, maxRows)
 	for i := 0; i < maxRows; i++ {
 		initial = append(initial, ActivePatch{
@@ -1035,6 +1171,11 @@ func TestConcurrentCachePressureDoesNotDuplicateBoundedSpill(t *testing.T) {
 	}
 	if err := m.MarkActive(ctx, initial); err != nil {
 		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+	select {
+	case <-pressureSignals:
+	default:
+		t.Fatal("initial high watermark did not signal pressure")
 	}
 
 	start := make(chan struct{})
@@ -1057,32 +1198,21 @@ func TestConcurrentCachePressureDoesNotDuplicateBoundedSpill(t *testing.T) {
 	ready.Wait()
 	close(start)
 
-	select {
-	case selected := <-store.entered:
-		if selected != pressureSpillRows {
-			t.Fatalf("first pressure flush selected %d rows, want bounded %d", selected, pressureSpillRows)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("first pressure flush did not reach the store")
-	}
-
-	duplicateSpill := false
-	select {
-	case selected := <-store.entered:
-		duplicateSpill = selected == pressureSpillRows
-	case <-time.After(200 * time.Millisecond):
-	}
-	releaseStore()
 	for i := 0; i < workers; i++ {
-		if err := <-errs; err != nil {
-			t.Fatalf("MarkActive(concurrent pressure) error = %v", err)
+		if err := <-errs; !errors.Is(err, ErrCachePressure) {
+			t.Fatalf("MarkActive(concurrent pressure) error = %v, want %v", err, ErrCachePressure)
 		}
 	}
-	if duplicateSpill {
-		t.Fatal("concurrent cache pressure duplicated the same bounded flush snapshot")
+	if len(store.touches) != 0 || len(store.batchKeys) != 0 {
+		t.Fatalf("concurrent admission performed durable IO: writes=%d reads=%d", len(store.touches), len(store.batchKeys))
 	}
-	if got := store.maxConcurrentCalls(); got != 1 {
-		t.Fatalf("maximum concurrent store flushes = %d, want 1", got)
+	select {
+	case <-pressureSignals:
+		t.Fatal("rejected admissions duplicated the in-progress pressure-cycle signal")
+	default:
+	}
+	if got := m.DirtyCountForTest(); got != maxRows {
+		t.Fatalf("dirty rows = %d, want unchanged %d after rejected admissions", got, maxRows)
 	}
 }
 

--- a/internal/runtime/conversationactive/types.go
+++ b/internal/runtime/conversationactive/types.go
@@ -24,8 +24,8 @@ type Options struct {
 	ActiveCooldown time.Duration
 	// MaxCachedRows bounds in-memory active rows across all users; zero disables the bound.
 	MaxCachedRows int
-	// PressureSpillRows sets reusable headroom for a cache-pressure spill; a larger immediate admission requirement takes precedence.
-	PressureSpillRows int
+	// PressureNotify receives nonblocking coalesced wakeups for proactive or hard-bound dirty cache pressure.
+	PressureNotify chan<- struct{}
 	// Observer receives low-cardinality cache and flush observations.
 	Observer Observer
 }
@@ -54,7 +54,7 @@ type CacheObservation struct {
 
 // FlushObservation reports one active dirty-row flush attempt.
 type FlushObservation struct {
-	// Result is a low-cardinality outcome such as ok, error, or no_dirty.
+	// Result is a low-cardinality outcome such as ok, error, timeout, or no_dirty.
 	Result string
 	// Selected is the number of dirty rows selected for the attempt.
 	Selected int

--- a/wukongim.toml.example
+++ b/wukongim.toml.example
@@ -142,7 +142,8 @@ authority_list_db_window_max = 1000
 authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
-authority_flush_batch_rows = 512
+# Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
+authority_flush_batch_rows = 128
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 


### PR DESCRIPTION
## What changed

- remove durable storage work from conversation-active admission
- add a capacity-one asynchronous pressure wakeup with 80%/70% high/dirty-low watermarks
- keep each pressure flush bounded by the existing batch and timeout settings
- enqueue recipient delivery before the independent conversation-active projection
- preserve large-channel paging and subscriber snapshot caching when active projection fails
- observe delivery and active failures independently without error-class contamination
- align tracked flush-batch examples to 128 rows and update runtime flow documentation

## Root cause

The cache-pressure path synchronously entered the serialized durable flush lane from `MarkActive`. Slow storage therefore propagated into conversation-authority admission and post-commit recipient work. Active-projection errors also shared the recipient-delivery control flow, so one projection failure could stop later large-channel pages or change delivery error classification.

## Impact

Conversation-active admission is now memory-only and returns cache pressure atomically while a single app worker performs bounded asynchronous flushes. Online delivery remains independent from this best-effort projection.

## Validation

- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `GOWORK=off go test -race ./internal/runtime/conversationactive ./internal/runtime/channelappend -count=1`
- `GOWORK=off go test -race ./internal/app -run TestConversationActiveFlushWorker -count=1`
- `git diff --check`
