### PR TITLE
fix: batch recipient presence delivery by leader

### DIFF
--- a/cmd/wukongim/wukongim.toml.example
+++ b/cmd/wukongim/wukongim.toml.example
@@ -148,9 +148,11 @@ authority_admit_concurrency = 16
 [delivery]
 enable = true
 fanout_page_size = 512
+# Maximum total recipients carried by one exact-target presence lookup and delivery plan.
 push_batch_size = 512
 pending_ack_ttl = "30s"
 pending_ack_max_per_session = 1024
+# Maximum recipient delivery plans waiting for asynchronous processing.
 event_queue_size = 1024
 # Maximum recipient-authority delivery batches processed concurrently by this node.
 # This is independent from channel_append.recipient_authority_dispatch_concurrency.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -45,6 +45,7 @@
 - Conversation active admission is memory-only: it may evict clean rows or return cache pressure, but it must never perform durable I/O or wait for the serialized flush lane.
 - Conversation active pressure uses one coalesced async worker wakeup, bounded flush attempts, and 80%/70% high/dirty-low watermarks; clean rows below the dirty watermark are the reusable eviction reserve.
 - Conversation active projection failure is observed independently and must not block recipient delivery, later large-channel pages, or subscriber snapshot caching.
+- Recipient delivery plans preserve complete UID-authority fences and batch presence RPC by actual leader; only stale/not-ready groups may batch-resolve fresh targets and retry once, without replaying successful siblings.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.
@@ -239,6 +240,8 @@
 - `wkbench dev-sim` must run warmup after prepare/connect and before measured run windows; warmup must touch every assigned channel at least once, and warmup counters are a baseline that must not be counted in `/status` measured traffic.
 - `wkbench dev-sim` `/status` distinguishes the configured steady-state online pool (`connected_users`) from the latest sampled live count (`active_users`) and reconnect churn (`reconnected_users`) so online flapping is visible during triage.
 - `wkbench` run-phase polling must budget deterministic churn reconnect pacing in addition to measured traffic duration; otherwise low connect rates turn healthy scheduled churn into a false `phase_timeout`.
+- `wkbench` worker state retains the complete Assignment, but status JSON must expose only assignment identity so polling cost is independent of Plan/Scenario size; legacy expanded status responses remain decodable.
+- A bounded worker status request that times out before the phase deadline is `worker_status`; at the phase deadline, use one independent final probe so an active response is `phase_completion` while another blocked response remains `worker_status`.
 - `wkbench` must prove every assigned worker reached exact `run_id + assignment_id` terminal stop before report collection, including non-fail-fast timeouts; a stopped identity is immutable and cannot be reused, `assignment_id` changes on same-ID reruns, stop serializes assignment work, outlives the HTTP caller, joins retries, waits hook exit, and tears down runner resources. Unconfirmed stop writes only minimal `worker_stop_failed` evidence; successful metrics/report reads use the same two-part identity.
 - Timed `wkbench` warmup and run polling must also budget the largest declared SENDACK/RECV timeout after scheduling stops; the base control-plane grace is not an operation-tail budget.
 - Mixed `wkbench` traffic must retain drained RECV frames only for channel types with receive verification; buffering unverified group fanout because person traffic verifies will create an unconsumed simulator backlog and invalidate the run.

--- a/internal/access/node/FLOW.md
+++ b/internal/access/node/FLOW.md
@@ -27,7 +27,24 @@ Supported authority calls:
 - `AbortRoute(RouteTarget, PendingRouteToken)`
 - `UnregisterRoute(RouteTarget, RouteIdentity, ownerSeq)`
 - `EndpointsByUID(RouteTarget, uid)`
+- `EndpointsByTargets([]{RouteTarget, []uid})`
 - `TouchRoutes(RouteTarget, []Route)`
+
+`EndpointsByTargets` is the bounded fanout lookup path. One request carries
+multiple exact authority targets that all name the destination leader, and the
+response stays aligned with the input groups. Each group has its own stable
+status and routes, so a stale target does not discard successful sibling
+groups. Authorities may implement `EndpointsByUIDs` to validate and read one
+target under a single directory lock; otherwise the adapter preserves
+compatibility by calling `EndpointsByUID` for each UID in that group. Both the
+group count and aggregate UID/route counts use the presence RPC collection
+limit. A group that would exceed the per-response route budget is returned as a
+group-scoped rejection while bounded sibling groups keep their aligned results.
+The original single-UID operation and its `WKVP2`/`WKVR2` byte layout
+remain unchanged. During a rolling upgrade, an older peer reports the new op id
+as unsupported; the new client recognizes only that capability error and falls
+back to the original single-UID RPC for the affected destination. Other
+transport failures do not trigger the compatibility fanout.
 
 ## Presence Owner RPC
 

--- a/internal/access/node/presence_codec.go
+++ b/internal/access/node/presence_codec.go
@@ -20,6 +20,7 @@ const (
 	presenceOpEndpointsByUIDID
 	presenceOpTouchRoutesID
 	presenceOpApplyRouteActionID
+	presenceOpEndpointsByTargetsID
 )
 
 const maxPresenceRPCCollectionLen = 4096
@@ -44,6 +45,16 @@ type presenceRPCRequest struct {
 	UID string
 	// OwnerSeq carries owner-side fencing for unregister requests.
 	OwnerSeq uint64
+	// EndpointGroups carries exact-target UID batches for grouped endpoint lookups.
+	EndpointGroups []presence.EndpointLookupGroup
+}
+
+// presenceRPCEndpointLookupResult is one group-aligned endpoint lookup wire result.
+type presenceRPCEndpointLookupResult struct {
+	// Status carries the stable error classification for this group.
+	Status string
+	// Routes contains all active routes returned for the group's UIDs.
+	Routes []presence.Route
 }
 
 // presenceRPCResponse is the deterministic binary DTO returned by authority calls.
