### PR TITLE
fix(conversation): bound full dirty cache admission

### DIFF
--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -9,9 +9,14 @@ Current flow:
 1. Channel append or another authority-owned caller submits an `ActiveBatch`.
 2. The manager merges rows by `(uid, kind, channel_id, channel_type)`.
 3. Admission mutates cache state only. It may evict already-clean rows while
-   holding the cache lock, but it never reads or writes `ActiveStore` and never
-   waits for the serialized durable flush lane. If a new row still exceeds the
-   hard bound, the whole admission is rejected with `ErrCachePressure`.
+   holding the cache lock, but it protects every address present in the incoming
+   batch and first compares the remaining exact clean-row count with the space
+   required by the whole batch. When too few evictable clean rows exist it
+   rejects immediately instead of scanning a full dirty cache or evicting a row
+   that the same batch will update. Admission never reads or writes
+   `ActiveStore` and never waits for the serialized durable flush lane. If a new
+   row still exceeds the hard bound, the whole admission is rejected with
+   `ErrCachePressure`.
 4. At 80% total cache occupancy with more than 70% of configured capacity still
    dirty, the manager starts a pressure-drain cycle by sending one nonblocking,
    coalesced wakeup to the app flush worker. A full dirty cache uses the same

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -191,14 +191,19 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 
 	for {
 		m.mu.Lock()
-		newRows := m.countNewRowsLocked(patches)
+		batchAddresses, newRows := m.batchAddressesAndNewRowsLocked(patches)
 		if m.cacheWouldExceedLocked(newRows) {
 			if newRows > m.maxCachedRows {
 				m.mu.Unlock()
 				return ErrCachePressure
 			}
 			over := m.totalRows + newRows - m.maxCachedRows
-			m.evictCleanRowsLocked(over)
+			// Reject without scanning the cache when the whole batch cannot fit by
+			// evicting clean rows outside this batch. A full dirty cache must keep
+			// admission bounded, and an existing batch row must never evict itself.
+			if m.evictableCleanRowsLocked(batchAddresses) >= over {
+				m.evictCleanRowsLocked(over, batchAddresses)
+			}
 		}
 		if !m.cacheWouldExceedLocked(newRows) {
 			for _, patch := range patches {
@@ -330,7 +335,7 @@ func (m *Manager) markActiveLocked(patch ActivePatch, hashSlot uint16, hasHashSl
 	byChannel[key] = next
 }
 
-func (m *Manager) countNewRowsLocked(patches []ActivePatch) int {
+func (m *Manager) batchAddressesAndNewRowsLocked(patches []ActivePatch) (map[cacheAddress]struct{}, int) {
 	seen := make(map[cacheAddress]struct{}, len(patches))
 	var count int
 	for _, patch := range patches {
@@ -350,14 +355,37 @@ func (m *Manager) countNewRowsLocked(patches []ActivePatch) int {
 		}
 		count++
 	}
-	return count
+	return seen, count
 }
 
 func (m *Manager) cacheWouldExceedLocked(newRows int) bool {
 	return m.maxCachedRows > 0 && newRows > 0 && m.totalRows+newRows > m.maxCachedRows
 }
 
-func (m *Manager) evictCleanRowsLocked(limit int) int {
+func (m *Manager) cleanRowsLocked() int {
+	clean := m.totalRows - m.dirtyRows
+	if clean < 0 {
+		return 0
+	}
+	return clean
+}
+
+func (m *Manager) evictableCleanRowsLocked(protected map[cacheAddress]struct{}) int {
+	clean := m.cleanRowsLocked()
+	for address := range protected {
+		byChannel := m.cache[address.uid]
+		entry, ok := byChannel[address.key]
+		if ok && !entry.dirty {
+			clean--
+		}
+	}
+	if clean < 0 {
+		return 0
+	}
+	return clean
+}
+
+func (m *Manager) evictCleanRowsLocked(limit int, protected map[cacheAddress]struct{}) int {
 	if limit <= 0 {
 		return 0
 	}
@@ -365,6 +393,9 @@ func (m *Manager) evictCleanRowsLocked(limit int) int {
 	for uid, byChannel := range m.cache {
 		for key, entry := range byChannel {
 			if entry.dirty {
+				continue
+			}
+			if _, ok := protected[cacheAddress{uid: uid, key: key}]; ok {
 				continue
 			}
 			delete(byChannel, key)

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -1101,6 +1101,53 @@ func TestAdmitUnderCachePressureEvictsCleanRowsWithoutFlush(t *testing.T) {
 	}
 }
 
+func TestCachePressureDoesNotEvictCleanRowUpdatedBySameBatch(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 2})
+	if err := m.MarkActive(ctx, []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "protected", ChannelType: 2, ActiveAtMS: 3000, ReadSeq: 30},
+		{Kind: metadb.ConversationKindNormal, UID: "u2", ChannelID: "dirty", ChannelType: 2, ActiveAtMS: 1000},
+	}); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+	if _, err := m.Flush(ctx, 0); err != nil {
+		t.Fatalf("Flush(initial) error = %v", err)
+	}
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind:        metadb.ConversationKindNormal,
+		UID:         "u2",
+		ChannelID:   "dirty",
+		ChannelType: 2,
+		ActiveAtMS:  2000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(dirty) error = %v", err)
+	}
+
+	err := m.MarkActive(ctx, []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "protected", ChannelType: 2, ActiveAtMS: 2000, ReadSeq: 20},
+		{Kind: metadb.ConversationKindNormal, UID: "u3", ChannelID: "new", ChannelType: 2, ActiveAtMS: 4000},
+	})
+	if !errors.Is(err, ErrCachePressure) {
+		t.Fatalf("MarkActive(protected batch) error = %v, want %v", err, ErrCachePressure)
+	}
+	protected, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "protected", 2)
+	if !ok || protected.ActiveAtMS != 3000 || protected.ReadSeq != 30 {
+		t.Fatalf("protected entry = %+v, %t, want retained active=3000 read=30", protected, ok)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u2", "dirty", 2); !ok {
+		t.Fatal("existing dirty row was removed after rejected protected batch")
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u3", "new", 2); ok {
+		t.Fatal("rejected new row was partially cached")
+	}
+	cache := m.cacheObservation()
+	if cache.Rows != 2 || cache.DirtyRows != 1 ||
+		cache.RowsByKind[metadb.ConversationKindNormal] != 2 ||
+		cache.DirtyRowsByKind[metadb.ConversationKindNormal] != 1 {
+		t.Fatalf("cache observation = %+v, want rows=2 dirty=1 with matching normal-kind counts", cache)
+	}
+}
+
 func TestCachePressureFlushContinuesUntilDirtyLowWatermark(t *testing.T) {
 	const (
 		maxRows = 10
@@ -1213,6 +1260,57 @@ func TestConcurrentCachePressureCoalescesAsyncFlushSignal(t *testing.T) {
 	}
 	if got := m.DirtyCountForTest(); got != maxRows {
 		t.Fatalf("dirty rows = %d, want unchanged %d after rejected admissions", got, maxRows)
+	}
+}
+
+func TestFullDirtyCachePressureAdmissionRemainsBounded(t *testing.T) {
+	const (
+		maxRows = 100_000
+		workers = 512
+	)
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: maxRows})
+	initial := make([]ActivePatch, 0, maxRows)
+	for i := 0; i < maxRows; i++ {
+		initial = append(initial, ActivePatch{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         fmt.Sprintf("existing-%d", i),
+			ChannelID:   "room",
+			ChannelType: 2,
+			ActiveAtMS:  1000,
+		})
+	}
+	if err := m.MarkActive(ctx, initial); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+
+	start := make(chan struct{})
+	ready := sync.WaitGroup{}
+	ready.Add(workers)
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		go func(worker int) {
+			ready.Done()
+			<-start
+			errs <- m.MarkActive(ctx, []ActivePatch{{
+				Kind:        metadb.ConversationKindNormal,
+				UID:         fmt.Sprintf("new-%d", worker),
+				ChannelID:   "room",
+				ChannelType: 2,
+				ActiveAtMS:  2000,
+			}})
+		}(i)
+	}
+	ready.Wait()
+	startedAt := time.Now()
+	close(start)
+	for i := 0; i < workers; i++ {
+		if err := <-errs; !errors.Is(err, ErrCachePressure) {
+			t.Fatalf("MarkActive(full dirty cache) error = %v, want %v", err, ErrCachePressure)
+		}
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("full dirty cache pressure admissions took %s, want <= 1s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject full-dirty cache pressure without scanning all cached rows under the admission lock
- protect existing rows referenced by the same batch from clean-row eviction
- document the bounded pressure path and add production-scale regression coverage

## Root cause

The exact cloud-medium run gh-29719829867-1 reached 100000/100000 dirty rows on node-2. Every rejected admission still called clean-row eviction, scanned all 100000 dirty rows while holding the cache mutex, and serialized all 128 conversation-authority RPC workers. The queue stayed at 3872/4096, task P99 stayed around 9-10s, and measured ingress fell to roughly 2100-2650/s versus the 5000/s target. Flush batches remained bounded at 128; this is a separate admission scan amplification, not a regression to all-dirty flushes.

The fix first compares exact evictable clean capacity outside the incoming batch. If the whole batch cannot fit, admission returns cache pressure immediately. Batch addresses are protected so an existing clean row cannot evict itself and later break the hard bound.

## Verification

- regression before fix: 512 concurrent admissions against 100000 dirty rows took 4.455s
- regression after fix: approximately 0.04s locally
- Go 1.25.11 stability matrix: normal, GOMAXPROCS=1, and race each passed 20/20
- GOWORK=off go test -race ./internal/runtime/conversationactive -run Test... -count=1
- GOWORK=off go test ./internal/runtime/conversationactive ./internal/app -count=1
- GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1
