### PR TITLE
fix: bound conversation active admission

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -43,6 +43,7 @@
 - Legacy `UserConversation*` and `CMDConversation*` APIs in `pkg/db/meta` are source compatibility shims only; they must map to the unified kind-aware conversation table.
 - Conversation active flush attempts must carry a bounded context because Slot proposal futures rely on caller deadlines for stale or uncommitted proposals.
 - Conversation active admission is memory-only: it may evict clean rows or return cache pressure, but it must never perform durable I/O or wait for the serialized flush lane.
+- Bounded conversation-active admission must locate clean eviction victims through an exact clean index and coalesce duplicate addresses before taking the cache lock; never scan the full dirty cache under that lock.
 - Conversation active pressure uses one coalesced async worker wakeup, bounded flush attempts, and 80%/70% high/dirty-low watermarks; clean rows below the dirty watermark are the reusable eviction reserve.
 - Conversation active projection failure is observed independently and must not block recipient delivery, later large-channel pages, or subscriber snapshot caching.
 - Recipient delivery plans preserve complete UID-authority fences and batch presence RPC by actual leader; only stale/not-ready groups may batch-resolve fresh targets and retry once, without replaying successful siblings.

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -7,12 +7,16 @@ does not infer kind from channel IDs.
 Current flow:
 
 1. Channel append or another authority-owned caller submits an `ActiveBatch`.
-2. The manager merges rows by `(uid, kind, channel_id, channel_type)`.
-3. Admission mutates cache state only. It may evict already-clean rows while
-   holding the cache lock, but it protects every address present in the incoming
-   batch and first compares the remaining exact clean-row count with the space
-   required by the whole batch. When too few evictable clean rows exist it
-   rejects immediately instead of scanning a full dirty cache or evicting a row
+2. Before taking the cache lock, the manager coalesces rows by
+   `(uid, kind, channel_id, channel_type)` using maximum `ActiveAtMS` and
+   `ReadSeq`. Small authority batches use an inline path without a temporary
+   map, so repeated addresses cause only one version and dirty-index mutation.
+3. Admission mutates cache state only. Bounded managers maintain an exact index
+   of clean cache addresses. When space is required, admission protects every
+   address present in the incoming batch and first selects the complete clean
+   victim set from that index. It mutates the cache only after all victims have
+   been found. When too few evictable clean rows exist it rejects immediately
+   without scanning dirty rows, partially evicting the batch, or evicting a row
    that the same batch will update. Admission never reads or writes
    `ActiveStore` and never waits for the serialized durable flush lane. If a new
    row still exceeds the hard bound, the whole admission is rejected with
@@ -54,7 +58,8 @@ Each snapshot carries a manager-local monotonic revision; the metrics adapter
 rejects delayed older snapshots so concurrent admissions cannot regress gauges.
 Production wiring coalesces admission-path aggregate snapshots to one per 100ms;
 flush completion and pressure transitions force a fresh snapshot. Mutation