@@ -64,6 +75,9 @@ func encodePresenceRPCRequestBinary(req presenceRPCRequest) ([]byte, error) {
 	dst := make([]byte, 0, 128)
 	dst = append(dst, presenceRPCRequestMagic[:]...)
 	dst = append(dst, opID)
+	if req.Op == presenceOpEndpointsByTargets {
+		return appendPresenceEndpointLookupGroups(dst, req.EndpointGroups)
+	}
 	dst = appendPresenceRouteTarget(dst, req.Target)
 	dst = appendPresenceRoute(dst, req.Route)
 	dst = appendPresenceRoutes(dst, req.Routes)
@@ -92,6 +106,15 @@ func decodePresenceRPCRequest(body []byte) (presenceRPCRequest, error) {
 
 	var req presenceRPCRequest
 	req.Op = op
+	if req.Op == presenceOpEndpointsByTargets {
+		if req.EndpointGroups, offset, err = readPresenceEndpointLookupGroups(body, offset); err != nil {
+			return presenceRPCRequest{}, err
+		}
+		if offset != len(body) {
+			return presenceRPCRequest{}, fmt.Errorf("internal/access/node: trailing presence request bytes")
+		}
+		return req, nil
+	}
 	if req.Target, offset, err = readPresenceRouteTarget(body, offset); err != nil {
 		return presenceRPCRequest{}, err
 	}
@@ -157,6 +180,64 @@ func decodePresenceRPCResponseBinary(body []byte) (presenceRPCResponse, error) {
 	return resp, nil
 }
 
+func encodePresenceEndpointsByTargetsResponseBinary(results []presenceRPCEndpointLookupResult) ([]byte, error) {
+	if len(results) > maxPresenceRPCCollectionLen {
+		return nil, fmt.Errorf("internal/access/node: presence endpoint results length exceeds limit")
+	}
+	dst := make([]byte, 0, 128)
+	dst = append(dst, presenceRPCResponseMagic[:]...)
+	dst = appendUvarint(dst, uint64(len(results)))
+	totalRoutes := 0
+	for _, result := range results {
+		status := result.Status
+		routes := result.Routes
+		if len(routes) > maxPresenceRPCCollectionLen || totalRoutes+len(routes) > maxPresenceRPCCollectionLen {
+			status = rpcStatusRejected
+			routes = nil
+		} else {
+			totalRoutes += len(routes)
+		}
+		dst = appendString(dst, status)
+		dst = appendPresenceRoutes(dst, routes)
+	}
+	return dst, nil
+}
+
+func decodePresenceEndpointsByTargetsResponseBinary(body []byte) ([]presenceRPCEndpointLookupResult, error) {
+	if !isPresenceRPCResponseBinary(body) {
+		return nil, fmt.Errorf("internal/access/node: invalid presence response codec")
+	}
+	offset := len(presenceRPCResponseMagic)
+	count, next, err := readUvarint(body, offset)
+	if err != nil {
+		return nil, err
+	}
+	offset = next
+	if err := validateCollectionLen(count, len(body)-offset, "presence endpoint results"); err != nil {
+		return nil, err
+	}
+	results := make([]presenceRPCEndpointLookupResult, 0, int(count))
+	totalRoutes := 0
+	for i := uint64(0); i < count; i++ {
+		var result presenceRPCEndpointLookupResult
+		if result.Status, offset, err = readString(body, offset); err != nil {
+			return nil, err
+		}
+		if result.Routes, offset, err = readPresenceRoutes(body, offset); err != nil {
+			return nil, err
+		}
+		totalRoutes += len(result.Routes)
+		if totalRoutes > maxPresenceRPCCollectionLen {
+			return nil, fmt.Errorf("internal/access/node: aggregate presence endpoint routes length exceeds limit")
+		}
+		results = append(results, result)
+	}
+	if offset != len(body) {
+		return nil, fmt.Errorf("internal/access/node: trailing presence response bytes")
+	}
+	return results, nil
+}
+
 func isPresenceRPCRequestBinary(body []byte) bool {
 	return hasMagic(body, presenceRPCRequestMagic[:])
 }
@@ -181,6 +262,8 @@ func presenceOpID(op string) (byte, error) {
 		return presenceOpTouchRoutesID, nil
 	case presenceOpApplyRouteAction:
 		return presenceOpApplyRouteActionID, nil
+	case presenceOpEndpointsByTargets:
+		return presenceOpEndpointsByTargetsID, nil
 	default:
 		return 0, fmt.Errorf("internal/access/node: unknown presence op %q", op)
 	}
@@ -202,9 +285,78 @@ func presenceOpFromID(op byte) (string, error) {
 		return presenceOpTouchRoutes, nil
 	case presenceOpApplyRouteActionID:
 		return presenceOpApplyRouteAction, nil
+	case presenceOpEndpointsByTargetsID:
+		return presenceOpEndpointsByTargets, nil
 	default:
 		return "", fmt.Errorf("internal/access/node: unknown presence op id %d", op)
 	}
+}
+
+func appendPresenceEndpointLookupGroups(dst []byte, groups []presence.EndpointLookupGroup) ([]byte, error) {
+	if len(groups) > maxPresenceRPCCollectionLen {
+		return nil, fmt.Errorf("internal/access/node: presence endpoint groups length exceeds limit")
+	}
+	totalUIDs := 0
+	for _, group := range groups {
+		if len(group.UIDs) > maxPresenceRPCCollectionLen {
+			return nil, fmt.Errorf("internal/access/node: presence endpoint UIDs length exceeds limit")
+		}
+		totalUIDs += len(group.UIDs)
+		if totalUIDs > maxPresenceRPCCollectionLen {
+			return nil, fmt.Errorf("internal/access/node: aggregate presence endpoint UIDs length exceeds limit")
+		}
+	}
+	dst = appendUvarint(dst, uint64(len(groups)))
+	for _, group := range groups {
+		dst = appendPresenceRouteTarget(dst, group.Target)
+		dst = appendUvarint(dst, uint64(len(group.UIDs)))
+		for _, uid := range group.UIDs {
+			dst = appendString(dst, uid)
+		}
+	}
+	return dst, nil
+}
+
+func readPresenceEndpointLookupGroups(body []byte, offset int) ([]presence.EndpointLookupGroup, int, error) {
+	count, next, err := readUvarint(body, offset)
+	if err != nil {
+		return nil, offset, err
+	}
+	offset = next
+	if err := validateCollectionLen(count, len(body)-offset, "presence endpoint groups"); err != nil {
+		return nil, offset, err
+	}
+	groups := make([]presence.EndpointLookupGroup, 0, int(count))
+	totalUIDs := 0
+	for i := uint64(0); i < count; i++ {
+		var group presence.EndpointLookupGroup
+		if group.Target, offset, err = readPresenceRouteTarget(body, offset); err != nil {
+			return nil, offset, err
+		}
+		uidCount, next, err := readUvarint(body, offset)
+		if err != nil {
+			return nil, offset, err
+		}
+		offset = next
+		if err := validateCollectionLen(uidCount, len(body)-offset, "presence endpoint UIDs"); err != nil {
+			return nil, offset, err
+		}
+		totalUIDs += int(uidCount)
+		if totalUIDs > maxPresenceRPCCollectionLen {
+			return nil, offset, fmt.Errorf("internal/access/node: aggregate presence endpoint UIDs length exceeds limit")
+		}
+		group.UIDs = make([]string, 0, int(uidCount))
+		for j := uint64(0); j < uidCount; j++ {
+			uid, next, err := readString(body, offset)
+			if err != nil {
+				return nil, offset, err
+			}
+			offset = next
+			group.UIDs = append(group.UIDs, uid)
+		}
+		groups = append(groups, group)
+	}
+	return groups, offset, nil
 }
 
 func appendPresenceRouteTarget(dst []byte, target presence.RouteTarget) []byte {

--- a/internal/access/node/presence_codec_test.go
+++ b/internal/access/node/presence_codec_test.go
@@ -166,6 +166,123 @@ func TestPresenceCodecResponseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPresenceCodecEndpointsByTargetsRoundTrip(t *testing.T) {
+	secondTarget := testPresenceTarget()
+	secondTarget.HashSlot++
+	secondTarget.SlotID++
+	groups := []presence.EndpointLookupGroup{
+		{Target: testPresenceTarget(), UIDs: []string{"u1", "u2"}},
+		{Target: secondTarget, UIDs: []string{"u3"}},
+	}
+	body, err := encodePresenceRPCRequestBinary(presenceRPCRequest{
+		Op:             presenceOpEndpointsByTargets,
+		EndpointGroups: groups,
+	})
+	if err != nil {
+		t.Fatalf("encodePresenceRPCRequestBinary() error = %v", err)
+	}
+	got, err := decodePresenceRPCRequest(body)
+	if err != nil {
+		t.Fatalf("decodePresenceRPCRequest() error = %v", err)
+	}
+	if got.Op != presenceOpEndpointsByTargets || !reflect.DeepEqual(got.EndpointGroups, groups) {
+		t.Fatalf("decoded request = %#v, want groups %#v", got, groups)
+	}
+
+	results := []presenceRPCEndpointLookupResult{
+		{Status: rpcStatusOK, Routes: []presence.Route{testPresenceRoute("u1", 101)}},
+		{Status: rpcStatusNotLeader},
+	}
+	responseBody, err := encodePresenceEndpointsByTargetsResponseBinary(results)
+	if err != nil {
+		t.Fatalf("encodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	gotResults, err := decodePresenceEndpointsByTargetsResponseBinary(responseBody)
+	if err != nil {
+		t.Fatalf("decodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	if !reflect.DeepEqual(gotResults, results) {
+		t.Fatalf("decoded results = %#v, want %#v", gotResults, results)
+	}
+}
+
+func TestPresenceCodecEndpointsByTargetsEnforcesAggregateBounds(t *testing.T) {
+	tooManyUIDs := make([]string, maxPresenceRPCCollectionLen+1)
+	if _, err := encodePresenceRPCRequestBinary(presenceRPCRequest{
+		Op: presenceOpEndpointsByTargets,
+		EndpointGroups: []presence.EndpointLookupGroup{{
+			Target: testPresenceTarget(),
+			UIDs:   tooManyUIDs,
+		}},
+	}); err == nil {
+		t.Fatal("encodePresenceRPCRequestBinary() accepted too many aggregate UIDs")
+	}
+
+	tooManyResults := make([]presenceRPCEndpointLookupResult, maxPresenceRPCCollectionLen+1)
+	if _, err := encodePresenceEndpointsByTargetsResponseBinary(tooManyResults); err == nil {
+		t.Fatal("encodePresenceEndpointsByTargetsResponseBinary() accepted too many results")
+	}
+}
+
+func TestPresenceCodecEndpointsByTargetsIsolatesRouteOverflowToOneGroup(t *testing.T) {
+	results := []presenceRPCEndpointLookupResult{
+		{Status: rpcStatusOK, Routes: make([]presence.Route, maxPresenceRPCCollectionLen-1)},
+		{Status: rpcStatusOK, Routes: []presence.Route{{UID: "overflow-1"}, {UID: "overflow-2"}}},
+		{Status: rpcStatusOK, Routes: []presence.Route{{UID: "sibling"}}},
+	}
+
+	body, err := encodePresenceEndpointsByTargetsResponseBinary(results)
+	if err != nil {
+		t.Fatalf("encodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	got, err := decodePresenceEndpointsByTargetsResponseBinary(body)
+	if err != nil {
+		t.Fatalf("decodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("decoded results = %d, want 3", len(got))
+	}
+	if got[0].Status != rpcStatusOK || len(got[0].Routes) != maxPresenceRPCCollectionLen-1 {
+		t.Fatalf("first result = status %q routes %d", got[0].Status, len(got[0].Routes))
+	}
+	if got[1].Status != rpcStatusRejected || len(got[1].Routes) != 0 {
+		t.Fatalf("overflow result = status %q routes %d, want isolated rejection", got[1].Status, len(got[1].Routes))
+	}
+	if got[2].Status != rpcStatusOK || len(got[2].Routes) != 1 || got[2].Routes[0].UID != "sibling" {
+		t.Fatalf("sibling result = %#v, want success", got[2])
+	}
+}
+
+func TestPresenceCodecEndpointsByTargetsRejectsTruncatedAndTrailingBytes(t *testing.T) {
+	body, err := encodePresenceRPCRequestBinary(presenceRPCRequest{
+		Op: presenceOpEndpointsByTargets,
+		EndpointGroups: []presence.EndpointLookupGroup{{
+			Target: testPresenceTarget(),
+			UIDs:   []string{"u1"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("encodePresenceRPCRequestBinary() error = %v", err)
+	}
+	if _, err := decodePresenceRPCRequest(body[:len(body)-1]); err == nil {
+		t.Fatal("decodePresenceRPCRequest() accepted truncated endpoint groups")
+	}
+	if _, err := decodePresenceRPCRequest(append(append([]byte(nil), body...), 0)); err == nil {
+		t.Fatal("decodePresenceRPCRequest() accepted trailing endpoint group bytes")
+	}
+
+	responseBody, err := encodePresenceEndpointsByTargetsResponseBinary([]presenceRPCEndpointLookupResult{{Status: rpcStatusOK}})
+	if err != nil {
+		t.Fatalf("encodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	if _, err := decodePresenceEndpointsByTargetsResponseBinary(responseBody[:len(responseBody)-1]); err == nil {
+		t.Fatal("decodePresenceEndpointsByTargetsResponseBinary() accepted truncated results")
+	}
+	if _, err := decodePresenceEndpointsByTargetsResponseBinary(append(append([]byte(nil), responseBody...), 0)); err == nil {
+		t.Fatal("decodePresenceEndpointsByTargetsResponseBinary() accepted trailing result bytes")
+	}
+}
+
 func TestPresenceCodecRejectsMalformedTruncatedAndTrailingBytes(t *testing.T) {
 	reqBody, err := encodePresenceRPCRequestBinary(presenceRPCRequest{
 		Op:     presenceOpEndpointsByUID,

--- a/internal/access/node/presence_rpc.go
+++ b/internal/access/node/presence_rpc.go
@@ -16,6 +16,7 @@ import (
 	clusternet "github.com/WuKongIM/WuKongIM/pkg/cluster/net"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 	"github.com/WuKongIM/WuKongIM/pkg/plugin/pluginproto"
+	"github.com/WuKongIM/WuKongIM/pkg/transport"
 	"github.com/WuKongIM/WuKongIM/pkg/wklog"
 )
 
@@ -30,13 +31,14 @@ const (
 	rpcStatusInvalidArgument         = "invalid_argument"
 	rpcStatusRejected                = "rejected"
 
-	presenceOpRegisterRoute    = "register_route"
-	presenceOpCommitRoute      = "commit_route"
-	presenceOpAbortRoute       = "abort_route"
-	presenceOpUnregisterRoute  = "unregister_route"
-	presenceOpEndpointsByUID   = "endpoints_by_uid"
-	presenceOpTouchRoutes      = "touch_routes"
-	presenceOpApplyRouteAction = "apply_route_action"
+	presenceOpRegisterRoute      = "register_route"
+	presenceOpCommitRoute        = "commit_route"
+	presenceOpAbortRoute         = "abort_route"
+	presenceOpUnregisterRoute    = "unregister_route"
+	presenceOpEndpointsByUID     = "endpoints_by_uid"
+	presenceOpEndpointsByTargets = "endpoints_by_targets"
+	presenceOpTouchRoutes        = "touch_routes"
+	presenceOpApplyRouteAction   = "apply_route_action"
 )
 
 // PresenceAuthorityRPCServiceID is the cluster RPC service for UID route authority calls.
@@ -53,6 +55,11 @@ type PresenceAuthority interface {
 	UnregisterRoute(context.Context, presence.RouteTarget, presence.RouteIdentity, uint64) error
 	EndpointsByUID(context.Context, presence.RouteTarget, string) ([]presence.Route, error)
 	TouchRoutes(context.Context, presence.RouteTarget, []presence.Route) error
+}
+
+// PresenceBatchAuthority optionally resolves multiple UIDs under one exact authority fence.
+type PresenceBatchAuthority interface {
+	EndpointsByUIDs(context.Context, presence.RouteTarget, []string) ([]presence.Route, error)
 }
 
 // PresenceOwner applies authority-requested actions to owner-local sessions.
@@ -351,6 +358,13 @@ func (a *Adapter) HandlePresenceAuthorityRPC(ctx context.Context, payload []byte
 		return nil, err
 	}
 	if a == nil || a.authority == nil {
+		if req.Op == presenceOpEndpointsByTargets {
+			results := make([]presenceRPCEndpointLookupResult, len(req.EndpointGroups))
+			for i := range results {
+				results[i].Status = rpcStatusRejected
+			}
+			return encodePresenceEndpointsByTargetsResponseBinary(results)
+		}
 		return encodePresenceRPCResponseBinary(presenceRPCResponse{Status: rpcStatusRejected})
 	}
 
@@ -386,6 +400,8 @@ func (a *Adapter) HandlePresenceAuthorityRPC(ctx context.Context, payload []byte
 			return encodePresenceRPCResponseBinary(presenceRPCResponse{Status: status})
 		}
 		return encodePresenceRPCResponseBinary(presenceRPCResponse{Status: rpcStatusOK, Endpoints: routes})
+	case presenceOpEndpointsByTargets:
+		return a.handlePresenceEndpointsByTargets(ctx, req.EndpointGroups)
 	case presenceOpTouchRoutes:
 		err := a.authority.TouchRoutes(ctx, req.Target, req.Routes)
 		status := presenceRPCStatusForError(err)
@@ -400,6 +416,34 @@ func (a *Adapter) HandlePresenceAuthorityRPC(ctx context.Context, payload []byte
 		)
 		return nil, err
 	}
+}
+
+func (a *Adapter) handlePresenceEndpointsByTargets(ctx context.Context, groups []presence.EndpointLookupGroup) ([]byte, error) {
+	results := make([]presenceRPCEndpointLookupResult, len(groups))
+	batchAuthority, hasBatchAuthority := a.authority.(PresenceBatchAuthority)
+	for i, group := range groups {
+		var routes []presence.Route
+		var err error
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		} else if hasBatchAuthority {
+			routes, err = batchAuthority.EndpointsByUIDs(ctx, group.Target, group.UIDs)
+		} else {
+			for _, uid := range group.UIDs {
+				var uidRoutes []presence.Route
+				uidRoutes, err = a.authority.EndpointsByUID(ctx, group.Target, uid)
+				if err != nil {
+					break
+				}
+				routes = append(routes, uidRoutes...)
+			}
+		}
+		results[i].Status = presenceRPCStatusForError(err)
+		if err == nil {
+			results[i].Routes = routes
+		}
+	}
+	return encodePresenceEndpointsByTargetsResponseBinary(results)
 }
 
 // HandlePresenceOwnerRPC handles one encoded presence owner-action RPC payload.
@@ -541,6 +585,83 @@ func (c *Client) EndpointsByUID(ctx context.Context, target presence.RouteTarget
 	return resp.Endpoints, nil
 }
 
+// EndpointsByTargets resolves exact-target UID groups on one destination node.
+func (c *Client) EndpointsByTargets(ctx context.Context, nodeID uint64, groups []presence.EndpointLookupGroup) ([]presence.EndpointLookupResult, error) {
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	if nodeID == 0 {
+		return nil, fmt.Errorf("internal/access/node: presence endpoint destination node is zero")
+	}
+	for i, group := range groups {
+		if group.Target.LeaderNodeID != nodeID {
+			return nil, fmt.Errorf("internal/access/node: presence endpoint group %d leader %d does not match destination %d", i, group.Target.LeaderNodeID, nodeID)
+		}
+	}
+	if c == nil || c.node == nil {
+		return nil, fmt.Errorf("internal/access/node: presence rpc client not configured")
+	}
+	body, err := encodePresenceRPCRequestBinary(presenceRPCRequest{
+		Op:             presenceOpEndpointsByTargets,
+		EndpointGroups: groups,
+	})
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := c.node.CallRPC(ctx, nodeID, PresenceAuthorityRPCServiceID, body)
+	if err != nil {
+		if isPresenceEndpointsByTargetsUnsupported(err) {
+			return c.endpointsByTargetsLegacy(ctx, groups), nil
+		}
+		return nil, err
+	}
+	wireResults, err := decodePresenceEndpointsByTargetsResponseBinary(responseBody)
+	if err != nil {
+		return nil, err
+	}
+	if len(wireResults) != len(groups) {
+		return nil, fmt.Errorf("internal/access/node: presence endpoint result count %d does not match group count %d", len(wireResults), len(groups))
+	}
+	results := make([]presence.EndpointLookupResult, len(wireResults))
+	for i, result := range wireResults {
+		results[i] = presence.EndpointLookupResult{
+			Routes: result.Routes,
+			Err:    presenceRPCErrorForStatus(result.Status),
+		}
+	}
+	return results, nil
+}
+
+func (c *Client) endpointsByTargetsLegacy(ctx context.Context, groups []presence.EndpointLookupGroup) []presence.EndpointLookupResult {
+	results := make([]presence.EndpointLookupResult, len(groups))
+	for i, group := range groups {
+		for _, uid := range group.UIDs {
+			if uid == "" {
+				continue
+			}
+			routes, err := c.EndpointsByUID(ctx, group.Target, uid)
+			if err != nil {
+				results[i].Err = err
+				break
+			}
+			results[i].Routes = append(results[i].Routes, routes...)
+		}
+	}
+	return results
+}
+
+func isPresenceEndpointsByTargetsUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	var remoteErr transport.RemoteError
+	if !errors.As(err, &remoteErr) {
+		return false
+	}
+	return remoteErr.Code == "remote_error" &&
+		remoteErr.Message == fmt.Sprintf("internal/access/node: unknown presence op id %d", presenceOpEndpointsByTargetsID)
+}
+
 // TouchRoutes refreshes owner routes on the target authority node.
 func (c *Client) TouchRoutes(ctx context.Context, target presence.RouteTarget, routes []presence.Route) error {
 	resp, err := c.call(ctx, target, presenceRPCRequest{Op: presenceOpTouchRoutes, Target: target, Routes: routes})
@@ -588,6 +709,10 @@ func presenceRPCStatusForError(err error) string {
 		return rpcStatusStaleRoute
 	case errors.Is(err, authoritypresence.ErrRouteNotReady):
 		return rpcStatusRouteNotReady
+	case errors.Is(err, context.Canceled):
+		return rpcStatusContextCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return rpcStatusContextDeadlineExceeded
 	default:
 		return rpcStatusRejected
 	}
@@ -603,6 +728,10 @@ func presenceRPCErrorForStatus(status string) error {
 		return authoritypresence.ErrStaleRoute
 	case rpcStatusRouteNotReady:
 		return authoritypresence.ErrRouteNotReady
+	case rpcStatusContextCanceled:
+		return context.Canceled
+	case rpcStatusContextDeadlineExceeded:
+		return context.DeadlineExceeded
 	case rpcStatusRejected:
 		return fmt.Errorf("internal/access/node: presence rpc rejected")
 	default:

--- a/internal/access/node/presence_rpc_test.go
+++ b/internal/access/node/presence_rpc_test.go
@@ -9,6 +9,7 @@ import (
 
 	authoritypresence "github.com/WuKongIM/WuKongIM/internal/runtime/presence"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/presence"
+	"github.com/WuKongIM/WuKongIM/pkg/transport"
 )
 
 func TestPresenceAuthorityRPCHandlerDispatchesOperations(t *testing.T) {
@@ -197,6 +198,75 @@ func TestPresenceAuthorityRPCHandlerMapsErrorsToStatus(t *testing.T) {
 	}
 }
 
+func TestPresenceAuthorityRPCHandlerReturnsAlignedEndpointTargetResults(t *testing.T) {
+	first := testPresenceTarget()
+	second := first
+	second.HashSlot++
+	second.SlotID++
+	authority := &fakeBatchPresenceAuthority{
+		fakePresenceAuthority: newFakePresenceAuthority(),
+		errorsByHashSlot:      map[uint16]error{second.HashSlot: authoritypresence.ErrNotLeader},
+	}
+	adapter := New(Options{Authority: authority})
+	groups := []presence.EndpointLookupGroup{
+		{Target: first, UIDs: []string{"u1", "u2"}},
+		{Target: second, UIDs: []string{"u3"}},
+	}
+	body, err := encodePresenceRPCRequestBinary(presenceRPCRequest{Op: presenceOpEndpointsByTargets, EndpointGroups: groups})
+	if err != nil {
+		t.Fatalf("encodePresenceRPCRequestBinary() error = %v", err)
+	}
+
+	responseBody, err := adapter.HandlePresenceAuthorityRPC(context.Background(), body)
+	if err != nil {
+		t.Fatalf("HandlePresenceAuthorityRPC() error = %v", err)
+	}
+	results, err := decodePresenceEndpointsByTargetsResponseBinary(responseBody)
+	if err != nil {
+		t.Fatalf("decodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %#v, want two aligned results", results)
+	}
+	if results[0].Status != rpcStatusOK || len(results[0].Routes) != 2 {
+		t.Fatalf("results[0] = %#v, want two routes", results[0])
+	}
+	if results[1].Status != rpcStatusNotLeader || len(results[1].Routes) != 0 {
+		t.Fatalf("results[1] = %#v, want not_leader", results[1])
+	}
+	if !reflect.DeepEqual(authority.batchCalls, groups) {
+		t.Fatalf("batch calls = %#v, want %#v", authority.batchCalls, groups)
+	}
+}
+
+func TestPresenceAuthorityRPCHandlerFallsBackToSingleUIDAuthority(t *testing.T) {
+	authority := newFakePresenceAuthority()
+	adapter := New(Options{Authority: authority})
+	group := presence.EndpointLookupGroup{Target: testPresenceTarget(), UIDs: []string{"u1", "u2"}}
+	body, err := encodePresenceRPCRequestBinary(presenceRPCRequest{
+		Op:             presenceOpEndpointsByTargets,
+		EndpointGroups: []presence.EndpointLookupGroup{group},
+	})
+	if err != nil {
+		t.Fatalf("encodePresenceRPCRequestBinary() error = %v", err)
+	}
+
+	responseBody, err := adapter.HandlePresenceAuthorityRPC(context.Background(), body)
+	if err != nil {
+		t.Fatalf("HandlePresenceAuthorityRPC() error = %v", err)
+	}
+	results, err := decodePresenceEndpointsByTargetsResponseBinary(responseBody)
+	if err != nil {
+		t.Fatalf("decodePresenceEndpointsByTargetsResponseBinary() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Status != rpcStatusOK || len(results[0].Routes) != 2 {
+		t.Fatalf("results = %#v, want one successful two-route group", results)
+	}
+	if len(authority.endpointCalls) != 2 || authority.endpointCalls[0].uid != "u1" || authority.endpointCalls[1].uid != "u2" {
+		t.Fatalf("endpoint fallback calls = %#v", authority.endpointCalls)
+	}
+}
+
 func TestPresenceOwnerRPCHandlerDispatchesAction(t *testing.T) {
 	action := presence.RouteAction{
 		UID:         "u1",
@@ -252,6 +322,151 @@ func TestPresenceClientEncodesRPCAndMapsStatusErrors(t *testing.T) {
 	}
 	if req.Op != presenceOpCommitRoute || req.PendingToken != "pending-1" {
 		t.Fatalf("client request = %#v", req)
+	}
+}
+
+func TestPresenceClientEndpointsByTargetsPreservesAlignedPartialFailures(t *testing.T) {
+	target := testPresenceTarget()
+	groups := []presence.EndpointLookupGroup{
+		{Target: target, UIDs: []string{"u1", "u2"}},
+		{Target: target, UIDs: []string{"u3"}},
+	}
+	node := &fakePresenceBatchRPCNode{results: []presenceRPCEndpointLookupResult{
+		{Status: rpcStatusOK, Routes: []presence.Route{testPresenceRoute("u1", 101)}},
+		{Status: rpcStatusNotLeader},
+	}}
+	client := NewClient(node)
+
+	results, err := client.EndpointsByTargets(context.Background(), target.LeaderNodeID, groups)
+	if err != nil {
+		t.Fatalf("EndpointsByTargets() error = %v", err)
+	}
+	if len(results) != 2 || len(results[0].Routes) != 1 || results[0].Err != nil {
+		t.Fatalf("results[0] = %#v", results[0])
+	}
+	if !errors.Is(results[1].Err, authoritypresence.ErrNotLeader) {
+		t.Fatalf("results[1].Err = %v, want ErrNotLeader", results[1].Err)
+	}
+	if node.nodeID != target.LeaderNodeID || node.serviceID != PresenceAuthorityRPCServiceID {
+		t.Fatalf("rpc destination = (%d,%d)", node.nodeID, node.serviceID)
+	}
+	req, err := decodePresenceRPCRequest(node.payload)
+	if err != nil {
+		t.Fatalf("decodePresenceRPCRequest() error = %v", err)
+	}
+	if req.Op != presenceOpEndpointsByTargets || !reflect.DeepEqual(req.EndpointGroups, groups) {
+		t.Fatalf("request = %#v, want groups %#v", req, groups)
+	}
+}
+
+func TestPresenceClientEndpointsByTargetsRejectsMismatchedDestination(t *testing.T) {
+	target := testPresenceTarget()
+	node := &fakePresenceBatchRPCNode{}
+	client := NewClient(node)
+
+	_, err := client.EndpointsByTargets(context.Background(), target.LeaderNodeID+1, []presence.EndpointLookupGroup{{
+		Target: target,
+		UIDs:   []string{"u1"},
+	}})
+	if err == nil {
+		t.Fatal("EndpointsByTargets() error = nil, want target leader mismatch")
+	}
+	if len(node.payload) != 0 {
+		t.Fatal("EndpointsByTargets() called transport after destination mismatch")
+	}
+}
+
+func TestPresenceClientEndpointsByTargetsRejectsMisalignedResponse(t *testing.T) {
+	target := testPresenceTarget()
+	client := NewClient(&fakePresenceBatchRPCNode{results: []presenceRPCEndpointLookupResult{{Status: rpcStatusOK}}})
+
+	_, err := client.EndpointsByTargets(context.Background(), target.LeaderNodeID, []presence.EndpointLookupGroup{
+		{Target: target, UIDs: []string{"u1"}},
+		{Target: target, UIDs: []string{"u2"}},
+	})
+	if err == nil {
+		t.Fatal("EndpointsByTargets() error = nil, want result cardinality error")
+	}
+}
+
+func TestPresenceClientEndpointsByTargetsFallsBackWhenBatchServiceIsUnavailable(t *testing.T) {
+	target := testPresenceTarget()
+	authority := newFakePresenceAuthority()
+	node := &rollingUpgradePresenceRPCNode{adapter: New(Options{Authority: authority})}
+	client := NewClient(node)
+	groups := []presence.EndpointLookupGroup{
+		{Target: target, UIDs: []string{"u1", "u2"}},
+		{Target: target, UIDs: []string{"u3"}},
+	}
+
+	results, err := client.EndpointsByTargets(context.Background(), target.LeaderNodeID, groups)
+	if err != nil {
+		t.Fatalf("EndpointsByTargets() error = %v", err)
+	}
+	if len(results) != 2 || len(results[0].Routes) != 2 || len(results[1].Routes) != 1 {
+		t.Fatalf("fallback results = %#v", results)
+	}
+	if node.batchServiceCalls != 1 || node.legacyServiceCalls != 3 {
+		t.Fatalf("service calls batch/legacy = %d/%d, want 1/3", node.batchServiceCalls, node.legacyServiceCalls)
+	}
+	if len(authority.endpointCalls) != 3 {
+		t.Fatalf("legacy endpoint calls = %#v, want 3", authority.endpointCalls)
+	}
+}
+
+func TestPresenceClientEndpointsByTargetsDoesNotFallbackForSimilarRemoteErrors(t *testing.T) {
+	target := testPresenceTarget()
+	groups := []presence.EndpointLookupGroup{{Target: target, UIDs: []string{"u1"}}}
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "different remote code",
+			err: transport.RemoteError{
+				Code:    "permission_denied",
+				Message: "internal/access/node: unknown presence op id 8",
+			},
+		},
+		{
+			name: "similar remote message",
+			err: transport.RemoteError{
+				Code:    "remote_error",
+				Message: "proxy rejected: unknown presence op id 8",
+			},
+		},
+		{
+			name: "different unknown operation",
+			err: transport.RemoteError{
+				Code:    "remote_error",
+				Message: "internal/access/node: unknown presence op id 7",
+			},
+		},
+		{
+			name: "non remote error",
+			err:  errors.New("internal/access/node: unknown presence op id 8"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &rejectingPresenceRPCNode{err: tt.err}
+			client := NewClient(node)
+
+			results, err := client.EndpointsByTargets(context.Background(), target.LeaderNodeID, groups)
+			if err == nil {
+				t.Fatalf("EndpointsByTargets() error = nil, want %v", tt.err)
+			}
+			if err.Error() != tt.err.Error() {
+				t.Fatalf("EndpointsByTargets() error = %q, want %q", err, tt.err)
+			}
+			if results != nil {
+				t.Fatalf("EndpointsByTargets() results = %#v, want nil", results)
+			}
+			if node.calls != 1 {
+				t.Fatalf("CallRPC() calls = %d, want one batch attempt without legacy fallback", node.calls)
+			}
+		})
 	}
 }
 
@@ -374,6 +589,24 @@ type fakePresenceAuthority struct {
 	touchCalls      []presenceTouchCall
 }
 
+type fakeBatchPresenceAuthority struct {
+	*fakePresenceAuthority
+	batchCalls       []presence.EndpointLookupGroup
+	errorsByHashSlot map[uint16]error
+}
+
+func (f *fakeBatchPresenceAuthority) EndpointsByUIDs(_ context.Context, target presence.RouteTarget, uids []string) ([]presence.Route, error) {
+	f.batchCalls = append(f.batchCalls, presence.EndpointLookupGroup{Target: target, UIDs: append([]string(nil), uids...)})
+	if err := f.errorsByHashSlot[target.HashSlot]; err != nil {
+		return nil, err
+	}
+	routes := make([]presence.Route, 0, len(uids))
+	for i, uid := range uids {
+		routes = append(routes, testPresenceRoute(uid, uint64(101+i)))
+	}
+	return routes, nil
+}
+
 type fakePresenceOwner struct {
 	actions []presence.RouteAction
 }
@@ -451,6 +684,55 @@ type fakePresenceRPCNode struct {
 	nodeID    uint64
 	serviceID uint8
 	payload   []byte
+}
+
+type fakePresenceBatchRPCNode struct {
+	results   []presenceRPCEndpointLookupResult
+	nodeID    uint64
+	serviceID uint8
+	payload   []byte
+}
+
+type rollingUpgradePresenceRPCNode struct {
+	adapter            *Adapter
+	batchServiceCalls  int
+	legacyServiceCalls int
+}
+
+type rejectingPresenceRPCNode struct {
+	err   error
+	calls int
+}
+
+func (n *rejectingPresenceRPCNode) CallRPC(context.Context, uint64, uint8, []byte) ([]byte, error) {
+	n.calls++
+	return nil, n.err
+}
+
+func (n *rollingUpgradePresenceRPCNode) CallRPC(ctx context.Context, _ uint64, serviceID uint8, payload []byte) ([]byte, error) {
+	if serviceID != PresenceAuthorityRPCServiceID {
+		return nil, fmt.Errorf("unexpected service %d", serviceID)
+	}
+	req, err := decodePresenceRPCRequest(payload)
+	if err != nil {
+		return nil, err
+	}
+	if req.Op == presenceOpEndpointsByTargets {
+		n.batchServiceCalls++
+		return nil, transport.RemoteError{
+			Code:    "remote_error",
+			Message: "internal/access/node: unknown presence op id 8",
+		}
+	}
+	n.legacyServiceCalls++
+	return n.adapter.HandlePresenceAuthorityRPC(ctx, payload)
+}
+
+func (f *fakePresenceBatchRPCNode) CallRPC(_ context.Context, nodeID uint64, serviceID uint8, payload []byte) ([]byte, error) {
+	f.nodeID = nodeID
+	f.serviceID = serviceID
+	f.payload = append([]byte(nil), payload...)
+	return encodePresenceEndpointsByTargetsResponseBinary(f.results)
 }
 
 func (f *fakePresenceRPCNode) CallRPC(_ context.Context, nodeID uint64, serviceID uint8, payload []byte) ([]byte, error) {

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -383,7 +383,12 @@ delivery disabled, committed message effects still run inside the channel
 authority writer so recent conversation state is updated, but no online
 delivery is submitted. With delivery enabled, gateway RECVACK and session close
 feedback flows to the delivery usecase, while channelappend post-commit effects
-enqueue recipient-authority delivery batches into the recipient delivery worker.
+enqueue bounded multi-target recipient delivery plans into the recipient
+delivery worker. Each plan retains every exact Slot authority fence. The app
+presence adapter converts all plan groups in one call; the cluster adapter then
+batches local groups in the presence directory and sends at most one batch RPC
+to each remote Slot leader. Results remain aligned per exact target so a failed
+leader group does not discard successful groups from the same plan.
 `Config.ChannelAppend.AuthorityShardCount` defaults to a CPU-aware lookup-shard
 count with a minimum of four. `ChannelAppend.AdvancePoolSize` is the direct ants
 pool capacity used to activate channelappend writer state machines.
@@ -399,11 +404,13 @@ backlog records and drops the newest already-durable envelope without returning
 Prepare runs inline on the writer advance path; append remains the foreground
 durable path that determines SEND/SENDACK throughput.
 `ChannelAppend.RecipientAuthorityDispatchConcurrency` defaults to a bounded
-recipient-authority target fanout per post-commit envelope.
+recipient-authority target fanout for legacy batch-only enqueuers. The
+production plan-capable worker admits exact-target groups together instead of
+using this target fanout.
 `Delivery.RecipientWorkerConcurrency` independently defaults to 100 and controls
-only the goroutines draining the bounded recipient delivery queue, so target
-fanout and delivery execution capacity can be tuned without changing each
-other. The lookup-shard count controls writer map sharding; effect workers run only blocking effects and never write channel
+only the goroutines draining the bounded recipient delivery queue. The legacy
+target fanout and production plan execution capacities therefore remain
+independent. The lookup-shard count controls writer map sharding; effect workers run only blocking effects and never write channel
 state concurrently with another advance for the same channel. The delivery
 observer maps aggregate writer pressure and effect pool observations into
 Prometheus, and also records direct ants/v2 occupancy for the channelappend
@@ -416,8 +423,9 @@ The foreground SEND path waits only for channel-authority durable append;
 subscriber scan, recipient authority grouping, delivery enqueue, and the
 independent conversation active projection all run after SENDACK from the
 authority writer's best-effort post-commit pipeline. The recipient delivery worker later
-drains accepted batches, resolves online routes, and pushes owner-node delivery
-commands. Post-commit persistence and restart replay are not part of
+drains accepted plans, resolves all exact-target groups through the batched
+presence seam, and pushes owner-node delivery commands. Post-commit persistence
+and restart replay are not part of
 channelappend. Post-commit enqueue failures are logged with the failing phase and
 route/dispatch context, counted through effect metrics, and dropped after the
 routed helper's bounded retry window; they do not change channel durability or
@@ -445,12 +453,15 @@ subscriber source, or the cluster Slot metadata source. When cluster exposes
 batch key routing, the app recipient resolver resolves each subscriber page's
 unique UIDs through one batch route lookup. After each recipient set is formed,
 channelappend groups recipients by exact UID hash-slot authority
-target including Slot leader term and Slot config epoch, then enqueues delivery.
+target including Slot leader term and Slot config epoch, then packs the groups
+into a bounded delivery plan. The worker preserves those fences while the
+presence usecase groups target lookups by actual leader and returns partial
+per-target results.
 It next admits an independent kind-aware `conversationactive.ActiveBatch`
 through the shared `ConversationAuthorityClient`; channelappend chooses normal
 versus CMD kind from the committed envelope, and active admission still runs
 when online delivery is disabled. When delivery is enabled, the app wires a bounded
-recipient delivery worker that drains those batches and runs the delivery-only
+recipient delivery worker that drains those plans and runs the delivery-only
 channelappend recipient processor outside the authority writer. `/bench/v1/channels`,
 `/bench/v1/channels/subscribers`, and `/bench/v1/channels/subscribers/remove`
 write real channel metadata or add/remove subscriber rows through Slot proposals.
@@ -458,7 +469,7 @@ The benchmark data writer uses bounded concurrency for independent
 channel/subscriber mutations while preserving subscriber mutation order within
 the same channel. Scoped UID delivery bypasses subscriber scan and
 flows through recipient authority grouping, presence resolution, and the local
-or RPC owner pusher after the recipient delivery worker accepts the batch.
+or RPC owner pusher after the recipient delivery worker accepts the plan.
 The app maps the worker's serialized execution-pressure observation into
 Prometheus worker capacity and in-flight gauges. These metrics do not include
 UID, channel, slot, or per-target labels.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -785,6 +785,13 @@ func (a presenceDirectoryAuthority) EndpointsByUID(ctx context.Context, target p
 	return a.directory.EndpointsByUID(target, uid)
 }
 
+func (a presenceDirectoryAuthority) EndpointsByUIDs(ctx context.Context, target presence.RouteTarget, uids []string) ([]presence.Route, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return a.directory.EndpointsByUIDs(target, uids)
+}
+
 func (a presenceDirectoryAuthority) TouchRoutes(ctx context.Context, target presence.RouteTarget, routes []presence.Route) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/internal/app/channel_append.go
+++ b/internal/app/channel_append.go
@@ -207,20 +207,78 @@ func (r channelAppendPresenceResolver) EndpointsByUIDs(ctx context.Context, uids
 	}
 	out := make([]channelappend.Route, 0)
 	for _, routes := range routesByUID {
-		for _, route := range routes {
-			out = append(out, channelappend.Route{
-				UID:         route.UID,
-				OwnerNodeID: route.OwnerNodeID,
-				OwnerBootID: route.OwnerBootID,
-				OwnerSeq:    route.OwnerSeq,
-				SessionID:   route.SessionID,
-				DeviceID:    route.DeviceID,
-				DeviceFlag:  route.DeviceFlag,
-				DeviceLevel: route.DeviceLevel,
-			})
-		}
+		out = appendChannelAppendRoutes(out, routes)
 	}
 	return out, nil
+}
+
+func (r channelAppendPresenceResolver) EndpointsByTargets(ctx context.Context, batches []channelappend.RecipientTargetBatch) []channelappend.RecipientTargetPresenceResult {
+	results := make([]channelappend.RecipientTargetPresenceResult, len(batches))
+	if len(batches) == 0 {
+		return results
+	}
+	if r.presence == nil {
+		for i := range results {
+			results[i].Err = presenceusecase.ErrAuthorityUnavailable
+		}
+		return results
+	}
+	groups := make([]presenceusecase.EndpointLookupGroup, len(batches))
+	for i, batch := range batches {
+		uids := make([]string, 0, len(batch.Recipients))
+		for _, recipient := range batch.Recipients {
+			if recipient.UID != "" {
+				uids = append(uids, recipient.UID)
+			}
+		}
+		groups[i] = presenceusecase.EndpointLookupGroup{
+			Target: presenceTargetFromRecipientTarget(batch.Target),
+			UIDs:   uids,
+		}
+	}
+	resolved := r.presence.EndpointsByTargets(ctx, groups)
+	for i := range results {
+		if i >= len(resolved) {
+			results[i].Err = channelappend.ErrRecipientPresenceResultMissing
+			continue
+		}
+		results[i].Err = resolved[i].Err
+		results[i].Routes = channelAppendRoutesFromPresence(resolved[i].Routes)
+	}
+	return results
+}
+
+func presenceTargetFromRecipientTarget(target channelappend.RecipientAuthorityTarget) presenceusecase.RouteTarget {
+	return presenceusecase.RouteTarget{
+		HashSlot:       target.HashSlot,
+		SlotID:         target.SlotID,
+		LeaderNodeID:   target.LeaderNodeID,
+		LeaderTerm:     target.LeaderTerm,
+		ConfigEpoch:    target.ConfigEpoch,
+		RouteRevision:  target.RouteRevision,
+		AuthorityEpoch: target.AuthorityEpoch,
+	}
+}
+
+func channelAppendRoutesFromPresence(routes []presenceusecase.Route) []channelappend.Route {
+	out := make([]channelappend.Route, 0, len(routes))
+	return appendChannelAppendRoutes(out, routes)
+}
+
+func appendChannelAppendRoutes(out []channelappend.Route, routes []presenceusecase.Route) []channelappend.Route {
+	for _, route := range routes {
+		out = append(out, channelappend.Route{
+			UID:         route.UID,
+			OwnerNodeID: route.OwnerNodeID,
+			OwnerBootID: route.OwnerBootID,
+			OwnerSeq:    route.OwnerSeq,
+			SessionID:   route.SessionID,
+			DeviceID:    route.DeviceID,
+			DeviceFlag:  route.DeviceFlag,
+			DeviceLevel: route.DeviceLevel,
+		})
+	}
+	return out
 }
 
 // channelAppendOwnerPusher adapts owner-node delivery pushes to channelappend.

--- a/internal/app/channel_append_test.go
+++ b/internal/app/channel_append_test.go
@@ -2,12 +2,14 @@ package app
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
 	clusterinfra "github.com/WuKongIM/WuKongIM/internal/infra/cluster"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	channelusecase "github.com/WuKongIM/WuKongIM/internal/usecase/channel"
+	presenceusecase "github.com/WuKongIM/WuKongIM/internal/usecase/presence"
 	"github.com/WuKongIM/WuKongIM/pkg/cluster"
 )
 
@@ -43,6 +45,39 @@ func TestChannelAppendRecipientResolverUsesBatchRouteNode(t *testing.T) {
 	}
 }
 
+func TestChannelAppendPresenceResolverPreservesExactTargetsAndPartialResults(t *testing.T) {
+	first := channelappend.RecipientAuthorityTarget{HashSlot: 1, SlotID: 11, LeaderNodeID: 10, LeaderTerm: 101, ConfigEpoch: 1001, RouteRevision: 100, AuthorityEpoch: 1000}
+	second := channelappend.RecipientAuthorityTarget{HashSlot: 2, SlotID: 22, LeaderNodeID: 20, LeaderTerm: 202, ConfigEpoch: 2002, RouteRevision: 200, AuthorityEpoch: 2000}
+	firstErr := errors.New("first target unavailable")
+	authority := &targetedPresenceAuthorityForChannelAppendTest{results: []presenceusecase.EndpointLookupResult{
+		{Err: firstErr},
+		{Routes: []presenceusecase.Route{{UID: "u2", OwnerNodeID: 3, OwnerBootID: 4, OwnerSeq: 5, SessionID: 6}}},
+	}}
+	resolver := channelAppendPresenceResolver{presence: presenceusecase.New(presenceusecase.Options{Authority: authority})}
+
+	got := resolver.EndpointsByTargets(context.Background(), []channelappend.RecipientTargetBatch{
+		{Target: first, Recipients: []channelappend.Recipient{{UID: "u1"}}},
+		{Target: second, Recipients: []channelappend.Recipient{{UID: "u2"}}},
+	})
+
+	if len(got) != 2 || !errors.Is(got[0].Err, firstErr) || got[1].Err != nil {
+		t.Fatalf("target results = %#v, want first error and second success", got)
+	}
+	if len(got[1].Routes) != 1 || got[1].Routes[0].UID != "u2" || got[1].Routes[0].OwnerNodeID != 3 {
+		t.Fatalf("second target routes = %#v, want converted u2 route", got[1].Routes)
+	}
+	wantGroups := []presenceusecase.EndpointLookupGroup{
+		{Target: presenceRouteTargetFromRecipientTargetForChannelAppendTest(first), UIDs: []string{"u1"}},
+		{Target: presenceRouteTargetFromRecipientTargetForChannelAppendTest(second), UIDs: []string{"u2"}},
+	}
+	if !reflect.DeepEqual(authority.groups, wantGroups) {
+		t.Fatalf("presence groups = %#v, want exact targets %#v", authority.groups, wantGroups)
+	}
+	if authority.legacyCalls != 0 {
+		t.Fatalf("legacy endpoint calls = %d, want 0", authority.legacyCalls)
+	}
+}
+
 func TestChannelAppendSubscriberMutationObserverRefreshesMetadataCache(t *testing.T) {
 	cache := clusterinfra.NewChannelAppendMetadataCache()
 	app := &App{channelAppendMetadata: cache}
@@ -68,6 +103,52 @@ type batchRecipientRouteNodeForChannelAppendTest struct {
 	singleCalls int
 	batchCalls  int
 	batchKeys   []string
+}
+
+type targetedPresenceAuthorityForChannelAppendTest struct {
+	groups      []presenceusecase.EndpointLookupGroup
+	results     []presenceusecase.EndpointLookupResult
+	legacyCalls int
+}
+
+func (a *targetedPresenceAuthorityForChannelAppendTest) RegisterRoute(context.Context, presenceusecase.Route) (presenceusecase.RegisterResult, error) {
+	return presenceusecase.RegisterResult{}, nil
+}
+
+func (a *targetedPresenceAuthorityForChannelAppendTest) CommitRoute(context.Context, presenceusecase.PendingRouteToken) error {
+	return nil
+}
+
+func (a *targetedPresenceAuthorityForChannelAppendTest) AbortRoute(context.Context, presenceusecase.PendingRouteToken) error {
+	return nil
+}
+
+func (a *targetedPresenceAuthorityForChannelAppendTest) EnqueueUnregister(context.Context, presenceusecase.RouteIdentity, uint64) {
+}
+
+func (a *targetedPresenceAuthorityForChannelAppendTest) EndpointsByUID(context.Context, string) ([]presenceusecase.Route, error) {
+	a.legacyCalls++
+	return nil, nil
+}
+
+func (a *targetedPresenceAuthorityForChannelAppendTest) EndpointsByTargets(_ context.Context, groups []presenceusecase.EndpointLookupGroup) []presenceusecase.EndpointLookupResult {
+	a.groups = make([]presenceusecase.EndpointLookupGroup, len(groups))
+	for i, group := range groups {
+		a.groups[i] = presenceusecase.EndpointLookupGroup{Target: group.Target, UIDs: append([]string(nil), group.UIDs...)}
+	}
+	return append([]presenceusecase.EndpointLookupResult(nil), a.results...)
+}
+
+func presenceRouteTargetFromRecipientTargetForChannelAppendTest(target channelappend.RecipientAuthorityTarget) presenceusecase.RouteTarget {
+	return presenceusecase.RouteTarget{
+		HashSlot:       target.HashSlot,
+		SlotID:         target.SlotID,
+		LeaderNodeID:   target.LeaderNodeID,
+		LeaderTerm:     target.LeaderTerm,
+		ConfigEpoch:    target.ConfigEpoch,
+		RouteRevision:  target.RouteRevision,
+		AuthorityEpoch: target.AuthorityEpoch,
+	}
 }
 
 func (n *batchRecipientRouteNodeForChannelAppendTest) RouteKey(key string) (cluster.Route, error) {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -365,15 +365,16 @@ type DeliveryConfig struct {
 	Enabled bool
 	// FanoutPageSize limits subscriber UIDs read by one fanout page.
 	FanoutPageSize int
-	// PushBatchSize limits owner-node route pushes produced by one delivery batch.
+	// PushBatchSize limits recipients in one exact-target lookup and delivery plan,
+	// which also bounds the owner-node routes produced from that plan.
 	PushBatchSize int
 	// PendingAckTTL bounds stale pending recvack cleanup during delivery activity.
 	PendingAckTTL time.Duration
 	// PendingAckMaxPerSession limits owner-local pending recvacks for one UID/session.
 	PendingAckMaxPerSession int
-	// EventQueueSize bounds committed-message events waiting for asynchronous delivery fanout.
+	// EventQueueSize bounds recipient delivery plans waiting for asynchronous processing.
 	EventQueueSize int
-	// RecipientWorkerConcurrency bounds recipient-authority delivery worker goroutines independently from per-message target dispatch.
+	// RecipientWorkerConcurrency bounds recipient delivery plan workers independently from per-message target dispatch.
 	RecipientWorkerConcurrency int
 }
 

--- a/internal/bench/FLOW.md
+++ b/internal/bench/FLOW.md
@@ -154,7 +154,14 @@ for example, connect waits for `phase_poll_timeout + total_users/connect_rate`.
 Warmup and run also add the largest declared SENDACK/RECV operation timeout so
 the last scheduled operation can settle without consuming the control-plane grace.
 If a status request itself reaches that child deadline, the coordinator reports
-`phase_timeout` instead of the ambiguous `phase_wait_failed` fallback.
+`phase_timeout` instead of the ambiguous `phase_wait_failed` fallback. A worker
+whose status endpoint never produced a valid response is attributed to the
+`worker_status` operation. Each ordinary status request has an independent
+short bound, so it cannot consume a long phase schedule by itself. When a GET
+straddles the total phase deadline, the coordinator performs one independent
+bounded final probe. A final active status is attributed to `phase_completion`,
+because the exhausted phase budget is then the terminal fact; a final probe
+that also blocks is attributed to `worker_status` as a real control-plane stall.
 The run phase additionally adds the deterministic reconnect pacing between
 scheduled churn windows for the busiest worker. Churn maintenance and the
 final measured operation tail therefore do not consume the base control-plane
@@ -388,6 +395,12 @@ GET  /v1/report
 `worker.State` stores the active assignment and lifecycle phase. Every assignment
 has a required `assignment_id`, which is an immutable generation token within
 `run_id`; reusing a run ID never makes two assignment generations equivalent.
+The in-process state retains the complete Assignment for runner execution,
+teardown, and report collection. `/v1/status` and other status-shaped control
+responses serialize only `run_id`, `assignment_id`, and `worker_id` from that
+assignment, so their response size does not grow with ChannelOwners, Plan,
+Target, or Scenario. Status decoding also accepts legacy expanded Assignment
+objects and preserves their additional fields during rolling upgrades.
 Phase and owner-channel preparation requests carry both values in their JSON
 body, stop carries both values in `StopRequest`, and metrics/report evidence
 reads carry both as query parameters. Missing identifiers are rejected, and a

--- a/internal/bench/coordinator/run.go
+++ b/internal/bench/coordinator/run.go
@@ -27,6 +27,7 @@ import (
 const (
 	defaultPollInterval            = 25 * time.Millisecond
 	defaultPollTimeout             = 10 * time.Second
+	defaultWorkerStatusTimeout     = time.Second
 	defaultStopTimeout             = 2 * time.Second
 	defaultTrafficOperationTimeout = 5 * time.Second
 	maxBodySnippetBytes            = 512
@@ -936,12 +937,15 @@ func (c *Coordinator) waitForPhase(parent context.Context, w model.Worker, runID
 	ticker := time.NewTicker(c.cfg.PollInterval)
 	defer ticker.Stop()
 	for {
-		status, err := c.workerStatus(ctx, w)
+		status, err := c.workerStatusBounded(ctx, w)
 		if err != nil {
 			if errorsIsParentContext(parent, err) {
 				return parent.Err()
 			}
 			if ctx.Err() != nil {
+				return c.finalPhaseStatus(parent, w, runID, assignmentID, want)
+			}
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				return phaseTimeoutOperationError(worker.FailureOperationWorkerStatus)
 			}
 			return err
@@ -965,10 +969,58 @@ func (c *Coordinator) waitForPhase(parent context.Context, w model.Worker, runID
 			if parentErr := parent.Err(); parentErr != nil {
 				return parentErr
 			}
-			return phaseTimeoutOperationError(worker.FailureOperationPhaseCompletion)
+			return c.finalPhaseStatus(parent, w, runID, assignmentID, want)
 		case <-ticker.C:
 		}
 	}
+}
+
+func (c *Coordinator) workerStatusBounded(ctx context.Context, w model.Worker) (worker.Status, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, c.workerStatusTimeout())
+	defer cancel()
+	return c.workerStatus(requestCtx, w)
+}
+
+func (c *Coordinator) finalPhaseStatus(parent context.Context, w model.Worker, runID, assignmentID string, want Phase) error {
+	if err := parent.Err(); err != nil {
+		return err
+	}
+	probeCtx, cancel := context.WithTimeout(parent, c.workerStatusTimeout())
+	defer cancel()
+	status, err := c.workerStatus(probeCtx, w)
+	if err != nil {
+		if parentErr := parent.Err(); parentErr != nil {
+			return parentErr
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return phaseTimeoutOperationError(worker.FailureOperationWorkerStatus)
+		}
+		return err
+	}
+	if err := validateStatusAssignment(status, w, runID, assignmentID); err != nil {
+		return err
+	}
+	if status.LastError != "" {
+		return workerStatusPhaseError(status.LastError, status.LastErrorCode, status.LastErrorOperation)
+	}
+	if status.CompletedPhase == want || (status.CompletedPhase == "" && status.Phase == want) {
+		return nil
+	}
+	if status.Phase == worker.PhaseStopped {
+		return fmt.Errorf("worker stopped before phase %s", want)
+	}
+	return phaseTimeoutOperationError(worker.FailureOperationPhaseCompletion)
+}
+
+func (c *Coordinator) workerStatusTimeout() time.Duration {
+	timeout := defaultWorkerStatusTimeout
+	if c.cfg.PollTimeout > 0 && c.cfg.PollTimeout < timeout {
+		timeout = c.cfg.PollTimeout
+	}
+	if timeout <= 0 {
+		return defaultWorkerStatusTimeout
+	}
+	return timeout
 }
 
 func (c *Coordinator) workerStatus(ctx context.Context, w model.Worker) (worker.Status, error) {

--- a/internal/bench/coordinator/run_test.go
+++ b/internal/bench/coordinator/run_test.go
@@ -925,6 +925,27 @@ func TestCoordinatorLaterWorkerStatusDeadlineStillReportsWorkerStatus(t *testing
 	require.Equal(t, "worker_status", result.Report.WorkerFailures[0].Operation)
 }
 
+func TestCoordinatorDeadlineStraddleFinalActiveStatusReportsPhaseCompletion(t *testing.T) {
+	workers := newFakeWorkers(t, 1)
+	workers[0].KeepPhaseInProgress(PhasePrepare)
+	workers[0].BlockOneStatusAfter(PhasePrepare, 1)
+	coord := New(CoordinatorConfig{
+		Workers:      workers.ClientConfigs(),
+		Target:       fakeTargetOK(),
+		Preflight:    preflightFunc(func(context.Context, model.Target, model.WorkerSet) error { return nil }),
+		PollInterval: time.Millisecond,
+		PollTimeout:  10 * time.Millisecond,
+	})
+
+	result, err := coord.Run(context.Background(), fakeScenario())
+
+	require.Error(t, err)
+	require.Equal(t, StatusWorkerFailed, result.Status)
+	require.Len(t, result.Report.WorkerFailures, 1)
+	require.Equal(t, "phase_timeout", result.Report.WorkerFailures[0].ReasonCode)
+	require.Equal(t, "phase_completion", result.Report.WorkerFailures[0].Operation)
+}
+
 func TestCoordinatorNonFailFastTimeoutStopsActiveWorker(t *testing.T) {
 	runner := newCoordinatorBlockingPrepareRunner()
 	workerServer := httptest.NewServer(worker.NewServer(worker.Config{
@@ -1777,6 +1798,7 @@ func newFakeWorkers(t *testing.T, count int) fakeWorkers {
 			failPhases:       make(map[Phase]fakePhaseFailure),
 			blockStatus:      make(map[Phase]bool),
 			blockStatusAfter: make(map[Phase]int),
+			blockStatusOnce:  make(map[Phase]int),
 			statusCalls:      make(map[Phase]int),
 			activePhase:      make(map[Phase]bool),
 			completeAfter:    make(map[Phase]time.Duration),
@@ -1826,6 +1848,7 @@ type fakeWorker struct {
 	lagPhases           map[Phase]bool
 	blockStatus         map[Phase]bool
 	blockStatusAfter    map[Phase]int
+	blockStatusOnce     map[Phase]int
 	statusCalls         map[Phase]int
 	activePhase         map[Phase]bool
 	completeAfter       map[Phase]time.Duration
@@ -1948,6 +1971,12 @@ func (fw *fakeWorker) BlockStatusAfter(phase Phase, successfulCalls int) {
 	fw.mu.Lock()
 	defer fw.mu.Unlock()
 	fw.blockStatusAfter[phase] = successfulCalls
+}
+
+func (fw *fakeWorker) BlockOneStatusAfter(phase Phase, successfulCalls int) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	fw.blockStatusOnce[phase] = successfulCalls + 1
 }
 
 func (fw *fakeWorker) LagPhase(phase Phase) {
@@ -2222,7 +2251,11 @@ func (fw *fakeWorker) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	phase := Phase(fw.phase)
 	fw.statusCalls[phase]++
-	blocked := fw.blockStatus[phase] || fw.blockStatusAfter[phase] > 0 && fw.statusCalls[phase] > fw.blockStatusAfter[phase]
+	blockedOnce := fw.blockStatusOnce[phase] > 0 && fw.statusCalls[phase] == fw.blockStatusOnce[phase]
+	if blockedOnce {
+		delete(fw.blockStatusOnce, phase)
+	}
+	blocked := blockedOnce || fw.blockStatus[phase] || fw.blockStatusAfter[phase] > 0 && fw.statusCalls[phase] > fw.blockStatusAfter[phase]
 	assignment := fw.assignment
 	if fw.statusAssignment != nil {
 		assignment = *fw.statusAssignment

--- a/internal/bench/worker/server_test.go
+++ b/internal/bench/worker/server_test.go
@@ -448,6 +448,33 @@ func TestWorkerPhaseEndpointsAdvanceStatus(t *testing.T) {
 	require.Equal(t, PhaseConnect, status.Phase)
 }
 
+func TestWorkerStatusResponseStaysCompactForLargeAssignment(t *testing.T) {
+	srv := NewServer(Config{ControlToken: "secret"})
+	assignment := Assignment{
+		RunID:        "run-large",
+		AssignmentID: "generation-large",
+		WorkerID:     "worker-large",
+		Plan: model.WorkerPlan{
+			WorkerID:              "worker-large",
+			OnlineIdentityIndexes: make([]int, 100_000),
+		},
+	}
+	require.NoError(t, srv.state.Assign(assignment))
+
+	rec := authorizedRecorder(t, srv, http.MethodGet, "/v1/status", "secret", nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Less(t, rec.Body.Len(), 1024, "status body must not scale with the worker plan")
+	require.NotContains(t, rec.Body.String(), "online_identity_indexes")
+	var status Status
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &status))
+	require.Equal(t, assignment.RunID, status.Assignment.RunID)
+	require.Equal(t, assignment.AssignmentID, status.Assignment.AssignmentID)
+	require.Equal(t, assignment.WorkerID, status.Assignment.WorkerID)
+	require.Empty(t, status.Assignment.Plan.OnlineIdentityIndexes)
+	require.Len(t, srv.state.Status().Assignment.Plan.OnlineIdentityIndexes, 100_000, "internal state must retain the full assignment")
+}
+
 func TestWorkerStopAllowsNewRunAssignment(t *testing.T) {
 	srv := NewServer(Config{ControlToken: "secret"})
 	assign(t, srv, "secret", "run-a")

--- a/internal/bench/worker/state.go
+++ b/internal/bench/worker/state.go
@@ -152,6 +152,39 @@ type Status struct {
 	Assignment Assignment `json:"assignment"`
 }
 
+type statusAssignmentIdentity struct {
+	RunID        string `json:"run_id"`
+	AssignmentID string `json:"assignment_id"`
+	WorkerID     string `json:"worker_id,omitempty"`
+}
+
+type statusJSON struct {
+	Phase              Phase                    `json:"phase"`
+	ActivePhase        Phase                    `json:"active_phase,omitempty"`
+	CompletedPhase     Phase                    `json:"completed_phase,omitempty"`
+	LastError          string                   `json:"last_error,omitempty"`
+	LastErrorCode      FailureReasonCode        `json:"last_error_code,omitempty"`
+	LastErrorOperation FailureOperationCode     `json:"last_error_operation,omitempty"`
+	Assignment         statusAssignmentIdentity `json:"assignment"`
+}
+
+// MarshalJSON keeps the worker control response independent from assignment plan size.
+func (s Status) MarshalJSON() ([]byte, error) {
+	return json.Marshal(statusJSON{
+		Phase:              s.Phase,
+		ActivePhase:        s.ActivePhase,
+		CompletedPhase:     s.CompletedPhase,
+		LastError:          s.LastError,
+		LastErrorCode:      s.LastErrorCode,
+		LastErrorOperation: s.LastErrorOperation,
+		Assignment: statusAssignmentIdentity{
+			RunID:        s.Assignment.RunID,
+			AssignmentID: s.Assignment.AssignmentID,
+			WorkerID:     s.Assignment.WorkerID,
+		},
+	})
+}
+
 // State stores the active worker assignment and monotonic phase.
 type State struct {
 	mu                 sync.Mutex

--- a/internal/bench/worker/state_test.go
+++ b/internal/bench/worker/state_test.go
@@ -20,6 +20,33 @@ func TestStateRejectsOutOfOrderPhaseTransition(t *testing.T) {
 	require.Equal(t, PhaseAssigned, state.Status().Phase)
 }
 
+func TestStatusUnmarshalAcceptsLegacyExpandedAssignment(t *testing.T) {
+	legacy := []byte(`{
+		"phase":"run",
+		"active_phase":"run",
+		"completed_phase":"warmup",
+		"assignment":{
+			"run_id":"run-legacy",
+			"assignment_id":"generation-legacy",
+			"worker_id":"worker-legacy",
+			"plan":{"worker_id":"worker-legacy","online_identity_indexes":[1,2,3]},
+			"channel_owners":{"group":{"1":"worker-legacy"}}
+		}
+	}`)
+
+	var status Status
+	require.NoError(t, json.Unmarshal(legacy, &status))
+	require.Equal(t, PhaseRun, status.Phase)
+	require.Equal(t, PhaseRun, status.ActivePhase)
+	require.Equal(t, PhaseWarmup, status.CompletedPhase)
+	require.Equal(t, "run-legacy", status.Assignment.RunID)
+	require.Equal(t, "generation-legacy", status.Assignment.AssignmentID)
+	require.Equal(t, "worker-legacy", status.Assignment.WorkerID)
+	require.Equal(t, "worker-legacy", status.Assignment.Plan.WorkerID)
+	require.Equal(t, []int{1, 2, 3}, status.Assignment.Plan.OnlineIdentityIndexes, "legacy expanded status fields must remain available")
+	require.Equal(t, map[string]map[int]string{"group": {1: "worker-legacy"}}, status.Assignment.ChannelOwners)
+}
+
 func TestStateRejectsAssignmentWithoutAssignmentID(t *testing.T) {
 	state := NewState("")
 

--- a/internal/infra/cluster/FLOW.md
+++ b/internal/infra/cluster/FLOW.md
@@ -739,6 +739,12 @@ presence.Route / uid
   -> one cluster.RouteKeysPartial(uids) snapshot lookup
   -> aligned []presence.RouteTargetResult with complete route fences
 
+[{exact presence.RouteTarget, uids}]
+  -> group target batches by LeaderNodeID without another route lookup
+  -> local leader: one target-batch authority read per exact target
+  -> remote leader: one access/node batch envelope RPC per leader
+  -> aligned []presence.EndpointLookupResult with group-scoped errors
+
 presence.RouteAction
   -> action.OwnerNodeID
   -> local accessnode.PresenceOwner when owner is this node
@@ -763,6 +769,20 @@ successful items retain the hash Slot, physical Slot, leader term, config
 epoch, route revision, and authority epoch fences from the single cluster
 routing snapshot. The app worker owns exact route requeue for failed items so a
 later flush can resolve them against a newer routing snapshot.
+
+Target-aware endpoint lookup consumes those already-resolved target fences. It
+never calls `RouteKey` or `RouteKeysPartial` on the happy path. Multiple exact
+hash-slot targets for the same remote leader share one RPC envelope, so network
+work scales with leader count instead of recipient or hash-slot count. The
+local path uses the optional batch authority surface and keeps each exact target
+fence intact. Remote transport or response-cardinality failures are copied only
+to groups assigned to that leader; per-group stale/not-leader errors remain
+aligned and do not discard successful results from other groups.
+If one group returns not-leader, stale-route, or route-not-ready after waiting
+in the asynchronous delivery queue, the adapter batch-resolves current targets
+for only that group's UIDs and retries it once. Successful sibling groups are
+not issued again. The retry remains aligned to the original group and rejects
+an inconsistent refresh whose UIDs no longer share one exact target.
 
 For the individual register, unregister, endpoint, commit, and abort paths, if
 route resolution reports route-not-ready, stale routing, or not-leader, the

--- a/internal/infra/cluster/presence.go
+++ b/internal/infra/cluster/presence.go
@@ -243,6 +243,190 @@ func (c *PresenceAuthorityClient) EndpointsByUIDs(ctx context.Context, uids []st
 	return out, nil
 }
 
+// EndpointsByTargets reads aligned endpoint groups through their exact observed targets.
+func (c *PresenceAuthorityClient) EndpointsByTargets(ctx context.Context, groups []presence.EndpointLookupGroup) []presence.EndpointLookupResult {
+	results := c.endpointsByTargetsOnce(ctx, groups)
+	return c.retryStaleEndpointLookupGroups(ctx, groups, results)
+}
+
+func (c *PresenceAuthorityClient) endpointsByTargetsOnce(ctx context.Context, groups []presence.EndpointLookupGroup) []presence.EndpointLookupResult {
+	results := make([]presence.EndpointLookupResult, len(groups))
+	if len(groups) == 0 {
+		return results
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if c == nil || c.node == nil {
+		return fillPresenceEndpointLookupErrors(results, nil, authoritypresence.ErrRouteNotReady)
+	}
+
+	type leaderBatch struct {
+		indexes []int
+		groups  []presence.EndpointLookupGroup
+	}
+	byLeader := make(map[uint64]*leaderBatch)
+	for i, group := range groups {
+		if len(group.UIDs) == 0 {
+			continue
+		}
+		if group.Target.LeaderNodeID == 0 {
+			results[i].Err = fmt.Errorf("%w: endpoint lookup target leader is unknown", authoritypresence.ErrRouteNotReady)
+			continue
+		}
+		batch := byLeader[group.Target.LeaderNodeID]
+		if batch == nil {
+			batch = &leaderBatch{}
+			byLeader[group.Target.LeaderNodeID] = batch
+		}
+		batch.indexes = append(batch.indexes, i)
+		batch.groups = append(batch.groups, group)
+	}
+
+	for leaderNodeID, batch := range byLeader {
+		if err := ctx.Err(); err != nil {
+			fillPresenceEndpointLookupErrors(results, batch.indexes, err)
+			continue
+		}
+		if leaderNodeID == c.node.NodeID() {
+			for i, group := range batch.groups {
+				results[batch.indexes[i]] = c.endpointsByExactTarget(ctx, group)
+			}
+			continue
+		}
+		if c.remote == nil {
+			fillPresenceEndpointLookupErrors(results, batch.indexes, authoritypresence.ErrRouteNotReady)
+			continue
+		}
+		remoteResults, err := c.remote.EndpointsByTargets(ctx, leaderNodeID, batch.groups)
+		if err != nil {
+			fillPresenceEndpointLookupErrors(results, batch.indexes, err)
+			continue
+		}
+		if len(remoteResults) != len(batch.indexes) {
+			err := fmt.Errorf("%w: aligned endpoint result count %d does not match group count %d", authoritypresence.ErrRouteNotReady, len(remoteResults), len(batch.indexes))
+			fillPresenceEndpointLookupErrors(results, batch.indexes, err)
+			continue
+		}
+		for i, result := range remoteResults {
+			results[batch.indexes[i]] = result
+		}
+	}
+	return results
+}
+
+func (c *PresenceAuthorityClient) retryStaleEndpointLookupGroups(
+	ctx context.Context,
+	groups []presence.EndpointLookupGroup,
+	results []presence.EndpointLookupResult,
+) []presence.EndpointLookupResult {
+	retryIndexes := make([]int, 0)
+	retryUIDs := make([]string, 0)
+	retryUIDCounts := make([]int, 0)
+	for i, result := range results {
+		if !shouldRetryPresenceRouteLookup(result.Err) || i >= len(groups) {
+			continue
+		}
+		groupUIDs := nonEmptyPresenceUIDs(groups[i].UIDs)
+		if len(groupUIDs) == 0 {
+			results[i] = presence.EndpointLookupResult{}
+			continue
+		}
+		retryIndexes = append(retryIndexes, i)
+		retryUIDCounts = append(retryUIDCounts, len(groupUIDs))
+		retryUIDs = append(retryUIDs, groupUIDs...)
+	}
+	if len(retryIndexes) == 0 {
+		return results
+	}
+
+	refreshedTargets := c.ResolveRouteTargets(ctx, retryUIDs)
+	refreshedGroups := make([]presence.EndpointLookupGroup, 0, len(retryIndexes))
+	refreshedIndexes := make([]int, 0, len(retryIndexes))
+	offset := 0
+	for retryIndex, resultIndex := range retryIndexes {
+		uidCount := retryUIDCounts[retryIndex]
+		next := offset + uidCount
+		if next > len(refreshedTargets) {
+			results[resultIndex] = presence.EndpointLookupResult{Err: fmt.Errorf("%w: refreshed target result count is not aligned", authoritypresence.ErrRouteNotReady)}
+			offset = next
+			continue
+		}
+		target, err := onePresenceRouteTarget(refreshedTargets[offset:next])
+		offset = next
+		if err != nil {
+			results[resultIndex] = presence.EndpointLookupResult{Err: err}
+			continue
+		}
+		refreshedGroups = append(refreshedGroups, presence.EndpointLookupGroup{
+			Target: target,
+			UIDs:   nonEmptyPresenceUIDs(groups[resultIndex].UIDs),
+		})
+		refreshedIndexes = append(refreshedIndexes, resultIndex)
+	}
+	if len(refreshedGroups) == 0 {
+		return results
+	}
+
+	retried := c.endpointsByTargetsOnce(ctx, refreshedGroups)
+	for i, resultIndex := range refreshedIndexes {
+		if i >= len(retried) {
+			results[resultIndex] = presence.EndpointLookupResult{Err: fmt.Errorf("%w: retried endpoint result count is not aligned", authoritypresence.ErrRouteNotReady)}
+			continue
+		}
+		results[resultIndex] = retried[i]
+	}
+	return results
+}
+
+func nonEmptyPresenceUIDs(uids []string) []string {
+	out := make([]string, 0, len(uids))
+	for _, uid := range uids {
+		if uid != "" {
+			out = append(out, uid)
+		}
+	}
+	return out
+}
+
+func onePresenceRouteTarget(results []presence.RouteTargetResult) (presence.RouteTarget, error) {
+	if len(results) == 0 {
+		return presence.RouteTarget{}, authoritypresence.ErrRouteNotReady
+	}
+	target := results[0].Target
+	for _, result := range results {
+		if result.Err != nil {
+			return presence.RouteTarget{}, result.Err
+		}
+		if result.Target != target {
+			return presence.RouteTarget{}, fmt.Errorf("%w: refreshed UIDs no longer share one exact target", authoritypresence.ErrRouteNotReady)
+		}
+	}
+	return target, nil
+}
+
+func (c *PresenceAuthorityClient) endpointsByExactTarget(ctx context.Context, group presence.EndpointLookupGroup) presence.EndpointLookupResult {
+	if c.local == nil {
+		return presence.EndpointLookupResult{Err: authoritypresence.ErrRouteNotReady}
+	}
+	if batch, ok := c.local.(accessnode.PresenceBatchAuthority); ok {
+		routes, err := batch.EndpointsByUIDs(ctx, group.Target, group.UIDs)
+		return presence.EndpointLookupResult{Routes: routes, Err: err}
+	}
+	var routes []presence.Route
+	for _, uid := range group.UIDs {
+		if uid == "" {
+			continue
+		}
+		uidRoutes, err := c.local.EndpointsByUID(ctx, group.Target, uid)
+		if err != nil {
+			return presence.EndpointLookupResult{Routes: routes, Err: err}
+		}
+		routes = append(routes, uidRoutes...)
+	}
+	return presence.EndpointLookupResult{Routes: routes}
+}
+
 // TouchRoutesTo refreshes owner routes in a specific observed authority epoch.
 func (c *PresenceAuthorityClient) TouchRoutesTo(ctx context.Context, target presence.RouteTarget, routes []presence.Route) error {
 	authority, err := c.authorityForTarget(target)
@@ -379,6 +563,19 @@ func routeTargetFromClusterRoute(route cluster.Route) presence.RouteTarget {
 func fillPresenceRouteTargetErrors(results []presence.RouteTargetResult, err error) []presence.RouteTargetResult {
 	for i := range results {
 		results[i].Err = err
+	}
+	return results
+}
+
+func fillPresenceEndpointLookupErrors(results []presence.EndpointLookupResult, indexes []int, err error) []presence.EndpointLookupResult {
+	if indexes == nil {
+		for i := range results {
+			results[i].Err = err
+		}
+		return results
+	}
+	for _, index := range indexes {
+		results[index].Err = err
 	}
 	return results
 }

--- a/internal/infra/cluster/presence_test.go
+++ b/internal/infra/cluster/presence_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -472,6 +473,156 @@ func TestPresenceAuthorityClientResolveRouteTargetsFansOutCanceledContext(t *tes
 	require.Zero(t, node.routeKeyCalls)
 }
 
+func TestPresenceAuthorityClientEndpointsByTargetsBatchesRemoteRPCsByLeader(t *testing.T) {
+	local := &fakePresenceAuthority{}
+	remoteTwo := &fakePresenceAuthority{}
+	remoteThree := &fakePresenceAuthority{}
+	node := &fakePresenceCluster{
+		nodeID: 1,
+		rpcByNode: map[uint64]cluster.NodeRPCHandler{
+			2: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remoteTwo})},
+			3: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remoteThree})},
+		},
+	}
+	client := NewPresenceAuthorityClient(node, local)
+
+	groups := make([]presence.EndpointLookupGroup, 0, 256)
+	for i := 0; i < 256; i++ {
+		leader := uint64(i%3 + 1)
+		groups = append(groups, presence.EndpointLookupGroup{
+			Target: presence.RouteTarget{
+				HashSlot:       uint16(i),
+				SlotID:         uint32(i%10 + 1),
+				LeaderNodeID:   leader,
+				LeaderTerm:     100 + leader,
+				ConfigEpoch:    200 + leader,
+				RouteRevision:  uint64(300 + i),
+				AuthorityEpoch: uint64(400 + i),
+			},
+			UIDs: []string{fmt.Sprintf("u-%03d-a", i), fmt.Sprintf("u-%03d-b", i)},
+		})
+	}
+
+	results := client.EndpointsByTargets(context.Background(), groups)
+
+	require.Len(t, results, len(groups))
+	for i, result := range results {
+		require.NoError(t, result.Err, "result index %d", i)
+		require.Equal(t, []string{groups[i].UIDs[0], groups[i].UIDs[1]}, []string{result.Routes[0].UID, result.Routes[1].UID})
+	}
+	require.Len(t, node.calls, 2, "remote RPC count must scale with remote leaders, not UIDs or hash slots")
+	require.ElementsMatch(t, []uint64{2, 3}, []uint64{node.calls[0].nodeID, node.calls[1].nodeID})
+	require.Zero(t, node.routeKeyCalls, "exact-target lookup must not resolve RouteKey again")
+	require.Empty(t, node.routeKeysCalls, "exact-target lookup must not resolve RouteKeysPartial again")
+
+	gotGroups := make(map[presence.RouteTarget][]string, len(groups))
+	for _, authority := range []*fakePresenceAuthority{local, remoteTwo, remoteThree} {
+		for _, call := range authority.endpointBatchCalls {
+			gotGroups[call.target] = call.uids
+		}
+	}
+	require.Len(t, gotGroups, len(groups))
+	for _, group := range groups {
+		require.Equal(t, group.UIDs, gotGroups[group.Target], "full authority fence must survive local and remote batching")
+	}
+}
+
+func TestPresenceAuthorityClientEndpointsByTargetsKeepsGroupErrorsPartialAndAligned(t *testing.T) {
+	local := &fakePresenceAuthority{}
+	remoteTwo := &fakePresenceAuthority{endpointBatchErrs: map[uint16]error{22: context.Canceled}}
+	remoteThree := &fakePresenceAuthority{}
+	node := &fakePresenceCluster{
+		nodeID: 1,
+		rpcByNode: map[uint64]cluster.NodeRPCHandler{
+			2: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remoteTwo})},
+			3: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remoteThree})},
+		},
+	}
+	client := NewPresenceAuthorityClient(node, local)
+	groups := []presence.EndpointLookupGroup{
+		{Target: testEndpointLookupTarget(11, 1), UIDs: []string{"local"}},
+		{Target: testEndpointLookupTarget(22, 2), UIDs: []string{"stale"}},
+		{Target: testEndpointLookupTarget(23, 2), UIDs: []string{"remote-two"}},
+		{Target: testEndpointLookupTarget(33, 3), UIDs: []string{"remote-three"}},
+	}
+
+	results := client.EndpointsByTargets(context.Background(), groups)
+
+	require.Len(t, results, len(groups))
+	require.Equal(t, "local", results[0].Routes[0].UID)
+	require.NoError(t, results[0].Err)
+	require.Empty(t, results[1].Routes)
+	require.ErrorIs(t, results[1].Err, context.Canceled)
+	require.Equal(t, "remote-two", results[2].Routes[0].UID)
+	require.NoError(t, results[2].Err)
+	require.Equal(t, "remote-three", results[3].Routes[0].UID)
+	require.NoError(t, results[3].Err)
+	require.Len(t, node.calls, 2)
+	require.Zero(t, node.routeKeyCalls)
+	require.Empty(t, node.routeKeysCalls)
+}
+
+func TestPresenceAuthorityClientEndpointsByTargetsReroutesOnlyStaleGroupOnce(t *testing.T) {
+	local := &fakePresenceAuthority{}
+	remoteTwo := &fakePresenceAuthority{endpointBatchErrs: map[uint16]error{22: authoritypresence.ErrStaleRoute}}
+	remoteThree := &fakePresenceAuthority{}
+	fresh := cluster.Route{
+		HashSlot:       22,
+		SlotID:         3,
+		Leader:         3,
+		LeaderTerm:     303,
+		ConfigEpoch:    403,
+		Revision:       503,
+		AuthorityEpoch: 603,
+	}
+	node := &fakePresenceCluster{
+		nodeID:          1,
+		routeKeyResults: []cluster.RouteKeyResult{{Route: fresh}},
+		rpcByNode: map[uint64]cluster.NodeRPCHandler{
+			2: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remoteTwo})},
+			3: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remoteThree})},
+		},
+	}
+	client := NewPresenceAuthorityClient(node, local)
+	groups := []presence.EndpointLookupGroup{
+		{Target: testEndpointLookupTarget(11, 1), UIDs: []string{"local"}},
+		{Target: testEndpointLookupTarget(22, 2), UIDs: []string{"stale"}},
+		{Target: testEndpointLookupTarget(23, 2), UIDs: []string{"remote-two"}},
+		{Target: testEndpointLookupTarget(33, 3), UIDs: []string{"remote-three"}},
+	}
+
+	results := client.EndpointsByTargets(context.Background(), groups)
+
+	require.Len(t, results, len(groups))
+	for i, result := range results {
+		require.NoError(t, result.Err, "result index %d", i)
+		require.Len(t, result.Routes, 1, "result index %d", i)
+	}
+	require.Equal(t, [][]string{{"stale"}}, node.routeKeysCalls, "only the stale group may be rerouted")
+	require.Zero(t, node.routeKeyCalls)
+	require.Len(t, node.calls, 3, "two initial leaders plus one bounded stale-group retry")
+	require.Equal(t, []presenceEndpointBatchCall{
+		{target: groups[1].Target, uids: []string{"stale"}},
+		{target: groups[2].Target, uids: []string{"remote-two"}},
+	}, remoteTwo.endpointBatchCalls)
+	require.Equal(t, []presenceEndpointBatchCall{
+		{target: groups[3].Target, uids: []string{"remote-three"}},
+		{target: routeTargetFromClusterRoute(fresh), uids: []string{"stale"}},
+	}, remoteThree.endpointBatchCalls)
+}
+
+func testEndpointLookupTarget(hashSlot uint16, leader uint64) presence.RouteTarget {
+	return presence.RouteTarget{
+		HashSlot:       hashSlot,
+		SlotID:         uint32(hashSlot%10 + 1),
+		LeaderNodeID:   leader,
+		LeaderTerm:     101 + leader,
+		ConfigEpoch:    201 + leader,
+		RouteRevision:  301 + uint64(hashSlot),
+		AuthorityEpoch: 401 + uint64(hashSlot),
+	}
+}
+
 func TestPresenceClientReturnsRouteNotReadyWhenRouteKeyFails(t *testing.T) {
 	cluster := &fakePresenceCluster{
 		nodeID:   1,
@@ -513,6 +664,7 @@ type fakePresenceCluster struct {
 	routeKeyResults []cluster.RouteKeyResult
 	routeKeysErr    error
 	rpc             cluster.NodeRPCHandler
+	rpcByNode       map[uint64]cluster.NodeRPCHandler
 	calls           []rpcCall
 	routeKeyCalls   int
 	routeKeysCalls  [][]string
@@ -575,6 +727,9 @@ func (f *fakePresenceCluster) RouteHashSlot(uint16) (cluster.Route, error) {
 
 func (f *fakePresenceCluster) CallRPC(ctx context.Context, nodeID uint64, serviceID uint8, payload []byte) ([]byte, error) {
 	f.calls = append(f.calls, rpcCall{nodeID: nodeID, serviceID: serviceID, payload: append([]byte(nil), payload...)})
+	if handler := f.rpcByNode[nodeID]; handler != nil {
+		return handler.HandleRPC(ctx, payload)
+	}
 	if f.rpc != nil {
 		return f.rpc.HandleRPC(ctx, payload)
 	}
@@ -599,17 +754,19 @@ func (f *fakePresenceCluster) WatchRouteAuthorities() <-chan cluster.RouteAuthor
 }
 
 type fakePresenceAuthority struct {
-	registerResult presence.RegisterResult
-	registerErrs   []error
-	registerHook   func() error
-	commitErrs     []error
-	abortErrs      []error
-	registerCalls  []presenceRegisterCall
-	commitCalls    []presenceTokenCall
-	abortCalls     []presenceTokenCall
-	unregCalls     []presenceUnregisterCall
-	endpointCalls  []presenceEndpointCall
-	touchCalls     []presenceTouchCall
+	registerResult     presence.RegisterResult
+	registerErrs       []error
+	registerHook       func() error
+	commitErrs         []error
+	abortErrs          []error
+	registerCalls      []presenceRegisterCall
+	commitCalls        []presenceTokenCall
+	abortCalls         []presenceTokenCall
+	unregCalls         []presenceUnregisterCall
+	endpointCalls      []presenceEndpointCall
+	endpointBatchCalls []presenceEndpointBatchCall
+	endpointBatchErrs  map[uint16]error
+	touchCalls         []presenceTouchCall
 }
 
 type fakePresenceOwner struct {
@@ -668,6 +825,21 @@ func (f *fakePresenceAuthority) EndpointsByUID(_ context.Context, target presenc
 	return []presence.Route{testInfraPresenceRoute(uid, 301)}, nil
 }
 
+func (f *fakePresenceAuthority) EndpointsByUIDs(_ context.Context, target presence.RouteTarget, uids []string) ([]presence.Route, error) {
+	f.endpointBatchCalls = append(f.endpointBatchCalls, presenceEndpointBatchCall{
+		target: target,
+		uids:   append([]string(nil), uids...),
+	})
+	if err := f.endpointBatchErrs[target.HashSlot]; err != nil {
+		return nil, err
+	}
+	routes := make([]presence.Route, 0, len(uids))
+	for i, uid := range uids {
+		routes = append(routes, testInfraPresenceRoute(uid, uint64(i+1)))
+	}
+	return routes, nil
+}
+
 func (f *fakePresenceAuthority) TouchRoutes(_ context.Context, target presence.RouteTarget, routes []presence.Route) error {
 	f.touchCalls = append(f.touchCalls, presenceTouchCall{target: target, routes: append([]presence.Route(nil), routes...)})
 	return nil
@@ -692,6 +864,11 @@ type presenceUnregisterCall struct {
 type presenceEndpointCall struct {
 	target presence.RouteTarget
 	uid    string
+}
+
+type presenceEndpointBatchCall struct {
+	target presence.RouteTarget
+	uids   []string
 }
 
 type presenceTouchCall struct {

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -247,8 +247,8 @@ page's recipients are admitted or dispatched, avoiding partial side effects for
 the invalid page before the envelope is dropped.
 
 After each recipient set is formed, channelappend first resolves the fenced
-recipient authority targets and enqueues recipient delivery batches, then admits
-one independent `conversationactive.ActiveBatch` projection.
+recipient authority targets and enqueues bounded recipient delivery plans, then
+admits one independent `conversationactive.ActiveBatch` projection.
 The batch carries an explicit `metadb.ConversationKind`: normal for ordinary
 channel commits, CMD for one-shot sync commits or command-channel ids. It also
 carries `SenderUID` from the committed event, channel identity, message
@@ -261,31 +261,49 @@ configured. If active admission fails, the post-commit failure phase is
 a successfully loaded non-large subscriber snapshot continue independently.
 
 Recipient delivery is an enqueue contract. When delivery enqueueing is
-configured, recipient batches are grouped by the full fenced recipient
-authority target, including Slot leader term and Slot config epoch. UID
-authority resolution is performed once per unique trimmed UID and uses the
-optional batch resolver when available; invalid
-or missing targets map to route-not-ready before enqueueing.
-Different recipient authority targets may enqueue concurrently up to
-`RecipientAuthorityDispatchConcurrency`; batches for the same target are enqueued
-sequentially. The dedicated delivery worker drains the accepted batches,
-resolves presence, groups routes by owner node, skips only the sender's exact
-accepted session for echo suppression, retries retryable owner pushes, and
-performs owner-local concrete session writes outside `channelState`.
+configured, recipients are grouped by the full fenced recipient authority
+target, including Slot leader term and Slot config epoch. UID authority
+resolution is performed once per unique trimmed UID and uses the optional batch
+resolver when available; invalid or missing targets map to route-not-ready
+before enqueueing. The production plan-capable enqueuer packs those exact-target
+groups into commands whose total recipient count is bounded by the existing
+recipient batch size. This preserves the complete target fence across the queue
+boundary while allowing one subscriber page to be admitted as one plan when it
+fits that bound. A legacy batch-only enqueuer remains supported; only that
+compatibility path dispatches different targets concurrently up to
+`RecipientAuthorityDispatchConcurrency`, while batches for the same target stay
+sequential.
+
+The dedicated delivery worker drains accepted plans. A target-aware presence
+resolver receives all target groups from one plan together and returns aligned
+per-group results, so one failed group is observed without suppressing the
+other groups. A legacy presence resolver remains supported by resolving the
+groups individually. A panic while processing one resolved group is converted
+to that group's terminal error and does not prevent later sibling groups from
+running. Successfully resolved routes are grouped by owner node,
+skip only the sender's exact accepted session for echo suppression, retry
+retryable owner pushes, and perform owner-local concrete session writes outside
+`channelState`.
 
 `RecipientDeliveryWorker` owns the bounded async queue for those delivery
-batches. The buffered queue is the admission backpressure primitive; there is
+plans. The buffered queue is the admission backpressure primitive; there is
 no second slot semaphore. Admission is open only between `Start` and `Stop`;
 closed admission returns `ErrRecipientDeliveryWorkerClosed`, and a full queue
 waits for capacity until the caller context expires. `Stop` closes admission
-first, then drains already accepted batches until the caller context expires.
+first and cancels the worker lifecycle context. Enqueue calls that crossed the
+open-state gate are counted until their queue send returns; workers may exit
+only after that sender barrier closes, then terminally drain every accepted
+plan with the canceled lifecycle context. Each plan also has a bounded
+processing deadline, so a transport RPC that never responds cannot occupy one
+worker indefinitely. The caller's Stop context bounds only how long Stop waits
+for this asynchronous shutdown protocol to finish.
 Processing failures are terminal best-effort delivery failures: they are
 observed through the same post-commit failure surface with the recipient
 authority target attached, and they are not returned to channelappend after the
-batch has been accepted. The worker also emits low-cardinality queue, admission,
+plan has been accepted. The worker also emits low-cardinality queue, admission,
 process, and execution-pressure observations: queue depth/capacity, configured
 worker capacity/current in-flight commands, enqueue result/wait time,
-processing result/duration, and recipient batch size. Queue and worker gauge
+processing result/duration, and total recipients per plan. Queue and worker gauge
 samples are serialized and read from current state so concurrent worker starts,
 finishes, and queue changes cannot leave a stale terminal gauge; every accepted
 command increments in-flight for the complete `runCommand` execution and the

--- a/internal/runtime/channelappend/contracts.go
+++ b/internal/runtime/channelappend/contracts.go
@@ -95,6 +95,48 @@ type Recipient = contract.Recipient
 // RecipientBatch carries one committed envelope and the recipients to process together.
 type RecipientBatch = contract.RecipientBatch
 
+// RecipientTargetBatch groups recipients that share one exact UID authority fence.
+type RecipientTargetBatch struct {
+	// Target is the exact recipient authority fence resolved before queue admission.
+	Target RecipientAuthorityTarget
+	// Recipients are the recipients owned by Target.
+	Recipients []Recipient
+}
+
+// Clone returns an independent recipient target batch.
+func (b RecipientTargetBatch) Clone() RecipientTargetBatch {
+	b.Recipients = append([]Recipient(nil), b.Recipients...)
+	return b
+}
+
+// RecipientDeliveryPlan carries one committed envelope and all exact-target
+// recipient groups selected for one bounded delivery command.
+type RecipientDeliveryPlan struct {
+	// Event is the immutable committed message being delivered.
+	Event CommittedEnvelope
+	// Targets preserve the exact UID authority fences resolved for the recipients.
+	Targets []RecipientTargetBatch
+}
+
+// Clone returns an independent delivery plan.
+func (p RecipientDeliveryPlan) Clone() RecipientDeliveryPlan {
+	p.Event = p.Event.Clone()
+	p.Targets = append([]RecipientTargetBatch(nil), p.Targets...)
+	for i := range p.Targets {
+		p.Targets[i] = p.Targets[i].Clone()
+	}
+	return p
+}
+
+// RecipientCount returns the number of recipient entries carried by the plan.
+func (p RecipientDeliveryPlan) RecipientCount() int {
+	total := 0
+	for _, target := range p.Targets {
+		total += len(target.Recipients)
+	}
+	return total
+}
+
 // OfflineRecipientsEvent reports durable recipients with no online route.
 type OfflineRecipientsEvent struct {
 	// Event is the committed message whose recipients were classified offline.

--- a/internal/runtime/channelappend/delivery.go
+++ b/internal/runtime/channelappend/delivery.go
@@ -17,6 +17,9 @@ var (
 	ErrEffectPanic = errors.New("internal/channelappend: effect panic")
 	// ErrRealtimeDeliveryRequired reports a transient send without a realtime delivery queue.
 	ErrRealtimeDeliveryRequired = errors.New("internal/channelappend: realtime delivery required")
+	// ErrRecipientPresenceResultMissing reports a target-aware presence response
+	// that is not aligned with the submitted exact-target groups.
+	ErrRecipientPresenceResultMissing = errors.New("internal/channelappend: recipient presence result missing")
 )
 
 // RecipientProcessorOptions configures recipient-authority post-commit processing.
@@ -73,6 +76,72 @@ func (p *RecipientProcessor) ProcessRecipientBatch(ctx context.Context, batch Re
 	return processRecipientBatch(ctx, batch, p.ports)
 }
 
+// ProcessRecipientDeliveryPlan resolves and processes every exact-target group
+// in one bounded plan. Returned errors align with plan.Targets; one failed
+// authority group does not prevent other groups from being delivered.
+func (p *RecipientProcessor) ProcessRecipientDeliveryPlan(ctx context.Context, plan RecipientDeliveryPlan) []error {
+	results := make([]error, len(plan.Targets))
+	if p == nil || len(plan.Targets) == 0 {
+		return results
+	}
+	if p.ports.presence == nil ||
+		(p.ports.pusher == nil && p.ports.offlineRecipientsObserver == nil && p.ports.offlineRecipientObserver == nil) {
+		return results
+	}
+	if err := contextErr(ctx); err != nil {
+		for i, target := range plan.Targets {
+			results[i] = withPostCommitFailureDetail(err, postCommitBatchDetail("context", RecipientBatch{
+				Event:      plan.Event,
+				Recipients: target.Recipients,
+			}))
+		}
+		return results
+	}
+	targetResolver, ok := p.ports.presence.(RecipientTargetPresenceResolver)
+	if !ok {
+		for i, target := range plan.Targets {
+			results[i] = processRecipientBatchSafely(ctx, RecipientBatch{Event: plan.Event, Recipients: target.Recipients}, p.ports)
+		}
+		return results
+	}
+
+	resolved := targetResolver.EndpointsByTargets(ctx, plan.Targets)
+	for i, target := range plan.Targets {
+		batch := RecipientBatch{Event: plan.Event, Recipients: target.Recipients}
+		if i >= len(resolved) {
+			results[i] = withPostCommitFailureDetail(ErrRecipientPresenceResultMissing, postCommitBatchDetail("presence_resolve", batch))
+			continue
+		}
+		if resolved[i].Err != nil {
+			detail := postCommitBatchDetail("presence_resolve", batch)
+			detail.UIDCount = len(recipientUIDs(batch.Recipients))
+			results[i] = withPostCommitFailureDetail(resolved[i].Err, detail)
+			continue
+		}
+		results[i] = processRecipientBatchWithRoutesSafely(ctx, batch, resolved[i].Routes, p.ports)
+	}
+	return results
+}
+
+func processRecipientBatchSafely(ctx context.Context, batch RecipientBatch, ports recipientPorts) (err error) {
+	defer recoverRecipientBatchPanic(batch, &err)
+	return processRecipientBatch(ctx, batch, ports)
+}
+
+func processRecipientBatchWithRoutesSafely(ctx context.Context, batch RecipientBatch, routes []Route, ports recipientPorts) (err error) {
+	defer recoverRecipientBatchPanic(batch, &err)
+	return processRecipientBatchWithRoutes(ctx, batch, routes, ports)
+}
+
+func recoverRecipientBatchPanic(batch RecipientBatch, err *error) {
+	if recovered := recover(); recovered != nil {
+		*err = withPostCommitFailureDetail(
+			effectPanicError(effectStagePostCommit, recovered),
+			postCommitBatchDetail("panic", batch),
+		)
+	}
+}
+
 func processRecipientBatch(ctx context.Context, batch RecipientBatch, ports recipientPorts) error {
 	if len(batch.Recipients) == 0 {
 		return nil
@@ -91,6 +160,11 @@ func processRecipientBatch(ctx context.Context, batch RecipientBatch, ports reci
 		detail.UIDCount = len(uids)
 		return withPostCommitFailureDetail(err, detail)
 	}
+	return processRecipientBatchWithRoutes(ctx, batch, routes, ports)
+}
+
+func processRecipientBatchWithRoutes(ctx context.Context, batch RecipientBatch, routes []Route, ports recipientPorts) error {
+	uids := recipientUIDs(batch.Recipients)
 	observeOfflineRecipients(ctx, batch, uids, routes, ports.offlineRecipientsObserver, ports.offlineRecipientObserver)
 	if ports.pusher == nil {
 		return nil

--- a/internal/runtime/channelappend/delivery_worker.go
+++ b/internal/runtime/channelappend/delivery_worker.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	defaultRecipientDeliveryQueueSize = 1024
-	defaultRecipientDeliveryWorkers   = 1
+	defaultRecipientDeliveryQueueSize   = 1024
+	defaultRecipientDeliveryWorkers     = 1
+	defaultRecipientDeliveryPlanTimeout = 5 * time.Second
 )
 
-// ErrRecipientDeliveryWorkerClosed reports that the recipient delivery worker is not accepting batches.
+// ErrRecipientDeliveryWorkerClosed reports that the recipient delivery worker is not accepting plans.
 var ErrRecipientDeliveryWorkerClosed = errors.New("internal/channelappend: recipient delivery worker closed")
 
 type recipientDeliveryWorkerState uint8
@@ -28,31 +29,40 @@ const (
 
 // RecipientDeliveryWorkerOptions configures the bounded recipient delivery worker.
 type RecipientDeliveryWorkerOptions struct {
-	// Processor runs one accepted recipient-authority delivery batch.
+	// Processor runs one accepted recipient delivery plan.
 	Processor *RecipientProcessor
-	// QueueSize bounds accepted recipient batches waiting for workers.
+	// QueueSize bounds accepted recipient delivery plans waiting for workers.
 	QueueSize int
 	// Workers controls the number of delivery worker goroutines.
 	Workers int
+	// PlanTimeout bounds one accepted delivery plan. Values <= 0 use a bounded default.
+	PlanTimeout time.Duration
 	// Observer receives terminal processing failures.
 	Observer AppendObserver
 }
 
-// RecipientDeliveryWorker owns bounded async delivery admission for recipient-authority batches.
+// RecipientDeliveryWorker owns bounded async delivery admission for recipient delivery plans.
 type RecipientDeliveryWorker struct {
-	processor  *RecipientProcessor
-	queue      chan recipientDeliveryCommand
-	workers    int
-	observer   AppendObserver
-	goroutines *goroutine.Registry
+	processor   *RecipientProcessor
+	queue       chan recipientDeliveryCommand
+	workers     int
+	planTimeout time.Duration
+	observer    AppendObserver
+	goroutines  *goroutine.Registry
 
 	mu sync.Mutex
 	// state gates admission and lifecycle transitions.
 	state recipientDeliveryWorkerState
 	// acceptDone closes when the current lifecycle stops accepting enqueue waiters.
 	acceptDone chan struct{}
+	// stopReady closes after every sender admitted before Stop has left Enqueue.
+	stopReady chan struct{}
+	// runCancel cancels in-flight and queued delivery plans for the current lifecycle.
+	runCancel context.CancelFunc
 	// done closes after all workers exit.
 	done chan struct{}
+	// admissionSenders counts Enqueue calls that crossed the open-state gate.
+	admissionSenders sync.WaitGroup
 
 	// inflight covers commands currently executing inside runCommand.
 	inflight atomic.Int64
@@ -69,8 +79,7 @@ func (w *RecipientDeliveryWorker) WorkerCapacity() int {
 }
 
 type recipientDeliveryCommand struct {
-	target RecipientAuthorityTarget
-	batch  RecipientBatch
+	plan RecipientDeliveryPlan
 }
 
 // NewRecipientDeliveryWorker creates a bounded async recipient delivery worker.
@@ -83,12 +92,17 @@ func NewRecipientDeliveryWorker(opts RecipientDeliveryWorkerOptions) *RecipientD
 	if workers <= 0 {
 		workers = defaultRecipientDeliveryWorkers
 	}
+	planTimeout := opts.PlanTimeout
+	if planTimeout <= 0 {
+		planTimeout = defaultRecipientDeliveryPlanTimeout
+	}
 	return &RecipientDeliveryWorker{
-		processor: opts.Processor,
-		queue:     make(chan recipientDeliveryCommand, queueSize),
-		workers:   workers,
-		observer:  opts.Observer,
-		state:     recipientDeliveryWorkerClosed,
+		processor:   opts.Processor,
+		queue:       make(chan recipientDeliveryCommand, queueSize),
+		workers:     workers,
+		planTimeout: planTimeout,
+		observer:    opts.Observer,
+		state:       recipientDeliveryWorkerClosed,
 	}
 }
 
@@ -109,13 +123,15 @@ func (w *RecipientDeliveryWorker) Start(context.Context) error {
 	}
 
 	acceptDone := make(chan struct{})
+	stopReady := make(chan struct{})
+	runCtx, runCancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(w.workers)
 	for i := 0; i < w.workers; i++ {
 		goroutine.SafeGo(w.goroutines, "channelappend", "delivery_worker", func() {
 			defer wg.Done()
-			w.runWorker(acceptDone)
+			w.runWorker(runCtx, stopReady)
 		})
 	}
 	goroutine.SafeGo(w.goroutines, "channelappend", "delivery_done_wait", func() {
@@ -123,13 +139,15 @@ func (w *RecipientDeliveryWorker) Start(context.Context) error {
 		close(done)
 	})
 	w.acceptDone = acceptDone
+	w.stopReady = stopReady
+	w.runCancel = runCancel
 	w.done = done
 	w.state = recipientDeliveryWorkerOpen
 	w.observePressure()
 	return nil
 }
 
-// Stop closes admission and drains already accepted delivery batches.
+// Stop closes admission and drains already accepted delivery plans.
 func (w *RecipientDeliveryWorker) Stop(ctx context.Context) error {
 	if w == nil {
 		return nil
@@ -149,15 +167,36 @@ func (w *RecipientDeliveryWorker) Stop(ctx context.Context) error {
 		return w.waitClosed(ctx, done)
 	}
 	acceptDone := w.acceptDone
+	stopReady := w.stopReady
+	runCancel := w.runCancel
 	done := w.done
 	w.state = recipientDeliveryWorkerClosing
 	close(acceptDone)
 	w.mu.Unlock()
+	if runCancel != nil {
+		runCancel()
+	}
+	goroutine.SafeGo(w.goroutines, "channelappend", "delivery_admission_wait", func() {
+		w.admissionSenders.Wait()
+		close(stopReady)
+	})
 	return w.waitClosed(ctx, done)
 }
 
 // EnqueueRecipientBatch admits one recipient-authority batch for asynchronous delivery processing.
 func (w *RecipientDeliveryWorker) EnqueueRecipientBatch(ctx context.Context, target RecipientAuthorityTarget, batch RecipientBatch) error {
+	return w.EnqueueRecipientDeliveryPlan(ctx, RecipientDeliveryPlan{
+		Event: batch.Event,
+		Targets: []RecipientTargetBatch{{
+			Target:     target,
+			Recipients: batch.Recipients,
+		}},
+	})
+}
+
+// EnqueueRecipientDeliveryPlan admits one bounded multi-target recipient plan
+// for asynchronous delivery processing.
+func (w *RecipientDeliveryWorker) EnqueueRecipientDeliveryPlan(ctx context.Context, plan RecipientDeliveryPlan) error {
 	if w == nil {
 		return nil
 	}
@@ -173,7 +212,7 @@ func (w *RecipientDeliveryWorker) EnqueueRecipientBatch(ctx context.Context, tar
 		admissionResult = recipientDeliveryAdmissionResultFromError(err)
 		return err
 	}
-	cmd := recipientDeliveryCommand{target: target, batch: batch}
+	cmd := recipientDeliveryCommand{plan: plan}
 	w.mu.Lock()
 	if w.state != recipientDeliveryWorkerOpen {
 		w.mu.Unlock()
@@ -182,7 +221,9 @@ func (w *RecipientDeliveryWorker) EnqueueRecipientBatch(ctx context.Context, tar
 	}
 	queue := w.queue
 	acceptDone := w.acceptDone
+	w.admissionSenders.Add(1)
 	w.mu.Unlock()
+	defer w.admissionSenders.Done()
 
 	select {
 	case queue <- cmd:
@@ -197,30 +238,30 @@ func (w *RecipientDeliveryWorker) EnqueueRecipientBatch(ctx context.Context, tar
 	}
 }
 
-func (w *RecipientDeliveryWorker) runWorker(acceptDone <-chan struct{}) {
+func (w *RecipientDeliveryWorker) runWorker(runCtx context.Context, stopReady <-chan struct{}) {
 	for {
 		select {
 		case cmd := <-w.queue:
-			w.runCommand(cmd)
-		case <-acceptDone:
-			w.drain()
+			w.runCommand(runCtx, cmd)
+		case <-stopReady:
+			w.drain(runCtx)
 			return
 		}
 	}
 }
 
-func (w *RecipientDeliveryWorker) drain() {
+func (w *RecipientDeliveryWorker) drain(runCtx context.Context) {
 	for {
 		select {
 		case cmd := <-w.queue:
-			w.runCommand(cmd)
+			w.runCommand(runCtx, cmd)
 		default:
 			return
 		}
 	}
 }
 
-func (w *RecipientDeliveryWorker) runCommand(cmd recipientDeliveryCommand) {
+func (w *RecipientDeliveryWorker) runCommand(runCtx context.Context, cmd recipientDeliveryCommand) {
 	w.inflight.Add(1)
 	defer func() {
 		w.inflight.Add(-1)
@@ -233,21 +274,50 @@ func (w *RecipientDeliveryWorker) runCommand(cmd recipientDeliveryCommand) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			result = recipientDeliveryResultPanic
-			w.observeProcessingFailure(cmd, withPostCommitFailureDetail(effectPanicError(effectStagePostCommit, recovered), postCommitBatchDetail("panic", cmd.batch)))
+			target, batch := recipientDeliveryCommandTarget(cmd, 0)
+			w.observeProcessingFailure(cmd, withPostCommitFailureDetail(effectPanicError(effectStagePostCommit, recovered), postCommitBatchDetail("panic", batch)), target)
 		}
 		w.observeProcess(RecipientDeliveryProcessObservation{
 			Result:     result,
-			Recipients: len(cmd.batch.Recipients),
+			Recipients: cmd.plan.RecipientCount(),
 			Duration:   positiveRecipientDeliveryDuration(time.Since(startedAt)),
 		})
 	}()
 	if w.processor == nil {
 		return
 	}
-	if err := w.processor.ProcessRecipientBatch(context.Background(), cmd.batch); err != nil {
-		result = recipientDeliveryResultError
-		w.observeProcessingFailure(cmd, err)
+	planCtx, cancel := context.WithTimeout(runCtx, w.planTimeout)
+	defer cancel()
+	for i, err := range w.processor.ProcessRecipientDeliveryPlan(planCtx, cmd.plan) {
+		if err == nil {
+			continue
+		}
+		result = recipientDeliveryProcessResult(result, err)
+		target, _ := recipientDeliveryCommandTarget(cmd, i)
+		w.observeProcessingFailure(cmd, err, target)
 	}
+}
+
+func recipientDeliveryProcessResult(current string, err error) string {
+	if errors.Is(err, ErrEffectPanic) {
+		return recipientDeliveryResultPanic
+	}
+	if current == recipientDeliveryResultPanic {
+		return current
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return recipientDeliveryResultTimeout
+	}
+	if current == recipientDeliveryResultTimeout {
+		return current
+	}
+	if errors.Is(err, context.Canceled) {
+		return recipientDeliveryResultCanceled
+	}
+	if current == recipientDeliveryResultCanceled {
+		return current
+	}
+	return recipientDeliveryResultError
 }
 
 func (w *RecipientDeliveryWorker) observePressure() {
@@ -298,13 +368,21 @@ func positiveRecipientDeliveryDuration(d time.Duration) time.Duration {
 	return d
 }
 
-func (w *RecipientDeliveryWorker) observeProcessingFailure(cmd recipientDeliveryCommand, err error) {
+func (w *RecipientDeliveryWorker) observeProcessingFailure(cmd recipientDeliveryCommand, err error, target RecipientAuthorityTarget) {
 	detail := postCommitFailureDetailFromError(err)
 	if detail.Phase == "" {
 		detail.Phase = "recipient_delivery"
 	}
-	detail = detail.withFallback(postCommitTargetDetail(cmd.target))
-	observePostCommitFailure(w.observer, detail.toObservation(cmd.batch.Event, 0, errorClass(err), err))
+	detail = detail.withFallback(postCommitTargetDetail(target))
+	observePostCommitFailure(w.observer, detail.toObservation(cmd.plan.Event, 0, errorClass(err), err))
+}
+
+func recipientDeliveryCommandTarget(cmd recipientDeliveryCommand, index int) (RecipientAuthorityTarget, RecipientBatch) {
+	if index < 0 || index >= len(cmd.plan.Targets) {
+		return RecipientAuthorityTarget{}, RecipientBatch{Event: cmd.plan.Event}
+	}
+	target := cmd.plan.Targets[index]
+	return target.Target, RecipientBatch{Event: cmd.plan.Event, Recipients: target.Recipients}
 }
 
 func (w *RecipientDeliveryWorker) waitClosed(ctx context.Context, done <-chan struct{}) error {
@@ -327,6 +405,8 @@ func (w *RecipientDeliveryWorker) finishClosedForDone(done <-chan struct{}) {
 	if w.state == recipientDeliveryWorkerClosing && w.done == done {
 		w.state = recipientDeliveryWorkerClosed
 		w.acceptDone = nil
+		w.stopReady = nil
+		w.runCancel = nil
 		w.done = nil
 		closed = true
 	}
@@ -341,12 +421,16 @@ func (w *RecipientDeliveryWorker) finishClosedIfDoneLocked() bool {
 	if done == nil {
 		w.state = recipientDeliveryWorkerClosed
 		w.acceptDone = nil
+		w.stopReady = nil
+		w.runCancel = nil
 		return true
 	}
 	select {
 	case <-done:
 		w.state = recipientDeliveryWorkerClosed
 		w.acceptDone = nil
+		w.stopReady = nil
+		w.runCancel = nil
 		w.done = nil
 		return true
 	default:

--- a/internal/runtime/channelappend/delivery_worker_test.go
+++ b/internal/runtime/channelappend/delivery_worker_test.go
@@ -3,6 +3,7 @@ package channelappend
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -51,6 +52,104 @@ func TestRecipientDeliveryWorkerProcessesAcceptedBatches(t *testing.T) {
 	}
 
 	waitDeliveryWorkerCondition(t, func() bool { return pusher.callCount() == 1 })
+}
+
+func TestRecipientDeliveryWorkerPreservesTargetsAndContinuesPartialPlan(t *testing.T) {
+	first := recipientAuthorityTargetForTest(1, 10, 100)
+	second := recipientAuthorityTargetForTest(2, 20, 200)
+	presenceErr := errors.New("first target unavailable")
+	resolver := &recordingTargetPresenceResolverForDeliveryWorkerTest{results: []RecipientTargetPresenceResult{
+		{Err: presenceErr},
+		{Routes: []Route{{UID: "u2", OwnerNodeID: 3, SessionID: 20}}},
+	}}
+	pusher := &recordingOwnerPusherForDeliveryTest{}
+	observer := &recordingRecipientDeliveryWorkerObserverForTest{}
+	worker := NewRecipientDeliveryWorker(RecipientDeliveryWorkerOptions{
+		Processor: NewRecipientProcessor(RecipientProcessorOptions{
+			PresenceResolver: resolver,
+			OwnerPusher:      pusher,
+		}),
+		QueueSize: 1,
+		Workers:   1,
+		Observer:  observer,
+	})
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	plan := RecipientDeliveryPlan{
+		Event: CommittedEnvelope{MessageID: 10, MessageSeq: 4, ChannelID: "g1", ChannelType: 2},
+		Targets: []RecipientTargetBatch{
+			{Target: first, Recipients: []Recipient{{UID: "u1"}}},
+			{Target: second, Recipients: []Recipient{{UID: "u2"}}},
+		},
+	}
+	if err := worker.EnqueueRecipientDeliveryPlan(context.Background(), plan); err != nil {
+		t.Fatalf("EnqueueRecipientDeliveryPlan() error = %v", err)
+	}
+
+	observer.waitFailures(t, 1)
+	waitDeliveryWorkerCondition(t, func() bool { return pusher.callCount() == 1 })
+	if resolver.legacyCalls != 0 || resolver.targetCalls != 1 {
+		t.Fatalf("presence calls legacy/target = %d/%d, want 0/1", resolver.legacyCalls, resolver.targetCalls)
+	}
+	if !reflect.DeepEqual(resolver.targets, []RecipientAuthorityTarget{first, second}) {
+		t.Fatalf("resolved targets = %#v, want exact queued targets", resolver.targets)
+	}
+	got := observer.failures[0]
+	if got.TargetHashSlot != first.HashSlot || got.TargetLeaderNodeID != first.LeaderNodeID || !errors.Is(got.Err, presenceErr) {
+		t.Fatalf("first target failure = %#v, want exact first target and error", got)
+	}
+}
+
+func TestRecipientDeliveryWorkerIsolatesTargetPanicAndContinuesSiblingGroups(t *testing.T) {
+	first := recipientAuthorityTargetForTest(1, 10, 100)
+	second := recipientAuthorityTargetForTest(2, 20, 200)
+	third := recipientAuthorityTargetForTest(3, 30, 300)
+	resolver := &recordingTargetPresenceResolverForDeliveryWorkerTest{results: []RecipientTargetPresenceResult{
+		{Routes: []Route{{UID: "u1", OwnerNodeID: 1, SessionID: 10}}},
+		{Routes: []Route{{UID: "u2", OwnerNodeID: 2, SessionID: 20}}},
+		{Routes: []Route{{UID: "u3", OwnerNodeID: 3, SessionID: 30}}},
+	}}
+	pusher := &selectivePanicOwnerPusherForDeliveryWorkerTest{panicOwnerNodeID: 2}
+	observer := &recordingRecipientDeliveryWorkerObserverForTest{}
+	worker := NewRecipientDeliveryWorker(RecipientDeliveryWorkerOptions{
+		Processor: NewRecipientProcessor(RecipientProcessorOptions{
+			PresenceResolver: resolver,
+			OwnerPusher:      pusher,
+		}),
+		QueueSize: 1,
+		Workers:   1,
+		Observer:  observer,
+	})
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+
+	plan := RecipientDeliveryPlan{
+		Event: CommittedEnvelope{MessageID: 20, MessageSeq: 5, ChannelID: "g2", ChannelType: 2},
+		Targets: []RecipientTargetBatch{
+			{Target: first, Recipients: []Recipient{{UID: "u1"}}},
+			{Target: second, Recipients: []Recipient{{UID: "u2"}}},
+			{Target: third, Recipients: []Recipient{{UID: "u3"}}},
+		},
+	}
+	if err := worker.EnqueueRecipientDeliveryPlan(context.Background(), plan); err != nil {
+		t.Fatalf("EnqueueRecipientDeliveryPlan() error = %v", err)
+	}
+
+	observer.waitFailures(t, 1)
+	failure := observer.failures[0]
+	if failure.TargetHashSlot != second.HashSlot || failure.TargetLeaderNodeID != second.LeaderNodeID || !errors.Is(failure.Err, ErrEffectPanic) {
+		t.Fatalf("panic failure = %#v, want exact second target", failure)
+	}
+	waitDeliveryWorkerCondition(t, func() bool { return reflect.DeepEqual(pusher.ownerNodeIDs(), []uint64{1, 2, 3}) })
+	observer.waitProcesses(t, 1)
+	if got := observer.processes[0]; got.Result != recipientDeliveryResultPanic || got.Recipients != 3 {
+		t.Fatalf("panic process observation = %+v, want panic recipients=3", got)
+	}
 }
 
 func TestRecipientDeliveryWorkerSharesImmutableEnvelopeWithOwnerPush(t *testing.T) {
@@ -219,9 +318,47 @@ func TestRecipientDeliveryWorkerObservesConcurrentInflightAndReturnsToZero(t *te
 	}
 }
 
-func TestRecipientDeliveryWorkerStopDrainsAcceptedBatches(t *testing.T) {
+func TestRecipientDeliveryWorkerPlanDeadlineCancelsStalledProcessor(t *testing.T) {
+	blocker := newBlockingPresenceResolverForDeliveryWorkerTest()
+	observer := &recordingRecipientDeliveryWorkerObserverForTest{}
+	worker := NewRecipientDeliveryWorker(RecipientDeliveryWorkerOptions{
+		Processor: NewRecipientProcessor(RecipientProcessorOptions{
+			PresenceResolver: blocker,
+			OwnerPusher:      &recordingOwnerPusherForDeliveryTest{},
+		}),
+		QueueSize:   1,
+		Workers:     1,
+		PlanTimeout: 20 * time.Millisecond,
+		Observer:    observer,
+	})
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		blocker.release()
+		_ = worker.Stop(context.Background())
+	})
+
+	batch := RecipientBatch{Event: CommittedEnvelope{MessageID: 1}, Recipients: []Recipient{{UID: "u1"}}}
+	if err := worker.EnqueueRecipientBatch(context.Background(), recipientAuthorityTargetForTest(1, 1, 1), batch); err != nil {
+		t.Fatalf("EnqueueRecipientBatch() error = %v", err)
+	}
+	blocker.waitStarted(t)
+	observer.waitFailures(t, 1)
+	observer.waitProcesses(t, 1)
+
+	if got := observer.failures[0]; !errors.Is(got.Err, context.DeadlineExceeded) {
+		t.Fatalf("processing failure = %v, want context deadline exceeded", got.Err)
+	}
+	if got := observer.processes[0]; got.Result != recipientDeliveryResultTimeout {
+		t.Fatalf("process result = %q, want %q", got.Result, recipientDeliveryResultTimeout)
+	}
+}
+
+func TestRecipientDeliveryWorkerStopCancelsAcceptedBatches(t *testing.T) {
 	blocker := newBlockingPresenceResolverForDeliveryWorkerTest()
 	pusher := &recordingOwnerPusherForDeliveryTest{}
+	observer := &recordingRecipientDeliveryWorkerObserverForTest{}
 	worker := NewRecipientDeliveryWorker(RecipientDeliveryWorkerOptions{
 		Processor: NewRecipientProcessor(RecipientProcessorOptions{
 			PresenceResolver: blocker,
@@ -229,10 +366,12 @@ func TestRecipientDeliveryWorkerStopDrainsAcceptedBatches(t *testing.T) {
 		}),
 		QueueSize: 2,
 		Workers:   1,
+		Observer:  observer,
 	})
 	if err := worker.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
+	t.Cleanup(blocker.release)
 	batch := RecipientBatch{Event: CommittedEnvelope{MessageID: 1}, Recipients: []Recipient{{UID: "u1"}}}
 	if err := worker.EnqueueRecipientBatch(context.Background(), recipientAuthorityTargetForTest(1, 1, 1), batch); err != nil {
 		t.Fatalf("first EnqueueRecipientBatch() error = %v", err)
@@ -242,24 +381,105 @@ func TestRecipientDeliveryWorkerStopDrainsAcceptedBatches(t *testing.T) {
 		t.Fatalf("second EnqueueRecipientBatch() error = %v", err)
 	}
 
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := worker.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if got := pusher.callCount(); got != 0 {
+		t.Fatalf("push calls = %d, want canceled plans to stop before owner push", got)
+	}
+	if len(observer.processes) != 2 {
+		t.Fatalf("process observations = %d, want both accepted batches terminated", len(observer.processes))
+	}
+	for i, got := range observer.processes {
+		if got.Result != recipientDeliveryResultCanceled {
+			t.Fatalf("process[%d] result = %q, want %q", i, got.Result, recipientDeliveryResultCanceled)
+		}
+	}
+	if len(observer.failures) != 2 {
+		t.Fatalf("processing failures = %d, want both accepted batches observed", len(observer.failures))
+	}
+	for i, got := range observer.failures {
+		if !errors.Is(got.Err, context.Canceled) {
+			t.Fatalf("failure[%d] = %v, want context canceled", i, got.Err)
+		}
+	}
+}
+
+func TestRecipientDeliveryWorkerStopWaitsForSenderPastAdmissionGate(t *testing.T) {
+	blocker := newBlockingPresenceResolverForDeliveryWorkerTest()
+	observer := &recordingRecipientDeliveryWorkerObserverForTest{}
+	worker := NewRecipientDeliveryWorker(RecipientDeliveryWorkerOptions{
+		Processor: NewRecipientProcessor(RecipientProcessorOptions{
+			PresenceResolver: blocker,
+			OwnerPusher:      &recordingOwnerPusherForDeliveryTest{},
+		}),
+		QueueSize: 1,
+		Workers:   1,
+		Observer:  observer,
+	})
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Model the exact interleaving after Enqueue crosses the open-state gate but
+	// before its channel send. Stop must not let workers exit during this window.
+	worker.mu.Lock()
+	worker.admissionSenders.Add(1)
+	queue := worker.queue
+	worker.mu.Unlock()
+	senderReleased := false
+	t.Cleanup(func() {
+		if !senderReleased {
+			worker.admissionSenders.Done()
+		}
+		blocker.release()
+		_ = worker.Stop(context.Background())
+	})
+
 	stopResult := make(chan error, 1)
 	go func() { stopResult <- worker.Stop(context.Background()) }()
+	waitDeliveryWorkerCondition(t, func() bool {
+		worker.mu.Lock()
+		defer worker.mu.Unlock()
+		return worker.state == recipientDeliveryWorkerClosing
+	})
 	select {
 	case err := <-stopResult:
-		t.Fatalf("Stop() returned before blocked batch was released: %v", err)
+		t.Fatalf("Stop() returned while an admitted sender was active: %v", err)
 	case <-time.After(20 * time.Millisecond):
 	}
-	blocker.release()
+
+	queue <- recipientDeliveryCommand{plan: RecipientDeliveryPlan{
+		Event: CommittedEnvelope{MessageID: 99},
+		Targets: []RecipientTargetBatch{{
+			Target:     recipientAuthorityTargetForTest(1, 1, 1),
+			Recipients: []Recipient{{UID: "u1"}},
+		}},
+	}}
+	observer.waitProcesses(t, 1)
+	select {
+	case err := <-stopResult:
+		t.Fatalf("Stop() returned before admitted sender left Enqueue: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	worker.admissionSenders.Done()
+	senderReleased = true
 	select {
 	case err := <-stopResult:
 		if err != nil {
 			t.Fatalf("Stop() error = %v", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("Stop() did not drain accepted batches")
+		t.Fatal("Stop() did not finish after admitted sender left Enqueue")
 	}
-	if got := pusher.callCount(); got != 2 {
-		t.Fatalf("push calls = %d, want both accepted batches drained", got)
+	if len(worker.queue) != 0 {
+		t.Fatalf("queue depth after Stop = %d, want 0", len(worker.queue))
+	}
+	if got := observer.failures[0]; got.MessageID != 99 || !errors.Is(got.Err, context.Canceled) {
+		t.Fatalf("admitted command failure = %#v, want canceled message 99", got)
 	}
 }
 
@@ -477,6 +697,55 @@ func (o *recordingRecipientDeliveryWorkerObserverForTest) lastWorkerPressure(t *
 		t.Fatalf("no worker pressure observations")
 	}
 	return o.workers[len(o.workers)-1]
+}
+
+type recordingTargetPresenceResolverForDeliveryWorkerTest struct {
+	legacyCalls int
+	targetCalls int
+	targets     []RecipientAuthorityTarget
+	results     []RecipientTargetPresenceResult
+}
+
+type selectivePanicOwnerPusherForDeliveryWorkerTest struct {
+	mu               sync.Mutex
+	panicOwnerNodeID uint64
+	owners           []uint64
+}
+
+func (p *selectivePanicOwnerPusherForDeliveryWorkerTest) Push(_ context.Context, cmd PushCommand) (PushResult, error) {
+	p.mu.Lock()
+	p.owners = append(p.owners, cmd.OwnerNodeID)
+	panicOwnerNodeID := p.panicOwnerNodeID
+	p.mu.Unlock()
+	if cmd.OwnerNodeID == panicOwnerNodeID {
+		panic("target owner push panic")
+	}
+	return PushResult{Accepted: append([]Route(nil), cmd.Routes...)}, nil
+}
+
+func (p *selectivePanicOwnerPusherForDeliveryWorkerTest) ownerNodeIDs() []uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]uint64(nil), p.owners...)
+}
+
+func (r *recordingTargetPresenceResolverForDeliveryWorkerTest) EndpointsByUIDs(context.Context, []string) ([]Route, error) {
+	r.legacyCalls++
+	return nil, nil
+}
+
+func (r *recordingTargetPresenceResolverForDeliveryWorkerTest) EndpointsByTargets(_ context.Context, batches []RecipientTargetBatch) []RecipientTargetPresenceResult {
+	r.targetCalls++
+	r.targets = make([]RecipientAuthorityTarget, len(batches))
+	for i, batch := range batches {
+		r.targets[i] = batch.Target
+	}
+	results := make([]RecipientTargetPresenceResult, len(r.results))
+	copy(results, r.results)
+	for i := range results {
+		results[i].Routes = append([]Route(nil), results[i].Routes...)
+	}
+	return results
 }
 
 type errorPresenceResolverForDeliveryWorkerTest struct {

--- a/internal/runtime/channelappend/options.go
+++ b/internal/runtime/channelappend/options.go
@@ -237,7 +237,7 @@ type EffectObserver interface {
 
 // RecipientDeliveryQueueObservation describes the dedicated recipient delivery worker queue.
 type RecipientDeliveryQueueObservation struct {
-	// QueueDepth is the current queued recipient delivery batch count.
+	// QueueDepth is the current queued recipient delivery plan count.
 	QueueDepth int
 	// QueueCapacity is the configured recipient delivery queue capacity.
 	QueueCapacity int
@@ -285,7 +285,7 @@ type RecipientDeliveryAdmissionObserver interface {
 type RecipientDeliveryProcessObservation struct {
 	// Result is ok, error, or panic.
 	Result string
-	// Recipients is the number of recipients in the processed batch.
+	// Recipients is the total number of recipients in the processed plan.
 	Recipients int
 	// Duration is the worker processing latency.
 	Duration time.Duration
@@ -324,6 +324,13 @@ type RecipientDeliveryEnqueuer interface {
 	EnqueueRecipientBatch(context.Context, RecipientAuthorityTarget, RecipientBatch) error
 }
 
+// RecipientDeliveryPlanEnqueuer accepts one bounded recipient set while
+// preserving every exact authority target in the same queue command.
+type RecipientDeliveryPlanEnqueuer interface {
+	// EnqueueRecipientDeliveryPlan queues one bounded exact-target delivery plan.
+	EnqueueRecipientDeliveryPlan(context.Context, RecipientDeliveryPlan) error
+}
+
 // PersistAfterEnqueuer accepts durable committed messages for plugin PersistAfter hooks.
 type PersistAfterEnqueuer interface {
 	// EnqueuePersistAfter queues one committed message for plugin side effects.
@@ -340,6 +347,22 @@ type ConversationActiveAdmitter interface {
 type PresenceResolver interface {
 	// EndpointsByUIDs returns currently known online endpoints for uids.
 	EndpointsByUIDs(context.Context, []string) ([]Route, error)
+}
+
+// RecipientTargetPresenceResult is one result aligned with an exact-target
+// recipient batch supplied to RecipientTargetPresenceResolver.
+type RecipientTargetPresenceResult struct {
+	// Routes are the currently known online endpoints for the target batch.
+	Routes []Route
+	// Err reports an authority lookup failure for only the aligned target batch.
+	Err error
+}
+
+// RecipientTargetPresenceResolver resolves multiple exact-target recipient
+// groups without discarding their authority fences.
+type RecipientTargetPresenceResolver interface {
+	// EndpointsByTargets returns one result per input target batch in the same order.
+	EndpointsByTargets(context.Context, []RecipientTargetBatch) []RecipientTargetPresenceResult
 }
 
 // OwnerPusher pushes committed messages to owner-node gateway sessions.
@@ -394,7 +417,7 @@ type Options struct {
 	ConversationActiveAdmitter ConversationActiveAdmitter
 	// SubscriberScanPageSize bounds each group-channel subscriber scan page. Values <= 0 use a bounded default.
 	SubscriberScanPageSize int
-	// RecipientBatchSize bounds one dispatched recipient batch. Values <= 0 use a bounded default.
+	// RecipientBatchSize bounds total recipients in one delivery plan. Values <= 0 use a bounded default.
 	RecipientBatchSize int
 	// RecipientAuthorityDispatchConcurrency bounds per-message recipient-authority dispatch fanout. Values <= 0 use a bounded default.
 	RecipientAuthorityDispatchConcurrency int

--- a/internal/runtime/channelappend/recipient.go
+++ b/internal/runtime/channelappend/recipient.go
@@ -189,6 +189,9 @@ func dispatchRecipientDelivery(ctx context.Context, event CommittedEnvelope, rec
 		grouped[target] = append(grouped[target], recipient)
 	}
 	batchSize := boundedPositive(ports.recipientBatchSize, defaultRecipientBatchSize)
+	if planEnqueuer, ok := enqueuer.(RecipientDeliveryPlanEnqueuer); ok {
+		return dispatchRecipientPlans(ctx, event, order, grouped, batchSize, planEnqueuer)
+	}
 	concurrency := boundedPositive(ports.recipientDispatchConcurrency, 1)
 	if concurrency <= 1 || len(order) <= 1 {
 		for _, target := range order {
@@ -199,6 +202,59 @@ func dispatchRecipientDelivery(ctx context.Context, event CommittedEnvelope, rec
 		return nil
 	}
 	return dispatchRecipientTargetsConcurrent(ctx, event, order, grouped, batchSize, concurrency, enqueuer)
+}
+
+func dispatchRecipientPlans(
+	ctx context.Context,
+	event CommittedEnvelope,
+	order []RecipientAuthorityTarget,
+	grouped map[RecipientAuthorityTarget][]Recipient,
+	batchSize int,
+	enqueuer RecipientDeliveryPlanEnqueuer,
+) error {
+	planTargetCapacity := min(batchSize, len(order))
+	plan := RecipientDeliveryPlan{Event: event, Targets: make([]RecipientTargetBatch, 0, planTargetCapacity)}
+	flush := func() error {
+		if plan.RecipientCount() == 0 {
+			return nil
+		}
+		if err := enqueuer.EnqueueRecipientDeliveryPlan(ctx, plan); err != nil {
+			target := plan.Targets[0].Target
+			detail := postCommitTargetDetail(target)
+			detail.Phase = "recipient_dispatch"
+			detail.UID = firstRecipientUID(plan.Targets[0].Recipients)
+			detail.RecipientCount = plan.RecipientCount()
+			detail.DispatchTargetCount = len(plan.Targets)
+			detail.DispatchBatchSize = plan.RecipientCount()
+			return withPostCommitFailureDetail(err, detail)
+		}
+		plan = RecipientDeliveryPlan{Event: event, Targets: make([]RecipientTargetBatch, 0, planTargetCapacity)}
+		return nil
+	}
+
+	remaining := batchSize
+	for _, target := range order {
+		recipients := grouped[target]
+		for len(recipients) > 0 {
+			if remaining == 0 {
+				if err := flush(); err != nil {
+					return err
+				}
+				remaining = batchSize
+			}
+			n := remaining
+			if n > len(recipients) {
+				n = len(recipients)
+			}
+			plan.Targets = append(plan.Targets, RecipientTargetBatch{
+				Target:     target,
+				Recipients: append([]Recipient(nil), recipients[:n]...),
+			})
+			recipients = recipients[n:]
+			remaining -= n
+		}
+	}
+	return flush()
 }
 
 func effectiveRecipientDeliveryEnqueuer(ports commitPorts) RecipientDeliveryEnqueuer {

--- a/internal/runtime/channelappend/recipient_test.go
+++ b/internal/runtime/channelappend/recipient_test.go
@@ -3,6 +3,7 @@ package channelappend
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -466,6 +467,80 @@ func TestRecipientDeliveryBatchesAreEnqueuedByRecipientAuthorityTarget(t *testin
 	}
 }
 
+func TestRecipientDeliveryPageUsesOneBoundedPlanAcrossAuthorityTargets(t *testing.T) {
+	enqueuer := &recordingRecipientPlanEnqueuerForRecipientTest{}
+	first := authority.Target{HashSlot: 1, SlotID: 11, LeaderNodeID: 10, LeaderTerm: 101, ConfigEpoch: 1001, RouteRevision: 100, AuthorityEpoch: 1000}
+	second := authority.Target{HashSlot: 2, SlotID: 12, LeaderNodeID: 10, LeaderTerm: 102, ConfigEpoch: 1002, RouteRevision: 101, AuthorityEpoch: 1001}
+	third := authority.Target{HashSlot: 3, SlotID: 13, LeaderNodeID: 20, LeaderTerm: 103, ConfigEpoch: 1003, RouteRevision: 102, AuthorityEpoch: 1002}
+
+	err := dispatchRecipientSet(context.Background(), CommittedEnvelope{MessageID: 1}, []Recipient{
+		{UID: "u1"},
+		{UID: "u2"},
+		{UID: "u3"},
+		{UID: "u4"},
+	}, commitPorts{
+		recipientAuthorityResolver: mapRecipientAuthorityResolverForRecipientTest{targets: map[string]RecipientAuthorityTarget{
+			"u1": first,
+			"u2": second,
+			"u3": first,
+			"u4": third,
+		}},
+		deliveryEnqueuer:   enqueuer,
+		recipientBatchSize: 4,
+	})
+	if err != nil {
+		t.Fatalf("dispatchRecipientSet() error = %v", err)
+	}
+
+	if enqueuer.legacyCalls != 0 {
+		t.Fatalf("legacy enqueue calls = %d, want 0 when plan admission is available", enqueuer.legacyCalls)
+	}
+	if len(enqueuer.plans) != 1 {
+		t.Fatalf("delivery plans = %d, want one recipient-page plan", len(enqueuer.plans))
+	}
+	plan := enqueuer.plans[0]
+	if plan.Event.MessageID != 1 || plan.RecipientCount() != 4 {
+		t.Fatalf("delivery plan = %#v, want message 1 and 4 recipients", plan)
+	}
+	if len(plan.Targets) != 3 {
+		t.Fatalf("target groups = %d, want 3 exact fenced targets", len(plan.Targets))
+	}
+	if plan.Targets[0].Target != first || plan.Targets[1].Target != second || plan.Targets[2].Target != third {
+		t.Fatalf("target order = %#v, want first-seen exact targets", plan.Targets)
+	}
+	if got := recipientUIDs(plan.Targets[0].Recipients); !reflect.DeepEqual(got, []string{"u1", "u3"}) {
+		t.Fatalf("first target recipients = %#v, want u1,u3", got)
+	}
+}
+
+func TestRecipientDeliveryPlansBoundTotalRecipientsAcrossTargets(t *testing.T) {
+	enqueuer := &recordingRecipientPlanEnqueuerForRecipientTest{}
+	targets := make(map[string]RecipientAuthorityTarget, 5)
+	recipients := make([]Recipient, 0, 5)
+	for i := 0; i < 5; i++ {
+		uid := fmt.Sprintf("u%d", i+1)
+		targets[uid] = recipientAuthorityTargetForTest(uint16(i+1), uint64(i+1), 100)
+		recipients = append(recipients, Recipient{UID: uid})
+	}
+
+	err := dispatchRecipientSet(context.Background(), CommittedEnvelope{MessageID: 2}, recipients, commitPorts{
+		recipientAuthorityResolver: mapRecipientAuthorityResolverForRecipientTest{targets: targets},
+		deliveryEnqueuer:           enqueuer,
+		recipientBatchSize:         2,
+	})
+	if err != nil {
+		t.Fatalf("dispatchRecipientSet() error = %v", err)
+	}
+	if len(enqueuer.plans) != 3 {
+		t.Fatalf("delivery plans = %d, want 3 bounded plans", len(enqueuer.plans))
+	}
+	for i, plan := range enqueuer.plans {
+		if got := plan.RecipientCount(); got < 1 || got > 2 {
+			t.Fatalf("plan %d recipients = %d, want 1..2", i, got)
+		}
+	}
+}
+
 func TestDispatchRecipientSetSharesImmutablePayloadBeforeDeliveryQueue(t *testing.T) {
 	payload := []byte("payload")
 	enqueuer := &payloadAliasRecipientEnqueuerForRecipientTest{payload: payload}
@@ -898,6 +973,21 @@ type recordingRecipientDeliveryEnqueuerForRecipientTest struct {
 	steps   *orderedStepsForDeliveryTest
 	targets []RecipientAuthorityTarget
 	batches []RecipientBatch
+}
+
+type recordingRecipientPlanEnqueuerForRecipientTest struct {
+	legacyCalls int
+	plans       []RecipientDeliveryPlan
+}
+
+func (e *recordingRecipientPlanEnqueuerForRecipientTest) EnqueueRecipientBatch(_ context.Context, _ RecipientAuthorityTarget, _ RecipientBatch) error {
+	e.legacyCalls++
+	return nil
+}
+
+func (e *recordingRecipientPlanEnqueuerForRecipientTest) EnqueueRecipientDeliveryPlan(_ context.Context, plan RecipientDeliveryPlan) error {
+	e.plans = append(e.plans, plan.Clone())
+	return nil
 }
 
 func (e *recordingRecipientDeliveryEnqueuerForRecipientTest) EnqueueRecipientBatch(_ context.Context, target RecipientAuthorityTarget, batch RecipientBatch) error {

--- a/internal/runtime/presence/FLOW.md
+++ b/internal/runtime/presence/FLOW.md
@@ -19,6 +19,11 @@ updates. `AuthorityEpoch` is local diagnostic metadata and is not a distributed
 authority fence. `LoseAuthority` removes the complete hash-slot state, including
 its expiry index, so stale callers receive `ErrNotLeader`.
 
+`EndpointsByUIDs` validates one exact target once, holds the corresponding
+shard read lock once, and returns routes in UID input order with deterministic
+route ordering inside each UID. A stale target rejects the whole exact-target
+group; callers isolate that error from groups carrying other targets.
+
 ## Register And Conflicts
 
 Routes without conflicts become active immediately. Conflicting routes are

--- a/internal/runtime/presence/directory.go
+++ b/internal/runtime/presence/directory.go
@@ -269,18 +269,39 @@ func (d *Directory) EndpointsByUID(target RouteTarget, uid string) ([]Route, err
 	if err != nil {
 		return nil, err
 	}
-	keys := slot.byUID[uid]
+	return slot.endpointsByUIDLocked(uid), nil
+}
+
+// EndpointsByUIDs returns active routes for one exact authority target in UID input order.
+func (d *Directory) EndpointsByUIDs(target RouteTarget, uids []string) ([]Route, error) {
+	shard := d.shard(target.HashSlot)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+
+	slot, err := d.validateTargetLocked(shard, target)
+	if err != nil {
+		return nil, err
+	}
+	var routes []Route
+	for _, uid := range uids {
+		routes = append(routes, slot.endpointsByUIDLocked(uid)...)
+	}
+	return routes, nil
+}
+
+func (s *authoritySlot) endpointsByUIDLocked(uid string) []Route {
+	keys := s.byUID[uid]
 	if len(keys) == 0 {
-		return nil, nil
+		return nil
 	}
 	routes := make([]Route, 0, len(keys))
 	for key := range keys {
-		if route, ok := slot.active[key]; ok {
+		if route, ok := s.active[key]; ok {
 			routes = append(routes, route)
 		}
 	}
 	sortRoutes(routes)
-	return routes, nil
+	return routes
 }
 
 // Identity returns the immutable identity fields for this route.

--- a/internal/runtime/presence/directory_test.go
+++ b/internal/runtime/presence/directory_test.go
@@ -27,6 +27,49 @@ func TestDirectoryRejectsStaleTarget(t *testing.T) {
 	}
 }
 
+func TestDirectoryEndpointsByUIDsReturnsRoutesInInputUIDOrder(t *testing.T) {
+	dir := NewDirectory(DirectoryOptions{ShardCount: 4})
+	target := RouteTarget{HashSlot: 1, SlotID: 1, LeaderNodeID: 1, LeaderTerm: 9, ConfigEpoch: 3}
+	dir.BecomeAuthority(target)
+
+	routes := []Route{
+		{UID: "u1", OwnerNodeID: 2, OwnerBootID: 1, OwnerSeq: 1, SessionID: 20, DeviceID: "d2"},
+		{UID: "u1", OwnerNodeID: 1, OwnerBootID: 1, OwnerSeq: 1, SessionID: 10, DeviceID: "d1"},
+		{UID: "u2", OwnerNodeID: 3, OwnerBootID: 1, OwnerSeq: 1, SessionID: 30, DeviceID: "d3"},
+	}
+	for _, route := range routes {
+		if _, err := dir.RegisterRoute(target, route); err != nil {
+			t.Fatalf("RegisterRoute(%q) error = %v", route.UID, err)
+		}
+	}
+
+	got, err := dir.EndpointsByUIDs(target, []string{"u2", "missing", "u1"})
+	if err != nil {
+		t.Fatalf("EndpointsByUIDs() error = %v", err)
+	}
+	want := []Route{routes[2], routes[1], routes[0]}
+	if len(got) != len(want) {
+		t.Fatalf("EndpointsByUIDs() routes = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("EndpointsByUIDs() route[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDirectoryEndpointsByUIDsRejectsStaleTargetAsOneGroup(t *testing.T) {
+	dir := NewDirectory(DirectoryOptions{ShardCount: 4})
+	target := RouteTarget{HashSlot: 1, SlotID: 1, LeaderNodeID: 1, LeaderTerm: 9, ConfigEpoch: 3}
+	dir.BecomeAuthority(target)
+
+	stale := target
+	stale.LeaderTerm--
+	if _, err := dir.EndpointsByUIDs(stale, []string{"u1", "u2"}); !errors.Is(err, ErrNotLeader) {
+		t.Fatalf("EndpointsByUIDs(stale target) error = %v, want ErrNotLeader", err)
+	}
+}
+
 func TestDirectoryAcceptsDifferentLocalAuthorityEpochWithSameRaftIdentity(t *testing.T) {
 	dir := NewDirectory(DirectoryOptions{LocalNodeID: 1})
 	installed := RouteTarget{

--- a/internal/usecase/presence/FLOW.md
+++ b/internal/usecase/presence/FLOW.md
@@ -78,9 +78,20 @@ EndpointsByUIDs(uids)
   -> authority.EndpointsByUIDs(uids) when the authority client exposes the
      optional batch surface
   -> otherwise loop through authority.EndpointsByUID(uid)
+
+EndpointsByTargets([{exact target, uids}])
+  -> authority.EndpointsByTargets(groups) when the authority client exposes the
+     target-aware batch surface
+  -> otherwise loop through authority.EndpointsByUID(uid) within each group
+     for compatibility with limited harnesses
 ```
 
-Lookup stays authority-routed behind the `AuthorityClient` port.
+Target-aware lookup returns one aligned `EndpointLookupResult` per input group.
+A group-scoped lookup error is recorded on that result and does not abort later
+groups. Production cluster adapters preserve the supplied complete target
+fence; the legacy fallback deliberately cannot do so and exists only for
+compatibility with older or limited authority implementations. Lookup stays
+authority-routed behind the `AuthorityClient` port.
 
 ## Import Boundary
 

--- a/internal/usecase/presence/lookup.go
+++ b/internal/usecase/presence/lookup.go
@@ -7,6 +7,12 @@ type BatchAuthorityClient interface {
 	EndpointsByUIDs(context.Context, []string) (map[string][]Route, error)
 }
 
+// TargetBatchAuthorityClient optionally reads endpoint groups through their exact authority targets.
+// Implementations must return one result per input group in the same order.
+type TargetBatchAuthorityClient interface {
+	EndpointsByTargets(context.Context, []EndpointLookupGroup) []EndpointLookupResult
+}
+
 // EndpointsByUID returns authoritative online routes for one UID.
 func (a *App) EndpointsByUID(ctx context.Context, uid string) ([]Route, error) {
 	if ctx == nil {
@@ -41,4 +47,35 @@ func (a *App) EndpointsByUIDs(ctx context.Context, uids []string) (map[string][]
 		out[uid] = append(out[uid], routes...)
 	}
 	return out, nil
+}
+
+// EndpointsByTargets returns one endpoint lookup result per exact-target group.
+func (a *App) EndpointsByTargets(ctx context.Context, groups []EndpointLookupGroup) []EndpointLookupResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	results := make([]EndpointLookupResult, len(groups))
+	if a.authority == nil {
+		for i := range results {
+			results[i].Err = ErrAuthorityUnavailable
+		}
+		return results
+	}
+	if batch, ok := a.authority.(TargetBatchAuthorityClient); ok {
+		return batch.EndpointsByTargets(ctx, groups)
+	}
+	for i, group := range groups {
+		for _, uid := range group.UIDs {
+			if uid == "" {
+				continue
+			}
+			routes, err := a.authority.EndpointsByUID(ctx, uid)
+			if err != nil {
+				results[i].Err = err
+				break
+			}
+			results[i].Routes = append(results[i].Routes, routes...)
+		}
+	}
+	return results
 }

--- a/internal/usecase/presence/lookup_test.go
+++ b/internal/usecase/presence/lookup_test.go
@@ -1,0 +1,103 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointsByTargetsUsesTargetAwareBatchAuthority(t *testing.T) {
+	target := RouteTarget{
+		HashSlot:       7,
+		SlotID:         11,
+		LeaderNodeID:   2,
+		LeaderTerm:     13,
+		ConfigEpoch:    17,
+		RouteRevision:  19,
+		AuthorityEpoch: 23,
+	}
+	groups := []EndpointLookupGroup{{Target: target, UIDs: []string{"u1", "u2"}}}
+	authority := &targetBatchLookupAuthority{
+		results: []EndpointLookupResult{{Routes: []Route{{UID: "u2", SessionID: 29}}}},
+	}
+	app := New(Options{Authority: authority})
+
+	results := app.EndpointsByTargets(context.Background(), groups)
+
+	require.Equal(t, authority.results, results)
+	require.Equal(t, groups, authority.groups)
+	require.Zero(t, authority.legacyCalls)
+}
+
+func TestEndpointsByTargetsLegacyFallbackContinuesAfterGroupError(t *testing.T) {
+	authority := &legacyLookupAuthority{
+		routesByUID: map[string][]Route{
+			"u1": {{UID: "u1", SessionID: 11}},
+			"u3": {{UID: "u3", SessionID: 33}},
+		},
+		errsByUID: map[string]error{"u2": errLookupFailed},
+	}
+	app := New(Options{Authority: authority})
+	groups := []EndpointLookupGroup{
+		{Target: RouteTarget{LeaderNodeID: 2}, UIDs: []string{"u1", "u2", "not-reached"}},
+		{Target: RouteTarget{LeaderNodeID: 3}, UIDs: []string{"u3"}},
+	}
+
+	results := app.EndpointsByTargets(context.Background(), groups)
+
+	require.Len(t, results, 2)
+	require.Equal(t, []Route{{UID: "u1", SessionID: 11}}, results[0].Routes)
+	require.ErrorIs(t, results[0].Err, errLookupFailed)
+	require.Equal(t, []Route{{UID: "u3", SessionID: 33}}, results[1].Routes)
+	require.NoError(t, results[1].Err)
+	require.Equal(t, []string{"u1", "u2", "u3"}, authority.legacyCalls)
+}
+
+func TestEndpointsByTargetsReportsUnavailableAuthorityPerGroup(t *testing.T) {
+	app := New(Options{})
+
+	results := app.EndpointsByTargets(nil, []EndpointLookupGroup{
+		{UIDs: []string{"u1"}},
+		{UIDs: []string{"u2"}},
+	})
+
+	require.Len(t, results, 2)
+	require.ErrorIs(t, results[0].Err, ErrAuthorityUnavailable)
+	require.ErrorIs(t, results[1].Err, ErrAuthorityUnavailable)
+}
+
+type legacyLookupAuthority struct {
+	routesByUID map[string][]Route
+	errsByUID   map[string]error
+	legacyCalls []string
+}
+
+func (a *legacyLookupAuthority) RegisterRoute(context.Context, Route) (RegisterResult, error) {
+	return RegisterResult{}, nil
+}
+
+func (a *legacyLookupAuthority) CommitRoute(context.Context, PendingRouteToken) error { return nil }
+
+func (a *legacyLookupAuthority) AbortRoute(context.Context, PendingRouteToken) error { return nil }
+
+func (a *legacyLookupAuthority) EnqueueUnregister(context.Context, RouteIdentity, uint64) {}
+
+func (a *legacyLookupAuthority) EndpointsByUID(_ context.Context, uid string) ([]Route, error) {
+	a.legacyCalls = append(a.legacyCalls, uid)
+	return append([]Route(nil), a.routesByUID[uid]...), a.errsByUID[uid]
+}
+
+type targetBatchLookupAuthority struct {
+	legacyLookupAuthority
+	groups  []EndpointLookupGroup
+	results []EndpointLookupResult
+}
+
+func (a *targetBatchLookupAuthority) EndpointsByTargets(_ context.Context, groups []EndpointLookupGroup) []EndpointLookupResult {
+	a.groups = append([]EndpointLookupGroup(nil), groups...)
+	return append([]EndpointLookupResult(nil), a.results...)
+}
+
+var errLookupFailed = errors.New("lookup failed")

--- a/internal/usecase/presence/types.go
+++ b/internal/usecase/presence/types.go
@@ -87,6 +87,22 @@ type RouteTargetResult struct {
 	Err error
 }
 
+// EndpointLookupGroup binds a bounded UID set to one exact authority target.
+type EndpointLookupGroup struct {
+	// Target is the complete authority fence observed for every UID in this group.
+	Target RouteTarget
+	// UIDs preserves the caller's lookup order within this authority target.
+	UIDs []string
+}
+
+// EndpointLookupResult preserves the aligned outcome for one endpoint lookup group.
+type EndpointLookupResult struct {
+	// Routes contains all active routes returned for the corresponding group.
+	Routes []Route
+	// Err records the group-scoped lookup failure without aborting other groups.
+	Err error
+}
+
 // Route identifies a virtual client connection known by the UID authority.
 type Route = authority.Route
 

--- a/wukongim.toml.example
+++ b/wukongim.toml.example
@@ -150,9 +150,11 @@ authority_admit_concurrency = 16
 [delivery]
 enable = true
 fanout_page_size = 512
+# Maximum total recipients carried by one exact-target presence lookup and delivery plan.
 push_batch_size = 512
 pending_ack_ttl = "30s"
 pending_ack_max_per_session = 1024
+# Maximum recipient delivery plans waiting for asynchronous processing.
 event_queue_size = 1024
 # Maximum recipient-authority delivery batches processed concurrently by this node.
 # This is independent from channel_append.recipient_authority_dispatch_concurrency.


### PR DESCRIPTION
## Root cause

The Cloud Medium run connected all 10,500 clients, but recipient delivery saturated at 100/100 workers and 1024/1024 queued plans. Exact recipient targets were discarded after paging, and presence lookup issued one fresh route/RPC per UID. This amplified delivery into tens of thousands of authority RPCs per second and drove RECV errors to 22.64% while infrastructure remained healthy.

## Fix

- preserve bounded multi-target delivery plans and exact authority fences through the worker queue
- group remote presence lookups by actual leader and batch exact target groups per RPC
- isolate per-target failures/panics, retry only stale groups once, and retain precise legacy-peer fallback
- bound each accepted delivery plan to 5 seconds and make Stop/Enqueue lifecycle synchronization lossless
- return compact wkbench status payloads and perform one independent terminal status probe at the phase deadline
- update FLOW and project knowledge documentation

## Verification

- focused tests across access/node, presence usecase/runtime/infra, channelappend, app, coordinator, and worker
- race tests for access/node and channelappend
- new lifecycle concurrency tests repeated 50 times
- full repository Go gate: `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`

A fresh Cloud Medium 30m run will be dispatched after merge for production-shape revalidation.