-counts remain per admission. Cache observations also expose dirty FIFO rows and
+counts remain per admission and count unique coalesced row transitions. Cache
+observations also expose dirty FIFO rows and
 live dirty-age bucket counts, while mutation and flush observations split cache
 lock wait from in-lock work. Admission lock histograms retain bounded
 `ok`/`cache_pressure` results so rejected attempts do not disappear from the

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -12,6 +12,8 @@ import (
 const (
 	pressureHighWatermarkPercent = 80
 	pressureLowWatermarkPercent  = 70
+	inlineActivePatchRows        = 8
+	preparedBatchInitialRows     = 512
 )
 
 type conversationKey struct {
@@ -23,6 +25,16 @@ type conversationKey struct {
 type cacheAddress struct {
 	uid string
 	key conversationKey
+}
+
+type preparedActivePatch struct {
+	address cacheAddress
+	patch   ActivePatch
+}
+
+type preparedActiveBatch struct {
+	rows      []preparedActivePatch
+	positions map[cacheAddress]int
 }
 
 type cacheEntry struct {
@@ -113,6 +125,9 @@ type Manager struct {
 	observationRevision uint64
 	// cache stores UID -> conversation key -> active projection entry.
 	cache map[string]map[conversationKey]cacheEntry
+	// cleanIndex contains every clean cache address when maxCachedRows is bounded.
+	// It lets admission find an eviction reserve without scanning dirty cache rows.
+	cleanIndex map[cacheAddress]struct{}
 	// dirtyByHashSlot indexes dirty cache rows by UID hash slot for bounded authority handoff drains.
 	dirtyByHashSlot map[uint16]map[cacheAddress]struct{}
 }
@@ -126,7 +141,7 @@ func NewManager(opts Options) *Manager {
 		}
 	}
 	pressureHighRows, pressureLowDirtyRows := pressureWatermarks(opts.MaxCachedRows)
-	return &Manager{
+	manager := &Manager{
 		nowMS:                    nowMS,
 		store:                    opts.Store,
 		activeCooldown:           opts.ActiveCooldown,
@@ -141,6 +156,10 @@ func NewManager(opts Options) *Manager {
 		cache:                    make(map[string]map[conversationKey]cacheEntry),
 		dirtyByHashSlot:          make(map[uint16]map[cacheAddress]struct{}),
 	}
+	if opts.MaxCachedRows > 0 {
+		manager.cleanIndex = make(map[cacheAddress]struct{})
+	}
+	return manager
 }
 
 // AdmitActiveBatch admits a channelappend recipient batch into the active cache.
@@ -159,7 +178,15 @@ func (m *Manager) admitActiveBatch(ctx context.Context, hashSlot uint16, hasHash
 		activeAtMS = m.nowMS()
 	}
 
-	patches := make([]ActivePatch, 0, len(batch.Recipients)+1)
+	patchCapacity := len(batch.Recipients)
+	if batch.SenderUID != "" {
+		patchCapacity++
+	}
+	var inlinePatches [inlineActivePatchRows]ActivePatch
+	patches := inlinePatches[:0]
+	if patchCapacity > cap(inlinePatches) {
+		patches = make([]ActivePatch, 0, patchCapacity)
+	}
 	if batch.SenderUID != "" {
 		patches = append(patches, ActivePatch{
 			UID:         batch.SenderUID,
@@ -211,12 +238,17 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 	if len(patches) == 0 {
 		return nil
 	}
+	var inlineRows [inlineActivePatchRows]preparedActivePatch
+	prepared := prepareActiveBatch(patches, inlineRows[:0])
+	if len(prepared.rows) == 0 {
+		return nil
+	}
 
 	lockStartedAt := time.Now()
 	m.mu.Lock()
 	lockAcquiredAt := time.Now()
 	mutation := MutationObservation{Result: "ok", LockWaitDuration: nonNegativeDuration(lockAcquiredAt.Sub(lockStartedAt))}
-	batchAddresses, newRows := m.batchAddressesAndNewRowsLocked(patches)
+	newRows := m.newRowsLocked(prepared.rows)
 	if m.cacheWouldExceedLocked(newRows) {
 		if newRows > m.maxCachedRows {
 			mutation.Result = "cache_pressure"
@@ -232,19 +264,17 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 			return ErrCachePressure
 		}
 		over := m.totalRows + newRows - m.maxCachedRows
-		// Reject without scanning the cache when the whole batch cannot fit by
-		// evicting clean rows outside this batch. A full dirty cache must keep
-		// admission bounded, and an existing batch row must never evict itself.
-		if m.evictableCleanRowsLocked(batchAddresses) >= over {
-			m.evictCleanRowsLocked(over, batchAddresses)
+		var inlineVictims [inlineActivePatchRows]cacheAddress
+		if m.evictableCleanRowsLocked(prepared) >= over {
+			victims, ok := m.planCleanEvictionsLocked(over, prepared, inlineVictims[:0])
+			if ok {
+				m.evictCleanVictimsLocked(victims)
+			}
 		}
 	}
 	if !m.cacheWouldExceedLocked(newRows) {
-		for _, patch := range patches {
-			if patch.UID == "" {
-				continue
-			}
-			switch m.markActiveLocked(patch, hashSlot, hasHashSlot) {
+		for _, row := range prepared.rows {
+			switch m.markActiveLocked(row, hashSlot, hasHashSlot) {
 			case cacheMutationBecameDirty:
 				mutation.BecameDirty++
 			case cacheMutationDirtyUpdated:
@@ -350,9 +380,10 @@ func pressureWatermarks(maxRows int) (int, int) {
 	return high, low
 }
 
-func (m *Manager) markActiveLocked(patch ActivePatch, hashSlot uint16, hasHashSlot bool) cacheMutationKind {
-	key := conversationKey{kind: patch.Kind, channelID: patch.ChannelID, channelType: patch.ChannelType}
-	address := cacheAddress{uid: patch.UID, key: key}
+func (m *Manager) markActiveLocked(row preparedActivePatch, hashSlot uint16, hasHashSlot bool) cacheMutationKind {
+	patch := row.patch
+	address := row.address
+	key := address.key
 	byChannel := m.cache[patch.UID]
 	if byChannel == nil {
 		byChannel = make(map[conversationKey]cacheEntry)
@@ -402,6 +433,7 @@ func (m *Manager) markActiveLocked(patch ActivePatch, hashSlot uint16, hasHashSl
 		next.readSeqDirty = current.readSeqDirty || readSeqAdvanced
 		m.moveDirtyLocked(address, current, next)
 	} else {
+		m.untrackCleanLocked(address)
 		next.dirty = true
 		next.readSeqDirty = readSeqAdvanced
 		m.trackDirtyLocked(address, next)
@@ -416,85 +448,157 @@ func (m *Manager) markActiveLocked(patch ActivePatch, hashSlot uint16, hasHashSl
 	return cacheMutationBecameDirty
 }
 
-func (m *Manager) batchAddressesAndNewRowsLocked(patches []ActivePatch) (map[cacheAddress]struct{}, int) {
-	seen := make(map[cacheAddress]struct{}, len(patches))
-	var count int
+func prepareActiveBatch(patches []ActivePatch, inline []preparedActivePatch) preparedActiveBatch {
+	if len(patches) <= cap(inline) {
+		rows := inline[:0]
+		for _, patch := range patches {
+			if patch.UID == "" {
+				continue
+			}
+			address := activePatchAddress(patch)
+			merged := false
+			for index := range rows {
+				if rows[index].address != address {
+					continue
+				}
+				mergeActivePatch(&rows[index].patch, patch)
+				merged = true
+				break
+			}
+			if !merged {
+				rows = append(rows, preparedActivePatch{address: address, patch: patch})
+			}
+		}
+		return preparedActiveBatch{rows: rows}
+	}
+
+	capacity := len(patches)
+	if capacity > preparedBatchInitialRows {
+		capacity = preparedBatchInitialRows
+	}
+	rows := make([]preparedActivePatch, 0, capacity)
+	positions := make(map[cacheAddress]int, capacity)
 	for _, patch := range patches {
 		if patch.UID == "" {
 			continue
 		}
-		key := conversationKey{kind: patch.Kind, channelID: patch.ChannelID, channelType: patch.ChannelType}
-		address := cacheAddress{uid: patch.UID, key: key}
-		if _, ok := seen[address]; ok {
+		address := activePatchAddress(patch)
+		if index, ok := positions[address]; ok {
+			mergeActivePatch(&rows[index].patch, patch)
 			continue
 		}
-		seen[address] = struct{}{}
-		if byChannel := m.cache[patch.UID]; byChannel != nil {
-			if _, ok := byChannel[key]; ok {
-				continue
-			}
-		}
-		count++
+		positions[address] = len(rows)
+		rows = append(rows, preparedActivePatch{address: address, patch: patch})
 	}
-	return seen, count
+	return preparedActiveBatch{rows: rows, positions: positions}
+}
+
+func activePatchAddress(patch ActivePatch) cacheAddress {
+	return cacheAddress{
+		uid: patch.UID,
+		key: conversationKey{kind: patch.Kind, channelID: patch.ChannelID, channelType: patch.ChannelType},
+	}
+}
+
+func mergeActivePatch(current *ActivePatch, incoming ActivePatch) {
+	if incoming.ActiveAtMS > current.ActiveAtMS {
+		current.ActiveAtMS = incoming.ActiveAtMS
+	}
+	if incoming.ReadSeq > current.ReadSeq {
+		current.ReadSeq = incoming.ReadSeq
+	}
+}
+
+func (b preparedActiveBatch) contains(address cacheAddress) bool {
+	if b.positions != nil {
+		_, ok := b.positions[address]
+		return ok
+	}
+	for _, row := range b.rows {
+		if row.address == address {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) newRowsLocked(rows []preparedActivePatch) int {
+	var count int
+	for _, row := range rows {
+		byChannel := m.cache[row.address.uid]
+		if byChannel == nil {
+			count++
+			continue
+		}
+		if _, ok := byChannel[row.address.key]; !ok {
+			count++
+		}
+	}
+	return count
 }
 
 func (m *Manager) cacheWouldExceedLocked(newRows int) bool {
 	return m.maxCachedRows > 0 && newRows > 0 && m.totalRows+newRows > m.maxCachedRows
 }
 
-func (m *Manager) cleanRowsLocked() int {
-	clean := m.totalRows - m.dirtyRows
-	if clean < 0 {
+func (m *Manager) evictableCleanRowsLocked(protected preparedActiveBatch) int {
+	cleanRows := len(m.cleanIndex)
+	for _, row := range protected.rows {
+		if _, ok := m.cleanIndex[row.address]; ok {
+			cleanRows--
+		}
+	}
+	if cleanRows < 0 {
 		return 0
 	}
-	return clean
+	return cleanRows
 }
 
-func (m *Manager) evictableCleanRowsLocked(protected map[cacheAddress]struct{}) int {
-	clean := m.cleanRowsLocked()
-	for address := range protected {
+func (m *Manager) planCleanEvictionsLocked(limit int, protected preparedActiveBatch, scratch []cacheAddress) ([]cacheAddress, bool) {
+	if limit <= 0 {
+		return scratch[:0], true
+	}
+	if cap(scratch) < limit {
+		scratch = make([]cacheAddress, 0, limit)
+	} else {
+		scratch = scratch[:0]
+	}
+	for address := range m.cleanIndex {
+		if protected.contains(address) {
+			continue
+		}
 		byChannel := m.cache[address.uid]
 		entry, ok := byChannel[address.key]
-		if ok && !entry.dirty {
-			clean--
+		if !ok || entry.dirty {
+			continue
+		}
+		scratch = append(scratch, address)
+		if len(scratch) == limit {
+			return scratch, true
 		}
 	}
-	if clean < 0 {
-		return 0
-	}
-	return clean
+	return scratch, false
 }
 
-func (m *Manager) evictCleanRowsLocked(limit int, protected map[cacheAddress]struct{}) int {
-	if limit <= 0 {
-		return 0
-	}
-	var evicted int
-	for uid, byChannel := range m.cache {
-		for key, entry := range byChannel {
-			if entry.dirty {
-				continue
-			}
-			if _, ok := protected[cacheAddress{uid: uid, key: key}]; ok {
-				continue
-			}
-			delete(byChannel, key)
-			m.totalRows--
-			decrementKindCount(m.rowsByKind, key.kind)
-			evicted++
-			if evicted >= limit {
-				break
-			}
+func (m *Manager) evictCleanVictimsLocked(victims []cacheAddress) bool {
+	for _, address := range victims {
+		byChannel := m.cache[address.uid]
+		entry, ok := byChannel[address.key]
+		if !ok || entry.dirty {
+			return false
 		}
+	}
+	for _, address := range victims {
+		byChannel := m.cache[address.uid]
+		delete(byChannel, address.key)
+		m.untrackCleanLocked(address)
+		m.totalRows--
+		decrementKindCount(m.rowsByKind, address.key.kind)
 		if len(byChannel) == 0 {
-			delete(m.cache, uid)
-		}
-		if evicted >= limit {
-			break
+			delete(m.cache, address.uid)
 		}
 	}
-	return evicted
+	return true
 }
 
 // Flush persists dirty active rows and clears only unchanged dirty markers.
@@ -925,7 +1029,20 @@ func (m *Manager) clearDirtyEntryLocked(entry flushEntry, restoreDurableActiveAt
 	current.dirty = false
 	current.readSeqDirty = false
 	byChannel[entry.key] = current
+	m.trackCleanLocked(cacheAddress{uid: entry.uid, key: entry.key})
 	result.cleared++
+}
+
+func (m *Manager) trackCleanLocked(address cacheAddress) {
+	if m.cleanIndex != nil {
+		m.cleanIndex[address] = struct{}{}
+	}
+}
+
+func (m *Manager) untrackCleanLocked(address cacheAddress) {
+	if m.cleanIndex != nil {
+		delete(m.cleanIndex, address)
+	}
 }
 
 func (m *Manager) trackDirtyLocked(address cacheAddress, entry cacheEntry) {

--- a/internal/runtime/conversationactive/manager_benchmark_test.go
+++ b/internal/runtime/conversationactive/manager_benchmark_test.go
@@ -8,6 +8,155 @@ import (
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
 
+func BenchmarkMarkActiveHotRowsAtFullCache(b *testing.B) {
+	const (
+		totalRows = 100_000
+		batchRows = 2
+	)
+	ctx := context.Background()
+	m := NewManager(Options{MaxCachedRows: totalRows})
+	seed := make([]ActivePatch, 0, totalRows)
+	for i := 0; i < totalRows; i++ {
+		seed = append(seed, ActivePatch{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         fmt.Sprintf("u-%06d", i),
+			ChannelID:   "room",
+			ChannelType: 2,
+			ActiveAtMS:  1_000,
+		})
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, seed); err != nil {
+		b.Fatal(err)
+	}
+	patches := make([]ActivePatch, batchRows)
+	for i := range patches {
+		patches[i] = seed[i]
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		activeAtMS := int64(2_000 + i)
+		for j := range patches {
+			patches[j].ActiveAtMS = activeAtMS
+		}
+		if err := m.MarkActiveForHashSlot(ctx, 7, patches); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAdmitActiveBatchOneRecipient(b *testing.B) {
+	ctx := context.Background()
+	m := NewManager(Options{MaxCachedRows: 100_000})
+	batch := ActiveBatch{
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "room",
+		ChannelType: 2,
+		Recipients:  []ActiveEntry{{UID: "u1"}},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch.ActiveAtMS = int64(i + 1)
+		if err := m.AdmitActiveBatchForHashSlot(ctx, 7, batch); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAdmitActiveBatch512Recipients(b *testing.B) {
+	ctx := context.Background()
+	recipients := make([]ActiveEntry, 0, 512)
+	for i := 0; i < cap(recipients); i++ {
+		recipients = append(recipients, ActiveEntry{UID: fmt.Sprintf("u-%04d", i)})
+	}
+	batch := ActiveBatch{
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "room",
+		ChannelType: 2,
+		ActiveAtMS:  1_000,
+		Recipients:  recipients,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m := NewManager(Options{MaxCachedRows: 100_000})
+		if err := m.AdmitActiveBatchForHashSlot(ctx, 7, batch); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAdmitActiveBatch512HotRecipients(b *testing.B) {
+	ctx := context.Background()
+	recipients := make([]ActiveEntry, 0, 512)
+	for i := 0; i < cap(recipients); i++ {
+		recipients = append(recipients, ActiveEntry{UID: fmt.Sprintf("u-%04d", i)})
+	}
+	batch := ActiveBatch{
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "room",
+		ChannelType: 2,
+		ActiveAtMS:  1_000,
+		Recipients:  recipients,
+	}
+	m := NewManager(Options{MaxCachedRows: 100_000})
+	if err := m.AdmitActiveBatchForHashSlot(ctx, 7, batch); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch.ActiveAtMS = int64(2_000 + i)
+		if err := m.AdmitActiveBatchForHashSlot(ctx, 7, batch); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAdmitOneRowWithOneCleanVictimInFullCache(b *testing.B) {
+	const totalRows = 100_000
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: totalRows})
+		seed := make([]ActivePatch, 0, totalRows)
+		for row := 0; row < totalRows; row++ {
+			seed = append(seed, ActivePatch{
+				Kind:        metadb.ConversationKindNormal,
+				UID:         fmt.Sprintf("u-%06d", row),
+				ChannelID:   "room",
+				ChannelType: 2,
+				ActiveAtMS:  1_000,
+			})
+		}
+		if err := m.MarkActiveForHashSlot(ctx, 1, seed[:1]); err != nil {
+			b.Fatal(err)
+		}
+		if err := m.MarkActiveForHashSlot(ctx, 2, seed[1:]); err != nil {
+			b.Fatal(err)
+		}
+		if result, err := m.FlushHashSlot(ctx, 1, 1); err != nil || result.Cleared != 1 {
+			b.Fatalf("FlushHashSlot() = %+v, %v", result, err)
+		}
+		incoming := []ActivePatch{{
+			Kind:        metadb.ConversationKindNormal,
+			UID:         "incoming",
+			ChannelID:   "room",
+			ChannelType: 2,
+			ActiveAtMS:  2_000,
+		}}
+		b.StartTimer()
+		if err := m.MarkActiveForHashSlot(ctx, 3, incoming); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkFlushHashSlotSelected128Of10KDirtyRows(b *testing.B) {
 	benchmarkFlushHashSlotSelectedRows(b, 10_000, 128)
 }
@@ -31,6 +180,7 @@ func BenchmarkMarkActiveCoalesces100KUpdates(b *testing.B) {
 	}
 
 	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m := NewManager(Options{})
 		if err := m.MarkActiveForHashSlot(ctx, 7, patches); err != nil {

--- a/internal/runtime/conversationactive/manager_pressure_regression_test.go
+++ b/internal/runtime/conversationactive/manager_pressure_regression_test.go
@@ -54,7 +54,53 @@ func TestDirtyActiveAtIndexRemainsBoundedAcrossHotUpdates(t *testing.T) {
 	if got := m.dirtyAge.Oldest(); got != finalHotActiveAt {
 		t.Fatalf("oldest dirty active-at after cold clear = %d, want final hot bucket %d", got, finalHotActiveAt)
 	}
-	requireDirtyIndexConservation(t, m)
+	requireCacheIndexConservation(t, m)
+}
+
+func TestMarkActiveCoalescesDuplicateAddressesBeforeMutation(t *testing.T) {
+	ctx := context.Background()
+	observer := &recordingConversationActiveObserver{}
+	m := NewManager(Options{Observer: observer, MaxCachedRows: 4})
+	initial := make([]ActivePatch, 0, 9)
+	for index := 0; index < cap(initial); index++ {
+		initial = append(initial, ActivePatch{
+			Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2,
+			ActiveAtMS: 1_000 + int64(index*25), ReadSeq: uint64(9 - index),
+		})
+	}
+	if err := m.MarkActive(ctx, initial); err != nil {
+		t.Fatalf("MarkActive(initial duplicates) error = %v", err)
+	}
+	if got := observer.lastMutation(t); got.BecameDirty != 1 || got.DirtyUpdated != 0 || got.Unchanged != 0 {
+		t.Fatalf("initial mutation = %+v, want one unique row transition", got)
+	}
+	if m.nextVersion != 1 {
+		t.Fatalf("initial version allocator=%d, want one version for one unique row", m.nextVersion)
+	}
+	entry, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2)
+	if !ok || entry.ActiveAtMS != 1_200 || entry.ReadSeq != 9 {
+		t.Fatalf("coalesced initial entry=%+v present=%v, want max active/read values", entry, ok)
+	}
+
+	updates := []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_300, ReadSeq: 9},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_250, ReadSeq: 10},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_400, ReadSeq: 8},
+	}
+	if err := m.MarkActive(ctx, updates); err != nil {
+		t.Fatalf("MarkActive(update duplicates) error = %v", err)
+	}
+	if got := observer.lastMutation(t); got.BecameDirty != 0 || got.DirtyUpdated != 1 || got.Unchanged != 0 {
+		t.Fatalf("update mutation = %+v, want one unique dirty update", got)
+	}
+	if m.nextVersion != 2 {
+		t.Fatalf("updated version allocator=%d, want one new version for one unique row", m.nextVersion)
+	}
+	entry, ok = m.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2)
+	if !ok || entry.ActiveAtMS != 1_400 || entry.ReadSeq != 10 {
+		t.Fatalf("coalesced updated entry=%+v present=%v, want max active/read values", entry, ok)
+	}
+	requireCacheIndexConservation(t, m)
 }
 
 func TestBoundedFlushSelectionVisitsEveryDirtyRowBeforeRepeating(t *testing.T) {
@@ -518,5 +564,54 @@ func requireDirtyIndexConservation(t *testing.T, manager *Manager) {
 	}
 	if observation.DirtyAgeBuckets > observation.DirtyRows {
 		t.Fatalf("dirty age buckets=%d, dirty rows=%d", observation.DirtyAgeBuckets, observation.DirtyRows)
+	}
+}
+
+func requireCacheIndexConservation(t *testing.T, manager *Manager) {
+	t.Helper()
+	requireDirtyIndexConservation(t, manager)
+
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+	if manager.maxCachedRows <= 0 {
+		if manager.cleanIndex != nil {
+			t.Fatalf("unbounded manager clean index is initialized with %d rows", len(manager.cleanIndex))
+		}
+		return
+	}
+	wantCleanRows := manager.totalRows - manager.dirtyRows
+	if got := len(manager.cleanIndex); got != wantCleanRows {
+		t.Fatalf("clean index rows=%d, total-clean rows=%d", got, wantCleanRows)
+	}
+	if manager.totalRows > manager.maxCachedRows {
+		t.Fatalf("cached rows=%d exceed bound=%d", manager.totalRows, manager.maxCachedRows)
+	}
+
+	var cachedRows int
+	for uid, byChannel := range manager.cache {
+		for key, entry := range byChannel {
+			cachedRows++
+			address := cacheAddress{uid: uid, key: key}
+			_, indexedClean := manager.cleanIndex[address]
+			if entry.dirty && indexedClean {
+				t.Fatalf("dirty cache address %+v is also indexed clean", address)
+			}
+			if !entry.dirty && !indexedClean {
+				t.Fatalf("clean cache address %+v is missing from clean index", address)
+			}
+		}
+	}
+	if cachedRows != manager.totalRows {
+		t.Fatalf("cache iteration rows=%d, tracked total rows=%d", cachedRows, manager.totalRows)
+	}
+	for address := range manager.cleanIndex {
+		byChannel := manager.cache[address.uid]
+		entry, ok := byChannel[address.key]
+		if !ok {
+			t.Fatalf("clean index contains missing cache address %+v", address)
+		}
+		if entry.dirty {
+			t.Fatalf("clean index contains dirty cache address %+v", address)
+		}
 	}
 }

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -441,10 +441,11 @@ func TestListActiveViewNonPositiveLimitReturnsEmptyDonePage(t *testing.T) {
 func TestFlushDirtyPersistsActiveRowsAndClearsDirty(t *testing.T) {
 	ctx := context.Background()
 	store := &recordingActiveStore{}
-	m := NewManager(Options{Store: store})
+	m := NewManager(Options{Store: store, MaxCachedRows: 1})
 	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 7}}); err != nil {
 		t.Fatalf("MarkActive() error = %v", err)
 	}
+	requireCacheIndexConservation(t, m)
 	if got := m.DirtyCountForTest(); got != 1 {
 		t.Fatalf("DirtyCountForTest() = %d, want 1", got)
 	}
@@ -462,6 +463,7 @@ func TestFlushDirtyPersistsActiveRowsAndClearsDirty(t *testing.T) {
 	if got := m.DirtyCountForTest(); got != 0 {
 		t.Fatalf("DirtyCountForTest() = %d, want 0", got)
 	}
+	requireCacheIndexConservation(t, m)
 
 	want := metadb.ConversationActivePatch{
 		UID:         "u1",
@@ -516,10 +518,11 @@ func TestFlushSkipsReceiverActiveWithinCooldown(t *testing.T) {
 			},
 		},
 	}
-	m := NewManager(Options{Store: store, ActiveCooldown: 2 * time.Hour})
+	m := NewManager(Options{Store: store, ActiveCooldown: 2 * time.Hour, MaxCachedRows: 1})
 	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: nextActiveAt}}); err != nil {
 		t.Fatalf("MarkActive() error = %v", err)
 	}
+	requireCacheIndexConservation(t, m)
 
 	result, err := m.Flush(ctx, 0)
 	if err != nil {
@@ -541,6 +544,7 @@ func TestFlushSkipsReceiverActiveWithinCooldown(t *testing.T) {
 	if entry.ActiveAtMS != previousActiveAt {
 		t.Fatalf("cached ActiveAtMS = %d, want durable active_at %d", entry.ActiveAtMS, previousActiveAt)
 	}
+	requireCacheIndexConservation(t, m)
 }
 
 func TestFlushCooldownSkipRetainsConcurrentNewerVersion(t *testing.T) {
@@ -927,7 +931,7 @@ func TestFlushFailureKeepsDirty(t *testing.T) {
 func TestFlushDoesNotClearConcurrentDirtyUpdate(t *testing.T) {
 	ctx := context.Background()
 	store := &recordingActiveStore{}
-	m := NewManager(Options{Store: store})
+	m := NewManager(Options{Store: store, MaxCachedRows: 1})
 	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 7}}); err != nil {
 		t.Fatalf("MarkActive() error = %v", err)
 	}
@@ -960,6 +964,7 @@ func TestFlushDoesNotClearConcurrentDirtyUpdate(t *testing.T) {
 	if got := store.touches[0][0].ActiveAt; got != 1000 {
 		t.Fatalf("flushed ActiveAt = %d, want original snapshot 1000", got)
 	}
+	requireCacheIndexConservation(t, m)
 }
 
 func TestClearFlushedDirtyClassifiesAlreadyCleanSnapshotAsSuperseded(t *testing.T) {
@@ -1236,6 +1241,7 @@ func TestAdmitUnderCachePressureEvictsCleanRowsWithoutFlush(t *testing.T) {
 	if _, err := m.Flush(ctx, 0); err != nil {
 		t.Fatalf("Flush(old) error = %v", err)
 	}
+	requireCacheIndexConservation(t, m)
 	flushObservations := len(observer.flush)
 	store.touches = nil
 
@@ -1265,6 +1271,64 @@ func TestAdmitUnderCachePressureEvictsCleanRowsWithoutFlush(t *testing.T) {
 	if cache.Rows != 2 || cache.DirtyRows != 1 {
 		t.Fatalf("cache observation = %+v, want rows=2 dirty=1", cache)
 	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestSparseCleanIndexProtectsBatchRowAndEvictsOnlyAvailableVictim(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingActiveStore{}
+	m := NewManager(Options{Store: store, MaxCachedRows: 4})
+	if err := m.MarkActiveForHashSlot(ctx, 1, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "clean-victim", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(clean victim) error = %v", err)
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 2, []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "dirty-1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000},
+		{Kind: metadb.ConversationKindNormal, UID: "dirty-2", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000},
+	}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(dirty rows) error = %v", err)
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 3, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "protected-clean", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_500,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(protected clean) error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 1, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(clean victim) = %+v, %v", result, err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 3, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(protected clean) = %+v, %v", result, err)
+	}
+	requireCacheIndexConservation(t, m)
+
+	patches := make([]ActivePatch, 0, 9)
+	for index := 0; index < cap(patches); index++ {
+		uid := "incoming"
+		activeAtMS := int64(2_000 + index)
+		if index%2 == 0 {
+			uid = "protected-clean"
+			activeAtMS = 1_500
+		}
+		patches = append(patches, ActivePatch{
+			Kind: metadb.ConversationKindNormal, UID: uid, ChannelID: "room", ChannelType: 2, ActiveAtMS: activeAtMS,
+		})
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 3, patches); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(incoming) error = %v", err)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "clean-victim", "room", 2); ok {
+		t.Fatal("the only clean victim remained cached after successful admission")
+	}
+	for _, uid := range []string{"protected-clean", "dirty-1", "dirty-2", "incoming"} {
+		if _, ok := m.EntryForTest(metadb.ConversationKindNormal, uid, "room", 2); !ok {
+			t.Fatalf("protected or dirty row %q was lost during clean eviction", uid)
+		}
+	}
+	if got := m.DirtyCountForTest(); got != 3 {
+		t.Fatalf("dirty rows = %d, want two retained rows plus incoming", got)
+	}
+	requireCacheIndexConservation(t, m)
 }
 
 func TestCachePressureDoesNotEvictCleanRowUpdatedBySameBatch(t *testing.T) {
@@ -1288,6 +1352,7 @@ func TestCachePressureDoesNotEvictCleanRowUpdatedBySameBatch(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("MarkActive(dirty) error = %v", err)
 	}
+	requireCacheIndexConservation(t, m)
 
 	err := m.MarkActive(ctx, []ActivePatch{
 		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "protected", ChannelType: 2, ActiveAtMS: 2000, ReadSeq: 20},
@@ -1312,6 +1377,58 @@ func TestCachePressureDoesNotEvictCleanRowUpdatedBySameBatch(t *testing.T) {
 		cache.DirtyRowsByKind[metadb.ConversationKindNormal] != 1 {
 		t.Fatalf("cache observation = %+v, want rows=2 dirty=1 with matching normal-kind counts", cache)
 	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestCachePressureRejectsAtomicallyWhenOnlyPartOfVictimSetIsAvailable(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 3})
+	if err := m.MarkActive(ctx, []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "victim", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000},
+		{Kind: metadb.ConversationKindNormal, UID: "protected", ChannelID: "room", ChannelType: 2, ActiveAtMS: 2_000},
+		{Kind: metadb.ConversationKindNormal, UID: "dirty", ChannelID: "room", ChannelType: 2, ActiveAtMS: 3_000},
+	}); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+	if result, err := m.Flush(ctx, 0); err != nil || result.Cleared != 3 {
+		t.Fatalf("Flush(initial) = %+v, %v", result, err)
+	}
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "dirty", ChannelID: "room", ChannelType: 2, ActiveAtMS: 4_000,
+	}}); err != nil {
+		t.Fatalf("MarkActive(dirty) error = %v", err)
+	}
+	requireCacheIndexConservation(t, m)
+
+	patches := []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "protected", ChannelID: "room", ChannelType: 2, ActiveAtMS: 2_000},
+		{Kind: metadb.ConversationKindNormal, UID: "new-1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 5_000},
+		{Kind: metadb.ConversationKindNormal, UID: "new-2", ChannelID: "room", ChannelType: 2, ActiveAtMS: 6_000},
+		{Kind: metadb.ConversationKindNormal, UID: "protected", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_900},
+		{Kind: metadb.ConversationKindNormal, UID: "new-1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 4_900},
+		{Kind: metadb.ConversationKindNormal, UID: "new-2", ChannelID: "room", ChannelType: 2, ActiveAtMS: 5_900},
+		{Kind: metadb.ConversationKindNormal, UID: "protected", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_800},
+		{Kind: metadb.ConversationKindNormal, UID: "new-1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 4_800},
+		{Kind: metadb.ConversationKindNormal, UID: "new-2", ChannelID: "room", ChannelType: 2, ActiveAtMS: 5_800},
+	}
+	if err := m.MarkActive(ctx, patches); !errors.Is(err, ErrCachePressure) {
+		t.Fatalf("MarkActive(partial victims) error = %v, want %v", err, ErrCachePressure)
+	}
+	for _, uid := range []string{"victim", "protected", "dirty"} {
+		if _, ok := m.EntryForTest(metadb.ConversationKindNormal, uid, "room", 2); !ok {
+			t.Fatalf("existing row %q was partially evicted by rejected admission", uid)
+		}
+	}
+	for _, uid := range []string{"new-1", "new-2"} {
+		if _, ok := m.EntryForTest(metadb.ConversationKindNormal, uid, "room", 2); ok {
+			t.Fatalf("rejected new row %q was partially admitted", uid)
+		}
+	}
+	protected, _ := m.EntryForTest(metadb.ConversationKindNormal, "protected", "room", 2)
+	if protected.ActiveAtMS != 2_000 {
+		t.Fatalf("protected row active_at=%d, want unchanged 2000", protected.ActiveAtMS)
+	}
+	requireCacheIndexConservation(t, m)
 }
 
 func TestCachePressureFlushContinuesUntilDirtyLowWatermark(t *testing.T) {

--- a/internal/runtime/conversationactive/types.go
+++ b/internal/runtime/conversationactive/types.go
@@ -73,15 +73,15 @@ type CacheObservation struct {
 	PressureDraining bool
 }
 
-// MutationObservation reports how one nonempty admission attempt affected dirty cache work and cache-lock latency.
+// MutationObservation reports how one admission with at least one non-empty UID affected dirty cache work and cache-lock latency.
 type MutationObservation struct {
 	// Result is ok or cache_pressure for the admission attempt.
 	Result string
-	// BecameDirty is the number of new or previously clean rows that became dirty.
+	// BecameDirty is the number of unique new or previously clean rows that became dirty.
 	BecameDirty int
-	// DirtyUpdated is the number of already-dirty rows advanced to a newer version.
+	// DirtyUpdated is the number of unique already-dirty rows advanced to a newer version.
 	DirtyUpdated int
-	// Unchanged is the number of existing rows whose projection and ownership were unchanged.
+	// Unchanged is the number of unique existing rows whose projection and ownership were unchanged.
 	Unchanged int
 	// LockWaitDuration is time spent waiting for the node-local cache lock.
 	LockWaitDuration time.Duration


### PR DESCRIPTION
## What changed

- maintain an exact bounded clean-row index for conversation-active cache eviction
- coalesce duplicate active patches before taking the cache lock, with zero-allocation inline paths for normal small batches
- select the complete eviction victim set before mutating cache state
- add cache-index conservation tests and production-shaped admission benchmarks
- document the updated runtime flow and performance invariant

## Root cause

Cloud Medium pressure testing showed the conversation-active cache reaching 100,000 rows per node with only a sparse clean reserve. Successful admission searched the entire nested cache while holding the global manager lock to find those clean rows. At roughly 80,000 to 96,000 admission lock acquisitions per second per node, one sparse scan delayed every later admission and flush clear, creating a positive feedback loop: lock wait grew, ingress collapsed, dirty rows aged, and SENDACK latency reached multi-second tails.

## Impact

Bounded admission now depends on the incoming unique batch plus the clean victims actually required, not on total dirty cache size. Single-recipient production admission is allocation-free, and the 100,000-row sparse-clean benchmark falls from 0.317-8.613 ms to typically 3-10 microseconds.

## Validation

- `GOWORK=off go test ./internal/runtime/conversationactive -count=1`
- `GOWORK=off go test -race ./internal/runtime/conversationactive -count=1`
- `GOWORK=off go test ./internal/app ./internal/infra/cluster ./internal/access/node ./internal/runtime/channelappend -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- targeted index/coalescing tests repeated 20 times
- production-shaped and 100,000-row admission benchmarks
