### PR TITLE
fix: relieve channel routing and conversation cache pressure

### DIFF
--- a/internal/access/node/FLOW.md
+++ b/internal/access/node/FLOW.md
@@ -109,6 +109,8 @@ Supported conversation authority calls:
 
 - `AdmitPatches(RouteTarget, []ActivePatch)`
 - `AdmitActiveBatch(RouteTarget, conversationactive.ActiveBatch)`
+- `HideConversationsForTarget(RouteTarget, []metadb.ConversationDelete)`
+  preserves canceled/deadline status across the node RPC boundary, matching local authority calls.
 - `ListConversationActiveViewForTarget(RouteTarget, kind, uid, activeCursor, limit)`
 - `DrainAuthority(RouteTarget)`
 
@@ -122,6 +124,15 @@ The RPC boundary is deliberately narrow:
   authority target. Sender/recipient route grouping is performed by
   `internal/infra/cluster`; this package only transports the exact batch
   subset it receives.
+- Hide carries one exact, ordered `ConversationDelete` collection to the fenced
+  UID authority target. The client does not split the mutation collection:
+  collections above 4,096 entries fail before transport, and malformed or
+  oversized wire collections fail closed during decode. The adapter waits for
+  the authority result and maps it through the existing route status contract.
+  The `WKVC1` hide extension follows the existing common request prefix and
+  appends `DeleteCount`, then each delete in the stable field order `UID`,
+  `Kind`, `ChannelID`, `ChannelType`, `DeletedToSeq`, and `UpdatedAt`. Existing
+  operation byte layouts are unchanged.
 - List reads the target-owned active view for one `metadb.ConversationKind`
   from the authority node. The local authority implementation decides how to
   merge unflushed cache rows with DB rows; this package only transports the

--- a/internal/access/node/conversation_codec.go
+++ b/internal/access/node/conversation_codec.go
@@ -18,16 +18,19 @@ const maxConversationAuthorityCollectionLen = 4096
 var maxConversationAuthorityDecodeLimit = int64(int(^uint(0) >> 1))
 
 const (
-	conversationOpAdmitPatches     = "admit_conversation_active_patches"
-	conversationOpAdmitActiveBatch = "admit_conversation_active_batch"
-	conversationOpList             = "list_conversations"
-	conversationOpDrain            = "drain_conversation_authority"
+	conversationOpAdmitPatches      = "admit_conversation_active_patches"
+	conversationOpAdmitActiveBatch  = "admit_conversation_active_batch"
+	conversationOpHideConversations = "hide_conversations_for_target"
+	conversationOpList              = "list_conversations"
+	conversationOpDrain             = "drain_conversation_authority"
 
 	conversationRPCStatusOK            = rpcStatusOK
 	conversationRPCStatusNotLeader     = rpcStatusNotLeader
 	conversationRPCStatusStaleRoute    = rpcStatusStaleRoute
 	conversationRPCStatusRouteNotReady = rpcStatusRouteNotReady
 	conversationRPCStatusCachePressure = "cache_pressure"
+	conversationRPCStatusCanceled      = rpcStatusContextCanceled
+	conversationRPCStatusDeadline      = rpcStatusContextDeadlineExceeded
 	conversationRPCStatusRejected      = rpcStatusRejected
 
 	conversationDrainResultDrained     = "drained"
@@ -54,6 +57,8 @@ type conversationAuthorityRequest struct {
 	Patches []conversationusecase.ActivePatch
 	// ActiveBatch carries channelappend active admission input for active-batch requests.
 	ActiveBatch conversationactive.ActiveBatch
+	// Deletes carries exact conversation hide mutations for hide requests.
+	Deletes []metadb.ConversationDelete
 }
 
 // conversationAuthorityResponse is the deterministic binary DTO returned by authority calls.
@@ -76,6 +81,12 @@ func encodeConversationAuthorityRequest(req conversationAuthorityRequest) ([]byt
 	dst = appendConversationActiveCursor(dst, req.After)
 	dst = appendVarint(dst, int64(req.Limit))
 	dst = appendConversationActivePatches(dst, req.Patches)
+	if req.Op == conversationOpHideConversations {
+		if len(req.Deletes) > maxConversationAuthorityCollectionLen {
+			return nil, fmt.Errorf("internal/access/node: conversation deletes length exceeds limit")
+		}
+		dst = appendConversationDeletes(dst, req.Deletes)
+	}
 	if req.Op == conversationOpAdmitActiveBatch {
 		dst = appendConversationActiveBatch(dst, req.ActiveBatch)
 	}
@@ -121,6 +132,11 @@ func decodeConversationAuthorityRequest(body []byte) (conversationAuthorityReque
 	if req.Patches, offset, err = readConversationActivePatches(body, offset); err != nil {
 		return conversationAuthorityRequest{}, err
 	}
+	if req.Op == conversationOpHideConversations {
+		if req.Deletes, offset, err = readConversationDeletes(body, offset); err != nil {
+			return conversationAuthorityRequest{}, err
+		}
+	}
 	if req.Op == conversationOpAdmitActiveBatch {
 		if req.ActiveBatch, offset, err = readConversationActiveBatch(body, offset); err != nil {
 			return conversationAuthorityRequest{}, err
@@ -165,11 +181,75 @@ func decodeConversationAuthorityResponse(body []byte) (conversationAuthorityResp
 
 func validateConversationAuthorityOp(op string) error {
 	switch op {
-	case conversationOpAdmitPatches, conversationOpAdmitActiveBatch, conversationOpList, conversationOpDrain:
+	case conversationOpAdmitPatches, conversationOpAdmitActiveBatch, conversationOpHideConversations, conversationOpList, conversationOpDrain:
 		return nil
 	default:
 		return fmt.Errorf("internal/access/node: unknown conversation authority op %q", op)
 	}
+}
+
+func appendConversationDelete(dst []byte, req metadb.ConversationDelete) []byte {
+	dst = appendString(dst, req.UID)
+	dst = appendConversationKind(dst, req.Kind)
+	dst = appendString(dst, req.ChannelID)
+	dst = appendVarint(dst, req.ChannelType)
+	dst = appendUvarint(dst, req.DeletedToSeq)
+	return appendVarint(dst, req.UpdatedAt)
+}
+
+func readConversationDelete(body []byte, offset int) (metadb.ConversationDelete, int, error) {
+	var req metadb.ConversationDelete
+	var err error
+	if req.UID, offset, err = readString(body, offset); err != nil {
+		return metadb.ConversationDelete{}, offset, err
+	}
+	if req.Kind, offset, err = readConversationKind(body, offset); err != nil {
+		return metadb.ConversationDelete{}, offset, err
+	}
+	if req.ChannelID, offset, err = readString(body, offset); err != nil {
+		return metadb.ConversationDelete{}, offset, err
+	}
+	if req.ChannelType, offset, err = readVarint(body, offset); err != nil {
+		return metadb.ConversationDelete{}, offset, err
+	}
+	if req.DeletedToSeq, offset, err = readUvarint(body, offset); err != nil {
+		return metadb.ConversationDelete{}, offset, err
+	}
+	if req.UpdatedAt, offset, err = readVarint(body, offset); err != nil {
+		return metadb.ConversationDelete{}, offset, err
+	}
+	return req, offset, nil
+}
+
+func appendConversationDeletes(dst []byte, reqs []metadb.ConversationDelete) []byte {
+	dst = appendUvarint(dst, uint64(len(reqs)))
+	for _, req := range reqs {
+		dst = appendConversationDelete(dst, req)
+	}
+	return dst
+}
+
+func readConversationDeletes(body []byte, offset int) ([]metadb.ConversationDelete, int, error) {
+	count, next, err := readUvarint(body, offset)
+	if err != nil {
+		return nil, offset, err
+	}
+	offset = next
+	if count == 0 {
+		return nil, offset, nil
+	}
+	if err := validateConversationCollectionLen(count, len(body)-offset, "conversation deletes"); err != nil {
+		return nil, offset, err
+	}
+	reqs := make([]metadb.ConversationDelete, 0, int(count))
+	for i := uint64(0); i < count; i++ {
+		var req metadb.ConversationDelete
+		if req, offset, err = readConversationDelete(body, offset); err != nil {
+			return nil, offset, err
+		}
+		reqs = append(reqs, req)
+	}
+	return reqs, offset, nil
 }
 
 func appendConversationRouteTarget(dst []byte, target conversationusecase.RouteTarget) []byte {

--- a/internal/access/node/conversation_codec_test.go
+++ b/internal/access/node/conversation_codec_test.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"bytes"
+	"encoding/hex"
 	"reflect"
 	"strings"
 	"testing"
@@ -9,6 +11,58 @@ import (
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
+
+func TestConversationAuthorityCodecHideConversationsWireLayout(t *testing.T) {
+	req := conversationAuthorityRequest{
+		Op:     conversationOpHideConversations,
+		Target: conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 3, LeaderTerm: 4, ConfigEpoch: 5, RouteRevision: 6, AuthorityEpoch: 7},
+		Kind:   metadb.ConversationKindNormal,
+		Deletes: []metadb.ConversationDelete{{
+			UID: "u", Kind: metadb.ConversationKindCMD, ChannelID: "g", ChannelType: 2, DeletedToSeq: 3, UpdatedAt: 4,
+		}},
+	}
+	want, err := hex.DecodeString("574b5643011d686964655f636f6e766572736174696f6e735f666f725f7461726765740102030405060700010000000000010175020167040308")
+	if err != nil {
+		t.Fatalf("decode golden bytes: %v", err)
+	}
+	got, err := encodeConversationAuthorityRequest(req)
+	if err != nil {
+		t.Fatalf("encodeConversationAuthorityRequest() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("encoded hide request = %x, want %x", got, want)
+	}
+}
+
+func TestConversationAuthorityCodecRoundTripHideConversations(t *testing.T) {
+	req := conversationAuthorityRequest{
+		Op:     conversationOpHideConversations,
+		Target: conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 3, LeaderTerm: 6, ConfigEpoch: 7, RouteRevision: 4, AuthorityEpoch: 5},
+		Kind:   metadb.ConversationKindNormal,
+		Deletes: []metadb.ConversationDelete{
+			{UID: "u2", Kind: metadb.ConversationKindCMD, ChannelID: "g2____cmd", ChannelType: 3, DeletedToSeq: 19, UpdatedAt: 102},
+			{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9, UpdatedAt: 101},
+		},
+	}
+	body, err := encodeConversationAuthorityRequest(req)
+	if err != nil {
+		t.Fatalf("encodeConversationAuthorityRequest() error = %v", err)
+	}
+	secondBody, err := encodeConversationAuthorityRequest(req)
+	if err != nil {
+		t.Fatalf("second encodeConversationAuthorityRequest() error = %v", err)
+	}
+	if !bytes.Equal(body, secondBody) {
+		t.Fatal("encoded hide request is not deterministic")
+	}
+	got, err := decodeConversationAuthorityRequest(body)
+	if err != nil {
+		t.Fatalf("decodeConversationAuthorityRequest() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, req) {
+		t.Fatalf("decoded = %#v, want %#v", got, req)
+	}
+}
 
 func TestConversationAuthorityCodecRoundTripAdmit(t *testing.T) {
 	req := conversationAuthorityRequest{
@@ -142,6 +196,8 @@ func TestConversationAuthorityCodecRejectsMalformedPayloads(t *testing.T) {
 		{name: "trailing bytes", body: append(append([]byte(nil), validReq...), 0)},
 		{name: "truncated payload", body: validReq[:len(validReq)-1]},
 		{name: "oversized patches", body: conversationAuthorityRequestWithPatchCount(maxConversationAuthorityCollectionLen + 1)},
+		{name: "oversized deletes", body: conversationAuthorityRequestWithDeleteCount(maxConversationAuthorityCollectionLen + 1)},
+		{name: "truncated delete", body: truncatedConversationAuthorityDeleteRequest(t)},
 		{name: "invalid op", body: conversationAuthorityRequestWithOp("unknown")},
 		{name: "invalid patch bool", body: conversationAuthorityRequestWithPatchBool(2)},
 		{name: "invalid response bool", body: conversationAuthorityResponseWithStateBool(2)},
@@ -159,6 +215,17 @@ func TestConversationAuthorityCodecRejectsMalformedPayloads(t *testing.T) {
 				t.Fatal("decode error = nil, want error")
 			}
 		})
+	}
+}
+
+func TestConversationAuthorityCodecRejectsOversizedDeleteCollectionOnEncode(t *testing.T) {
+	req := conversationAuthorityRequest{
+		Op:      conversationOpHideConversations,
+		Kind:    metadb.ConversationKindNormal,
+		Deletes: make([]metadb.ConversationDelete, maxConversationAuthorityCollectionLen+1),
+	}
+	if _, err := encodeConversationAuthorityRequest(req); err == nil {
+		t.Fatal("encodeConversationAuthorityRequest() error = nil, want collection limit error")
 	}
 }
 
@@ -205,6 +272,32 @@ func conversationAuthorityRequestWithPatchCount(count int) []byte {
 	dst = dst[:len(dst)-1]
 	dst = appendUvarint(dst, uint64(count))
 	return append(dst, make([]byte, count)...)
+}
+
+func conversationAuthorityRequestWithDeleteCount(count int) []byte {
+	dst := conversationAuthorityRequestWithOpAndLimit(conversationOpHideConversations, 1)
+	dst = appendUvarint(dst, uint64(count))
+	for i := 0; i < count; i++ {
+		// Six zero varints encode empty UID, normal kind, empty channel,
+		// channel type 0, deleted sequence 0, and update time 0.
+		dst = append(dst, 0, 0, 0, 0, 0, 0)
+	}
+	return dst
+}
+
+func truncatedConversationAuthorityDeleteRequest(t *testing.T) []byte {
+	t.Helper()
+	body, err := encodeConversationAuthorityRequest(conversationAuthorityRequest{
+		Op:   conversationOpHideConversations,
+		Kind: metadb.ConversationKindNormal,
+		Deletes: []metadb.ConversationDelete{{
+			UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9, UpdatedAt: 101,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("encode hide request: %v", err)
+	}
+	return body[:len(body)-1]
 }
 
 func conversationAuthorityRequestWithPatchBool(flag byte) []byte {

--- a/internal/access/node/conversation_rpc.go
+++ b/internal/access/node/conversation_rpc.go
@@ -36,6 +36,9 @@ func (a *Adapter) HandleConversationAuthorityRPC(ctx context.Context, payload []
 	case conversationOpAdmitActiveBatch:
 		err = a.conversation.AdmitActiveBatch(ctx, req.Target, req.ActiveBatch)
 		return encodeConversationAuthorityResponse(conversationAuthorityResponse{Status: conversationRPCStatusForError(err)})
+	case conversationOpHideConversations:
+		err = a.conversation.HideConversationsForTarget(ctx, req.Target, req.Deletes)
+		return encodeConversationAuthorityResponse(conversationAuthorityResponse{Status: conversationRPCStatusForError(err)})
 	case conversationOpList:
 		page, err := a.conversation.ListConversationActiveViewForTarget(ctx, req.Target, req.Kind, req.UID, req.After, req.Limit)
 		return encodeConversationAuthorityResponse(conversationAuthorityResponse{Status: conversationRPCStatusForError(err), Page: page})
@@ -109,6 +112,23 @@ func (c *Client) AdmitConversationActiveBatch(ctx context.Context, nodeID uint64
 	return nil
 }
 
+// HideConversations forwards one bounded exact-target hide collection to nodeID.
+func (c *Client) HideConversations(ctx context.Context, nodeID uint64, target conversationusecase.RouteTarget, deletes []metadb.ConversationDelete) error {
+	if len(deletes) > maxConversationAuthorityCollectionLen {
+		return fmt.Errorf("internal/access/node: conversation deletes length exceeds limit")
+	}
+	resp, err := c.callConversationAuthority(ctx, nodeID, conversationAuthorityRequest{
+		Op:      conversationOpHideConversations,
+		Target:  target,
+		Kind:    metadb.ConversationKindNormal,
+		Deletes: deletes,
+	})
+	if err != nil {
+		return err
+	}
+	return conversationRPCErrorForStatus(resp.Status)
+}
+
 // ListConversations reads the target-owned active conversation page from nodeID.
 func (c *Client) ListConversations(ctx context.Context, nodeID uint64, target conversationusecase.RouteTarget, kind metadb.ConversationKind, uid string, after metadb.ConversationActiveCursor, limit int) (conversationusecase.ActiveViewPage, error) {
 	resp, err := c.callConversationAuthority(ctx, nodeID, conversationAuthorityRequest{Op: conversationOpList, Target: target, Kind: kind, UID: uid, After: after, Limit: limit})
@@ -160,6 +180,10 @@ func conversationRPCStatusForError(err error) string {
 		return conversationRPCStatusRouteNotReady
 	case errors.Is(err, conversationusecase.ErrCachePressure):
 		return conversationRPCStatusCachePressure
+	case errors.Is(err, context.Canceled):
+		return conversationRPCStatusCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return conversationRPCStatusDeadline
 	default:
 		return conversationRPCStatusRejected
 	}
@@ -177,6 +201,10 @@ func conversationRPCErrorForStatus(status string) error {
 		return conversationusecase.ErrRouteNotReady
 	case conversationRPCStatusCachePressure:
 		return conversationusecase.ErrCachePressure
+	case conversationRPCStatusCanceled:
+		return context.Canceled
+	case conversationRPCStatusDeadline:
+		return context.DeadlineExceeded
 	case conversationRPCStatusRejected:
 		return fmt.Errorf("internal/access/node: conversation authority rpc rejected")
 	default:

--- a/internal/access/node/conversation_rpc_test.go
+++ b/internal/access/node/conversation_rpc_test.go
@@ -124,6 +124,39 @@ func TestConversationAuthorityRPCDispatchesAdmitActiveBatch(t *testing.T) {
 	}
 }
 
+func TestConversationAuthorityRPCDispatchesHideConversations(t *testing.T) {
+	target := testConversationAuthorityTarget()
+	deletes := []metadb.ConversationDelete{
+		{UID: "u2", Kind: metadb.ConversationKindCMD, ChannelID: "g2____cmd", ChannelType: 3, DeletedToSeq: 19, UpdatedAt: 102},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9, UpdatedAt: 101},
+	}
+	local := &fakeConversationAuthority{hideErr: conversationusecase.ErrStaleRoute}
+	adapter := New(Options{ConversationAuthority: local})
+	body, err := encodeConversationAuthorityRequest(conversationAuthorityRequest{
+		Op:      conversationOpHideConversations,
+		Target:  target,
+		Kind:    metadb.ConversationKindNormal,
+		Deletes: deletes,
+	})
+	if err != nil {
+		t.Fatalf("encode hide request: %v", err)
+	}
+	respBody, err := adapter.HandleConversationAuthorityRPC(context.Background(), body)
+	if err != nil {
+		t.Fatalf("HandleConversationAuthorityRPC(hide) error = %v", err)
+	}
+	resp, err := decodeConversationAuthorityResponse(respBody)
+	if err != nil {
+		t.Fatalf("decode hide response: %v", err)
+	}
+	if resp.Status != conversationRPCStatusStaleRoute {
+		t.Fatalf("hide status = %q, want %q", resp.Status, conversationRPCStatusStaleRoute)
+	}
+	if local.hideTarget != target || !reflect.DeepEqual(local.deletes, deletes) {
+		t.Fatalf("hide target/deletes = %#v/%#v, want %#v/%#v", local.hideTarget, local.deletes, target, deletes)
+	}
+}
+
 func TestConversationAuthorityClientCallsExpectedServiceAndMapsStatus(t *testing.T) {
 	target := testConversationAuthorityTarget()
 	after := metadb.ConversationActiveCursor{ActiveAt: 99, ChannelID: "g0____cmd", ChannelType: 2}
@@ -191,6 +224,66 @@ func TestConversationAuthorityClientAdmitActiveBatchMapsStatus(t *testing.T) {
 	}
 }
 
+func TestConversationAuthorityClientHideConversationsMapsStatus(t *testing.T) {
+	target := testConversationAuthorityTarget()
+	deletes := []metadb.ConversationDelete{
+		{UID: "u2", Kind: metadb.ConversationKindCMD, ChannelID: "g2____cmd", ChannelType: 3, DeletedToSeq: 19, UpdatedAt: 102},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9, UpdatedAt: 101},
+	}
+	node := &fakeConversationRPCNode{response: conversationAuthorityResponse{Status: conversationRPCStatusRouteNotReady}}
+	client := NewClient(node)
+
+	err := client.HideConversations(context.Background(), 13, target, deletes)
+	if !errors.Is(err, conversationusecase.ErrRouteNotReady) {
+		t.Fatalf("HideConversations() error = %v, want ErrRouteNotReady", err)
+	}
+	if node.nodeID != 13 || node.serviceID != ConversationAuthorityRPCServiceID {
+		t.Fatalf("rpc target = node %d service %d, want node 13 service %d", node.nodeID, node.serviceID, ConversationAuthorityRPCServiceID)
+	}
+	req, err := decodeConversationAuthorityRequest(node.payload)
+	if err != nil {
+		t.Fatalf("decodeConversationAuthorityRequest(client hide payload) error = %v", err)
+	}
+	if req.Op != conversationOpHideConversations || req.Target != target || !reflect.DeepEqual(req.Deletes, deletes) {
+		t.Fatalf("client hide request = %#v, want target %#v deletes %#v", req, target, deletes)
+	}
+}
+
+func TestConversationAuthorityClientRejectsOversizedHideCollectionBeforeTransport(t *testing.T) {
+	deletes := make([]metadb.ConversationDelete, maxConversationAuthorityCollectionLen+1)
+	node := &fakeConversationRPCNode{response: conversationAuthorityResponse{Status: conversationRPCStatusOK}}
+	err := NewClient(node).HideConversations(context.Background(), 13, testConversationAuthorityTarget(), deletes)
+	if err == nil {
+		t.Fatal("HideConversations() error = nil, want collection limit error")
+	}
+	if len(node.payloads) != 0 {
+		t.Fatalf("rpc payload count = %d, want 0", len(node.payloads))
+	}
+}
+
+func TestConversationAuthorityClientAcceptsMaximumHideCollection(t *testing.T) {
+	deletes := make([]metadb.ConversationDelete, maxConversationAuthorityCollectionLen)
+	for i := range deletes {
+		deletes[i] = metadb.ConversationDelete{
+			UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: uint64(i + 1), UpdatedAt: int64(i + 1),
+		}
+	}
+	node := &fakeConversationRPCNode{response: conversationAuthorityResponse{Status: conversationRPCStatusOK}}
+	if err := NewClient(node).HideConversations(context.Background(), 13, testConversationAuthorityTarget(), deletes); err != nil {
+		t.Fatalf("HideConversations() error = %v", err)
+	}
+	if len(node.payloads) != 1 {
+		t.Fatalf("rpc payload count = %d, want 1", len(node.payloads))
+	}
+	req, err := decodeConversationAuthorityRequest(node.payload)
+	if err != nil {
+		t.Fatalf("decodeConversationAuthorityRequest(maximum hide payload) error = %v", err)
+	}
+	if !reflect.DeepEqual(req.Deletes, deletes) {
+		t.Fatalf("decoded delete count/content mismatch: got %d entries, want %d", len(req.Deletes), len(deletes))
+	}
+}
+
 func TestConversationAuthorityClientChunksOversizedAdmitPayloads(t *testing.T) {
 	target := testConversationAuthorityTarget()
 	patches := make([]conversationusecase.ActivePatch, maxConversationAuthorityCollectionLen+1)
@@ -240,6 +333,12 @@ func TestConversationAuthorityClientRejectsNilNodeAndUnknownStatus(t *testing.T)
 			},
 		},
 		{
+			name: "hide",
+			call: func(client *Client) error {
+				return client.HideConversations(context.Background(), 13, target, nil)
+			},
+		},
+		{
 			name: "list",
 			call: func(client *Client) error {
 				_, err := client.ListConversations(context.Background(), 13, target, metadb.ConversationKindCMD, "u1", metadb.ConversationActiveCursor{}, 10)
@@ -285,6 +384,8 @@ func TestConversationAuthorityRPCStatusMapping(t *testing.T) {
 		{name: "stale route", err: conversationusecase.ErrStaleRoute, status: conversationRPCStatusStaleRoute},
 		{name: "route not ready", err: conversationusecase.ErrRouteNotReady, status: conversationRPCStatusRouteNotReady},
 		{name: "cache pressure", err: conversationusecase.ErrCachePressure, status: conversationRPCStatusCachePressure},
+		{name: "context canceled", err: context.Canceled, status: conversationRPCStatusCanceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, status: conversationRPCStatusDeadline},
 		{name: "rejected", err: errors.New("boom"), status: conversationRPCStatusRejected},
 	}
 	for _, tt := range tests {
@@ -310,12 +411,15 @@ type fakeConversationAuthority struct {
 	target       conversationusecase.RouteTarget
 	admitTarget  conversationusecase.RouteTarget
 	activeTarget conversationusecase.RouteTarget
+	hideTarget   conversationusecase.RouteTarget
 	drainTarget  conversationusecase.RouteTarget
 	patches      []conversationusecase.ActivePatch
 	activeBatch  conversationactive.ActiveBatch
+	deletes      []metadb.ConversationDelete
 	page         conversationusecase.ActiveViewPage
 	drainResult  string
 	listKind     metadb.ConversationKind
+	hideErr      error
 }
 
 func testConversationAuthorityTarget() conversationusecase.RouteTarget {
@@ -340,6 +444,12 @@ func (f *fakeConversationAuthority) AdmitActiveBatch(_ context.Context, target c
 	f.activeTarget = target
 	f.activeBatch = batch
 	return nil
+}
+
+func (f *fakeConversationAuthority) HideConversationsForTarget(_ context.Context, target conversationusecase.RouteTarget, deletes []metadb.ConversationDelete) error {
+	f.hideTarget = target
+	f.deletes = append([]metadb.ConversationDelete(nil), deletes...)
+	return f.hideErr
 }
 
 func (f *fakeConversationAuthority) ListConversationActiveViewForTarget(_ context.Context, target conversationusecase.RouteTarget, kind metadb.ConversationKind, _ string, _ metadb.ConversationActiveCursor, _ int) (conversationusecase.ActiveViewPage, error) {

--- a/internal/access/node/presence_rpc.go
+++ b/internal/access/node/presence_rpc.go
@@ -77,11 +77,13 @@ type DeliveryFanoutRunner interface {
 	RunTask(context.Context, runtimedelivery.FanoutTask) error
 }
 
-// ConversationAuthority handles UID-owned conversation active cache requests.
+// ConversationAuthority handles UID-owned conversation active cache and durable hide requests.
 type ConversationAuthority interface {
 	AdmitPatches(context.Context, conversationusecase.RouteTarget, []conversationusecase.ActivePatch) error
 	// AdmitActiveBatch admits one already-routed channelappend active batch at the target authority.
 	AdmitActiveBatch(context.Context, conversationusecase.RouteTarget, conversationactive.ActiveBatch) error
+	// HideConversationsForTarget applies exact hide mutations at one fenced UID authority target.
+	HideConversationsForTarget(context.Context, conversationusecase.RouteTarget, []metadb.ConversationDelete) error
 	ListConversationActiveViewForTarget(context.Context, conversationusecase.RouteTarget, metadb.ConversationKind, string, metadb.ConversationActiveCursor, int) (conversationusecase.ActiveViewPage, error)
 	DrainAuthority(context.Context, conversationusecase.RouteTarget) (string, error)
 }

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -129,8 +129,8 @@ New(Config)
        runtime/conversationactive.Manager plus one routed
        ConversationAuthorityClient, register the conversation authority RPC
        adapter, create the route-authority lifecycle, and use that client as
-       the conversation list Store while keeping the read adapter as Messages,
-       durable state reads, read-cursor writes, and delete-barrier writes
+       the conversation list and delete Store while keeping the read adapter as
+       Messages, durable state reads, and read-cursor writes
   -> when the cluster exposes cluster Slot metadata subscriber APIs, create
      a delivery metadata adapter backed by real storage for bench setup,
      channelappend subscriber scans, and optional delivery fanout
@@ -621,6 +621,26 @@ normalize zero conversation kinds. It trusts the cluster-routed client to send
 `SenderUID` only to the sender-owned authority target; non-sender recipient
 targets arrive with an empty sender field.
 
+Conversation delete with authority enabled:
+
+```text
+DeleteConversation
+  -> ConversationAuthorityClient groups deletes by UID and resolves a fresh exact target
+  -> local or access/node RPC authority HideConversationsForTarget
+  -> durable HideConversationsBatch advances deleted_to_seq and clears active_at
+  -> runtime/conversationactive.Manager reconciles cached MessageSeq against the barrier
+  -> authority revalidates the exact target before returning success
+```
+
+Rows at or below the delete barrier are removed from cache. A concurrently
+observed newer message stays visible and becomes dirty against the cleared
+durable baseline. A successful store call applies those confirmed barriers to
+cache. A multi-proposal store error can have an unknown committed prefix, so it
+only invalidates every requested durable baseline and forces present rows dirty;
+it never removes an unconfirmed tail. Later durable hydration fences the
+committed prefix, while the routed client retries the monotonic barrier when the
+error is retryable.
+
 Legacy user management requests flow from internal HTTP through
 `internal/usecase/user` and the `internal/infra/cluster`
 `UserMetadataStore` adapter to `pkg/cluster.Node` Slot metadata facades.
@@ -648,6 +668,11 @@ touch patches through the conversation active flush worker or handoff drain.
 Cache pressure only sends a nonblocking wakeup to that worker; admission never
 performs durable I/O. The app conversation authority keeps route target fencing,
 lifecycle handoff, observer mapping, and usecase/RPC type adaptation.
+Authority activation and final drain keep the exact clean-slot purge atomic
+with target publish/fencing under the authority mutex. The purge mutates only
+cache state in that critical section; aggregate cache observers run after the
+target state is published and the authority mutex is released, so observer
+callbacks may safely re-enter authority reads.
 Aggregate admission cache snapshots are coalesced to a 100ms interval in the
 production authority wiring; pressure transitions and flush completion still
 publish immediate snapshots, while mutation counters remain unsampled.
@@ -832,6 +857,9 @@ periodic tick or coalesced cache-pressure wakeup
      cleared; a zero-progress attempt waits for the next periodic tick
 
 cache admission
+  -> keep the latest receiver activity visible in cache while suppressing only
+     its durable dirty work against a separately tracked clean ActiveAt baseline
+     strictly inside AuthorityActiveCooldown
   -> at 80% total occupancy with dirty rows above the 70% low watermark, start
      one pressure cycle
   -> if clean-row eviction cannot satisfy the hard cache bound, reject
@@ -859,6 +887,7 @@ cluster.RouteAuthorityEvent
   -> ignore stale events by hash-slot route revision, Slot config epoch, Slot leader term, and diagnostic authority epoch tie-break
   -> if local node becomes authority:
        mark the exact conversation authority target active
+       purge clean rows for that hash slot before reusing its cache baseline
   -> if leader becomes unknown:
        drain the previous local or warming target with AuthorityHandoffTimeout
        mark the no-leader target warming
@@ -872,7 +901,13 @@ through the routed `ConversationAuthorityClient`. The watcher only maintains
 local cache/list readiness for targets that this node can serve. Handoff drains
 only dirty runtime rows indexed under the previous target's UID hash slot, using
 `AuthorityFlushBatchRows` per iteration until the target is clean or
-`AuthorityHandoffTimeout` expires. Dirty rows for other hash slots stay owned by
+`AuthorityHandoffTimeout` expires. A successful drain then purges clean rows for
+that hash slot; activation also purges any clean rows retained from an older
+leader tenure, so a stale durable baseline is never reused after leadership
+returns. Every drain iteration and its final purge revalidate the exact draining
+target. If a newer local tenure has replaced it, the obsolete drain returns
+`transferred` without purging or continuing through the new tenure. Dirty rows
+for other hash slots stay owned by
 their current authorities and are left for their own scoped drains or the normal
 conversation active flush worker. The lifecycle also periodically pulls current
 authorities from the same initial route source so missed watch events and startup

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7339,6 +7339,34 @@ func (s *appRecordingConversationAuthorityStore) TouchConversationActiveAtBatch(
 	return nil
 }
 
+func (s *appRecordingConversationAuthorityStore) HideConversationsBatch(ctx context.Context, deletes []metadb.ConversationDelete) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.rows == nil {
+		s.rows = make(map[metadb.ConversationKey]metadb.ConversationState)
+	}
+	for _, req := range deletes {
+		key := metadb.ConversationKey{ChannelID: req.ChannelID, ChannelType: req.ChannelType}
+		row := s.rows[key]
+		if row.UID == "" {
+			row = metadb.ConversationState{UID: req.UID, Kind: req.Kind, ChannelID: req.ChannelID, ChannelType: req.ChannelType}
+		}
+		if req.DeletedToSeq <= row.DeletedToSeq {
+			continue
+		}
+		row.DeletedToSeq = req.DeletedToSeq
+		row.ActiveAt = 0
+		if req.UpdatedAt > row.UpdatedAt {
+			row.UpdatedAt = req.UpdatedAt
+		}
+		s.rows[key] = row
+	}
+	return nil
+}
+
 func (s *appRecordingConversationAuthorityStore) UpsertConversationStatesBatch(ctx context.Context, states []metadb.ConversationState) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -7900,6 +7928,10 @@ func (f *fakeConversationFallbackCluster) UpsertConversationStatesBatch(_ contex
 
 func (f *fakeConversationFallbackCluster) TouchConversationActiveAtBatch(context.Context, []metadb.ConversationActivePatch) error {
 	return errors.New("unexpected authority active patch fallback write")
+}
+
+func (f *fakeConversationFallbackCluster) HideConversationsBatch(context.Context, []metadb.ConversationDelete) error {
+	return errors.New("unexpected authority conversation hide fallback write")
 }
 
 func (f *fakeConversationFallbackCluster) ListChannelSubscribersPage(_ context.Context, channelID string, _ int64, afterUID string, limit int) ([]string, string, bool, error) {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -330,7 +330,7 @@ type ConversationConfig struct {
 	AuthorityListDBWindowMax int
 	// AuthorityHandoffTimeout bounds how long a new authority waits for old-authority drain before explicit abandon.
 	AuthorityHandoffTimeout time.Duration
-	// AuthorityActiveCooldown skips receiver-only active_at flushes newer than the durable row by less than this duration.
+	// AuthorityActiveCooldown coalesces receiver-only active_at persistence while the authority cache keeps the latest activity visible.
 	AuthorityActiveCooldown time.Duration
 	// AuthorityFlushInterval controls how often dirty authority active rows are flushed to durable storage.
 	AuthorityFlushInterval time.Duration

--- a/internal/app/conversation_authority.go
+++ b/internal/app/conversation_authority.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/WuKongIM/WuKongIM/internal/runtime/conversationactive"
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
+	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/propose"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
 
@@ -22,6 +24,9 @@ type conversationAuthorityStore interface {
 	// TouchConversationActiveAtBatch flushes activity hints across bounded Slot proposals.
 	// An error does not prove that no earlier proposal committed, so callers must retain the full batch for idempotent retry.
 	TouchConversationActiveAtBatch(context.Context, []metadb.ConversationActivePatch) error
+	// HideConversationsBatch durably advances UID-owned delete barriers through Slot ownership.
+	// An error does not prove that no earlier proposal committed.
+	HideConversationsBatch(context.Context, []metadb.ConversationDelete) error
 }
 
 type conversationAuthorityOptions struct {
@@ -39,7 +44,7 @@ type conversationAuthorityOptions struct {
 	AdmissionBatchRows int
 	// AdmissionConcurrency mirrors routed-client admission config and is retained for config compatibility.
 	AdmissionConcurrency int
-	// ActiveCooldown skips receiver-only active_at flushes newer than the durable row by less than this duration.
+	// ActiveCooldown coalesces receiver-only active_at persistence while the authority cache keeps the latest activity visible.
 	ActiveCooldown time.Duration
 	// FlushBatchRows bounds dirty rows per periodic, pressure-woken, and authority handoff flush attempt.
 	FlushBatchRows int
@@ -224,9 +229,24 @@ func newConversationAuthority(opts conversationAuthorityOptions) *conversationAu
 
 // markActive marks a fenced target ready for local cache admission and list reads.
 func (a *conversationAuthority) markActive(target conversationusecase.RouteTarget) {
+	if a == nil {
+		return
+	}
+	key := targetKey(target)
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.setTargetStateLocked(targetKey(target), conversationAuthorityActive)
+	alreadyActive := a.targets[key] == conversationAuthorityActive
+	// Purge stale clean rows before publishing the target as active. Publishing
+	// first would allow a concurrent cooldown-suppressed admission to refresh a
+	// clean row that the subsequent purge could then discard.
+	purged := 0
+	if !alreadyActive && a.active != nil {
+		purged = a.active.PurgeCleanHashSlotStateOnly(target.HashSlot)
+	}
+	a.setTargetStateLocked(key, conversationAuthorityActive)
+	a.mu.Unlock()
+	if purged > 0 {
+		a.active.ObserveCacheState()
+	}
 }
 
 // markWarming marks a target as not yet safe to serve active-view reads.
@@ -290,6 +310,61 @@ func (a *conversationAuthority) AdmitActiveBatch(ctx context.Context, target con
 	return err
 }
 
+// HideConversationsForTarget persists delete barriers through the exact local
+// authority and then reconciles the corresponding cache rows before success.
+func (a *conversationAuthority) HideConversationsForTarget(ctx context.Context, target conversationusecase.RouteTarget, deletes []metadb.ConversationDelete) (err error) {
+	if a == nil {
+		return conversationusecase.ErrRouteNotReady
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err = validateConversationDeletes(deletes); err != nil {
+		return err
+	}
+	if len(deletes) == 0 {
+		return nil
+	}
+	if a.store == nil {
+		return conversationusecase.ErrRouteNotReady
+	}
+	if err = a.ensureTarget(target); err != nil {
+		return err
+	}
+
+	deletes = append([]metadb.ConversationDelete(nil), deletes...)
+	err = mapConversationActiveError(a.store.HideConversationsBatch(ctx, deletes))
+	if err != nil {
+		// A bounded multi-proposal error can have an unknown committed prefix.
+		// Invalidate every requested baseline without treating an unconfirmed
+		// tail as deleted; durable hydration decides which barriers committed.
+		a.active.InvalidateConversationDeleteAttempts(deletes)
+		return err
+	}
+	a.active.ApplyConversationDeletes(deletes)
+	a.mu.Lock()
+	err = a.ensureTargetKeyLocked(targetKey(target))
+	a.mu.Unlock()
+	return err
+}
+
+func validateConversationDeletes(deletes []metadb.ConversationDelete) error {
+	var uid string
+	for _, req := range deletes {
+		if req.UID == "" || req.ChannelID == "" || req.ChannelType <= 0 || req.ChannelType > 255 || req.DeletedToSeq == 0 || !validConversationKind(req.Kind) {
+			return fmt.Errorf("internal/app: invalid conversation delete")
+		}
+		if uid == "" {
+			uid = req.UID
+			continue
+		}
+		if req.UID != uid {
+			return fmt.Errorf("internal/app: conversation deletes span multiple UIDs")
+		}
+	}
+	return nil
+}
+
 func (a *conversationAuthority) ensureTargetLocked(target conversationusecase.RouteTarget) error {
 	return a.ensureTargetKeyLocked(targetKey(target))
 }
@@ -308,16 +383,28 @@ func (a *conversationAuthority) ensureTarget(target conversationusecase.RouteTar
 	if !errors.Is(err, conversationusecase.ErrStaleRoute) || !a.canLazyActivateTarget(target) {
 		return err
 	}
-	current, ok := a.currentRouteTarget(target.HashSlot)
-	if !ok || targetKey(current) != key {
-		return err
-	}
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if err := a.ensureTargetKeyLocked(key); err == nil {
+		a.mu.Unlock()
 		return nil
 	}
+	// Re-read the authoritative route only after serializing with lifecycle
+	// marks. Otherwise a newer markActive can win between the route lookup and
+	// this lazy activation, only to be overwritten by the stale target.
+	current, ok := a.currentRouteTarget(target.HashSlot)
+	if !ok || targetKey(current) != key {
+		a.mu.Unlock()
+		return err
+	}
+	purged := 0
+	if a.active != nil {
+		purged = a.active.PurgeCleanHashSlotStateOnly(target.HashSlot)
+	}
 	a.setTargetStateLocked(key, conversationAuthorityActive)
+	a.mu.Unlock()
+	if purged > 0 {
+		a.active.ObserveCacheState()
+	}
 	return nil
 }
 
@@ -395,7 +482,7 @@ func (a *conversationAuthority) DrainAuthority(ctx context.Context, target conve
 	if err != nil {
 		return result, err
 	}
-	return a.flushDrainingAuthority(ctx, target.HashSlot)
+	return a.flushDrainingAuthority(ctx, target)
 }
 
 func (a *conversationAuthority) beginDrainAuthority(target conversationusecase.RouteTarget) (conversationDrainResult, error) {
@@ -423,20 +510,43 @@ func (a *conversationAuthority) finishDrainingAuthority(ctx context.Context, tar
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return a.flushDrainingAuthority(ctx, target.HashSlot)
+	return a.flushDrainingAuthority(ctx, target)
 }
 
-func (a *conversationAuthority) flushDrainingAuthority(ctx context.Context, hashSlot uint16) (conversationDrainResult, error) {
+func (a *conversationAuthority) flushDrainingAuthority(ctx context.Context, target conversationusecase.RouteTarget) (conversationDrainResult, error) {
+	targetKey := targetKey(target)
 	selected := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return conversationDrainResultBusy, err
 		}
-		flush, flushErr := a.active.FlushHashSlot(ctx, hashSlot, a.flushBatchRows)
+		if err := a.ensureDrainingTarget(targetKey); err != nil {
+			if errors.Is(err, conversationusecase.ErrStaleRoute) {
+				return conversationDrainResultTransferred, nil
+			}
+			return conversationDrainResultBusy, err
+		}
+		flush, flushErr := a.active.FlushHashSlot(ctx, target.HashSlot, a.flushBatchRows)
 		if flushErr != nil {
 			return conversationDrainResultBusy, mapConversationActiveError(flushErr)
 		}
 		if flush.Selected == 0 {
+			// Keep the exact draining-target check and clean purge atomic with
+			// respect to markActive. An obsolete drain must never purge rows
+			// admitted by a newer local authority tenure for the same hash slot.
+			a.mu.Lock()
+			if err := a.ensureDrainingTargetKeyLocked(targetKey); err != nil {
+				a.mu.Unlock()
+				if errors.Is(err, conversationusecase.ErrStaleRoute) {
+					return conversationDrainResultTransferred, nil
+				}
+				return conversationDrainResultBusy, err
+			}
+			purged := a.active.PurgeCleanHashSlotStateOnly(target.HashSlot)
+			a.mu.Unlock()
+			if purged > 0 {
+				a.active.ObserveCacheState()
+			}
 			if selected == 0 {
 				return conversationDrainResultNoDirty, nil
 			}
@@ -444,6 +554,22 @@ func (a *conversationAuthority) flushDrainingAuthority(ctx context.Context, hash
 		}
 		selected += flush.Selected
 	}
+}
+
+func (a *conversationAuthority) ensureDrainingTarget(target conversationAuthorityTargetKey) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.ensureDrainingTargetKeyLocked(target)
+}
+
+func (a *conversationAuthority) ensureDrainingTargetKeyLocked(target conversationAuthorityTargetKey) error {
+	if target.leaderNodeID != 0 && target.leaderNodeID != a.localNodeID {
+		return conversationusecase.ErrNotLeader
+	}
+	if a.targets[target] != conversationAuthorityDraining {
+		return conversationusecase.ErrStaleRoute
+	}
+	return nil
 }
 
 // ListConversationActiveView is a conservative test/backward adapter for unscoped reads.
@@ -561,6 +687,7 @@ func conversationActivePatches(patches []conversationusecase.ActivePatch) ([]con
 			ChannelType: uint8(patch.ChannelType),
 			ActiveAtMS:  patch.ActiveAt,
 			ReadSeq:     patch.ReadSeq,
+			MessageSeq:  patch.MessageSeq,
 		})
 	}
 	return activePatches, nil
@@ -580,6 +707,11 @@ func mapConversationActiveError(err error) error {
 		return nil
 	}
 	switch {
+	case errors.Is(err, clusterpkg.ErrNotLeader), errors.Is(err, propose.ErrNotLeader):
+		return fmt.Errorf("%w: %w", conversationusecase.ErrNotLeader, err)
+	case errors.Is(err, clusterpkg.ErrRouteNotReady), errors.Is(err, clusterpkg.ErrNoSlotLeader),
+		errors.Is(err, propose.ErrProposalBackpressure), errors.Is(err, propose.ErrBackgroundProposalThrottled):
+		return fmt.Errorf("%w: %w", conversationusecase.ErrRouteNotReady, err)
 	case errors.Is(err, conversationactive.ErrCachePressure):
 		return conversationusecase.ErrCachePressure
 	case errors.Is(err, conversationactive.ErrStoreRequired):

--- a/internal/app/conversation_authority_test.go
+++ b/internal/app/conversation_authority_test.go
@@ -9,6 +9,7 @@ import (
 	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/conversationactive"
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster/propose"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
 
@@ -414,8 +415,8 @@ func TestConversationAuthorityFlushPersistsRuntimeReadFloor(t *testing.T) {
 	if err := authority.Flush(context.Background()); err != nil {
 		t.Fatalf("Flush() error = %v", err)
 	}
-	if len(store.touched) != 1 || store.touched[0].ReadSeq != 8 || store.touched[0].DeletedToSeq != 0 || store.touched[0].MessageSeq != 0 {
-		t.Fatalf("durable patches = %#v, want flushed runtime read floor only", store.touched)
+	if len(store.touched) != 1 || store.touched[0].ReadSeq != 8 || store.touched[0].DeletedToSeq != 0 || store.touched[0].MessageSeq != 9 {
+		t.Fatalf("durable patches = %#v, want flushed runtime read floor and message fence", store.touched)
 	}
 	page, err := authority.ListConversationActiveViewForTarget(context.Background(), target, metadb.ConversationKindNormal, "u1", metadb.ConversationActiveCursor{}, 10)
 	if err != nil {
@@ -426,7 +427,257 @@ func TestConversationAuthorityFlushPersistsRuntimeReadFloor(t *testing.T) {
 	}
 }
 
-func TestConversationAuthorityCacheOnlyRowHydratesPrimaryDeleteBarrier(t *testing.T) {
+func TestConversationAuthorityHideReconcilesCooldownCacheAndAllowsNewerMessage(t *testing.T) {
+	const baselineActiveAt int64 = 1_000
+	key := metadb.ConversationKey{ChannelID: "room", ChannelType: 2}
+	baseline := metadb.ConversationState{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: key.ChannelID, ChannelType: key.ChannelType, ActiveAt: baselineActiveAt}
+	store := &recordingConversationAuthorityStore{
+		activeRows: []metadb.ConversationState{baseline},
+		primary:    map[metadb.ConversationKey]metadb.ConversationState{key: baseline},
+	}
+	authority := newConversationAuthority(conversationAuthorityOptions{
+		LocalNodeID:    1,
+		Store:          store,
+		MaxRows:        100,
+		ActiveCooldown: 2 * time.Hour,
+	})
+	target := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	authority.markActive(target)
+	insideCooldown := baselineActiveAt + int64(time.Hour/time.Millisecond)
+	if err := authority.AdmitActiveBatch(context.Background(), target, conversationactive.ActiveBatch{
+		Kind: metadb.ConversationKindNormal, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType), MessageSeq: 9, ActiveAtMS: insideCooldown,
+		Recipients: []conversationactive.ActiveEntry{{UID: "u1"}},
+	}); err != nil {
+		t.Fatalf("AdmitActiveBatch(before hide) error = %v", err)
+	}
+	if result, err := authority.FlushActiveRows(context.Background(), 0); err != nil || result.Skipped != 1 || result.Cleared != 1 {
+		t.Fatalf("FlushActiveRows(before hide) = %+v, %v, want cooldown skip", result, err)
+	}
+
+	deleteReq := metadb.ConversationDelete{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: key.ChannelID, ChannelType: key.ChannelType, DeletedToSeq: 9, UpdatedAt: 200}
+	if err := authority.HideConversationsForTarget(context.Background(), target, []metadb.ConversationDelete{deleteReq}); err != nil {
+		t.Fatalf("HideConversationsForTarget() error = %v", err)
+	}
+	page, err := authority.ListConversationActiveViewForTarget(context.Background(), target, metadb.ConversationKindNormal, "u1", metadb.ConversationActiveCursor{}, 10)
+	if err != nil {
+		t.Fatalf("ListConversationActiveViewForTarget(after hide) error = %v", err)
+	}
+	if len(page.Rows) != 0 {
+		t.Fatalf("rows after hide = %#v, want hidden conversation", page.Rows)
+	}
+
+	newActiveAt := baselineActiveAt + int64(90*time.Minute/time.Millisecond)
+	if err := authority.AdmitActiveBatch(context.Background(), target, conversationactive.ActiveBatch{
+		Kind: metadb.ConversationKindNormal, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType), MessageSeq: 10, ActiveAtMS: newActiveAt,
+		Recipients: []conversationactive.ActiveEntry{{UID: "u1"}},
+	}); err != nil {
+		t.Fatalf("AdmitActiveBatch(after hide) error = %v", err)
+	}
+	if result, err := authority.FlushActiveRows(context.Background(), 0); err != nil || result.Persisted != 1 || result.Cleared != 1 {
+		t.Fatalf("FlushActiveRows(after hide) = %+v, %v, want newer message persisted", result, err)
+	}
+	state := store.primary[key]
+	if state.ActiveAt != newActiveAt || state.DeletedToSeq != 9 {
+		t.Fatalf("durable state = %+v, want newer activity above delete barrier", state)
+	}
+}
+
+func TestConversationAuthorityHideReturnsStaleAfterAuthorityMoves(t *testing.T) {
+	store := &recordingConversationAuthorityStore{}
+	authority := newConversationAuthority(conversationAuthorityOptions{LocalNodeID: 1, Store: store, MaxRows: 100})
+	oldTarget := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	freshTarget := oldTarget
+	freshTarget.LeaderTerm++
+	freshTarget.RouteRevision++
+	authority.markActive(oldTarget)
+	store.beforeHide = func() { authority.markActive(freshTarget) }
+
+	err := authority.HideConversationsForTarget(context.Background(), oldTarget, []metadb.ConversationDelete{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2, DeletedToSeq: 9,
+	}})
+	if !errors.Is(err, conversationusecase.ErrStaleRoute) {
+		t.Fatalf("HideConversationsForTarget() error = %v, want ErrStaleRoute", err)
+	}
+	if len(store.hidden) != 1 {
+		t.Fatalf("durable hides = %#v, want committed idempotent barrier before stale retry", store.hidden)
+	}
+}
+
+func TestConversationAuthorityHideMapsProposalNotLeader(t *testing.T) {
+	store := &recordingConversationAuthorityStore{hideErr: propose.ErrNotLeader}
+	authority := newConversationAuthority(conversationAuthorityOptions{LocalNodeID: 1, Store: store, MaxRows: 100})
+	target := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	authority.markActive(target)
+
+	err := authority.HideConversationsForTarget(context.Background(), target, []metadb.ConversationDelete{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2, DeletedToSeq: 9,
+	}})
+	if !errors.Is(err, conversationusecase.ErrNotLeader) {
+		t.Fatalf("HideConversationsForTarget() error = %v, want ErrNotLeader", err)
+	}
+}
+
+func TestConversationAuthorityHideErrorPreservesUncommittedTail(t *testing.T) {
+	store := &recordingConversationAuthorityStore{}
+	authority := newConversationAuthority(conversationAuthorityOptions{LocalNodeID: 1, Store: store, MaxRows: 100})
+	target := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	authority.markActive(target)
+	patches := []conversationusecase.ActivePatch{
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "committed-prefix", ChannelType: 2, ActiveAt: 1_000, MessageSeq: 10},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "uncommitted-tail", ChannelType: 2, ActiveAt: 2_000, MessageSeq: 20},
+	}
+	if err := authority.AdmitPatches(context.Background(), target, patches); err != nil {
+		t.Fatalf("AdmitPatches() error = %v", err)
+	}
+	if err := authority.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	prefixKey := metadb.ConversationKey{ChannelID: "committed-prefix", ChannelType: 2}
+	tailKey := metadb.ConversationKey{ChannelID: "uncommitted-tail", ChannelType: 2}
+	store.beforeHide = func() {
+		prefix := store.primary[prefixKey]
+		prefix.DeletedToSeq = 10
+		prefix.ActiveAt = 0
+		store.primary[prefixKey] = prefix
+		store.activeRows = []metadb.ConversationState{store.primary[tailKey]}
+	}
+	store.hideErr = context.DeadlineExceeded
+	deletes := []metadb.ConversationDelete{
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: prefixKey.ChannelID, ChannelType: prefixKey.ChannelType, DeletedToSeq: 10},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: tailKey.ChannelID, ChannelType: tailKey.ChannelType, DeletedToSeq: 20},
+	}
+
+	err := authority.HideConversationsForTarget(context.Background(), target, deletes)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("HideConversationsForTarget() error = %v, want DeadlineExceeded", err)
+	}
+	for _, channelID := range []string{prefixKey.ChannelID, tailKey.ChannelID} {
+		if _, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", channelID, 2); !ok {
+			t.Fatalf("uncertain delete removed cache row %q before durable reconciliation", channelID)
+		}
+	}
+	if got := authority.active.DirtyCountForTest(); got != 2 {
+		t.Fatalf("dirty rows after unknown-prefix error = %d, want 2", got)
+	}
+
+	page, err := authority.ListConversationActiveViewForTarget(context.Background(), target, metadb.ConversationKindNormal, "u1", metadb.ConversationActiveCursor{}, 10)
+	if err != nil {
+		t.Fatalf("ListConversationActiveViewForTarget() error = %v", err)
+	}
+	if len(page.Rows) != 1 || page.Rows[0].ChannelID != tailKey.ChannelID {
+		t.Fatalf("rows after partial commit = %#v, want only uncommitted tail visible", page.Rows)
+	}
+	if _, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", prefixKey.ChannelID, 2); ok {
+		t.Fatal("durably committed prefix survived hydration fence")
+	}
+	if _, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", tailKey.ChannelID, 2); !ok {
+		t.Fatal("uncommitted tail disappeared after hydration")
+	}
+}
+
+func TestConversationAuthorityHideValidatesBeforeLazyActivation(t *testing.T) {
+	target := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	routeLookups := 0
+	authority := newConversationAuthority(conversationAuthorityOptions{
+		LocalNodeID: 1,
+		Store:       &recordingConversationAuthorityStore{},
+		MaxRows:     100,
+		CurrentRouteTarget: func(uint16) (conversationusecase.RouteTarget, bool) {
+			routeLookups++
+			return target, true
+		},
+	})
+
+	err := authority.HideConversationsForTarget(context.Background(), target, []metadb.ConversationDelete{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 256, DeletedToSeq: 9,
+	}})
+	if err == nil {
+		t.Fatal("HideConversationsForTarget() error = nil, want invalid channel type")
+	}
+	if routeLookups != 0 || len(authority.targets) != 0 {
+		t.Fatalf("invalid hide routeLookups=%d targets=%#v, want no authority mutation", routeLookups, authority.targets)
+	}
+}
+
+func TestConversationAuthorityActivationPurgesFormerCleanRows(t *testing.T) {
+	store := &recordingConversationAuthorityStore{}
+	authority := newConversationAuthority(conversationAuthorityOptions{LocalNodeID: 1, Store: store, MaxRows: 100})
+	oldTarget := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	authority.markActive(oldTarget)
+	if err := authority.AdmitActiveBatch(context.Background(), oldTarget, conversationactive.ActiveBatch{
+		Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2, MessageSeq: 9, ActiveAtMS: 100,
+		Recipients: []conversationactive.ActiveEntry{{UID: "u1"}},
+	}); err != nil {
+		t.Fatalf("AdmitActiveBatch() error = %v", err)
+	}
+	if _, err := authority.FlushActiveRows(context.Background(), 0); err != nil {
+		t.Fatalf("FlushActiveRows() error = %v", err)
+	}
+	if _, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2); !ok {
+		t.Fatal("clean cache row missing before authority refresh")
+	}
+
+	freshTarget := oldTarget
+	freshTarget.LeaderTerm++
+	freshTarget.RouteRevision++
+	authority.markActive(freshTarget)
+	if _, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2); ok {
+		t.Fatal("former clean cache row survived authority activation")
+	}
+}
+
+func TestConversationAuthorityActivationObservesPurgeAfterPublishAndUnlock(t *testing.T) {
+	store := &recordingConversationAuthorityStore{}
+	observer := &reentrantConversationActiveCacheObserver{done: make(chan error, 1)}
+	authority := newConversationAuthority(conversationAuthorityOptions{
+		LocalNodeID: 1,
+		Store:       store,
+		MaxRows:     100,
+		Observer:    observer,
+	})
+	observer.authority = authority
+	oldTarget := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, ConfigEpoch: 4, RouteRevision: 5}
+	authority.markActive(oldTarget)
+	if err := authority.AdmitActiveBatch(context.Background(), oldTarget, conversationactive.ActiveBatch{
+		Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2, MessageSeq: 9, ActiveAtMS: 100,
+		Recipients: []conversationactive.ActiveEntry{{UID: "u1"}},
+	}); err != nil {
+		t.Fatalf("AdmitActiveBatch() error = %v", err)
+	}
+	if _, err := authority.FlushActiveRows(context.Background(), 0); err != nil {
+		t.Fatalf("FlushActiveRows() error = %v", err)
+	}
+
+	freshTarget := oldTarget
+	freshTarget.LeaderTerm++
+	freshTarget.RouteRevision++
+	observer.target = freshTarget
+	observer.reenter = true
+	activated := make(chan struct{})
+	go func() {
+		authority.markActive(freshTarget)
+		close(activated)
+	}()
+
+	select {
+	case <-activated:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("markActive() did not return; cache observer likely ran while authority lock was held")
+	}
+	select {
+	case err := <-observer.done:
+		if err != nil {
+			t.Fatalf("cache observer saw target before active publish: %v", err)
+		}
+	default:
+		t.Fatal("cache observer did not run after clean-row purge")
+	}
+	if _, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2); ok {
+		t.Fatal("former clean cache row survived authority activation")
+	}
+}
+
+func TestConversationAuthorityCacheOnlyRowRespectsPrimaryDeleteBarrier(t *testing.T) {
 	store := &recordingConversationAuthorityStore{
 		primary: map[metadb.ConversationKey]metadb.ConversationState{
 			{ChannelID: "hidden", ChannelType: 2}: {UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "hidden", ChannelType: 2, DeletedToSeq: 10, ActiveAt: 0},
@@ -444,8 +695,8 @@ func TestConversationAuthorityCacheOnlyRowHydratesPrimaryDeleteBarrier(t *testin
 	if err != nil {
 		t.Fatalf("ListConversationActiveView() error = %v", err)
 	}
-	if len(page.Rows) != 1 || page.Rows[0].ChannelID != "hidden" || page.Rows[0].DeletedToSeq != 10 || page.Rows[0].ActiveAt != 300 {
-		t.Fatalf("rows = %#v, want cache row hydrated with durable delete barrier", page.Rows)
+	if len(page.Rows) != 0 {
+		t.Fatalf("rows = %#v, want stale cache activity fenced by durable delete barrier", page.Rows)
 	}
 }
 
@@ -467,8 +718,8 @@ func TestConversationAuthorityDBActiveRowKeepsDeleteBarrierDuringCacheOverlay(t 
 	if err != nil {
 		t.Fatalf("ListConversationActiveViewForTarget() error = %v", err)
 	}
-	if len(page.Rows) != 1 || page.Rows[0].ActiveAt != 300 || page.Rows[0].DeletedToSeq != 10 {
-		t.Fatalf("rows = %#v, want cache active time over durable delete barrier", page.Rows)
+	if len(page.Rows) != 1 || page.Rows[0].ActiveAt != 100 || page.Rows[0].DeletedToSeq != 10 {
+		t.Fatalf("rows = %#v, want durable active row without stale cache overlay", page.Rows)
 	}
 }
 
@@ -577,8 +828,8 @@ func TestConversationAuthorityListHydratesDurableDeleteBarriers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListConversationActiveView() error = %v", err)
 	}
-	if len(page.Rows) != 1 || page.Rows[0].ChannelID != "hidden-a" || page.Rows[0].DeletedToSeq != 10 {
-		t.Fatalf("rows = %#v, want highest runtime row hydrated with durable delete barrier", page.Rows)
+	if len(page.Rows) != 1 || page.Rows[0].ChannelID != "visible" || page.Rows[0].DeletedToSeq != 0 {
+		t.Fatalf("rows = %#v, want stale hidden rows fenced before pagination", page.Rows)
 	}
 }
 
@@ -622,7 +873,7 @@ func TestConversationAuthorityFlushUsesRuntimeTouchPatch(t *testing.T) {
 	if err := authority.Flush(context.Background()); err != nil {
 		t.Fatalf("Flush() error = %v", err)
 	}
-	if len(store.touched) != 1 || store.touched[0].MessageSeq != 0 || store.touched[0].SparseActiveSet {
+	if len(store.touched) != 1 || store.touched[0].MessageSeq != 30 || store.touched[0].SparseActiveSet {
 		t.Fatalf("touched = %#v, want one runtime active touch patch", store.touched)
 	}
 }
@@ -858,6 +1109,59 @@ func TestConversationAuthorityDrainFlushesTargetDirtyRowsBeforeHandoff(t *testin
 	}
 }
 
+func TestConversationAuthorityObsoleteDrainDoesNotPurgeNewTenureCleanRow(t *testing.T) {
+	store := &recordingConversationAuthorityStore{}
+	authority := newConversationAuthority(conversationAuthorityOptions{
+		LocalNodeID:     1,
+		Store:           store,
+		ActiveCooldown:  time.Hour,
+		MaxRowsPerUID:   10,
+		MaxRows:         100,
+		ListDBWindowMax: 20,
+	})
+	oldTarget := conversationusecase.RouteTarget{HashSlot: 1, SlotID: 2, LeaderNodeID: 1, LeaderTerm: 3, RouteRevision: 3, AuthorityEpoch: 4}
+	newTarget := oldTarget
+	newTarget.LeaderTerm = 4
+	newTarget.RouteRevision = 5
+	newTarget.AuthorityEpoch = 6
+	authority.markActive(oldTarget)
+	if _, err := authority.beginDrainAuthority(oldTarget); err != nil {
+		t.Fatalf("beginDrainAuthority(oldTarget) error = %v", err)
+	}
+	authority.markActive(newTarget)
+	if err := authority.AdmitPatches(context.Background(), newTarget, []conversationusecase.ActivePatch{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new-tenure", ChannelType: 2, ActiveAt: 1_000, MessageSeq: 10,
+	}}); err != nil {
+		t.Fatalf("AdmitPatches(newTarget initial) error = %v", err)
+	}
+	if err := authority.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush(newTarget initial) error = %v", err)
+	}
+	if err := authority.AdmitPatches(context.Background(), newTarget, []conversationusecase.ActivePatch{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new-tenure", ChannelType: 2, ActiveAt: 1_100, MessageSeq: 11,
+	}}); err != nil {
+		t.Fatalf("AdmitPatches(newTarget cooldown) error = %v", err)
+	}
+	if got := authority.active.DirtyCountForTest(); got != 0 {
+		t.Fatalf("new-tenure dirty rows = %d, want cooldown-suppressed clean row", got)
+	}
+
+	result, err := authority.finishDrainingAuthority(context.Background(), oldTarget)
+	if err != nil {
+		t.Fatalf("finishDrainingAuthority(oldTarget) error = %v", err)
+	}
+	if result != conversationDrainResultTransferred {
+		t.Fatalf("finishDrainingAuthority(oldTarget) result = %q, want %q", result, conversationDrainResultTransferred)
+	}
+	patch, ok := authority.active.EntryForTest(metadb.ConversationKindNormal, "u1", "new-tenure", 2)
+	if !ok || patch.MessageSeq != 11 || patch.ActiveAtMS != 1_100 {
+		t.Fatalf("new-tenure cache patch = %+v ok=%v, want preserved latest clean view", patch, ok)
+	}
+	if len(store.touched) != 1 {
+		t.Fatalf("durable touches = %#v, want no obsolete-drain touch", store.touched)
+	}
+}
+
 func TestConversationAuthorityDrainFlushesOnlyTargetHashSlot(t *testing.T) {
 	store := &recordingConversationAuthorityStore{}
 	authority := newConversationAuthority(conversationAuthorityOptions{LocalNodeID: 1, Store: store, MaxRowsPerUID: 10, MaxRows: 100, ListDBWindowMax: 20})
@@ -1015,6 +1319,9 @@ type recordingConversationAuthorityStore struct {
 	touched    []metadb.ConversationActivePatch
 	listErr    error
 	beforeList func()
+	beforeHide func()
+	hidden     []metadb.ConversationDelete
+	hideErr    error
 }
 
 func (s *recordingConversationAuthorityStore) ListConversationActivePage(_ context.Context, kind metadb.ConversationKind, uid string, after metadb.ConversationActiveCursor, limit int) ([]metadb.ConversationState, metadb.ConversationActiveCursor, bool, error) {
@@ -1119,6 +1426,47 @@ func (s *recordingConversationAuthorityStore) TouchConversationActiveAtBatch(ctx
 	return nil
 }
 
+func (s *recordingConversationAuthorityStore) HideConversationsBatch(ctx context.Context, deletes []metadb.ConversationDelete) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.beforeHide != nil {
+		s.beforeHide()
+	}
+	s.hidden = append(s.hidden, deletes...)
+	if s.hideErr != nil {
+		return s.hideErr
+	}
+	for _, req := range deletes {
+		key := metadb.ConversationKey{ChannelID: req.ChannelID, ChannelType: req.ChannelType}
+		state := s.primary[key]
+		if state.UID == "" {
+			state = metadb.ConversationState{UID: req.UID, Kind: req.Kind, ChannelID: req.ChannelID, ChannelType: req.ChannelType}
+		}
+		if req.DeletedToSeq <= state.DeletedToSeq {
+			continue
+		}
+		state.DeletedToSeq = req.DeletedToSeq
+		state.ActiveAt = 0
+		if req.UpdatedAt > state.UpdatedAt {
+			state.UpdatedAt = req.UpdatedAt
+		}
+		if s.primary == nil {
+			s.primary = make(map[metadb.ConversationKey]metadb.ConversationState)
+		}
+		s.primary[key] = state
+		filtered := s.activeRows[:0]
+		for _, row := range s.activeRows {
+			if row.UID == req.UID && row.Kind == req.Kind && row.ChannelID == req.ChannelID && row.ChannelType == req.ChannelType {
+				continue
+			}
+			filtered = append(filtered, row)
+		}
+		s.activeRows = filtered
+	}
+	return nil
+}
+
 func (s *recordingConversationAuthorityStore) upsertActiveRow(state metadb.ConversationState) {
 	if s.primary == nil {
 		s.primary = make(map[metadb.ConversationKey]metadb.ConversationState)
@@ -1219,6 +1567,30 @@ type reentrantConversationAuthorityObserver struct {
 	target    conversationusecase.RouteTarget
 	uid       string
 	done      chan error
+}
+
+type reentrantConversationActiveCacheObserver struct {
+	recordingConversationAuthorityObserver
+	authority *conversationAuthority
+	target    conversationusecase.RouteTarget
+	reenter   bool
+	done      chan error
+}
+
+func (o *reentrantConversationActiveCacheObserver) ObserveConversationActiveCache(conversationactive.CacheObservation) {
+	if !o.reenter {
+		return
+	}
+	o.done <- o.authority.ensureTarget(o.target)
+}
+
+func (*reentrantConversationActiveCacheObserver) ObserveConversationActiveMutation(conversationactive.MutationObservation) {
+}
+
+func (*reentrantConversationActiveCacheObserver) ObserveConversationActiveFlush(conversationactive.FlushObservation) {
+}
+
+func (*reentrantConversationActiveCacheObserver) ObserveConversationActivePressure(conversationactive.PressureObservation) {
 }
 
 func (o *reentrantConversationAuthorityObserver) ObserveConversationAuthorityCachePressure(event conversationAuthorityCachePressureEvent) {

--- a/internal/app/observability.go
+++ b/internal/app/observability.go
@@ -510,7 +510,7 @@ func (o conversationAuthorityMetricsObserver) ObserveConversationActiveMutation(
 	if o.metrics == nil || o.metrics.Conversation == nil {
 		return
 	}
-	o.metrics.Conversation.ObserveActiveMutation(event.BecameDirty, event.DirtyUpdated, event.Unchanged)
+	o.metrics.Conversation.ObserveActiveMutation(event.BecameDirty, event.DirtyUpdated, event.CooldownSuppressed, event.Unchanged)
 	o.metrics.Conversation.ObserveActiveMutationLock(event.Result, event.LockWaitDuration, event.LockHoldDuration, event.CacheObservationDuration)
 }
 
@@ -524,6 +524,7 @@ func (o conversationAuthorityMetricsObserver) ObserveConversationActiveFlush(eve
 		Selected:              event.Selected,
 		Persisted:             event.Persisted,
 		Skipped:               event.Skipped,
+		DeleteFenced:          event.DeleteFenced,
 		Cleared:               event.Cleared,
 		VersionConflicts:      event.VersionConflicts,
 		Superseded:            event.Superseded,

--- a/internal/app/observability_test.go
+++ b/internal/app/observability_test.go
@@ -1298,7 +1298,7 @@ func TestObservabilityConversationAuthorityMetricsObserverMapsCounters(t *testin
 		},
 	})
 	observer.ObserveConversationActiveMutation(conversationactive.MutationObservation{
-		Result: "ok", BecameDirty: 3, DirtyUpdated: 2, Unchanged: 1,
+		Result: "ok", BecameDirty: 3, DirtyUpdated: 2, CooldownSuppressed: 4, Unchanged: 1,
 		LockWaitDuration: time.Millisecond, LockHoldDuration: 2 * time.Millisecond,
 		CacheObservationDuration: 3 * time.Millisecond,
 	})
@@ -1307,9 +1307,10 @@ func TestObservabilityConversationAuthorityMetricsObserverMapsCounters(t *testin
 	})
 	observer.ObserveConversationActiveFlush(conversationactive.FlushObservation{
 		Result:                "ok",
-		Selected:              5,
+		Selected:              7,
 		Persisted:             4,
 		Skipped:               1,
+		DeleteFenced:          2,
 		Cleared:               4,
 		VersionConflicts:      1,
 		Requeued:              1,
@@ -1374,9 +1375,18 @@ func TestObservabilityConversationAuthorityMetricsObserverMapsCounters(t *testin
 	if got := findAppMetricByLabels(t, flushRowsTotal, map[string]string{"result": "ok", "stage": "requeued", "reason": "version_conflict"}).GetCounter().GetValue(); got != 1 {
 		t.Fatalf("active flush version-conflict rows metric = %v, want 1", got)
 	}
+	if got := findAppMetricByLabels(t, flushRowsTotal, map[string]string{"result": "ok", "stage": "skipped", "reason": "active_cooldown"}).GetCounter().GetValue(); got != 1 {
+		t.Fatalf("active flush cooldown rows metric = %v, want 1", got)
+	}
+	if got := findAppMetricByLabels(t, flushRowsTotal, map[string]string{"result": "ok", "stage": "skipped", "reason": "delete_barrier"}).GetCounter().GetValue(); got != 2 {
+		t.Fatalf("active flush delete-barrier rows metric = %v, want 2", got)
+	}
 	dirtyMutations := requireAppMetricFamily(t, families, "wukongim_conversation_active_dirty_mutations_total")
 	if got := findAppMetricByLabels(t, dirtyMutations, map[string]string{"event": "became_dirty"}).GetCounter().GetValue(); got != 3 {
 		t.Fatalf("active dirty became metric = %v, want 3", got)
+	}
+	if got := findAppMetricByLabels(t, dirtyMutations, map[string]string{"event": "cooldown_suppressed"}).GetCounter().GetValue(); got != 4 {
+		t.Fatalf("active cooldown suppressed metric = %v, want 4", got)
 	}
 	cacheLock := requireAppMetricFamily(t, families, "wukongim_conversation_active_cache_lock_duration_seconds")
 	if got := findAppMetricByLabels(t, cacheLock, map[string]string{"result": "ok", "phase": "wait"}).GetHistogram().GetSampleCount(); got != 1 {

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -348,14 +348,16 @@ func (a *App) wireConversations(conversationReadStore *clusterinfra.Conversation
 	if a.conversations == nil {
 		if conversationReadStore != nil {
 			var store conversationusecase.Store = conversationReadStore
+			var deleteStore conversationusecase.DeleteStore = conversationReadStore
 			if a.conversationAuthorityClient != nil {
 				store = a.conversationAuthorityClient
+				deleteStore = a.conversationAuthorityClient
 			}
 			a.conversations = conversationusecase.New(conversationusecase.Options{
 				Store:              store,
 				StateStore:         conversationReadStore,
 				StateMutationStore: conversationReadStore,
-				DeleteStore:        conversationReadStore,
+				DeleteStore:        deleteStore,
 				Messages:           conversationReadStore,
 			})
 		}

--- a/internal/infra/cluster/FLOW.md
+++ b/internal/infra/cluster/FLOW.md
@@ -574,13 +574,17 @@ conversation sync usecase
        -> filter SyncOnce/CMD rows from ordinary legacy recents
        -> channel-owned committed rows used for legacy recents
 
-conversation mutation usecase
+conversation read-state mutation usecase
   -> UpsertConversationStates(uid-owned normal-kind read row)
        -> UpsertConversationStatesBatch
        -> UID-owned Slot metadata propose
+
+conversation delete usecase
   -> HideConversations(uid-owned normal-kind delete barrier)
-       -> HideConversationsBatch
-       -> UID-owned Slot metadata propose that clears active_at
+       -> ConversationAuthorityClient resolves the UID's exact RouteTarget
+       -> local or RPC authority HideConversationsForTarget
+       -> authority-owned HideConversationsBatch propose clears durable active_at
+       -> authority reconciles the exact active-cache row before returning
 ```
 
 The adapter clones row slices and message payloads across the boundary. It does
@@ -619,6 +623,11 @@ admission retries route-not-ready, stale-route, not-leader, and background Slot
 proposal backpressure within a small bounded fresh-route window, regrouping
 only target groups that failed on the prior attempt; continued failure is
 returned to the caller so the post-commit path remains bounded.
+Delete-barrier writes group rows by UID and use the same fresh-target retry
+loop as authority reads. The actual Slot write runs on the resolved authority
+leader, which reconciles its cache and revalidates the exact target before it
+returns. A stale target therefore causes an idempotent retry against the new
+leader instead of leaving a clean cache baseline detached from durable state.
 The remote RPC client chunks large patch groups and active-batch recipient
 groups at the codec collection limit before sending them. List resolves the
 requested UID once per retry attempt and reads the active view from that
@@ -644,6 +653,12 @@ ConversationAuthorityClient
        -> RouteKey(uid)
        -> local conversation authority active view for kind when local
        -> access/node Conversation Authority List RPC carrying kind when remote
+  -> HideConversations([]ConversationDelete)
+     -> group by UID and reject any group above the bounded 4096-row RPC contract before leader selection
+       -> group rows by UID
+       -> resolve a fresh exact RouteTarget for each UID group
+       -> local authority hide when local
+       -> access/node Conversation Authority Hide RPC when remote
   -> DrainAuthority(target)
        -> local drain when target leader is this node
        -> access/node Conversation Authority Drain RPC when remote

--- a/internal/infra/cluster/conversation_authority.go
+++ b/internal/infra/cluster/conversation_authority.go
@@ -34,11 +34,15 @@ type ConversationAuthorityClient struct {
 }
 
 var _ conversationusecase.Store = (*ConversationAuthorityClient)(nil)
+var _ conversationusecase.DeleteStore = (*ConversationAuthorityClient)(nil)
 
 const (
 	defaultConversationRouteRetryAttempts = 100
 	conversationAdmissionRetryAttempts    = 3
 	defaultConversationRouteRetryBackoff  = 5 * time.Millisecond
+	// maxConversationAuthorityDeleteGroup matches the bounded node RPC collection contract.
+	// Validate before authority selection so local and remote leaders expose identical behavior.
+	maxConversationAuthorityDeleteGroup = 4096
 )
 
 // NewConversationAuthorityClient creates a cluster-routed conversation authority client.
@@ -143,6 +147,37 @@ func (c *ConversationAuthorityClient) ListConversationActiveView(ctx context.Con
 	return page, nil
 }
 
+// HideConversations routes durable delete barriers through the exact UID
+// authority so the leader can reconcile its active cache before returning.
+func (c *ConversationAuthorityClient) HideConversations(ctx context.Context, deletes []metadb.ConversationDelete) error {
+	if len(deletes) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	for _, group := range groupConversationDeletesByUID(deletes) {
+		group := group
+		if len(group.deletes) > maxConversationAuthorityDeleteGroup {
+			return fmt.Errorf("internal/infra/cluster: conversation deletes for one UID exceed limit")
+		}
+		if err := c.withFreshTarget(ctx, group.uid, func(target conversationusecase.RouteTarget) error {
+			authority, err := c.authorityForTarget(target)
+			if err != nil {
+				return err
+			}
+			return mapConversationRouteError(authority.HideConversationsForTarget(ctx, target, group.deletes))
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DrainAuthority drains one exact authority target for handoff.
 func (c *ConversationAuthorityClient) DrainAuthority(ctx context.Context, target conversationusecase.RouteTarget) (string, error) {
 	authority, err := c.authorityForTarget(target)
@@ -160,6 +195,25 @@ type conversationAuthorityPatchGroup struct {
 type conversationAuthorityActiveBatchGroup struct {
 	target conversationusecase.RouteTarget
 	batch  conversationactive.ActiveBatch
+}
+
+type conversationAuthorityDeleteGroup struct {
+	uid     string
+	deletes []metadb.ConversationDelete
+}
+
+func groupConversationDeletesByUID(deletes []metadb.ConversationDelete) []conversationAuthorityDeleteGroup {
+	groupIndex := make(map[string]int, len(deletes))
+	groups := make([]conversationAuthorityDeleteGroup, 0, len(deletes))
+	for _, req := range deletes {
+		if idx, ok := groupIndex[req.UID]; ok {
+			groups[idx].deletes = append(groups[idx].deletes, req)
+			continue
+		}
+		groupIndex[req.UID] = len(groups)
+		groups = append(groups, conversationAuthorityDeleteGroup{uid: req.UID, deletes: []metadb.ConversationDelete{req}})
+	}
+	return groups
 }
 
 func (c *ConversationAuthorityClient) groupByTarget(patches []conversationusecase.ActivePatch) ([]conversationAuthorityPatchGroup, error) {
@@ -385,7 +439,7 @@ func mapConversationRouteError(err error) error {
 		return err
 	case errors.Is(err, cluster.ErrRouteNotReady), errors.Is(err, cluster.ErrNoSlotLeader):
 		return fmt.Errorf("%w: %w", conversationusecase.ErrRouteNotReady, err)
-	case errors.Is(err, cluster.ErrNotLeader):
+	case errors.Is(err, cluster.ErrNotLeader), errors.Is(err, propose.ErrNotLeader):
 		return fmt.Errorf("%w: %w", conversationusecase.ErrNotLeader, err)
 	case errors.Is(err, propose.ErrProposalBackpressure), errors.Is(err, propose.ErrBackgroundProposalThrottled):
 		return fmt.Errorf("%w: %w", conversationusecase.ErrRouteNotReady, err)
@@ -419,6 +473,13 @@ func (a remoteConversationAuthority) ListConversationActiveViewForTarget(ctx con
 	}
 	page, err := a.client.ListConversations(ctx, a.nodeID, target, kind, uid, after, limit)
 	return page, mapConversationRouteError(err)
+}
+
+func (a remoteConversationAuthority) HideConversationsForTarget(ctx context.Context, target conversationusecase.RouteTarget, deletes []metadb.ConversationDelete) error {
+	if a.client == nil || a.nodeID == 0 {
+		return conversationusecase.ErrRouteNotReady
+	}
+	return mapConversationRouteError(a.client.HideConversations(ctx, a.nodeID, target, deletes))
 }
 
 func (a remoteConversationAuthority) DrainAuthority(ctx context.Context, target conversationusecase.RouteTarget) (string, error) {

--- a/internal/infra/cluster/conversation_authority_test.go
+++ b/internal/infra/cluster/conversation_authority_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -372,6 +373,122 @@ func TestConversationAuthorityClientRoutesRemoteList(t *testing.T) {
 	}
 }
 
+func TestConversationAuthorityClientRoutesDeletesThroughExactLocalAuthority(t *testing.T) {
+	local := &fakeConversationAuthorityLocal{}
+	target := cluster.Route{HashSlot: 7, SlotID: 2, Leader: 1, LeaderTerm: 5, ConfigEpoch: 6, Revision: 3, AuthorityEpoch: 4}
+	node := &fakeConversationAuthorityNode{nodeID: 1, route: target}
+	client := NewConversationAuthorityClient(node, local)
+	deletes := []metadb.ConversationDelete{
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9, UpdatedAt: 100},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g2", ChannelType: 2, DeletedToSeq: 10, UpdatedAt: 101},
+	}
+
+	if err := client.HideConversations(context.Background(), deletes); err != nil {
+		t.Fatalf("HideConversations() error = %v", err)
+	}
+	wantTarget := conversationRouteTargetFromClusterRoute(target)
+	if len(local.hideAttempts) != 1 || local.hideAttempts[0].target != wantTarget || !reflect.DeepEqual(local.hideAttempts[0].deletes, deletes) {
+		t.Fatalf("hide attempts = %#v, want exact target %#v and deletes %#v", local.hideAttempts, wantTarget, deletes)
+	}
+}
+
+func TestConversationAuthorityClientRejectsOversizedDeleteGroupBeforeAuthoritySelection(t *testing.T) {
+	local := &fakeConversationAuthorityLocal{}
+	node := &fakeConversationAuthorityNode{
+		nodeID: 1,
+		route:  cluster.Route{HashSlot: 7, SlotID: 2, Leader: 1, Revision: 3, AuthorityEpoch: 4},
+	}
+	client := NewConversationAuthorityClient(node, local)
+	deletes := make([]metadb.ConversationDelete, maxConversationAuthorityDeleteGroup+1)
+	for index := range deletes {
+		deletes[index] = metadb.ConversationDelete{
+			UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: fmt.Sprintf("g-%d", index), ChannelType: 2, DeletedToSeq: 9,
+		}
+	}
+
+	err := client.HideConversations(context.Background(), deletes)
+	if err == nil {
+		t.Fatal("HideConversations() error = nil, want per-UID collection limit error")
+	}
+	if got := node.routeKeyCallsForUID("u1"); got != 0 {
+		t.Fatalf("RouteKey(u1) calls = %d, want oversized group rejected before leader selection", got)
+	}
+	if len(local.hideAttempts) != 0 {
+		t.Fatalf("local hide attempts = %d, want none", len(local.hideAttempts))
+	}
+}
+
+func TestConversationAuthorityClientRetriesDeleteOnFreshAuthorityTarget(t *testing.T) {
+	local := &fakeConversationAuthorityLocal{hideErrs: []error{conversationusecase.ErrStaleRoute, nil}}
+	first := cluster.Route{HashSlot: 7, SlotID: 2, Leader: 1, LeaderTerm: 5, ConfigEpoch: 6, Revision: 3, AuthorityEpoch: 4}
+	fresh := first
+	fresh.LeaderTerm++
+	fresh.Revision++
+	node := &fakeConversationAuthorityNode{
+		nodeID:              1,
+		routesByUIDSequence: map[string][]cluster.Route{"u1": {first, fresh}},
+	}
+	client := NewConversationAuthorityClient(node, local)
+	client.routeRetrySleep = func(context.Context, time.Duration) error { return nil }
+	deletes := []metadb.ConversationDelete{{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9}}
+
+	if err := client.HideConversations(context.Background(), deletes); err != nil {
+		t.Fatalf("HideConversations() error = %v", err)
+	}
+	if got := node.routeKeyCallsForUID("u1"); got != 2 {
+		t.Fatalf("RouteKey(u1) calls = %d, want 2", got)
+	}
+	if len(local.hideAttempts) != 2 || local.hideAttempts[0].target.RouteRevision != first.Revision || local.hideAttempts[1].target.RouteRevision != fresh.Revision {
+		t.Fatalf("hide attempts = %#v, want stale then fresh target", local.hideAttempts)
+	}
+}
+
+func TestConversationAuthorityClientRetriesDeleteOnProposalNotLeader(t *testing.T) {
+	local := &fakeConversationAuthorityLocal{hideErrs: []error{propose.ErrNotLeader, nil}}
+	first := cluster.Route{HashSlot: 7, SlotID: 2, Leader: 1, LeaderTerm: 5, ConfigEpoch: 6, Revision: 3, AuthorityEpoch: 4}
+	fresh := first
+	fresh.LeaderTerm++
+	fresh.Revision++
+	node := &fakeConversationAuthorityNode{
+		nodeID:              1,
+		routesByUIDSequence: map[string][]cluster.Route{"u1": {first, fresh}},
+	}
+	client := NewConversationAuthorityClient(node, local)
+	client.routeRetrySleep = func(context.Context, time.Duration) error { return nil }
+	deletes := []metadb.ConversationDelete{{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9}}
+
+	if err := client.HideConversations(context.Background(), deletes); err != nil {
+		t.Fatalf("HideConversations() error = %v", err)
+	}
+	if got := node.routeKeyCallsForUID("u1"); got != 2 {
+		t.Fatalf("RouteKey(u1) calls = %d, want 2", got)
+	}
+	if len(local.hideAttempts) != 2 || local.hideAttempts[0].target.RouteRevision != first.Revision || local.hideAttempts[1].target.RouteRevision != fresh.Revision {
+		t.Fatalf("hide attempts = %#v, want proposal-not-leader then fresh target", local.hideAttempts)
+	}
+}
+
+func TestConversationAuthorityClientRoutesRemoteDelete(t *testing.T) {
+	remoteAuthority := &fakeConversationAuthorityLocal{}
+	adapter := accessnode.New(accessnode.Options{ConversationAuthority: remoteAuthority})
+	node := &fakeConversationAuthorityNode{
+		nodeID: 1,
+		route:  cluster.Route{HashSlot: 7, SlotID: 2, Leader: 2, Revision: 3, AuthorityEpoch: 4},
+		handler: nodeRPCHandlerFunc(func(ctx context.Context, payload []byte) ([]byte, error) {
+			return adapter.HandleConversationAuthorityRPC(ctx, payload)
+		}),
+	}
+	client := NewConversationAuthorityClient(node, nil)
+	deletes := []metadb.ConversationDelete{{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2, DeletedToSeq: 9}}
+
+	if err := client.HideConversations(context.Background(), deletes); err != nil {
+		t.Fatalf("HideConversations() error = %v", err)
+	}
+	if len(remoteAuthority.hideAttempts) != 1 || !reflect.DeepEqual(remoteAuthority.hideAttempts[0].deletes, deletes) {
+		t.Fatalf("remote hide attempts = %#v, want %#v", remoteAuthority.hideAttempts, deletes)
+	}
+}
+
 func TestConversationAuthorityClientGroupsByExactTarget(t *testing.T) {
 	local := &fakeConversationAuthorityLocal{}
 	node := &fakeConversationAuthorityNode{
@@ -735,6 +852,7 @@ func TestConversationAuthorityClientMapsRouteErrors(t *testing.T) {
 		{name: "route not ready", err: cluster.ErrRouteNotReady, want: conversationusecase.ErrRouteNotReady},
 		{name: "no slot leader", err: cluster.ErrNoSlotLeader, want: conversationusecase.ErrRouteNotReady},
 		{name: "not leader", err: cluster.ErrNotLeader, want: conversationusecase.ErrNotLeader},
+		{name: "proposal not leader", err: propose.ErrNotLeader, want: conversationusecase.ErrNotLeader},
 		{name: "proposal backpressure", err: propose.ErrProposalBackpressure, want: conversationusecase.ErrRouteNotReady},
 		{name: "background proposal throttled", err: propose.ErrBackgroundProposalThrottled, want: conversationusecase.ErrRouteNotReady},
 		{name: "context canceled", err: context.Canceled, want: context.Canceled},
@@ -862,6 +980,8 @@ type fakeConversationAuthorityLocal struct {
 	listErrs                  []error
 	drainResult               string
 	drainTargets              []conversationusecase.RouteTarget
+	hideAttempts              []conversationDeleteDelivery
+	hideErrs                  []error
 }
 
 func (f *fakeConversationAuthorityLocal) AdmitPatches(_ context.Context, target conversationusecase.RouteTarget, patches []conversationusecase.ActivePatch) error {
@@ -918,6 +1038,16 @@ func (f *fakeConversationAuthorityLocal) ListConversationActiveViewForTarget(_ c
 	return f.page, nil
 }
 
+func (f *fakeConversationAuthorityLocal) HideConversationsForTarget(_ context.Context, target conversationusecase.RouteTarget, deletes []metadb.ConversationDelete) error {
+	f.hideAttempts = append(f.hideAttempts, conversationDeleteDelivery{target: target, deletes: append([]metadb.ConversationDelete(nil), deletes...)})
+	if len(f.hideErrs) == 0 {
+		return nil
+	}
+	err := f.hideErrs[0]
+	f.hideErrs = f.hideErrs[1:]
+	return err
+}
+
 func (f *fakeConversationAuthorityLocal) DrainAuthority(_ context.Context, target conversationusecase.RouteTarget) (string, error) {
 	f.drainTargets = append(f.drainTargets, target)
 	return f.drainResult, nil
@@ -934,6 +1064,11 @@ func deliveredConversationPatchUIDCounts(patches []conversationusecase.ActivePat
 type activeBatchDelivery struct {
 	target conversationusecase.RouteTarget
 	batch  conversationactive.ActiveBatch
+}
+
+type conversationDeleteDelivery struct {
+	target  conversationusecase.RouteTarget
+	deletes []metadb.ConversationDelete
 }
 
 func activeBatchesByHashSlot(deliveries []activeBatchDelivery) map[uint16]conversationactive.ActiveBatch {

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -31,8 +31,10 @@ transient realtime enqueue.
 Router.SendBatch
   -> side-effect-safe pre-route validation / canonical channel derivation
   -> AuthorityResolver.ResolveAppendAuthority(canonical channel)
-  -> local target: LocalSubmitter.SubmitLocal(target, original items)
-  -> remote target: RemoteForwarder.ForwardSendBatch(target, original items)
+  -> bounded concurrent submission of independent canonical-channel groups
+     -> local target: LocalSubmitter.SubmitLocal(target, original items)
+     -> remote target: RemoteForwarder.ForwardSendBatch(target, original items)
+  -> fold group results in original group/item order
   -> item-aligned results
 ```
 
@@ -46,7 +48,23 @@ leader movement without hiding caller/session cancellation. Retry sleeps wake
 when pending item cancellation or deadlines arrive, so expired work does not
 wait for the whole backoff. Remote outbound admission is bounded per
 `LeaderNodeID`, not per channel, so different channels to the same remote
-authority share the same pressure limit.
+authority share the same pressure limit. Resolved remote groups in one batch
+are assigned to at most `MaxOutboundPerNode` batch-local lanes for that leader.
+Groups in one lane submit serially, so they do not reject one another merely
+because the router made independent groups concurrent. The existing global
+outbound admission remains fail-fast, so occupancy from another `SendBatch`
+still returns real cross-batch backpressure. When no leader exceeds the bound,
+the hot path submits group indexes directly and does not allocate lane maps or
+per-group lane slices.
+
+Authority resolution remains ordered and side-effect safe. After resolution,
+different canonical-channel groups from one multi-item batch are submitted with
+a fixed per-batch concurrency bound. The caller participates as one worker, so
+the router creates at most `bound-1` helper goroutines. A single canonical
+channel still forms one ordered group, and completed group results are folded
+in original group and item order before retry selection. This removes
+cross-channel head-of-line waiting without adding an unbounded goroutine or a
+second cross-request queue.
 
 Router submit contexts are neutral batch transport contexts. Per-item contexts
 and deadlines are checked before route lookup, before submission, and while

--- a/internal/runtime/channelappend/options.go
+++ b/internal/runtime/channelappend/options.go
@@ -86,6 +86,7 @@ type RouterObservation struct {
 }
 
 // RouterObserver receives foreground channel authority routing observations.
+// Implementations must be safe for concurrent calls from SendBatch.
 type RouterObserver interface {
 	// ObserveChannelAppendRouter records one routed foreground SEND group.
 	ObserveChannelAppendRouter(RouterObservation)

--- a/internal/runtime/channelappend/router.go
+++ b/internal/runtime/channelappend/router.go
@@ -4,29 +4,34 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	runtimechannelid "github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
 )
 
 const (
-	defaultRouterRetryBackoff     = time.Millisecond
-	defaultRouterMaxRouteAttempts = 3
+	defaultRouterRetryBackoff                = time.Millisecond
+	defaultRouterMaxRouteAttempts            = 3
+	defaultRouterMaxConcurrentGroupsPerBatch = 3
 )
 
 // AuthorityResolver resolves the append authority for a canonical channel.
+// Implementations must be safe for concurrent calls from one or more Router instances.
 type AuthorityResolver interface {
 	// ResolveAppendAuthority returns the current fenced channel authority target.
 	ResolveAppendAuthority(context.Context, ChannelID) (AuthorityTarget, error)
 }
 
 // LocalSubmitter submits sends to the local channel authority runtime.
+// Implementations must be safe for concurrent calls from SendBatch.
 type LocalSubmitter interface {
 	// SubmitLocal admits a batch to the local channel authority.
 	SubmitLocal(context.Context, AuthorityTarget, []SendBatchItem) (*Future, error)
 }
 
 // RemoteForwarder forwards sends to a remote channel authority.
+// Implementations must be safe for concurrent calls from SendBatch.
 type RemoteForwarder interface {
 	// ForwardSendBatch forwards items to the resolved remote channel authority.
 	ForwardSendBatch(context.Context, AuthorityTarget, []SendBatchItem) []SendBatchItemResult
@@ -48,6 +53,8 @@ type RouterOptions struct {
 	MaxRouteAttempts int
 	// MaxOutboundPerNode bounds concurrent remote forwards per leader node. Values <= 0 disable this limit.
 	MaxOutboundPerNode int
+	// MaxConcurrentGroupsPerBatch bounds concurrently submitted independent canonical-channel groups within one SendBatch. Values <= 0 use the default.
+	MaxConcurrentGroupsPerBatch int
 	// Observer receives foreground routing observations.
 	Observer RouterObserver
 }
@@ -59,12 +66,13 @@ type Router struct {
 	local       LocalSubmitter
 	remote      RemoteForwarder
 
-	retryBackoff     time.Duration
-	maxRouteAttempts int
-	maxOutbound      int
-	outbound         map[uint64]int
-	outboundMu       sync.Mutex
-	observer         RouterObserver
+	retryBackoff                time.Duration
+	maxRouteAttempts            int
+	maxConcurrentGroupsPerBatch int
+	maxOutbound                 int
+	outbound                    map[uint64]int
+	outboundMu                  sync.Mutex
+	observer                    RouterObserver
 }
 
 // NewRouter creates a channel authority router.
@@ -77,16 +85,21 @@ func NewRouter(opts RouterOptions) *Router {
 	if maxRouteAttempts <= 0 {
 		maxRouteAttempts = defaultRouterMaxRouteAttempts
 	}
+	maxConcurrentGroupsPerBatch := opts.MaxConcurrentGroupsPerBatch
+	if maxConcurrentGroupsPerBatch <= 0 {
+		maxConcurrentGroupsPerBatch = defaultRouterMaxConcurrentGroupsPerBatch
+	}
 	return &Router{
-		localNodeID:      opts.LocalNodeID,
-		resolver:         opts.Resolver,
-		local:            opts.Local,
-		remote:           opts.Remote,
-		retryBackoff:     retryBackoff,
-		maxRouteAttempts: maxRouteAttempts,
-		maxOutbound:      opts.MaxOutboundPerNode,
-		outbound:         make(map[uint64]int),
-		observer:         opts.Observer,
+		localNodeID:                 opts.LocalNodeID,
+		resolver:                    opts.Resolver,
+		local:                       opts.Local,
+		remote:                      opts.Remote,
+		retryBackoff:                retryBackoff,
+		maxRouteAttempts:            maxRouteAttempts,
+		maxConcurrentGroupsPerBatch: maxConcurrentGroupsPerBatch,
+		maxOutbound:                 opts.MaxOutboundPerNode,
+		outbound:                    make(map[uint64]int),
+		observer:                    opts.Observer,
 	}
 }
 
@@ -121,8 +134,9 @@ func (r *Router) SendBatch(items []SendBatchItem) []SendBatchItemResult {
 
 	for len(pending) > 0 {
 		groups, nextPending := r.resolvePending(items, routeChannels, results, pending, attempts)
-		for _, group := range groups {
-			groupResults := r.submitGroup(group)
+		submitted := r.submitResolvedGroups(groups)
+		for groupIndex, group := range groups {
+			groupResults := submitted[groupIndex]
 			for i, result := range normalizeRouterGroupResults(len(group.indexes), groupResults) {
 				index := group.indexes[i]
 				if shouldRetryRouterError(result.Err) && canRetryRouterItem(items[index], attempts[index], r.maxRouteAttempts, time.Now()) {
@@ -182,6 +196,11 @@ type routerBatchGroup struct {
 	items   []SendBatchItem
 }
 
+// routerBatchLane serializes resolved groups that share one batch-local outbound lane.
+type routerBatchLane struct {
+	groupIndexes []int
+}
+
 func (r *Router) resolvePending(items []SendBatchItem, routeChannels []ChannelID, results []SendBatchItemResult, pending []int, attempts []int) ([]routerBatchGroup, []int) {
 	groups := make([]routerBatchGroup, 0, len(pending))
 	indexesByChannel := make(map[ChannelID][]int, len(pending))
@@ -237,6 +256,120 @@ func (r *Router) resolvePending(items []SendBatchItem, routeChannels []ChannelID
 		groups = append(groups, group)
 	}
 	return groups, nextPending
+}
+
+// submitResolvedGroups submits independent channel groups while retaining group-index result alignment.
+func (r *Router) submitResolvedGroups(groups []routerBatchGroup) [][]SendBatchItemResult {
+	results := make([][]SendBatchItemResult, len(groups))
+	if len(groups) == 0 {
+		return results
+	}
+	if !r.requiresResolvedGroupLanes(groups) {
+		runRouterBatchWorkers(len(groups), r.maxConcurrentGroupsPerBatch, func(groupIndex int) {
+			results[groupIndex] = r.submitGroup(groups[groupIndex])
+		})
+		return results
+	}
+
+	lanes := r.resolvedGroupLanes(groups)
+	runRouterBatchWorkers(len(lanes), r.maxConcurrentGroupsPerBatch, func(laneIndex int) {
+		for _, groupIndex := range lanes[laneIndex].groupIndexes {
+			results[groupIndex] = r.submitGroup(groups[groupIndex])
+		}
+	})
+	return results
+}
+
+// runRouterBatchWorkers executes indexed work with the caller participating in the fixed worker bound.
+func runRouterBatchWorkers(workItems int, maxWorkers int, submit func(int)) {
+	workers := maxWorkers
+	if workers > workItems {
+		workers = workItems
+	}
+	if workers <= 1 {
+		for index := 0; index < workItems; index++ {
+			submit(index)
+		}
+		return
+	}
+
+	var next atomic.Uint64
+	run := func() {
+		for {
+			index := int(next.Add(1) - 1)
+			if index >= workItems {
+				return
+			}
+			submit(index)
+		}
+	}
+	var wg sync.WaitGroup
+	wg.Add(workers - 1)
+	for worker := 1; worker < workers; worker++ {
+		go func() {
+			defer wg.Done()
+			run()
+		}()
+	}
+	run()
+	wg.Wait()
+}
+
+// requiresResolvedGroupLanes reports whether one remote leader exceeds its batch-local outbound concurrency limit.
+func (r *Router) requiresResolvedGroupLanes(groups []routerBatchGroup) bool {
+	if r.maxOutbound <= 0 || r.maxOutbound >= len(groups) {
+		return false
+	}
+	for groupIndex, group := range groups {
+		leaderNodeID := group.target.LeaderNodeID
+		if leaderNodeID == r.localNodeID {
+			continue
+		}
+		leaderGroups := 1
+		for candidateIndex := groupIndex + 1; candidateIndex < len(groups); candidateIndex++ {
+			if groups[candidateIndex].target.LeaderNodeID != leaderNodeID {
+				continue
+			}
+			leaderGroups++
+			if leaderGroups > r.maxOutbound {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resolvedGroupLanes keeps one batch from consuming more concurrent remote slots per leader than the configured outbound limit.
+func (r *Router) resolvedGroupLanes(groups []routerBatchGroup) []routerBatchLane {
+	lanes := make([]routerBatchLane, 0, len(groups))
+	if r.maxOutbound <= 0 {
+		for groupIndex := range groups {
+			lanes = append(lanes, routerBatchLane{groupIndexes: []int{groupIndex}})
+		}
+		return lanes
+	}
+
+	remoteLanes := make(map[uint64][]int)
+	remoteLaneCursor := make(map[uint64]int)
+	for groupIndex, group := range groups {
+		leaderNodeID := group.target.LeaderNodeID
+		if leaderNodeID == r.localNodeID {
+			lanes = append(lanes, routerBatchLane{groupIndexes: []int{groupIndex}})
+			continue
+		}
+		leaderLanes := remoteLanes[leaderNodeID]
+		if len(leaderLanes) < r.maxOutbound {
+			laneIndex := len(lanes)
+			lanes = append(lanes, routerBatchLane{groupIndexes: []int{groupIndex}})
+			remoteLanes[leaderNodeID] = append(leaderLanes, laneIndex)
+			continue
+		}
+		cursor := remoteLaneCursor[leaderNodeID]
+		laneIndex := leaderLanes[cursor%len(leaderLanes)]
+		remoteLaneCursor[leaderNodeID] = cursor + 1
+		lanes[laneIndex].groupIndexes = append(lanes[laneIndex].groupIndexes, groupIndex)
+	}
+	return lanes
 }
 
 func (r *Router) submitGroup(group routerBatchGroup) []SendBatchItemResult {

--- a/internal/runtime/channelappend/router_test.go
+++ b/internal/runtime/channelappend/router_test.go
@@ -75,6 +75,173 @@ func TestRouterResolvesSameChannelBatchOnce(t *testing.T) {
 	}
 }
 
+func TestRouterSendBatchRunsIndependentChannelGroupsWithBoundedConcurrency(t *testing.T) {
+	targets := make(map[ChannelID]AuthorityTarget, 4)
+	for _, channelID := range []string{"a", "b", "c", "d"} {
+		target := routerTarget(channelID, 2, 7)
+		targets[target.ChannelID] = target
+	}
+	resolver := &routerResolverForTest{targetsByChannel: targets}
+	local := newRouterControlledLocalSubmitter(4)
+	router := NewRouter(RouterOptions{
+		LocalNodeID:                 7,
+		Resolver:                    resolver,
+		Local:                       local,
+		MaxConcurrentGroupsPerBatch: 2,
+	})
+	items := []SendBatchItem{
+		routerItem("u0", "a", 2),
+		routerItem("u1", "b", 2),
+		routerItem("u2", "a", 2),
+		routerItem("u3", "c", 2),
+		routerItem("u4", "d", 2),
+	}
+	done := make(chan []SendBatchItemResult, 1)
+	go func() {
+		done <- router.SendBatch(items)
+	}()
+
+	first := local.nextCall(t)
+	second := local.nextCall(t)
+	select {
+	case call := <-local.entered:
+		t.Fatalf("third group %q entered before a concurrency slot was released", call.target.ChannelID.ID)
+	default:
+	}
+	local.complete(first, controlledRouterResults(first.items))
+	third := local.nextCall(t)
+	local.complete(second, controlledRouterResults(second.items))
+	fourth := local.nextCall(t)
+	local.complete(fourth, controlledRouterResults(fourth.items))
+	local.complete(third, controlledRouterResults(third.items))
+
+	var results []SendBatchItemResult
+	select {
+	case results = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SendBatch did not finish after every group completed")
+	}
+	if len(results) != len(items) {
+		t.Fatalf("results len = %d, want %d", len(results), len(items))
+	}
+	for index, result := range results {
+		wantID := uint64(index + 1)
+		if result.Err != nil || result.Result.MessageID != wantID {
+			t.Fatalf("results[%d] = %+v, want message id %d", index, result, wantID)
+		}
+	}
+	if got := local.maxConcurrentCalls(); got != 2 {
+		t.Fatalf("max concurrent groups = %d, want 2", got)
+	}
+	calls := local.callsSnapshot()
+	if len(calls) != 4 {
+		t.Fatalf("local calls = %d, want one per canonical channel", len(calls))
+	}
+	for _, call := range calls {
+		if call.target.ChannelID.ID != "a" {
+			continue
+		}
+		if len(call.items) != 2 || call.items[0].Command.FromUID != "u0" || call.items[1].Command.FromUID != "u2" {
+			t.Fatalf("channel a items = %+v, want u0 then u2", call.items)
+		}
+		return
+	}
+	t.Fatal("channel a group was not submitted")
+}
+
+func TestRouterSendBatchSerializesRemoteGroupsWithinSameLeaderOutboundLane(t *testing.T) {
+	targetA := routerTarget("remote-a", 2, 8)
+	targetB := routerTarget("remote-b", 2, 8)
+	resolver := &routerResolverForTest{targetsByChannel: map[ChannelID]AuthorityTarget{
+		targetA.ChannelID: targetA,
+		targetB.ChannelID: targetB,
+	}}
+	remote := newRouterControlledRemoteForwarder(2)
+	router := NewRouter(RouterOptions{
+		LocalNodeID:                 7,
+		Resolver:                    resolver,
+		Remote:                      remote,
+		MaxOutboundPerNode:          1,
+		MaxConcurrentGroupsPerBatch: 2,
+	})
+	done := make(chan []SendBatchItemResult, 1)
+	go func() {
+		done <- router.SendBatch([]SendBatchItem{
+			routerItem("u0", "remote-a", 2),
+			routerItem("u1", "remote-b", 2),
+		})
+	}()
+
+	first := remote.nextCall(t)
+	if first.target.ChannelID != targetA.ChannelID {
+		t.Fatalf("first remote group = %#v, want channel %#v", first.target.ChannelID, targetA.ChannelID)
+	}
+	select {
+	case call := <-remote.entered:
+		t.Fatalf("second remote group %q entered while the same-leader outbound lane was occupied", call.target.ChannelID.ID)
+	case <-time.After(50 * time.Millisecond):
+	}
+	remote.complete(first)
+	second := remote.nextCall(t)
+	if second.target.ChannelID != targetB.ChannelID {
+		t.Fatalf("second remote group = %#v, want channel %#v", second.target.ChannelID, targetB.ChannelID)
+	}
+	remote.complete(second)
+
+	select {
+	case results := <-done:
+		if len(results) != 2 || results[0].Err != nil || results[0].Result.MessageID != 1 || results[1].Err != nil || results[1].Result.MessageID != 2 {
+			t.Fatalf("results = %#v, want both remote groups to succeed in input order", results)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendBatch did not finish after both remote groups completed")
+	}
+	if got := remote.maxConcurrentCalls(); got != 1 {
+		t.Fatalf("max concurrent remote calls = %d, want 1 for the same leader", got)
+	}
+}
+
+func TestRouterSendBatchRetriesOnlyFailedConcurrentGroupAndPreservesInputOrder(t *testing.T) {
+	targetA := routerTarget("retry-a", 2, 7)
+	targetB := routerTarget("retry-b", 2, 7)
+	resolver := &routerResolverForTest{targetsByChannel: map[ChannelID]AuthorityTarget{
+		targetA.ChannelID: targetA,
+		targetB.ChannelID: targetB,
+	}}
+	local := &routerRetryingLocalSubmitterForTest{retryChannel: targetA.ChannelID}
+	router := NewRouter(RouterOptions{
+		LocalNodeID:                 7,
+		Resolver:                    resolver,
+		Local:                       local,
+		RetryBackoff:                time.Millisecond,
+		MaxConcurrentGroupsPerBatch: 2,
+	})
+
+	results := router.SendBatch([]SendBatchItem{
+		routerItem("u0", "retry-a", 2),
+		routerItem("u1", "retry-b", 2),
+		routerItem("u2", "retry-a", 2),
+	})
+
+	if len(results) != 3 {
+		t.Fatalf("results len = %d, want 3", len(results))
+	}
+	for index, wantMessageID := range []uint64{1, 2, 3} {
+		if results[index].Err != nil || results[index].Result.MessageID != wantMessageID {
+			t.Fatalf("results[%d] = %+v, want message id %d", index, results[index], wantMessageID)
+		}
+	}
+	if got := local.callsFor(targetA.ChannelID); got != 2 {
+		t.Fatalf("retry-a calls = %d, want one failed call and one retry", got)
+	}
+	if got := local.callsFor(targetB.ChannelID); got != 1 {
+		t.Fatalf("retry-b calls = %d, want successful group submitted only once", got)
+	}
+	if resolver.calls != 3 {
+		t.Fatalf("resolver calls = %d, want retry-a resolved twice and retry-b once", resolver.calls)
+	}
+}
+
 func TestRouterAllItemsContextDoesNotStartWaitersForPlainItems(t *testing.T) {
 	items := make([]SendBatchItem, 128)
 	for i := range items {
@@ -435,6 +602,39 @@ func TestRouterRejectsMissingChannelWithoutResolve(t *testing.T) {
 	}
 }
 
+func BenchmarkRouterSubmitResolvedGroupsNoLeaderOverflow(b *testing.B) {
+	const groupCount = 32
+	groups := make([]routerBatchGroup, groupCount)
+	for index := range groups {
+		channelID := ChannelID{ID: "remote-" + string(rune('a'+index)), Type: 2}
+		groups[index] = routerBatchGroup{
+			target: AuthorityTarget{
+				ChannelID:    channelID,
+				ChannelKey:   channelKey(channelID),
+				LeaderNodeID: 8,
+				Epoch:        1,
+				LeaderEpoch:  1,
+			},
+			indexes: []int{index},
+			items:   []SendBatchItem{routerItem("u0", channelID.ID, channelID.Type)},
+		}
+	}
+	router := NewRouter(RouterOptions{
+		LocalNodeID:                 7,
+		Remote:                      routerImmediateRemoteForwarder{},
+		MaxOutboundPerNode:          1024,
+		MaxConcurrentGroupsPerBatch: 3,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		results := router.submitResolvedGroups(groups)
+		if len(results) != groupCount {
+			b.Fatalf("results len = %d, want %d", len(results), groupCount)
+		}
+	}
+}
+
 func routerTarget(channelID string, channelType uint8, leader uint64) AuthorityTarget {
 	return AuthorityTarget{
 		ChannelID:    ChannelID{ID: channelID, Type: channelType},
@@ -491,6 +691,188 @@ type routerLocalSubmitterForTest struct {
 	calls         int
 	onSubmit      func()
 	completeDelay time.Duration
+}
+
+type routerControlledSubmitCall struct {
+	target AuthorityTarget
+	items  []SendBatchItem
+	future *Future
+	once   sync.Once
+}
+
+type routerControlledLocalSubmitter struct {
+	mu          sync.Mutex
+	entered     chan *routerControlledSubmitCall
+	calls       []*routerControlledSubmitCall
+	inFlight    int
+	maxInFlight int
+}
+
+type routerControlledRemoteCall struct {
+	target  AuthorityTarget
+	items   []SendBatchItem
+	release chan struct{}
+	once    sync.Once
+}
+
+type routerControlledRemoteForwarder struct {
+	mu          sync.Mutex
+	entered     chan *routerControlledRemoteCall
+	inFlight    int
+	maxInFlight int
+}
+
+type routerRetryingLocalSubmitterForTest struct {
+	mu           sync.Mutex
+	retryChannel ChannelID
+	calls        map[ChannelID]int
+}
+
+func (s *routerRetryingLocalSubmitterForTest) SubmitLocal(_ context.Context, target AuthorityTarget, items []SendBatchItem) (*Future, error) {
+	s.mu.Lock()
+	if s.calls == nil {
+		s.calls = make(map[ChannelID]int)
+	}
+	s.calls[target.ChannelID]++
+	call := s.calls[target.ChannelID]
+	s.mu.Unlock()
+	if target.ChannelID == s.retryChannel && call == 1 {
+		return nil, ErrNotLeader
+	}
+	future := newFuture(len(items))
+	future.complete(controlledRouterResults(items))
+	return future, nil
+}
+
+func (s *routerRetryingLocalSubmitterForTest) callsFor(channelID ChannelID) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[channelID]
+}
+
+type routerImmediateRemoteForwarder struct{}
+
+func (routerImmediateRemoteForwarder) ForwardSendBatch(_ context.Context, _ AuthorityTarget, items []SendBatchItem) []SendBatchItemResult {
+	return controlledRouterResults(items)
+}
+
+func newRouterControlledRemoteForwarder(capacity int) *routerControlledRemoteForwarder {
+	return &routerControlledRemoteForwarder{entered: make(chan *routerControlledRemoteCall, capacity)}
+}
+
+func (r *routerControlledRemoteForwarder) ForwardSendBatch(_ context.Context, target AuthorityTarget, items []SendBatchItem) []SendBatchItemResult {
+	call := &routerControlledRemoteCall{
+		target:  target,
+		items:   append([]SendBatchItem(nil), items...),
+		release: make(chan struct{}),
+	}
+	r.mu.Lock()
+	r.inFlight++
+	if r.inFlight > r.maxInFlight {
+		r.maxInFlight = r.inFlight
+	}
+	r.mu.Unlock()
+	r.entered <- call
+	<-call.release
+	r.mu.Lock()
+	r.inFlight--
+	r.mu.Unlock()
+	return controlledRouterResults(call.items)
+}
+
+func (r *routerControlledRemoteForwarder) nextCall(t *testing.T) *routerControlledRemoteCall {
+	t.Helper()
+	select {
+	case call := <-r.entered:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for remote routed group")
+		return nil
+	}
+}
+
+func (r *routerControlledRemoteForwarder) complete(call *routerControlledRemoteCall) {
+	call.once.Do(func() { close(call.release) })
+}
+
+func (r *routerControlledRemoteForwarder) maxConcurrentCalls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.maxInFlight
+}
+
+func newRouterControlledLocalSubmitter(capacity int) *routerControlledLocalSubmitter {
+	return &routerControlledLocalSubmitter{entered: make(chan *routerControlledSubmitCall, capacity)}
+}
+
+func (s *routerControlledLocalSubmitter) SubmitLocal(_ context.Context, target AuthorityTarget, items []SendBatchItem) (*Future, error) {
+	call := &routerControlledSubmitCall{
+		target: target,
+		items:  append([]SendBatchItem(nil), items...),
+		future: newFuture(len(items)),
+	}
+	s.mu.Lock()
+	s.calls = append(s.calls, call)
+	s.inFlight++
+	if s.inFlight > s.maxInFlight {
+		s.maxInFlight = s.inFlight
+	}
+	s.mu.Unlock()
+	s.entered <- call
+	return call.future, nil
+}
+
+func (s *routerControlledLocalSubmitter) nextCall(t *testing.T) *routerControlledSubmitCall {
+	t.Helper()
+	select {
+	case call := <-s.entered:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for routed group")
+		return nil
+	}
+}
+
+func (s *routerControlledLocalSubmitter) complete(call *routerControlledSubmitCall, results []SendBatchItemResult) {
+	call.once.Do(func() {
+		s.mu.Lock()
+		s.inFlight--
+		s.mu.Unlock()
+		call.future.complete(results)
+	})
+}
+
+func (s *routerControlledLocalSubmitter) maxConcurrentCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFlight
+}
+
+func (s *routerControlledLocalSubmitter) callsSnapshot() []*routerControlledSubmitCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*routerControlledSubmitCall(nil), s.calls...)
+}
+
+func controlledRouterResults(items []SendBatchItem) []SendBatchItemResult {
+	results := make([]SendBatchItemResult, len(items))
+	for index, item := range items {
+		var messageID uint64
+		switch item.Command.FromUID {
+		case "u0":
+			messageID = 1
+		case "u1":
+			messageID = 2
+		case "u2":
+			messageID = 3
+		case "u3":
+			messageID = 4
+		case "u4":
+			messageID = 5
+		}
+		results[index] = SendBatchItemResult{Result: SendResult{MessageID: messageID, Reason: ReasonSuccess}}
+	}
+	return results
 }
 
 func (s *routerLocalSubmitterForTest) SubmitLocal(_ context.Context, target AuthorityTarget, items []SendBatchItem) (*Future, error) {

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -8,9 +8,10 @@ Current flow:
 
 1. Channel append or another authority-owned caller submits an `ActiveBatch`.
 2. Before taking the cache lock, the manager coalesces rows by
-   `(uid, kind, channel_id, channel_type)` using maximum `ActiveAtMS` and
-   `ReadSeq`. Small authority batches use an inline path without a temporary
-   map, so repeated addresses cause only one version and dirty-index mutation.
+   `(uid, kind, channel_id, channel_type)` using maximum `ActiveAtMS`,
+   `ReadSeq`, and `MessageSeq`. Small authority batches use an inline path
+   without a temporary map, so repeated addresses cause only one version and
+   dirty-index mutation.
 3. Admission mutates cache state only. Bounded managers maintain an exact index
    of clean cache addresses. When space is required, admission protects every
    address present in the incoming batch and first selects the complete clean
@@ -20,20 +21,52 @@ Current flow:
    that the same batch will update. Admission never reads or writes
    `ActiveStore` and never waits for the serialized durable flush lane. If a new
    row still exceeds the hard bound, the whole admission is rejected with
-   `ErrCachePressure`.
+   `ErrCachePressure`. A clean row keeps its latest observed `ActiveAtMS` and
+   `MessageSeq` for immediate list reads separately from its confirmed durable
+   `ActiveAt` baseline. Receiver-only activity that remains strictly inside
+   `ActiveCooldown` advances the cached view, emits a low-cardinality
+   `CooldownSuppressed` mutation, and leaves the clean/dirty indexes unchanged.
+   Sender `ReadSeq` advances, cooldown boundaries, and authority hash-slot
+   changes still mark the row dirty.
 4. At 80% total cache occupancy with more than 70% of configured capacity still
    dirty, the manager starts a pressure-drain cycle by sending one nonblocking,
    coalesced wakeup to the app flush worker. A full dirty cache uses the same
    wakeup and rejection path.
 5. Each pressure wake persists at most the configured flush batch through
-   `ActiveStore.TouchConversationActiveAt`. Successful attempts requeue one
+   `ActiveStore.TouchConversationActiveAt`. Flush filtering checks durable
+   delete barriers for sender and receiver rows before write: a stale or unknown
+   `MessageSeq` is reconciled out of cache instead of treating the store's
+   idempotent no-op as a confirmed active baseline. Successful attempts requeue one
    wakeup while dirty rows remain above the 70% low watermark and the attempt
    cleared at least one dirty marker. A zero-progress attempt keeps the drain
    active but waits for the periodic worker tick instead of forming a tight
    wakeup loop. Retained clean rows form an immediately evictable reserve for
    later admissions.
-6. Active view reads merge cache rows with durable `(uid, kind)` active-index pages.
-7. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority moves.
+6. Active view reads carry each cache row's `MessageSeq` while merging the
+   latest cached view with durable `(uid, kind)` active-index pages and primary
+   row hydration. A durable `DeletedToSeq` hides an unknown or older cached
+   activity even when a stale touch returned nil and left that cache row clean.
+   Hydration reconciles the discovered barrier back into the bounded cache:
+   stale rows are removed, while a newer cache view that is not yet reflected
+   durably is forced dirty. A cooldown skip confirms only the durable baseline;
+   it never rolls the newer cached `ActiveAtMS` or `MessageSeq` backward.
+7. A committed conversation delete is reconciled by exact cache address under
+   the manager lock. A cached row with unknown `MessageSeq`, or a sequence at or
+   below `DeletedToSeq`, is removed from every cache index. A newer row keeps its
+   latest view, receives a new durable-baseline generation, and is forced dirty
+   so the durable delete barrier can fence its retry. The generation prevents an
+   in-flight pre-delete flush from confirming the invalidated baseline. A lower
+   already-observed barrier is ignored. Reapplying an equal barrier keeps an
+   already-dirty newer row idempotent, but re-invalidates a clean newer row so a
+   stale durable read followed by equal-barrier hydration cannot leave the
+   conversation clean on an obsolete baseline. A separate unknown-prefix error
+   path never removes rows or records an attempted barrier; it invalidates the
+   requested durable baselines and forces present rows dirty until durable
+   hydration distinguishes the committed prefix from the uncommitted tail.
+8. Hash-slot handoff drains dirty rows scoped by UID hash slot before authority
+   moves, then purges clean rows through an exact per-slot clean index. The
+   purge is bounded by rows owned by that slot and does not scan or allocate for
+   the full cache. Dirty rows are never purged by the clean-slot purge.
 
 Only periodic, pressure-woken, and hash-slot-scoped durable flush attempts enter
 the serialized flush lane. Version fencing preserves updates that arrive during
@@ -47,8 +80,11 @@ dirty activity uses a typed deletable counted min-heap containing only live
 positive `ActiveAtMS` buckets, so its size is bounded by live dirty rows rather
 than cumulative updates. Cooldown classification uses whether the current
 dirty version advanced `ReadSeq`; a historical cached sender `ReadSeq` does not
-turn later receiver-only activity into a sender write. Skipped and persisted
-results are cleared together under one cache-lock acquisition.
+turn later receiver-only activity into a sender write. No-write and persisted
+snapshots are reconciled together under one cache-lock acquisition. Both successful
+writes and durable cooldown reads advance the confirmed baseline when their
+baseline generation still matches, including across a cache-version conflict;
+the cached list view remains the maximum observation.
 
 Cache observations report aggregate row/dirty counts plus fixed kind-aware
 normal/CMD counts maintained incrementally on cache mutation. Observation does
@@ -66,14 +102,18 @@ lock wait from in-lock work. Admission lock histograms retain bounded
 pressure tail.
 
 Successful flush observations use an explicit conservation model. `Selected`
-is divided into acknowledged `Persisted` and cooldown `Skipped` rows; after
+is divided into acknowledged `Persisted`, cooldown `Skipped`, and durable
+delete-barrier `DeleteFenced` rows; after
 durable completion those same rows are divided into actually `Cleared` rows,
 version-conflicted rows retained for retry, and `Superseded` stale snapshots
 that are no longer present or dirty. Persisted
 rows are never reported as cleared merely because the store call succeeded. A
-store error keeps every selected dirty marker for idempotent retry, but its
-durable row count is unknown because the adapter may have completed an earlier
-Slot proposal. The observer also records the serialized lane wait plus select,
-filter, persist, and clear stage durations.
+store error reports `Requeued` from the selected addresses that are still dirty
+at error observation time. This includes a newer version recreated after a
+delete-fenced snapshot was removed, so first-stage `DeleteFenced` and
+second-stage `Requeued` may overlap. The durable row count remains unknown
+because the adapter may have completed an earlier Slot proposal. The observer
+also records the serialized lane wait plus select, filter, persist, and clear
+stage durations.
 Pressure signals carry their enqueue time so the app-owned worker can report
 signal-to-receive wait without adding UID, channel, hash-slot, or Slot labels.

--- a/internal/runtime/conversationactive/active_view.go
+++ b/internal/runtime/conversationactive/active_view.go
@@ -12,6 +12,13 @@ type activeViewKey struct {
 	channelType int64
 }
 
+type activeViewCacheRow struct {
+	// state is the cache projection exposed through the active view.
+	state metadb.ConversationState
+	// messageSeq fences this cache projection against a durable delete barrier.
+	messageSeq uint64
+}
+
 // ListActiveView returns active conversations from cache and durable store.
 func (m *Manager) ListActiveView(ctx context.Context, kind metadb.ConversationKind, uid string, after metadb.ConversationActiveCursor, limit int) (ActiveViewPage, error) {
 	if m.store == nil {
@@ -48,7 +55,7 @@ func (m *Manager) ListActiveView(ctx context.Context, kind metadb.ConversationKi
 	}, nil
 }
 
-func (m *Manager) cacheRowsForActiveView(kind metadb.ConversationKind, uid string, after metadb.ConversationActiveCursor) ([]metadb.ConversationState, map[activeViewKey]metadb.ConversationState, map[activeViewKey]metadb.ConversationState) {
+func (m *Manager) cacheRowsForActiveView(kind metadb.ConversationKind, uid string, after metadb.ConversationActiveCursor) ([]activeViewCacheRow, map[activeViewKey]activeViewCacheRow, map[activeViewKey]activeViewCacheRow) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -57,61 +64,115 @@ func (m *Manager) cacheRowsForActiveView(kind metadb.ConversationKind, uid strin
 		return nil, nil, nil
 	}
 
-	rows := make([]metadb.ConversationState, 0, len(byChannel))
-	afterRows := make(map[activeViewKey]metadb.ConversationState, len(byChannel))
-	allRows := make(map[activeViewKey]metadb.ConversationState, len(byChannel))
+	rows := make([]activeViewCacheRow, 0, len(byChannel))
+	afterRows := make(map[activeViewKey]activeViewCacheRow, len(byChannel))
+	allRows := make(map[activeViewKey]activeViewCacheRow, len(byChannel))
 	for key, entry := range byChannel {
 		if key.kind != kind {
 			continue
 		}
-		row := activePatchState(entry.patch)
-		if row.ActiveAt <= 0 {
+		state := activePatchState(entry.patch)
+		if state.ActiveAt <= 0 {
 			continue
 		}
+		row := activeViewCacheRow{state: state, messageSeq: entry.patch.MessageSeq}
 		viewKey := activeViewKey{channelID: key.channelID, channelType: int64(key.channelType)}
 		allRows[viewKey] = row
-		if !activeRowAfter(row, after) {
+		if !activeRowAfter(state, after) {
 			continue
 		}
 		rows = append(rows, row)
 		afterRows[viewKey] = row
 	}
-	sortActiveViewRows(rows)
+	sortActiveViewCacheRows(rows)
 	return rows, afterRows, allRows
 }
 
-func (m *Manager) mergeActiveViewRows(ctx context.Context, kind metadb.ConversationKind, uid string, dbRows []metadb.ConversationState, cacheRows []metadb.ConversationState, cacheAfter map[activeViewKey]metadb.ConversationState, cacheAll map[activeViewKey]metadb.ConversationState) ([]metadb.ConversationState, error) {
+func (m *Manager) mergeActiveViewRows(ctx context.Context, kind metadb.ConversationKind, uid string, dbRows []metadb.ConversationState, cacheRows []activeViewCacheRow, cacheAfter map[activeViewKey]activeViewCacheRow, cacheAll map[activeViewKey]activeViewCacheRow) ([]metadb.ConversationState, error) {
 	merged := make([]metadb.ConversationState, 0, len(dbRows)+len(cacheRows))
 	mergedKeys := make(map[activeViewKey]struct{}, len(dbRows)+len(cacheRows))
+	deleteReconciliations := make([]metadb.ConversationDelete, 0)
 	for _, dbRow := range dbRows {
 		key := activeViewKey{channelID: dbRow.ChannelID, channelType: dbRow.ChannelType}
 		if cacheRow, ok := cacheAfter[key]; ok {
-			merged = append(merged, mergeActiveViewState(dbRow, cacheRow))
+			if cacheActivityNeedsDeleteReconciliation(cacheRow.state, cacheRow.messageSeq, dbRow) {
+				deleteReconciliations = append(deleteReconciliations, activeViewDeleteReconciliation(dbRow))
+			}
+			if cacheActivityFencedByDelete(cacheRow.messageSeq, dbRow.DeletedToSeq) {
+				merged = append(merged, dbRow)
+			} else {
+				merged = append(merged, mergeActiveViewState(dbRow, cacheRow.state))
+			}
 			mergedKeys[key] = struct{}{}
 			continue
 		}
-		if _, ok := cacheAll[key]; ok {
+		if cacheRow, ok := cacheAll[key]; ok {
+			if cacheActivityNeedsDeleteReconciliation(cacheRow.state, cacheRow.messageSeq, dbRow) {
+				deleteReconciliations = append(deleteReconciliations, activeViewDeleteReconciliation(dbRow))
+			}
+			if cacheActivityFencedByDelete(cacheRow.messageSeq, dbRow.DeletedToSeq) {
+				merged = append(merged, dbRow)
+				mergedKeys[key] = struct{}{}
+			}
 			continue
 		}
 		merged = append(merged, dbRow)
 		mergedKeys[key] = struct{}{}
 	}
 	for _, cacheRow := range cacheRows {
-		key := activeViewKey{channelID: cacheRow.ChannelID, channelType: cacheRow.ChannelType}
+		key := activeViewKey{channelID: cacheRow.state.ChannelID, channelType: cacheRow.state.ChannelType}
 		if _, ok := mergedKeys[key]; ok {
 			continue
 		}
-		durable, ok, err := m.store.GetConversationState(ctx, kind, uid, cacheRow.ChannelID, cacheRow.ChannelType)
+		durable, ok, err := m.store.GetConversationState(ctx, kind, uid, cacheRow.state.ChannelID, cacheRow.state.ChannelType)
 		if err != nil {
 			return nil, err
 		}
 		if ok {
-			cacheRow = mergeActiveViewState(durable, cacheRow)
+			if cacheActivityNeedsDeleteReconciliation(cacheRow.state, cacheRow.messageSeq, durable) {
+				deleteReconciliations = append(deleteReconciliations, activeViewDeleteReconciliation(durable))
+			}
+			if cacheActivityFencedByDelete(cacheRow.messageSeq, durable.DeletedToSeq) {
+				continue
+			}
+			cacheRow.state = mergeActiveViewState(durable, cacheRow.state)
 		}
-		merged = append(merged, cacheRow)
+		merged = append(merged, cacheRow.state)
 		mergedKeys[key] = struct{}{}
 	}
+	m.ApplyConversationDeletes(deleteReconciliations)
 	return merged, nil
+}
+
+// cacheActivityFencedByDelete reports whether a durable delete barrier rejects
+// the message sequence represented by one cached activity observation.
+func cacheActivityFencedByDelete(messageSeq, deletedToSeq uint64) bool {
+	return deletedToSeq > 0 && (messageSeq == 0 || messageSeq <= deletedToSeq)
+}
+
+// cacheActivityNeedsDeleteReconciliation reports whether hydration discovered
+// a barrier or durable lag that must be reflected back into the cache indexes.
+func cacheActivityNeedsDeleteReconciliation(cacheRow metadb.ConversationState, messageSeq uint64, durable metadb.ConversationState) bool {
+	if durable.DeletedToSeq == 0 {
+		return false
+	}
+	if cacheActivityFencedByDelete(messageSeq, durable.DeletedToSeq) {
+		return true
+	}
+	return cacheRow.ActiveAt > durable.ActiveAt || cacheRow.ReadSeq > durable.ReadSeq
+}
+
+// activeViewDeleteReconciliation maps hydrated durable state to the exact-row
+// cache invalidation contract shared with committed delete callbacks.
+func activeViewDeleteReconciliation(durable metadb.ConversationState) metadb.ConversationDelete {
+	return metadb.ConversationDelete{
+		UID:          durable.UID,
+		Kind:         durable.Kind,
+		ChannelID:    durable.ChannelID,
+		ChannelType:  durable.ChannelType,
+		DeletedToSeq: durable.DeletedToSeq,
+		UpdatedAt:    durable.UpdatedAt,
+	}
 }
 
 func activePatchState(patch ActivePatch) metadb.ConversationState {
@@ -169,5 +230,19 @@ func sortActiveViewRows(rows []metadb.ConversationState) {
 			return rows[i].ChannelID < rows[j].ChannelID
 		}
 		return rows[i].ChannelType < rows[j].ChannelType
+	})
+}
+
+func sortActiveViewCacheRows(rows []activeViewCacheRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		left := rows[i].state
+		right := rows[j].state
+		if left.ActiveAt != right.ActiveAt {
+			return left.ActiveAt > right.ActiveAt
+		}
+		if left.ChannelID != right.ChannelID {
+			return left.ChannelID < right.ChannelID
+		}
+		return left.ChannelType < right.ChannelType
 	})
 }

--- a/internal/runtime/conversationactive/manager.go
+++ b/internal/runtime/conversationactive/manager.go
@@ -38,8 +38,14 @@ type preparedActiveBatch struct {
 }
 
 type cacheEntry struct {
-	// patch is the latest coalesced active projection for this cached row.
+	// patch is the latest observed active projection exposed by the cache view and used by the next required flush.
 	patch ActivePatch
+	// durableActiveAtMS is the latest ActiveAt confirmed by a durable read or successful write for this baseline generation.
+	durableActiveAtMS int64
+	// baselineGeneration fences durable confirmations from a removed, recreated, or delete-invalidated entry.
+	baselineGeneration uint64
+	// deleteBarrier is the newest durable delete floor already applied to this cached entry.
+	deleteBarrier uint64
 	// version changes whenever patch content changes, fencing stale flush snapshots.
 	version uint64
 	// dirty reports that patch still needs to be flushed to the durable store.
@@ -61,6 +67,10 @@ type flushEntry struct {
 	patch ActivePatch
 	// version fences dirty clearing against concurrent cache updates.
 	version uint64
+	// baselineGeneration fences durable confirmations against delete invalidation or row recreation.
+	baselineGeneration uint64
+	// confirmedActiveAtMS is filled after a durable cooldown read for skipped snapshots.
+	confirmedActiveAtMS int64
 	// readSeqDirty keeps receiver-only cooldown classification independent from a historical cached ReadSeq.
 	readSeqDirty bool
 }
@@ -71,6 +81,7 @@ const (
 	cacheMutationUnchanged cacheMutationKind = iota
 	cacheMutationBecameDirty
 	cacheMutationDirtyUpdated
+	cacheMutationCooldownSuppressed
 )
 
 type dirtyClearResult struct {
@@ -89,7 +100,7 @@ type Manager struct {
 	nowMS func() int64
 	// store reads and persists durable active rows for cache/store merging.
 	store ActiveStore
-	// activeCooldown skips receiver-only active_at flushes within this durable row age window.
+	// activeCooldown suppresses receiver-only re-dirtying and flushes within this durable row age window.
 	activeCooldown time.Duration
 	// maxCachedRows bounds cached rows across all UIDs; zero means unbounded.
 	maxCachedRows int
@@ -121,6 +132,8 @@ type Manager struct {
 	dirtyQueue dirtyAddressQueue
 	// nextVersion allocates monotonic cache-entry versions for dirty flush fencing.
 	nextVersion uint64
+	// nextBaselineGeneration allocates identities for durable baselines across deletion and row recreation.
+	nextBaselineGeneration uint64
 	// observationRevision orders cache snapshots delivered by concurrent callers.
 	observationRevision uint64
 	// cache stores UID -> conversation key -> active projection entry.
@@ -128,6 +141,8 @@ type Manager struct {
 	// cleanIndex contains every clean cache address when maxCachedRows is bounded.
 	// It lets admission find an eviction reserve without scanning dirty cache rows.
 	cleanIndex map[cacheAddress]struct{}
+	// cleanByHashSlot indexes clean cache rows with an authority hash slot for bounded handoff purges.
+	cleanByHashSlot map[uint16]map[cacheAddress]struct{}
 	// dirtyByHashSlot indexes dirty cache rows by UID hash slot for bounded authority handoff drains.
 	dirtyByHashSlot map[uint16]map[cacheAddress]struct{}
 }
@@ -195,6 +210,7 @@ func (m *Manager) admitActiveBatch(ctx context.Context, hashSlot uint16, hasHash
 			ChannelType: batch.ChannelType,
 			ActiveAtMS:  activeAtMS,
 			ReadSeq:     batch.MessageSeq,
+			MessageSeq:  batch.MessageSeq,
 		})
 	}
 
@@ -218,6 +234,7 @@ func (m *Manager) admitActiveBatch(ctx context.Context, hashSlot uint16, hasHash
 			ChannelType: batch.ChannelType,
 			ActiveAtMS:  activeAtMS,
 			ReadSeq:     readSeq,
+			MessageSeq:  batch.MessageSeq,
 		})
 	}
 
@@ -232,6 +249,172 @@ func (m *Manager) MarkActive(ctx context.Context, patches []ActivePatch) error {
 // MarkActiveForHashSlot merges active conversation patches owned by one UID hash slot.
 func (m *Manager) MarkActiveForHashSlot(ctx context.Context, hashSlot uint16, patches []ActivePatch) error {
 	return m.markActive(ctx, hashSlot, true, patches)
+}
+
+// ApplyConversationDeletes reconciles committed delete barriers with exact cached rows.
+// Rows at or below the barrier, including rows with an unknown message sequence, are removed.
+// Newer rows retain their latest active view and become dirty against an invalid durable baseline.
+// Reapplying the same barrier re-invalidates a clean newer row after a prior uncommitted delete attempt.
+func (m *Manager) ApplyConversationDeletes(deletes []metadb.ConversationDelete) {
+	if m == nil || len(deletes) == 0 {
+		return
+	}
+
+	m.mu.Lock()
+	for _, deletion := range deletes {
+		if deletion.UID == "" || deletion.ChannelID == "" || deletion.ChannelType <= 0 || deletion.ChannelType > 255 || deletion.DeletedToSeq == 0 {
+			continue
+		}
+		key := conversationKey{kind: deletion.Kind, channelID: deletion.ChannelID, channelType: uint8(deletion.ChannelType)}
+		address := cacheAddress{uid: deletion.UID, key: key}
+		byChannel := m.cache[deletion.UID]
+		if byChannel == nil {
+			continue
+		}
+		current, ok := byChannel[key]
+		if !ok || deletion.DeletedToSeq < current.deleteBarrier {
+			continue
+		}
+		if current.patch.MessageSeq == 0 || current.patch.MessageSeq <= deletion.DeletedToSeq {
+			m.removeCacheEntryLocked(address, current)
+			continue
+		}
+		if deletion.DeletedToSeq == current.deleteBarrier && current.dirty {
+			continue
+		}
+
+		current.deleteBarrier = deletion.DeletedToSeq
+		current.durableActiveAtMS = 0
+		m.nextBaselineGeneration++
+		current.baselineGeneration = m.nextBaselineGeneration
+		if !current.dirty {
+			m.untrackCleanLocked(address, current)
+			current.dirty = true
+			current.readSeqDirty = false
+			m.trackDirtyLocked(address, current)
+		}
+		m.nextVersion++
+		current.version = m.nextVersion
+		byChannel[key] = current
+	}
+	signalPressure := m.startPressureDrainLocked()
+	stopPressure := false
+	if m.pressureDraining && m.dirtyRows <= m.pressureLowDirtyRows {
+		m.pressureDraining = false
+		stopPressure = true
+		signalPressure = false
+	}
+	m.mu.Unlock()
+
+	if stopPressure {
+		m.observePressure(PressureObservation{Event: "stop_low_watermark"})
+	}
+	if signalPressure {
+		m.observePressure(PressureObservation{Event: "start_high_watermark"})
+		m.signalPressure()
+	}
+	m.observeCache()
+}
+
+// InvalidateConversationDeleteAttempts conservatively fences cache baselines
+// after a delete batch returns an unknown committed prefix. It never treats an
+// attempted barrier as confirmed and never removes a cached row; every present
+// row is forced dirty so durable state decides whether its activity survives.
+func (m *Manager) InvalidateConversationDeleteAttempts(deletes []metadb.ConversationDelete) {
+	if m == nil || len(deletes) == 0 {
+		return
+	}
+
+	m.mu.Lock()
+	for _, deletion := range deletes {
+		if deletion.UID == "" || deletion.ChannelID == "" || deletion.ChannelType <= 0 || deletion.ChannelType > 255 || deletion.DeletedToSeq == 0 {
+			continue
+		}
+		key := conversationKey{kind: deletion.Kind, channelID: deletion.ChannelID, channelType: uint8(deletion.ChannelType)}
+		address := cacheAddress{uid: deletion.UID, key: key}
+		byChannel := m.cache[deletion.UID]
+		if byChannel == nil {
+			continue
+		}
+		current, ok := byChannel[key]
+		if !ok {
+			continue
+		}
+
+		current.durableActiveAtMS = 0
+		m.nextBaselineGeneration++
+		current.baselineGeneration = m.nextBaselineGeneration
+		if !current.dirty {
+			m.untrackCleanLocked(address, current)
+			current.dirty = true
+			current.readSeqDirty = false
+			m.trackDirtyLocked(address, current)
+		}
+		m.nextVersion++
+		current.version = m.nextVersion
+		byChannel[key] = current
+	}
+	signalPressure := m.startPressureDrainLocked()
+	stopPressure := false
+	if m.pressureDraining && m.dirtyRows <= m.pressureLowDirtyRows {
+		m.pressureDraining = false
+		stopPressure = true
+		signalPressure = false
+	}
+	m.mu.Unlock()
+
+	if stopPressure {
+		m.observePressure(PressureObservation{Event: "stop_low_watermark"})
+	}
+	if signalPressure {
+		m.observePressure(PressureObservation{Event: "start_high_watermark"})
+		m.signalPressure()
+	}
+	m.observeCache()
+}
+
+// PurgeCleanHashSlot removes clean cache rows retained from one authority hash slot.
+// Dirty rows are preserved for the existing scoped handoff drain.
+func (m *Manager) PurgeCleanHashSlot(hashSlot uint16) int {
+	purged := m.PurgeCleanHashSlotStateOnly(hashSlot)
+	if purged > 0 {
+		m.ObserveCacheState()
+	}
+	return purged
+}
+
+// PurgeCleanHashSlotStateOnly removes clean rows without invoking the observer.
+// Callers holding an outer lifecycle lock must observe after publishing state and unlocking.
+func (m *Manager) PurgeCleanHashSlotStateOnly(hashSlot uint16) int {
+	if m == nil {
+		return 0
+	}
+
+	m.mu.Lock()
+	purged := 0
+	for address := range m.cleanByHashSlot[hashSlot] {
+		entry, ok := m.cache[address.uid][address.key]
+		if !ok || entry.dirty || !entry.hasHashSlot || entry.hashSlot != hashSlot {
+			// Discard a stale index entry defensively without falling back to a full-cache scan.
+			delete(m.cleanByHashSlot[hashSlot], address)
+			continue
+		}
+		m.removeCacheEntryLocked(address, entry)
+		purged++
+	}
+	if len(m.cleanByHashSlot[hashSlot]) == 0 {
+		delete(m.cleanByHashSlot, hashSlot)
+	}
+	m.mu.Unlock()
+	return purged
+}
+
+// ObserveCacheState publishes one current cache snapshot outside caller lifecycle locks.
+func (m *Manager) ObserveCacheState() {
+	if m == nil {
+		return
+	}
+	m.observeCache()
 }
 
 func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot bool, patches []ActivePatch) error {
@@ -279,6 +462,8 @@ func (m *Manager) markActive(ctx context.Context, hashSlot uint16, hasHashSlot b
 				mutation.BecameDirty++
 			case cacheMutationDirtyUpdated:
 				mutation.DirtyUpdated++
+			case cacheMutationCooldownSuppressed:
+				mutation.CooldownSuppressed++
 			default:
 				mutation.Unchanged++
 			}
@@ -393,13 +578,15 @@ func (m *Manager) markActiveLocked(row preparedActivePatch, hashSlot uint16, has
 	current, ok := byChannel[key]
 	if !ok {
 		m.nextVersion++
+		m.nextBaselineGeneration++
 		entry := cacheEntry{
-			patch:        patch,
-			version:      m.nextVersion,
-			dirty:        true,
-			readSeqDirty: patch.ReadSeq > 0,
-			hashSlot:     hashSlot,
-			hasHashSlot:  hasHashSlot,
+			patch:              patch,
+			version:            m.nextVersion,
+			baselineGeneration: m.nextBaselineGeneration,
+			dirty:              true,
+			readSeqDirty:       patch.ReadSeq > 0,
+			hashSlot:           hashSlot,
+			hasHashSlot:        hasHashSlot,
 		}
 		byChannel[key] = entry
 		m.totalRows++
@@ -411,6 +598,7 @@ func (m *Manager) markActiveLocked(row preparedActivePatch, hashSlot uint16, has
 		return cacheMutationBecameDirty
 	}
 
+	slotChanged := current.hashSlot != hashSlot || current.hasHashSlot != hasHashSlot
 	merged := current.patch
 	readSeqAdvanced := patch.ReadSeq > merged.ReadSeq
 	if patch.ActiveAtMS > merged.ActiveAtMS {
@@ -419,9 +607,18 @@ func (m *Manager) markActiveLocked(row preparedActivePatch, hashSlot uint16, has
 	if patch.ReadSeq > merged.ReadSeq {
 		merged.ReadSeq = patch.ReadSeq
 	}
-	slotChanged := current.hashSlot != hashSlot || current.hasHashSlot != hasHashSlot
+	if patch.MessageSeq > merged.MessageSeq {
+		merged.MessageSeq = patch.MessageSeq
+	}
 	if merged == current.patch && !slotChanged {
 		return cacheMutationUnchanged
+	}
+	if m.shouldSuppressCleanReceiverActive(current, merged, readSeqAdvanced, slotChanged) {
+		m.nextVersion++
+		current.patch = merged
+		current.version = m.nextVersion
+		byChannel[key] = current
+		return cacheMutationCooldownSuppressed
 	}
 
 	next := current
@@ -433,7 +630,7 @@ func (m *Manager) markActiveLocked(row preparedActivePatch, hashSlot uint16, has
 		next.readSeqDirty = current.readSeqDirty || readSeqAdvanced
 		m.moveDirtyLocked(address, current, next)
 	} else {
-		m.untrackCleanLocked(address)
+		m.untrackCleanLocked(address, current)
 		next.dirty = true
 		next.readSeqDirty = readSeqAdvanced
 		m.trackDirtyLocked(address, next)
@@ -446,6 +643,19 @@ func (m *Manager) markActiveLocked(row preparedActivePatch, hashSlot uint16, has
 		return cacheMutationDirtyUpdated
 	}
 	return cacheMutationBecameDirty
+}
+
+// shouldSuppressCleanReceiverActive reports whether a receiver-only update is
+// still covered by the durable ActiveAt baseline retained in a clean entry.
+func (m *Manager) shouldSuppressCleanReceiverActive(current cacheEntry, merged ActivePatch, readSeqAdvanced, slotChanged bool) bool {
+	if current.dirty || slotChanged || readSeqAdvanced {
+		return false
+	}
+	cooldownMS := int64(m.activeCooldown / time.Millisecond)
+	if cooldownMS <= 0 || current.durableActiveAtMS <= 0 || merged.ActiveAtMS < current.durableActiveAtMS {
+		return false
+	}
+	return merged.ActiveAtMS-current.durableActiveAtMS < cooldownMS
 }
 
 func prepareActiveBatch(patches []ActivePatch, inline []preparedActivePatch) preparedActiveBatch {
@@ -506,6 +716,9 @@ func mergeActivePatch(current *ActivePatch, incoming ActivePatch) {
 	}
 	if incoming.ReadSeq > current.ReadSeq {
 		current.ReadSeq = incoming.ReadSeq
+	}
+	if incoming.MessageSeq > current.MessageSeq {
+		current.MessageSeq = incoming.MessageSeq
 	}
 }
 
@@ -590,15 +803,29 @@ func (m *Manager) evictCleanVictimsLocked(victims []cacheAddress) bool {
 	}
 	for _, address := range victims {
 		byChannel := m.cache[address.uid]
-		delete(byChannel, address.key)
-		m.untrackCleanLocked(address)
-		m.totalRows--
-		decrementKindCount(m.rowsByKind, address.key.kind)
-		if len(byChannel) == 0 {
-			delete(m.cache, address.uid)
-		}
+		m.removeCacheEntryLocked(address, byChannel[address.key])
 	}
 	return true
+}
+
+func (m *Manager) removeCacheEntryLocked(address cacheAddress, entry cacheEntry) {
+	byChannel := m.cache[address.uid]
+	if byChannel == nil {
+		return
+	}
+	if entry.dirty {
+		m.untrackDirtyLocked(address, entry)
+	} else {
+		m.untrackCleanLocked(address, entry)
+	}
+	delete(byChannel, address.key)
+	if m.totalRows > 0 {
+		m.totalRows--
+	}
+	decrementKindCount(m.rowsByKind, address.key.kind)
+	if len(byChannel) == 0 {
+		delete(m.cache, address.uid)
+	}
 }
 
 // Flush persists dirty active rows and clears only unchanged dirty markers.
@@ -654,18 +881,22 @@ func (m *Manager) flushDirtyEntries(ctx context.Context, startedAt time.Time, la
 	}
 
 	filterStartedAt := time.Now()
-	flushEntries, skippedEntries, err := m.filterFlushEntries(ctx, entries)
+	flushEntries, skippedEntries, deleteFenced, err := m.filterFlushEntries(ctx, entries)
 	observation.FilterDuration = nonNegativeDuration(time.Since(filterStartedAt))
 	if err != nil {
 		observation.Result = flushErrorResult(err)
 		observation.FailureStage = "filter"
-		observation.Requeued = len(entries)
+		observation.Requeued = m.currentDirtySelectedCount(entries)
 		observation.Duration = positiveDuration(time.Since(startedAt))
 		m.observeFlush(observation)
 		m.observePressurePause(err)
 		m.observeCache()
-		return FlushResult{Selected: len(entries), Requeued: len(entries)}, err
+		return FlushResult{Selected: len(entries), Requeued: observation.Requeued}, err
 	}
+	// Durable delete reconciliation already removed these rows during filtering.
+	// Publish that terminal classification even if a later touch for the
+	// remaining rows fails; only rows still present can be requeued.
+	observation.DeleteFenced = deleteFenced
 	patches := make([]metadb.ConversationActivePatch, 0, len(flushEntries))
 	for _, entry := range flushEntries {
 		patches = append(patches, activePatchMetaPatch(entry.patch))
@@ -676,17 +907,17 @@ func (m *Manager) flushDirtyEntries(ctx context.Context, startedAt time.Time, la
 			observation.PersistDuration = nonNegativeDuration(time.Since(persistStartedAt))
 			observation.Result = flushErrorResult(err)
 			observation.FailureStage = "persist"
-			observation.Requeued = len(entries)
+			observation.Requeued = m.currentDirtySelectedCount(entries)
 			observation.Duration = positiveDuration(time.Since(startedAt))
 			m.observeFlush(observation)
 			m.observePressurePause(err)
 			m.observeCache()
-			return FlushResult{Selected: len(entries), Requeued: len(entries)}, err
+			return FlushResult{Selected: len(entries), DeleteFenced: deleteFenced, Requeued: observation.Requeued}, err
 		}
 		observation.PersistDuration = nonNegativeDuration(time.Since(persistStartedAt))
 	}
 	observation.Persisted = len(flushEntries)
-	observation.Skipped = len(skippedEntries)
+	observation.Skipped = len(skippedEntries) - deleteFenced
 	clearStartedAt := time.Now()
 	skippedClear, persistedClear, clearLockWait, clearApply := m.clearDirtyEntries(skippedEntries, flushEntries)
 	observation.ClearDuration = nonNegativeDuration(time.Since(clearStartedAt))
@@ -705,11 +936,31 @@ func (m *Manager) flushDirtyEntries(ctx context.Context, startedAt time.Time, la
 		Selected:         observation.Selected,
 		Persisted:        observation.Persisted,
 		Skipped:          observation.Skipped,
+		DeleteFenced:     observation.DeleteFenced,
 		Cleared:          observation.Cleared,
 		VersionConflicts: observation.VersionConflicts,
 		Superseded:       observation.Superseded,
 		Requeued:         observation.Requeued,
 	}, nil
+}
+
+// currentDirtySelectedCount reports how many selected addresses currently
+// retain dirty work. A delete-fenced snapshot can be removed and then become
+// dirty again when a newer activity version arrives before an error returns.
+func (m *Manager) currentDirtySelectedCount(entries []flushEntry) int {
+	if m == nil || len(entries) == 0 {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	dirty := 0
+	for _, entry := range entries {
+		current, ok := m.cache[entry.uid][entry.key]
+		if ok && current.dirty {
+			dirty++
+		}
+	}
+	return dirty
 }
 
 func flushErrorResult(err error) string {
@@ -738,15 +989,12 @@ func (m *Manager) observePressurePause(err error) {
 	}
 }
 
-func (m *Manager) filterFlushEntries(ctx context.Context, entries []flushEntry) ([]flushEntry, []flushEntry, error) {
+func (m *Manager) filterFlushEntries(ctx context.Context, entries []flushEntry) ([]flushEntry, []flushEntry, int, error) {
 	if m.activeCooldown <= 0 {
-		return entries, nil, nil
+		return entries, nil, 0, nil
 	}
 	keys := make([]metadb.ConversationStateKey, 0, len(entries))
 	for _, entry := range entries {
-		if entry.readSeqDirty {
-			continue
-		}
 		keys = append(keys, metadb.ConversationStateKey{
 			UID:         entry.patch.UID,
 			Kind:        entry.patch.Kind,
@@ -755,23 +1003,21 @@ func (m *Manager) filterFlushEntries(ctx context.Context, entries []flushEntry) 
 		})
 	}
 	if len(keys) == 0 {
-		return entries, nil, nil
+		return entries, nil, 0, nil
 	}
 	states, err := m.store.GetConversationStates(ctx, keys)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	cooldownMS := int64(m.activeCooldown / time.Millisecond)
 	if cooldownMS <= 0 {
-		return entries, nil, nil
+		return entries, nil, 0, nil
 	}
 	flushEntries := make([]flushEntry, 0, len(entries))
 	skippedEntries := make([]flushEntry, 0)
+	deleteReconciliations := make([]metadb.ConversationDelete, 0)
+	deleteFenced := 0
 	for _, entry := range entries {
-		if entry.readSeqDirty {
-			flushEntries = append(flushEntries, entry)
-			continue
-		}
 		key := metadb.ConversationStateKey{
 			UID:         entry.patch.UID,
 			Kind:        entry.patch.Kind,
@@ -779,14 +1025,26 @@ func (m *Manager) filterFlushEntries(ctx context.Context, entries []flushEntry) 
 			ChannelType: int64(entry.patch.ChannelType),
 		}
 		state, ok := states[key]
+		if ok && cacheActivityFencedByDelete(entry.patch.MessageSeq, state.DeletedToSeq) {
+			entry.confirmedActiveAtMS = state.ActiveAt
+			skippedEntries = append(skippedEntries, entry)
+			deleteReconciliations = append(deleteReconciliations, activeViewDeleteReconciliation(state))
+			deleteFenced++
+			continue
+		}
+		if entry.readSeqDirty {
+			flushEntries = append(flushEntries, entry)
+			continue
+		}
 		if !ok || state.ActiveAt <= 0 || entry.patch.ActiveAtMS-state.ActiveAt >= cooldownMS {
 			flushEntries = append(flushEntries, entry)
 			continue
 		}
-		entry.patch.ActiveAtMS = state.ActiveAt
+		entry.confirmedActiveAtMS = state.ActiveAt
 		skippedEntries = append(skippedEntries, entry)
 	}
-	return flushEntries, skippedEntries, nil
+	m.ApplyConversationDeletes(deleteReconciliations)
+	return flushEntries, skippedEntries, deleteFenced, nil
 }
 
 func (m *Manager) clearSkippedDirty(entries []flushEntry) dirtyClearResult {
@@ -947,11 +1205,12 @@ func (m *Manager) dirtyFlushEntriesForHashSlot(hashSlot uint16, limit int) []flu
 			continue
 		}
 		entries = append(entries, flushEntry{
-			uid:          address.uid,
-			key:          address.key,
-			patch:        entry.patch,
-			version:      entry.version,
-			readSeqDirty: entry.readSeqDirty,
+			uid:                address.uid,
+			key:                address.key,
+			patch:              entry.patch,
+			version:            entry.version,
+			baselineGeneration: entry.baselineGeneration,
+			readSeqDirty:       entry.readSeqDirty,
 		})
 		if limit > 0 && len(entries) >= limit {
 			return entries
@@ -962,11 +1221,12 @@ func (m *Manager) dirtyFlushEntriesForHashSlot(hashSlot uint16, limit int) []flu
 
 func newFlushEntry(address cacheAddress, entry cacheEntry) flushEntry {
 	return flushEntry{
-		uid:          address.uid,
-		key:          address.key,
-		patch:        entry.patch,
-		version:      entry.version,
-		readSeqDirty: entry.readSeqDirty,
+		uid:                address.uid,
+		key:                address.key,
+		patch:              entry.patch,
+		version:            entry.version,
+		baselineGeneration: entry.baselineGeneration,
+		readSeqDirty:       entry.readSeqDirty,
 	}
 }
 
@@ -1008,6 +1268,13 @@ func (m *Manager) clearDirtyEntryLocked(entry flushEntry, restoreDurableActiveAt
 		result.staleSnapshots++
 		return
 	}
+	confirmedActiveAtMS := entry.patch.ActiveAtMS
+	if restoreDurableActiveAt {
+		confirmedActiveAtMS = entry.confirmedActiveAtMS
+	}
+	if current.baselineGeneration == entry.baselineGeneration {
+		current.durableActiveAtMS = confirmedActiveAtMS
+	}
 	if current.version != entry.version {
 		if !restoreDurableActiveAt {
 			// A successful persisted snapshot covers its ReadSeq even when a
@@ -1015,33 +1282,48 @@ func (m *Manager) clearDirtyEntryLocked(entry flushEntry, restoreDurableActiveAt
 			// Rebase classification so only a newer sender sequence bypasses
 			// cooldown on the retry.
 			current.readSeqDirty = current.patch.ReadSeq > entry.patch.ReadSeq
-			byChannel[entry.key] = current
 		}
+		byChannel[entry.key] = current
 		result.versionConflicts++
 		return
 	}
 	m.untrackDirtyLocked(cacheAddress{uid: entry.uid, key: entry.key}, current)
-	if restoreDurableActiveAt {
-		current.patch.ActiveAtMS = entry.patch.ActiveAtMS
-		m.nextVersion++
-		current.version = m.nextVersion
-	}
 	current.dirty = false
 	current.readSeqDirty = false
 	byChannel[entry.key] = current
-	m.trackCleanLocked(cacheAddress{uid: entry.uid, key: entry.key})
+	m.trackCleanLocked(cacheAddress{uid: entry.uid, key: entry.key}, current)
 	result.cleared++
 }
 
-func (m *Manager) trackCleanLocked(address cacheAddress) {
+func (m *Manager) trackCleanLocked(address cacheAddress, entry cacheEntry) {
 	if m.cleanIndex != nil {
 		m.cleanIndex[address] = struct{}{}
 	}
+	if !entry.hasHashSlot {
+		return
+	}
+	if m.cleanByHashSlot == nil {
+		m.cleanByHashSlot = make(map[uint16]map[cacheAddress]struct{})
+	}
+	byAddress := m.cleanByHashSlot[entry.hashSlot]
+	if byAddress == nil {
+		byAddress = make(map[cacheAddress]struct{})
+		m.cleanByHashSlot[entry.hashSlot] = byAddress
+	}
+	byAddress[address] = struct{}{}
 }
 
-func (m *Manager) untrackCleanLocked(address cacheAddress) {
+func (m *Manager) untrackCleanLocked(address cacheAddress, entry cacheEntry) {
 	if m.cleanIndex != nil {
 		delete(m.cleanIndex, address)
+	}
+	if !entry.hasHashSlot {
+		return
+	}
+	byAddress := m.cleanByHashSlot[entry.hashSlot]
+	delete(byAddress, address)
+	if len(byAddress) == 0 {
+		delete(m.cleanByHashSlot, entry.hashSlot)
 	}
 }
 
@@ -1136,6 +1418,7 @@ func activePatchMetaPatch(patch ActivePatch) metadb.ConversationActivePatch {
 		ReadSeq:     patch.ReadSeq,
 		ActiveAt:    patch.ActiveAtMS,
 		UpdatedAt:   patch.ActiveAtMS,
+		MessageSeq:  patch.MessageSeq,
 	}
 }
 

--- a/internal/runtime/conversationactive/manager_benchmark_test.go
+++ b/internal/runtime/conversationactive/manager_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 )
@@ -163,6 +164,107 @@ func BenchmarkFlushHashSlotSelected128Of10KDirtyRows(b *testing.B) {
 
 func BenchmarkFlushHashSlotSelected128Of100KDirtyRows(b *testing.B) {
 	benchmarkFlushHashSlotSelectedRows(b, 100_000, 128)
+}
+
+func BenchmarkFlushHashSlotCooldown128Rows(b *testing.B) {
+	testCases := []struct {
+		name             string
+		readSeq          uint64
+		durable          bool
+		deletedToSeq     uint64
+		wantPersisted    int
+		wantSkipped      int
+		wantDeleteFenced int
+		wantCleared      int
+		wantSuperseded   int
+		wantTouchBatches int
+	}{
+		{name: "receiver_within_cooldown", durable: true, wantSkipped: 128, wantCleared: 128},
+		{name: "sender_within_cooldown", durable: true, readSeq: 10, wantPersisted: 128, wantCleared: 128, wantTouchBatches: 1},
+		{name: "receiver_missing_durable_row", wantPersisted: 128, wantCleared: 128, wantTouchBatches: 1},
+		{name: "receiver_fenced_by_delete", durable: true, deletedToSeq: 10, wantDeleteFenced: 128, wantSuperseded: 128},
+	}
+	for _, testCase := range testCases {
+		b.Run(testCase.name, func(b *testing.B) {
+			const rows = 128
+			ctx := context.Background()
+			b.ReportAllocs()
+			for iteration := 0; iteration < b.N; iteration++ {
+				b.StopTimer()
+				store := &recordingActiveStore{primary: make(map[metadb.ConversationStateKey]metadb.ConversationState, rows)}
+				manager := NewManager(Options{Store: store, ActiveCooldown: 2 * time.Hour, MaxCachedRows: rows})
+				patches := make([]ActivePatch, 0, rows)
+				for row := 0; row < rows; row++ {
+					uid := fmt.Sprintf("u-%03d", row)
+					key := metadb.ConversationStateKey{
+						UID: uid, Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2,
+					}
+					patches = append(patches, ActivePatch{
+						UID: uid, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType),
+						ActiveAtMS: 2_000, ReadSeq: testCase.readSeq, MessageSeq: 10,
+					})
+					if testCase.durable {
+						store.primary[key] = metadb.ConversationState{
+							UID: uid, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: key.ChannelType,
+							ActiveAt: 1_000, DeletedToSeq: testCase.deletedToSeq,
+						}
+					}
+				}
+				if err := manager.MarkActiveForHashSlot(ctx, 7, patches); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+
+				result, err := manager.FlushHashSlot(ctx, 7, rows)
+
+				b.StopTimer()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if result.Selected != rows || result.Persisted != testCase.wantPersisted || result.Skipped != testCase.wantSkipped || result.DeleteFenced != testCase.wantDeleteFenced ||
+					result.Cleared != testCase.wantCleared || result.Superseded != testCase.wantSuperseded {
+					b.Fatalf("FlushHashSlot() = %+v, want selected=%d persisted=%d skipped=%d delete_fenced=%d cleared=%d superseded=%d",
+						result, rows, testCase.wantPersisted, testCase.wantSkipped, testCase.wantDeleteFenced, testCase.wantCleared, testCase.wantSuperseded)
+				}
+				if len(store.batchKeys) != rows {
+					b.Fatalf("durable lookup keys = %d, want %d", len(store.batchKeys), rows)
+				}
+				if len(store.touches) != testCase.wantTouchBatches {
+					b.Fatalf("touch batches = %d, want %d", len(store.touches), testCase.wantTouchBatches)
+				}
+				if testCase.wantTouchBatches > 0 && len(store.touches[0]) != rows {
+					b.Fatalf("touched rows = %d, want %d", len(store.touches[0]), rows)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPurgeCleanHashSlot128Of100KCleanRows(b *testing.B) {
+	const (
+		totalRows      = 100_000
+		targetRows     = 128
+		targetHashSlot = uint16(7)
+	)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: totalRows})
+		seedDirtyHashSlots(b, ctx, m, totalRows, targetHashSlot, targetRows)
+		if result, err := m.Flush(ctx, 0); err != nil || result.Cleared != totalRows {
+			b.Fatalf("Flush() = %+v, %v, want %d clean rows", result, err, totalRows)
+		}
+		b.StartTimer()
+
+		purged := m.PurgeCleanHashSlot(targetHashSlot)
+
+		b.StopTimer()
+		if purged != targetRows {
+			b.Fatalf("PurgeCleanHashSlot() = %d, want %d", purged, targetRows)
+		}
+	}
 }
 
 func BenchmarkMarkActiveCoalesces100KUpdates(b *testing.B) {

--- a/internal/runtime/conversationactive/manager_pressure_regression_test.go
+++ b/internal/runtime/conversationactive/manager_pressure_regression_test.go
@@ -65,7 +65,7 @@ func TestMarkActiveCoalescesDuplicateAddressesBeforeMutation(t *testing.T) {
 	for index := 0; index < cap(initial); index++ {
 		initial = append(initial, ActivePatch{
 			Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2,
-			ActiveAtMS: 1_000 + int64(index*25), ReadSeq: uint64(9 - index),
+			ActiveAtMS: 1_000 + int64(index*25), ReadSeq: uint64(9 - index), MessageSeq: uint64(index + 1),
 		})
 	}
 	if err := m.MarkActive(ctx, initial); err != nil {
@@ -78,14 +78,14 @@ func TestMarkActiveCoalescesDuplicateAddressesBeforeMutation(t *testing.T) {
 		t.Fatalf("initial version allocator=%d, want one version for one unique row", m.nextVersion)
 	}
 	entry, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2)
-	if !ok || entry.ActiveAtMS != 1_200 || entry.ReadSeq != 9 {
+	if !ok || entry.ActiveAtMS != 1_200 || entry.ReadSeq != 9 || entry.MessageSeq != 9 {
 		t.Fatalf("coalesced initial entry=%+v present=%v, want max active/read values", entry, ok)
 	}
 
 	updates := []ActivePatch{
-		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_300, ReadSeq: 9},
-		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_250, ReadSeq: 10},
-		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_400, ReadSeq: 8},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_300, ReadSeq: 9, MessageSeq: 10},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_250, ReadSeq: 10, MessageSeq: 12},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_400, ReadSeq: 8, MessageSeq: 11},
 	}
 	if err := m.MarkActive(ctx, updates); err != nil {
 		t.Fatalf("MarkActive(update duplicates) error = %v", err)
@@ -97,7 +97,7 @@ func TestMarkActiveCoalescesDuplicateAddressesBeforeMutation(t *testing.T) {
 		t.Fatalf("updated version allocator=%d, want one new version for one unique row", m.nextVersion)
 	}
 	entry, ok = m.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2)
-	if !ok || entry.ActiveAtMS != 1_400 || entry.ReadSeq != 10 {
+	if !ok || entry.ActiveAtMS != 1_400 || entry.ReadSeq != 10 || entry.MessageSeq != 12 {
 		t.Fatalf("coalesced updated entry=%+v present=%v, want max active/read values", entry, ok)
 	}
 	requireCacheIndexConservation(t, m)
@@ -140,7 +140,7 @@ func TestBoundedFlushSelectionVisitsEveryDirtyRowBeforeRepeating(t *testing.T) {
 	requireDirtyIndexConservation(t, m)
 }
 
-func TestReceiverCooldownDoesNotInheritHistoricalSenderReadSeq(t *testing.T) {
+func TestCleanReceiverCooldownDoesNotInheritHistoricalSenderReadSeq(t *testing.T) {
 	ctx := context.Background()
 	const (
 		initialActiveAt  int64 = 1_000
@@ -181,11 +181,19 @@ func TestReceiverCooldownDoesNotInheritHistoricalSenderReadSeq(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Flush(receiver) error = %v", err)
 	}
-	if result.Selected != 1 || result.Persisted != 0 || result.Skipped != 1 || result.Cleared != 1 {
-		t.Fatalf("Flush(receiver) = %+v, want cooldown skip despite cached historical ReadSeq", result)
+	if result.Selected != 0 {
+		t.Fatalf("Flush(receiver) = %+v, want clean receiver update suppressed inside cooldown", result)
 	}
 	if got := len(store.touches); got != 1 {
 		t.Fatalf("durable touch batches = %d, want only initial sender flush", got)
+	}
+	entry, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2)
+	if !ok || entry.ActiveAtMS != receiverActiveAt || entry.ReadSeq != 9 {
+		t.Fatalf("cache entry = %+v present=%v, want latest receiver view with historical sender read floor", entry, ok)
+	}
+	address := cacheAddress{uid: "u1", key: conversationKey{kind: metadb.ConversationKindNormal, channelID: "room", channelType: 2}}
+	if baseline := m.cache[address.uid][address.key].durableActiveAtMS; baseline != initialActiveAt {
+		t.Fatalf("durable baseline = %d, want %d", baseline, initialActiveAt)
 	}
 	requireDirtyIndexConservation(t, m)
 }
@@ -327,8 +335,8 @@ func TestMixedSenderAndReceiverFlushPreservesCurrentDirtyClassification(t *testi
 		t.Fatalf("durable touches = %+v, want only sticky sender update", store.touches)
 	}
 	receiver, ok := m.EntryForTest(metadb.ConversationKindNormal, "receiver", "room", 2)
-	if !ok || receiver.ActiveAtMS != 900 {
-		t.Fatalf("receiver cache entry = %+v present=%v, want durable ActiveAt 900 restored", receiver, ok)
+	if !ok || receiver.ActiveAtMS != 1_100 {
+		t.Fatalf("receiver cache entry = %+v present=%v, want latest receiver ActiveAt 1100", receiver, ok)
 	}
 	requireDirtyIndexConservation(t, m)
 	if observation := m.cacheObservation(); observation.DirtyRows != 0 || observation.DirtyQueueRows != 0 || observation.DirtyAgeBuckets != 0 {
@@ -415,6 +423,92 @@ func TestPressureDrainDoesNotSpinAfterZeroProgress(t *testing.T) {
 	case <-pressureSignals:
 	default:
 		t.Fatal("progressing periodic flush did not resume pressure drain")
+	}
+	requireDirtyIndexConservation(t, m)
+}
+
+func TestReceiverCooldownTrafficDoesNotRestartPressureDrain(t *testing.T) {
+	ctx := context.Background()
+	const rows = 10
+	const durableActiveAt int64 = 1_000
+	pressureSignals := make(chan PressureSignal, 1)
+	observer := &recordingConversationActiveObserver{}
+	primary := make(map[metadb.ConversationStateKey]metadb.ConversationState, rows)
+	initial := make([]ActivePatch, 0, rows)
+	for index := 0; index < rows; index++ {
+		uid := fmt.Sprintf("u-%02d", index)
+		key := metadb.ConversationStateKey{
+			UID:         uid,
+			Kind:        metadb.ConversationKindNormal,
+			ChannelID:   "room",
+			ChannelType: 2,
+		}
+		primary[key] = metadb.ConversationState{
+			UID:         uid,
+			Kind:        key.Kind,
+			ChannelID:   key.ChannelID,
+			ChannelType: key.ChannelType,
+			ActiveAt:    durableActiveAt,
+		}
+		initial = append(initial, ActivePatch{
+			Kind:        key.Kind,
+			UID:         uid,
+			ChannelID:   key.ChannelID,
+			ChannelType: uint8(key.ChannelType),
+			ActiveAtMS:  durableActiveAt + int64(30*time.Minute/time.Millisecond),
+			MessageSeq:  1,
+		})
+	}
+	m := NewManager(Options{
+		Store:          &recordingActiveStore{primary: primary},
+		ActiveCooldown: time.Hour,
+		MaxCachedRows:  rows,
+		PressureNotify: pressureSignals,
+		Observer:       observer,
+	})
+	if err := m.MarkActive(ctx, initial); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+	select {
+	case <-pressureSignals:
+	default:
+		t.Fatal("initial dirty rows did not start pressure drain")
+	}
+	if result, err := m.Flush(ctx, 0); err != nil || result.Skipped != rows || result.Cleared != rows {
+		t.Fatalf("Flush(initial) = %+v, %v, want all receiver rows skipped and cleared", result, err)
+	}
+	if got := m.cacheObservation(); got.DirtyRows != 0 || got.PressureDraining {
+		t.Fatalf("post-flush cache = %+v, want clean rows below pressure watermark", got)
+	}
+
+	for iteration := 0; iteration < 100; iteration++ {
+		updates := append([]ActivePatch(nil), initial...)
+		for index := range updates {
+			updates[index].ActiveAtMS = durableActiveAt + int64(45*time.Minute/time.Millisecond) + int64(iteration)
+			updates[index].MessageSeq = uint64(iteration + 2)
+		}
+		if err := m.MarkActive(ctx, updates); err != nil {
+			t.Fatalf("MarkActive(iteration=%d) error = %v", iteration, err)
+		}
+	}
+	if got := m.cacheObservation(); got.DirtyRows != 0 || got.DirtyQueueRows != 0 || got.DirtyAgeBuckets != 0 || got.PressureDraining {
+		t.Fatalf("steady receiver cooldown cache = %+v, want clean pressure-free cache", got)
+	}
+	lastActiveAt := durableActiveAt + int64(45*time.Minute/time.Millisecond) + 99
+	for index := 0; index < rows; index++ {
+		uid := fmt.Sprintf("u-%02d", index)
+		entry, ok := m.EntryForTest(metadb.ConversationKindNormal, uid, "room", 2)
+		if !ok || entry.ActiveAtMS != lastActiveAt || entry.MessageSeq != 101 {
+			t.Fatalf("steady receiver row %s = %+v present=%t, want latest view active=%d seq=101", uid, entry, ok, lastActiveAt)
+		}
+	}
+	if mutation := observer.lastMutation(t); mutation.CooldownSuppressed != rows || mutation.Unchanged != 0 || mutation.BecameDirty != 0 || mutation.DirtyUpdated != 0 {
+		t.Fatalf("steady receiver mutation = %+v, want %d cooldown-suppressed rows", mutation, rows)
+	}
+	select {
+	case signal := <-pressureSignals:
+		t.Fatalf("receiver cooldown traffic restarted pressure drain: %+v", signal)
+	default:
 	}
 	requireDirtyIndexConservation(t, m)
 }
@@ -573,6 +667,39 @@ func requireCacheIndexConservation(t *testing.T, manager *Manager) {
 
 	manager.mu.RLock()
 	defer manager.mu.RUnlock()
+	var indexedHashSlotRows int
+	for hashSlot, byAddress := range manager.cleanByHashSlot {
+		if len(byAddress) == 0 {
+			t.Fatalf("clean hash-slot index %d contains an empty address set", hashSlot)
+		}
+		for address := range byAddress {
+			indexedHashSlotRows++
+			byChannel := manager.cache[address.uid]
+			entry, ok := byChannel[address.key]
+			if !ok {
+				t.Fatalf("clean hash-slot index %d contains missing cache address %+v", hashSlot, address)
+			}
+			if entry.dirty || !entry.hasHashSlot || entry.hashSlot != hashSlot {
+				t.Fatalf("clean hash-slot index %d contains invalid cache entry %+v for address %+v", hashSlot, entry, address)
+			}
+		}
+	}
+	var wantHashSlotRows int
+	for uid, byChannel := range manager.cache {
+		for key, entry := range byChannel {
+			if entry.dirty || !entry.hasHashSlot {
+				continue
+			}
+			wantHashSlotRows++
+			address := cacheAddress{uid: uid, key: key}
+			if _, ok := manager.cleanByHashSlot[entry.hashSlot][address]; !ok {
+				t.Fatalf("clean cache address %+v is missing from hash-slot index %d", address, entry.hashSlot)
+			}
+		}
+	}
+	if indexedHashSlotRows != wantHashSlotRows {
+		t.Fatalf("clean hash-slot index rows=%d, clean hash-slot cache rows=%d", indexedHashSlotRows, wantHashSlotRows)
+	}
 	if manager.maxCachedRows <= 0 {
 		if manager.cleanIndex != nil {
 			t.Fatalf("unbounded manager clean index is initialized with %d rows", len(manager.cleanIndex))

--- a/internal/runtime/conversationactive/manager_test.go
+++ b/internal/runtime/conversationactive/manager_test.go
@@ -43,6 +43,9 @@ func TestAdmitActiveBatchUpdatesCacheAndSenderReadSeq(t *testing.T) {
 	if sender.ReadSeq != 42 {
 		t.Fatalf("sender ReadSeq = %d, want 42", sender.ReadSeq)
 	}
+	if sender.MessageSeq != 42 {
+		t.Fatalf("sender MessageSeq = %d, want 42", sender.MessageSeq)
+	}
 
 	receiver, ok := m.EntryForTest(metadb.ConversationKindNormal, "bob", "room-1", 2)
 	if !ok {
@@ -53,6 +56,9 @@ func TestAdmitActiveBatchUpdatesCacheAndSenderReadSeq(t *testing.T) {
 	}
 	if receiver.ReadSeq != 0 {
 		t.Fatalf("receiver ReadSeq = %d, want 0", receiver.ReadSeq)
+	}
+	if receiver.MessageSeq != 42 {
+		t.Fatalf("receiver MessageSeq = %d, want 42", receiver.MessageSeq)
 	}
 }
 
@@ -286,7 +292,7 @@ func TestListActiveViewMergesCacheOverDB(t *testing.T) {
 	m := NewManager(Options{Store: store})
 
 	err := m.MarkActive(ctx, []ActivePatch{
-		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "shared", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 10},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "shared", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 10, MessageSeq: 8},
 		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "b-cache-tie", ChannelType: 2, ActiveAtMS: 800},
 	})
 	if err != nil {
@@ -334,7 +340,7 @@ func TestListActiveViewHydratesCacheOnlyDurableRow(t *testing.T) {
 	}
 	m := NewManager(Options{Store: store})
 	err := m.MarkActive(ctx, []ActivePatch{
-		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "shared", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 10},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "shared", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 10, MessageSeq: 8},
 	})
 	if err != nil {
 		t.Fatalf("MarkActive() error = %v", err)
@@ -354,6 +360,97 @@ func TestListActiveViewHydratesCacheOnlyDurableRow(t *testing.T) {
 	}
 	if len(store.lookups) != 1 || store.lookups[0] != (metadb.ConversationStateKey{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "shared", ChannelType: 2}) {
 		t.Fatalf("lookups = %+v, want shared primary lookup", store.lookups)
+	}
+}
+
+func TestListActiveViewFencesStaleCacheActivityAtDurableDeleteBarrier(t *testing.T) {
+	ctx := context.Background()
+	key := metadb.ConversationStateKey{
+		UID:         "u1",
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "deleted",
+		ChannelType: 2,
+	}
+	store := &recordingActiveStore{primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+		key: {
+			UID:          key.UID,
+			Kind:         key.Kind,
+			ChannelID:    key.ChannelID,
+			ChannelType:  key.ChannelType,
+			DeletedToSeq: 10,
+		},
+	}}
+	m := NewManager(Options{Store: store})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType),
+		ActiveAtMS: 2_000, MessageSeq: 10,
+	}}); err != nil {
+		t.Fatalf("MarkActive(stale) error = %v", err)
+	}
+
+	page, err := m.ListActiveView(ctx, key.Kind, key.UID, metadb.ConversationActiveCursor{}, 10)
+	if err != nil {
+		t.Fatalf("ListActiveView() error = %v", err)
+	}
+	if len(page.Rows) != 0 {
+		t.Fatalf("ListActiveView() rows = %+v, want stale cache activity hidden by delete barrier", page.Rows)
+	}
+}
+
+func TestFlushFencesStaleActivityWithoutListBeforeNewerActivity(t *testing.T) {
+	ctx := context.Background()
+	key := metadb.ConversationStateKey{
+		UID:         "u1",
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "deleted",
+		ChannelType: 2,
+	}
+	store := &recordingActiveStore{primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+		key: {
+			UID:          key.UID,
+			Kind:         key.Kind,
+			ChannelID:    key.ChannelID,
+			ChannelType:  key.ChannelType,
+			DeletedToSeq: 10,
+		},
+	}}
+	m := NewManager(Options{Store: store, ActiveCooldown: time.Hour})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType),
+		ActiveAtMS: 2_000, ReadSeq: 10, MessageSeq: 10,
+	}}); err != nil {
+		t.Fatalf("MarkActive(stale) error = %v", err)
+	}
+	result, err := m.Flush(ctx, 1)
+	if err != nil {
+		t.Fatalf("Flush(stale) error = %v", err)
+	}
+	if result.Skipped != 0 || result.DeleteFenced != 1 || result.Superseded != 1 || result.Persisted != 0 || m.DirtyCountForTest() != 0 {
+		t.Fatalf("Flush(stale) = %+v dirty=%d, want durable barrier to remove stale activity without a touch", result, m.DirtyCountForTest())
+	}
+	if _, ok := m.EntryForTest(key.Kind, key.UID, key.ChannelID, uint8(key.ChannelType)); ok {
+		t.Fatal("stale activity remained cached after durable barrier filtering")
+	}
+
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType),
+		ActiveAtMS: 2_100, MessageSeq: 11,
+	}}); err != nil {
+		t.Fatalf("MarkActive(newer) error = %v", err)
+	}
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows after newer activity = %d, want durable reactivation without list hydration", got)
+	}
+	result, err = m.Flush(ctx, 1)
+	if err != nil {
+		t.Fatalf("Flush(newer) error = %v", err)
+	}
+	if result.Persisted != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(newer) = %+v, want sequence above barrier persisted", result)
+	}
+	last := store.touches[len(store.touches)-1][0]
+	if last.MessageSeq != 11 || last.ActiveAt != 2_100 {
+		t.Fatalf("persisted newer activity = %+v, want message_seq=11 active_at=2100", last)
 	}
 }
 
@@ -442,7 +539,7 @@ func TestFlushDirtyPersistsActiveRowsAndClearsDirty(t *testing.T) {
 	ctx := context.Background()
 	store := &recordingActiveStore{}
 	m := NewManager(Options{Store: store, MaxCachedRows: 1})
-	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 7}}); err != nil {
+	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1000, ReadSeq: 7, MessageSeq: 42}}); err != nil {
 		t.Fatalf("MarkActive() error = %v", err)
 	}
 	requireCacheIndexConservation(t, m)
@@ -473,6 +570,7 @@ func TestFlushDirtyPersistsActiveRowsAndClearsDirty(t *testing.T) {
 		ReadSeq:     7,
 		ActiveAt:    1000,
 		UpdatedAt:   1000,
+		MessageSeq:  42,
 	}
 	if len(store.touches) != 1 || len(store.touches[0]) != 1 {
 		t.Fatalf("touches = %+v, want one patch", store.touches)
@@ -480,7 +578,7 @@ func TestFlushDirtyPersistsActiveRowsAndClearsDirty(t *testing.T) {
 	if got := store.touches[0][0]; !reflect.DeepEqual(got, want) {
 		t.Fatalf("touch patch = %+v, want %+v", got, want)
 	}
-	if patch := store.touches[0][0]; patch.DeletedToSeq != 0 || patch.MessageSeq != 0 || patch.SparseActive || patch.SparseActiveSet {
+	if patch := store.touches[0][0]; patch.DeletedToSeq != 0 || patch.MessageSeq != 42 || patch.SparseActive || patch.SparseActiveSet {
 		t.Fatalf("touch patch set unmanaged fields: %+v", patch)
 	}
 }
@@ -541,8 +639,581 @@ func TestFlushSkipsReceiverActiveWithinCooldown(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected cache entry to remain after filtered flush")
 	}
-	if entry.ActiveAtMS != previousActiveAt {
-		t.Fatalf("cached ActiveAtMS = %d, want durable active_at %d", entry.ActiveAtMS, previousActiveAt)
+	if entry.ActiveAtMS != nextActiveAt {
+		t.Fatalf("cached ActiveAtMS = %d, want latest observed active_at %d", entry.ActiveAtMS, nextActiveAt)
+	}
+	page, err := m.ListActiveView(ctx, metadb.ConversationKindNormal, "u1", metadb.ConversationActiveCursor{}, 1)
+	if err != nil {
+		t.Fatalf("ListActiveView() error = %v", err)
+	}
+	if len(page.Rows) != 1 || page.Rows[0].ActiveAt != nextActiveAt {
+		t.Fatalf("ListActiveView() rows = %+v, want immediate latest active_at %d", page.Rows, nextActiveAt)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestCleanReceiverWithinCooldownDoesNotRedirty(t *testing.T) {
+	ctx := context.Background()
+	const previousActiveAt int64 = 1_000
+	cooldown := 2 * time.Hour
+	key := metadb.ConversationStateKey{
+		UID:         "u1",
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "room-1",
+		ChannelType: 2,
+	}
+	store := &recordingActiveStore{
+		primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+			key: {
+				UID:         key.UID,
+				Kind:        key.Kind,
+				ChannelID:   key.ChannelID,
+				ChannelType: key.ChannelType,
+				ActiveAt:    previousActiveAt,
+			},
+		},
+	}
+	observer := &recordingConversationActiveObserver{}
+	m := NewManager(Options{
+		Store:          store,
+		ActiveCooldown: cooldown,
+		MaxCachedRows:  1,
+		Observer:       observer,
+	})
+	initial := ActivePatch{
+		Kind:        key.Kind,
+		UID:         key.UID,
+		ChannelID:   key.ChannelID,
+		ChannelType: uint8(key.ChannelType),
+		ActiveAtMS:  previousActiveAt + int64(time.Hour/time.Millisecond),
+	}
+	if err := m.MarkActive(ctx, []ActivePatch{initial}); err != nil {
+		t.Fatalf("MarkActive(initial) error = %v", err)
+	}
+	if result, err := m.Flush(ctx, 0); err != nil || result.Skipped != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(initial) = %+v, %v, want one cooldown skip and clear", result, err)
+	}
+	address := cacheAddress{uid: key.UID, key: conversationKey{kind: key.Kind, channelID: key.ChannelID, channelType: uint8(key.ChannelType)}}
+	version := m.cache[key.UID][address.key].version
+	lookups := len(store.batchKeys)
+
+	withinCooldown := initial
+	withinCooldown.ActiveAtMS = previousActiveAt + int64(90*time.Minute/time.Millisecond)
+	if err := m.MarkActive(ctx, []ActivePatch{withinCooldown}); err != nil {
+		t.Fatalf("MarkActive(within cooldown) error = %v", err)
+	}
+	if got := m.DirtyCountForTest(); got != 0 {
+		t.Fatalf("DirtyCountForTest() = %d, want clean receiver row to stay clean inside cooldown", got)
+	}
+	entry := m.cache[key.UID][address.key]
+	if entry.version <= version || entry.patch.ActiveAtMS != withinCooldown.ActiveAtMS {
+		t.Fatalf("cache entry = %+v, want latest observed active_at=%d with a new version after suppression", entry, withinCooldown.ActiveAtMS)
+	}
+	if mutation := observer.lastMutation(t); mutation.CooldownSuppressed != 1 || mutation.Unchanged != 0 || mutation.BecameDirty != 0 || mutation.DirtyUpdated != 0 {
+		t.Fatalf("receiver cooldown mutation = %+v, want one cooldown-suppressed row", mutation)
+	}
+	page, err := m.ListActiveView(ctx, key.Kind, key.UID, metadb.ConversationActiveCursor{}, 1)
+	if err != nil {
+		t.Fatalf("ListActiveView(after suppression) error = %v", err)
+	}
+	if len(page.Rows) != 1 || page.Rows[0].ActiveAt != withinCooldown.ActiveAtMS {
+		t.Fatalf("ListActiveView(after suppression) rows = %+v, want immediate active_at=%d", page.Rows, withinCooldown.ActiveAtMS)
+	}
+	result, err := m.Flush(ctx, 0)
+	if err != nil || result.Selected != 0 {
+		t.Fatalf("Flush(after suppressed receiver update) = %+v, %v, want no dirty selection", result, err)
+	}
+	if got := len(store.batchKeys); got != lookups {
+		t.Fatalf("durable lookup keys = %d, want unchanged %d", got, lookups)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestCleanReceiverCooldownSuppressionBoundaries(t *testing.T) {
+	ctx := context.Background()
+	const baselineActiveAt int64 = 1_000
+	cooldown := time.Hour
+	cooldownMS := int64(cooldown / time.Millisecond)
+	tests := []struct {
+		name       string
+		cooldown   time.Duration
+		activeAtMS int64
+		readSeq    uint64
+		hashSlot   uint16
+		wantDirty  bool
+	}{
+		{name: "inside cooldown", cooldown: cooldown, activeAtMS: baselineActiveAt + cooldownMS - 1, hashSlot: 1},
+		{name: "at cooldown", cooldown: cooldown, activeAtMS: baselineActiveAt + cooldownMS, hashSlot: 1, wantDirty: true},
+		{name: "after cooldown", cooldown: cooldown, activeAtMS: baselineActiveAt + cooldownMS + 1, hashSlot: 1, wantDirty: true},
+		{name: "sender read sequence advances", cooldown: cooldown, activeAtMS: baselineActiveAt + 1, readSeq: 10, hashSlot: 1, wantDirty: true},
+		{name: "hash slot changes", cooldown: cooldown, activeAtMS: baselineActiveAt + 1, hashSlot: 2, wantDirty: true},
+		{name: "cooldown disabled", activeAtMS: baselineActiveAt + 1, hashSlot: 1, wantDirty: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(Options{Store: &recordingActiveStore{}, ActiveCooldown: tt.cooldown, MaxCachedRows: 1})
+			baseline := ActivePatch{
+				Kind:        metadb.ConversationKindNormal,
+				UID:         "u1",
+				ChannelID:   "room-1",
+				ChannelType: 2,
+				ActiveAtMS:  baselineActiveAt,
+				ReadSeq:     9,
+			}
+			if err := m.MarkActiveForHashSlot(ctx, 1, []ActivePatch{baseline}); err != nil {
+				t.Fatalf("MarkActiveForHashSlot(baseline) error = %v", err)
+			}
+			if result, err := m.Flush(ctx, 0); err != nil || result.Persisted != 1 || result.Cleared != 1 {
+				t.Fatalf("Flush(baseline) = %+v, %v, want persisted clean baseline", result, err)
+			}
+			incoming := baseline
+			incoming.ActiveAtMS = tt.activeAtMS
+			incoming.ReadSeq = tt.readSeq
+			if err := m.MarkActiveForHashSlot(ctx, tt.hashSlot, []ActivePatch{incoming}); err != nil {
+				t.Fatalf("MarkActiveForHashSlot(incoming) error = %v", err)
+			}
+			if got := m.DirtyCountForTest(); (got == 1) != tt.wantDirty {
+				t.Fatalf("DirtyCountForTest() = %d, wantDirty=%v", got, tt.wantDirty)
+			}
+			requireCacheIndexConservation(t, m)
+		})
+	}
+}
+
+func TestApplyConversationDeletesUsesLatestMessageSequenceBarrier(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingActiveStore{}
+	m := NewManager(Options{Store: store, ActiveCooldown: time.Hour, MaxCachedRows: 8})
+	for _, patch := range []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "old", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 10},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "new", ChannelType: 2, ActiveAtMS: 2_000, MessageSeq: 20},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "unknown", ChannelType: 2, ActiveAtMS: 3_000},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "other", ChannelType: 2, ActiveAtMS: 4_000, MessageSeq: 40},
+	} {
+		if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{patch}); err != nil {
+			t.Fatalf("MarkActiveForHashSlot(%s) error = %v", patch.ChannelID, err)
+		}
+	}
+	if result, err := m.Flush(ctx, 0); err != nil || result.Cleared != 4 {
+		t.Fatalf("Flush(initial) = %+v, %v, want four clean rows", result, err)
+	}
+
+	deletes := []metadb.ConversationDelete{
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "old", ChannelType: 2, DeletedToSeq: 10},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new", ChannelType: 2, DeletedToSeq: 15},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "unknown", ChannelType: 2, DeletedToSeq: 15},
+	}
+	m.ApplyConversationDeletes(deletes)
+
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "old", 2); ok {
+		t.Fatal("message at the delete barrier remained cached")
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "unknown", 2); ok {
+		t.Fatal("message with an unknown sequence remained cached")
+	}
+	newer, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "new", 2)
+	if !ok || newer.ActiveAtMS != 2_000 || newer.MessageSeq != 20 {
+		t.Fatalf("newer row = %+v present=%t, want latest view retained", newer, ok)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "other", 2); !ok {
+		t.Fatal("unrelated row was removed")
+	}
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows = %d, want only the newer row forced dirty", got)
+	}
+	entry := m.cache["u1"][conversationKey{kind: metadb.ConversationKindNormal, channelID: "new", channelType: 2}]
+	if entry.durableActiveAtMS != 0 || !entry.dirty {
+		t.Fatalf("newer cache entry = %+v, want invalid durable baseline and dirty retry", entry)
+	}
+	m.ApplyConversationDeletes(deletes)
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows after duplicate apply = %d, want idempotent one", got)
+	}
+	repeated := m.cache["u1"][conversationKey{kind: metadb.ConversationKindNormal, channelID: "new", channelType: 2}]
+	if repeated.version != entry.version {
+		t.Fatalf("duplicate delete advanced version from %d to %d", entry.version, repeated.version)
+	}
+	m.ApplyConversationDeletes([]metadb.ConversationDelete{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new", ChannelType: 2, DeletedToSeq: 14,
+	}})
+	lower := m.cache["u1"][conversationKey{kind: metadb.ConversationKindNormal, channelID: "new", channelType: 2}]
+	if lower.version != entry.version || lower.deleteBarrier != 15 {
+		t.Fatalf("lower delete barrier changed cache entry from %+v to %+v", entry, lower)
+	}
+	requireCacheIndexConservation(t, m)
+
+	store.primary = map[metadb.ConversationStateKey]metadb.ConversationState{
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new", ChannelType: 2}: {
+			UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new", ChannelType: 2, DeletedToSeq: 15,
+		},
+	}
+	if result, err := m.Flush(ctx, 1); err != nil || result.Persisted != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(newer) = %+v, %v, want newer sequence persisted", result, err)
+	}
+	last := store.touches[len(store.touches)-1][0]
+	if last.ChannelID != "new" || last.MessageSeq != 20 || last.ActiveAt != 2_000 {
+		t.Fatalf("persisted newer patch = %+v", last)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestEqualDeleteBarrierRetryRedirtiesCleanNewerActivity(t *testing.T) {
+	ctx := context.Background()
+	key := metadb.ConversationStateKey{
+		UID:         "u1",
+		Kind:        metadb.ConversationKindNormal,
+		ChannelID:   "room",
+		ChannelType: 2,
+	}
+	store := &recordingActiveStore{primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+		key: {
+			UID:         key.UID,
+			Kind:        key.Kind,
+			ChannelID:   key.ChannelID,
+			ChannelType: key.ChannelType,
+			ActiveAt:    1_000,
+		},
+	}}
+	m := NewManager(Options{Store: store, ActiveCooldown: time.Hour, MaxCachedRows: 1})
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType),
+		ActiveAtMS: 1_100, MessageSeq: 11,
+	}}); err != nil {
+		t.Fatalf("MarkActive() error = %v", err)
+	}
+	deletion := metadb.ConversationDelete{
+		UID: key.UID, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: key.ChannelType, DeletedToSeq: 10,
+	}
+
+	// A confirmed callback can race a stale durable read snapshot that does not
+	// yet expose the barrier, allowing one cooldown skip to leave the row clean.
+	m.ApplyConversationDeletes([]metadb.ConversationDelete{deletion})
+	result, err := m.Flush(ctx, 1)
+	if err != nil {
+		t.Fatalf("Flush(before durable hide) error = %v", err)
+	}
+	if result.Skipped != 1 || result.Cleared != 1 || m.DirtyCountForTest() != 0 {
+		t.Fatalf("Flush(before durable hide) = %+v dirty=%d, want cooldown skip to leave the newer row clean", result, m.DirtyCountForTest())
+	}
+
+	// Later hydration rediscovers the same confirmed barrier. Equal-barrier
+	// reconciliation must re-invalidate the clean row while durable ActiveAt is
+	// still cleared.
+	store.primary[key] = metadb.ConversationState{
+		UID: key.UID, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: key.ChannelType, DeletedToSeq: 10,
+	}
+	m.ApplyConversationDeletes([]metadb.ConversationDelete{deletion})
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows after equal confirmed retry = %d, want newer activity forced dirty", got)
+	}
+	result, err = m.Flush(ctx, 1)
+	if err != nil {
+		t.Fatalf("Flush(after confirmed retry) error = %v", err)
+	}
+	if result.Persisted != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(after confirmed retry) = %+v, want newer activity reactivated durably", result)
+	}
+	last := store.touches[len(store.touches)-1][0]
+	if last.MessageSeq != 11 || last.ActiveAt != 1_100 {
+		t.Fatalf("reactivation patch = %+v, want message_seq=11 active_at=1100", last)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestSuppressedReceiverAfterDeleteBecomesDirtyAndPersists(t *testing.T) {
+	ctx := context.Background()
+	key := metadb.ConversationStateKey{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2}
+	store := &recordingActiveStore{primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+		key: {UID: key.UID, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: key.ChannelType, ActiveAt: 1_000},
+	}}
+	m := NewManager(Options{Store: store, ActiveCooldown: time.Hour, MaxCachedRows: 1})
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType), ActiveAtMS: 1_500, MessageSeq: 10,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(initial) error = %v", err)
+	}
+	if result, err := m.Flush(ctx, 1); err != nil || result.Skipped != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(initial) = %+v, %v, want cooldown skip", result, err)
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType), ActiveAtMS: 1_600, MessageSeq: 11,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(suppressed) error = %v", err)
+	}
+	if got := m.DirtyCountForTest(); got != 0 {
+		t.Fatalf("dirty rows before delete = %d, want suppressed clean row", got)
+	}
+
+	m.ApplyConversationDeletes([]metadb.ConversationDelete{{
+		UID: key.UID, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: key.ChannelType, DeletedToSeq: 11,
+	}})
+	if _, ok := m.EntryForTest(key.Kind, key.UID, key.ChannelID, uint8(key.ChannelType)); ok {
+		t.Fatal("suppressed row at delete barrier remained cached")
+	}
+	store.primary[key] = metadb.ConversationState{
+		UID: key.UID, Kind: key.Kind, ChannelID: key.ChannelID, ChannelType: key.ChannelType, DeletedToSeq: 11,
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: key.Kind, UID: key.UID, ChannelID: key.ChannelID, ChannelType: uint8(key.ChannelType), ActiveAtMS: 1_700, MessageSeq: 12,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(after delete) error = %v", err)
+	}
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows after delete = %d, want newer receiver dirty", got)
+	}
+	if result, err := m.Flush(ctx, 1); err != nil || result.Persisted != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(after delete) = %+v, %v, want newer receiver persisted", result, err)
+	}
+	last := store.touches[len(store.touches)-1][0]
+	if last.MessageSeq != 12 || last.ActiveAt != 1_700 {
+		t.Fatalf("persisted after-delete patch = %+v, want message_seq=12 active_at=1700", last)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestInvalidateConversationDeleteAttemptsPreservesUnconfirmedRows(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingActiveStore{}
+	m := NewManager(Options{Store: store, MaxCachedRows: 4})
+	patches := []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "old", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 5},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "new", ChannelType: 2, ActiveAtMS: 2_000, MessageSeq: 20},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "unknown", ChannelType: 2, ActiveAtMS: 3_000},
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, patches); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+	if result, err := m.Flush(ctx, 0); err != nil || result.Cleared != len(patches) {
+		t.Fatalf("Flush(initial) = %+v, %v, want clean cached rows", result, err)
+	}
+
+	deletes := []metadb.ConversationDelete{
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "old", ChannelType: 2, DeletedToSeq: 10},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "new", ChannelType: 2, DeletedToSeq: 10},
+		{UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "unknown", ChannelType: 2, DeletedToSeq: 10},
+	}
+	m.InvalidateConversationDeleteAttempts(deletes)
+	for _, patch := range patches {
+		got, ok := m.EntryForTest(patch.Kind, patch.UID, patch.ChannelID, patch.ChannelType)
+		if !ok || got.ActiveAtMS != patch.ActiveAtMS || got.MessageSeq != patch.MessageSeq {
+			t.Fatalf("unconfirmed row %s = %+v present=%t, want preserved cache projection %+v", patch.ChannelID, got, ok, patch)
+		}
+		entry := m.cache[patch.UID][conversationKey{kind: patch.Kind, channelID: patch.ChannelID, channelType: patch.ChannelType}]
+		if !entry.dirty || entry.durableActiveAtMS != 0 || entry.deleteBarrier != 0 {
+			t.Fatalf("unconfirmed cache entry %s = %+v, want dirty invalid baseline without confirmed barrier", patch.ChannelID, entry)
+		}
+	}
+	if got := m.DirtyCountForTest(); got != len(patches) {
+		t.Fatalf("dirty rows = %d, want all %d uncertain rows retried", got, len(patches))
+	}
+	if result, err := m.Flush(ctx, 0); err != nil || result.Persisted != len(patches) || result.Cleared != len(patches) {
+		t.Fatalf("Flush(unconfirmed) = %+v, %v, want rows restored when durable barriers were not committed", result, err)
+	}
+	for _, patch := range patches {
+		if _, ok := m.EntryForTest(patch.Kind, patch.UID, patch.ChannelID, patch.ChannelType); !ok {
+			t.Fatalf("unconfirmed row %s disappeared after successful retry flush", patch.ChannelID)
+		}
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestApplyConversationDeletesRemovesDirtyOldRowAndPreservesUnrelatedDirty(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 4})
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "deleted", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 5},
+		{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "unrelated", ChannelType: 2, ActiveAtMS: 2_000, MessageSeq: 6},
+	}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+	m.ApplyConversationDeletes([]metadb.ConversationDelete{{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "deleted", ChannelType: 2, DeletedToSeq: 5,
+	}})
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "deleted", 2); ok {
+		t.Fatal("dirty row at the delete barrier remained cached")
+	}
+	if row, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "unrelated", 2); !ok || row.MessageSeq != 6 {
+		t.Fatalf("unrelated dirty row = %+v present=%t", row, ok)
+	}
+	if got := m.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows = %d, want one unrelated row", got)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestDeleteInvalidationFencesInFlightDurableBaseline(t *testing.T) {
+	ctx := context.Background()
+	store := &recordingActiveStore{}
+	m := NewManager(Options{Store: store, MaxCachedRows: 1})
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 2_000, MessageSeq: 20,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+	store.touchHook = func() {
+		store.touchHook = nil
+		m.ApplyConversationDeletes([]metadb.ConversationDelete{{
+			UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "room", ChannelType: 2, DeletedToSeq: 15,
+		}})
+	}
+	result, err := m.Flush(ctx, 1)
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if result.Persisted != 1 || result.Cleared != 0 || result.VersionConflicts != 1 || result.Requeued != 1 {
+		t.Fatalf("Flush() = %+v, want persisted stale snapshot fenced by delete invalidation", result)
+	}
+	address := cacheAddress{uid: "u1", key: conversationKey{kind: metadb.ConversationKindNormal, channelID: "room", channelType: 2}}
+	entry := m.cache[address.uid][address.key]
+	if !entry.dirty || entry.durableActiveAtMS != 0 || entry.patch.MessageSeq != 20 {
+		t.Fatalf("cache entry after in-flight delete = %+v, want dirty newer view with invalid baseline", entry)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestPurgeCleanHashSlotPreservesDirtyAndOtherSlots(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 4})
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "clean-7", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 1,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(clean 7) error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 7, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(7) = %+v, %v", result, err)
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "dirty-7", ChannelID: "room", ChannelType: 2, ActiveAtMS: 2_000, MessageSeq: 2,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(dirty 7) error = %v", err)
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 9, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "clean-9", ChannelID: "room", ChannelType: 2, ActiveAtMS: 3_000, MessageSeq: 3,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(9) error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 9, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(9) = %+v, %v", result, err)
+	}
+
+	if purged := m.PurgeCleanHashSlot(7); purged != 1 {
+		t.Fatalf("PurgeCleanHashSlot(7) = %d, want 1", purged)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "clean-7", "room", 2); ok {
+		t.Fatal("clean target-slot row remained cached")
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "dirty-7", "room", 2); !ok {
+		t.Fatal("dirty target-slot row was purged")
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "clean-9", "room", 2); !ok {
+		t.Fatal("clean other-slot row was purged")
+	}
+	if purged := m.PurgeCleanHashSlot(7); purged != 0 {
+		t.Fatalf("duplicate PurgeCleanHashSlot(7) = %d, want 0", purged)
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestPurgeCleanHashSlotWorksWithoutBoundedCleanIndex(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}})
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "clean-7", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 1,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 7, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot() = %+v, %v", result, err)
+	}
+	if purged := m.PurgeCleanHashSlot(7); purged != 1 {
+		t.Fatalf("PurgeCleanHashSlot(7) = %d, want 1", purged)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "clean-7", "room", 2); ok {
+		t.Fatal("unbounded manager retained the clean target-slot row")
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestPurgeCleanHashSlotTracksCleanDirtyAndSlotTransitions(t *testing.T) {
+	ctx := context.Background()
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 2})
+	patch := ActivePatch{
+		Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 1,
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{patch}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(slot 7) error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 7, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(7) = %+v, %v", result, err)
+	}
+	requireCacheIndexConservation(t, m)
+
+	patch.ActiveAtMS = 2_000
+	patch.MessageSeq = 2
+	if err := m.MarkActiveForHashSlot(ctx, 9, []ActivePatch{patch}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(slot 9) error = %v", err)
+	}
+	if purged := m.PurgeCleanHashSlot(7); purged != 0 {
+		t.Fatalf("PurgeCleanHashSlot(7) = %d, want moved dirty row preserved", purged)
+	}
+	if purged := m.PurgeCleanHashSlot(9); purged != 0 {
+		t.Fatalf("PurgeCleanHashSlot(9) = %d, want dirty row preserved", purged)
+	}
+	requireCacheIndexConservation(t, m)
+
+	if result, err := m.FlushHashSlot(ctx, 9, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(9) = %+v, %v", result, err)
+	}
+	if purged := m.PurgeCleanHashSlot(9); purged != 1 {
+		t.Fatalf("PurgeCleanHashSlot(9) = %d, want clean moved row purged", purged)
+	}
+	if _, ok := m.EntryForTest(metadb.ConversationKindNormal, "u1", "room", 2); ok {
+		t.Fatal("clean moved row remained cached")
+	}
+	requireCacheIndexConservation(t, m)
+}
+
+func TestPurgeCleanHashSlotStateOnlyDefersCacheObservation(t *testing.T) {
+	ctx := context.Background()
+	observer := &recordingConversationActiveObserver{}
+	m := NewManager(Options{Store: &recordingActiveStore{}, MaxCachedRows: 1, Observer: observer})
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room", ChannelType: 2, ActiveAtMS: 1_000, MessageSeq: 1,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 7, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot() = %+v, %v", result, err)
+	}
+	observationsBeforePurge := len(observer.cache)
+
+	if purged := m.PurgeCleanHashSlotStateOnly(7); purged != 1 {
+		t.Fatalf("PurgeCleanHashSlotStateOnly() = %d, want 1", purged)
+	}
+	if len(observer.cache) != observationsBeforePurge {
+		t.Fatalf("state-only purge emitted %d cache observations, want none", len(observer.cache)-observationsBeforePurge)
+	}
+	m.ObserveCacheState()
+	if len(observer.cache) != observationsBeforePurge+1 {
+		t.Fatalf("ObserveCacheState() cache observations = %d, want %d", len(observer.cache), observationsBeforePurge+1)
+	}
+	if got := observer.lastCache(t); got.Rows != 0 || got.DirtyRows != 0 {
+		t.Fatalf("observed cache after purge = %+v, want empty", got)
+	}
+	if err := m.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "u2", ChannelID: "room", ChannelType: 2, ActiveAtMS: 2_000, MessageSeq: 2,
+	}}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot(second row) error = %v", err)
+	}
+	if result, err := m.FlushHashSlot(ctx, 7, 1); err != nil || result.Cleared != 1 {
+		t.Fatalf("FlushHashSlot(second row) = %+v, %v", result, err)
+	}
+	observationsBeforeNormalPurge := len(observer.cache)
+	if purged := m.PurgeCleanHashSlot(7); purged != 1 {
+		t.Fatalf("PurgeCleanHashSlot() = %d, want 1", purged)
+	}
+	if len(observer.cache) != observationsBeforeNormalPurge+1 {
+		t.Fatalf("normal purge cache observations = %d, want %d", len(observer.cache), observationsBeforeNormalPurge+1)
 	}
 	requireCacheIndexConservation(t, m)
 }
@@ -562,7 +1233,7 @@ func TestFlushCooldownSkipRetainsConcurrentNewerVersion(t *testing.T) {
 		},
 	}
 	m := NewManager(Options{Store: store, ActiveCooldown: time.Hour})
-	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1_100}}); err != nil {
+	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1_100, MessageSeq: 10}}); err != nil {
 		t.Fatalf("MarkActive(initial) error = %v", err)
 	}
 
@@ -576,7 +1247,7 @@ func TestFlushCooldownSkipRetainsConcurrentNewerVersion(t *testing.T) {
 		finished <- flushOutcome{result: result, err: err}
 	}()
 	<-lookupStarted
-	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1_200}}); err != nil {
+	if err := m.MarkActive(ctx, []ActivePatch{{Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1_200, MessageSeq: 11}}); err != nil {
 		t.Fatalf("MarkActive(concurrent) error = %v", err)
 	}
 	close(releaseLookup)
@@ -589,6 +1260,24 @@ func TestFlushCooldownSkipRetainsConcurrentNewerVersion(t *testing.T) {
 	}
 	if got := m.DirtyCountForTest(); got != 1 {
 		t.Fatalf("dirty rows = %d, want concurrent newer version retained", got)
+	}
+	address := cacheAddress{uid: "u1", key: conversationKey{kind: metadb.ConversationKindNormal, channelID: "room-1", channelType: 2}}
+	entry := m.cache[address.uid][address.key]
+	if entry.durableActiveAtMS != 1_000 || entry.patch.ActiveAtMS != 1_200 || entry.patch.MessageSeq != 11 {
+		t.Fatalf("cache after version conflict = %+v, want confirmed baseline 1000 and latest view 1200/seq11", entry)
+	}
+	store.batchLookupHook = nil
+	if result, err := m.Flush(ctx, 1); err != nil || result.Skipped != 1 || result.Cleared != 1 {
+		t.Fatalf("Flush(retry) = %+v, %v, want cooldown skip and clear", result, err)
+	}
+	if err := m.MarkActive(ctx, []ActivePatch{{
+		Kind: metadb.ConversationKindNormal, UID: "u1", ChannelID: "room-1", ChannelType: 2, ActiveAtMS: 1_300, MessageSeq: 12,
+	}}); err != nil {
+		t.Fatalf("MarkActive(after confirmed baseline) error = %v", err)
+	}
+	entry = m.cache[address.uid][address.key]
+	if entry.dirty || entry.durableActiveAtMS != 1_000 || entry.patch.ActiveAtMS != 1_300 || entry.patch.MessageSeq != 12 {
+		t.Fatalf("cache after clean suppression = %+v, want clean latest view on confirmed baseline", entry)
 	}
 }
 
@@ -661,6 +1350,116 @@ func TestFlushReportsFilterFailureAsRequeued(t *testing.T) {
 	if got := m.DirtyCountForTest(); got != 1 {
 		t.Fatalf("dirty rows = %d, want failed filter row retained", got)
 	}
+}
+
+func TestFlushPersistFailureAccountsDeleteFencedRowsWithoutRequeueingThem(t *testing.T) {
+	ctx := context.Background()
+	deleteKey := metadb.ConversationStateKey{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "deleted", ChannelType: 2,
+	}
+	liveKey := metadb.ConversationStateKey{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "live", ChannelType: 2,
+	}
+	touchErr := errors.New("touch failed")
+	store := &recordingActiveStore{
+		primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+			deleteKey: {
+				UID: deleteKey.UID, Kind: deleteKey.Kind, ChannelID: deleteKey.ChannelID,
+				ChannelType: deleteKey.ChannelType, DeletedToSeq: 10,
+			},
+		},
+		touchErr: touchErr,
+	}
+	observer := &recordingConversationActiveObserver{}
+	manager := NewManager(Options{Store: store, ActiveCooldown: time.Hour, Observer: observer})
+	if err := manager.MarkActiveForHashSlot(ctx, 7, []ActivePatch{
+		{UID: deleteKey.UID, Kind: deleteKey.Kind, ChannelID: deleteKey.ChannelID, ChannelType: uint8(deleteKey.ChannelType), ActiveAtMS: 1_000, MessageSeq: 10},
+		{UID: liveKey.UID, Kind: liveKey.Kind, ChannelID: liveKey.ChannelID, ChannelType: uint8(liveKey.ChannelType), ActiveAtMS: 2_000, MessageSeq: 11},
+	}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+
+	result, err := manager.FlushHashSlot(ctx, 7, 2)
+	if !errors.Is(err, touchErr) {
+		t.Fatalf("FlushHashSlot() error = %v, want %v", err, touchErr)
+	}
+	if result.Selected != 2 || result.Persisted != 0 || result.Skipped != 0 || result.DeleteFenced != 1 || result.Requeued != 1 {
+		t.Fatalf("FlushHashSlot() = %+v, want selected=2 delete_fenced=1 requeued=1", result)
+	}
+	if _, ok := manager.EntryForTest(deleteKey.Kind, deleteKey.UID, deleteKey.ChannelID, uint8(deleteKey.ChannelType)); ok {
+		t.Fatal("delete-fenced row remained cached after durable reconciliation")
+	}
+	if _, ok := manager.EntryForTest(liveKey.Kind, liveKey.UID, liveKey.ChannelID, uint8(liveKey.ChannelType)); !ok {
+		t.Fatal("persist-failed live row disappeared instead of remaining dirty")
+	}
+	if got := manager.DirtyCountForTest(); got != 1 {
+		t.Fatalf("dirty rows = %d, want only the persist-failed live row", got)
+	}
+	observation := observer.lastFlush(t)
+	if observation.Result != "error" || observation.FailureStage != "persist" || observation.Selected != 2 ||
+		observation.DeleteFenced != 1 || observation.Requeued != 1 {
+		t.Fatalf("flush observation = %+v, want persist error with delete_fenced=1 requeued=1", observation)
+	}
+	requireCacheIndexConservation(t, manager)
+}
+
+func TestFlushPersistFailureCountsNewerActivityAfterDeleteFenceAsRequeued(t *testing.T) {
+	ctx := context.Background()
+	deleteKey := metadb.ConversationStateKey{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "deleted", ChannelType: 2,
+	}
+	liveKey := metadb.ConversationStateKey{
+		UID: "u1", Kind: metadb.ConversationKindNormal, ChannelID: "live", ChannelType: 2,
+	}
+	touchErr := errors.New("touch failed")
+	store := &recordingActiveStore{
+		primary: map[metadb.ConversationStateKey]metadb.ConversationState{
+			deleteKey: {
+				UID: deleteKey.UID, Kind: deleteKey.Kind, ChannelID: deleteKey.ChannelID,
+				ChannelType: deleteKey.ChannelType, DeletedToSeq: 10,
+			},
+		},
+		touchErr: touchErr,
+	}
+	observer := &recordingConversationActiveObserver{}
+	manager := NewManager(Options{Store: store, ActiveCooldown: time.Hour, Observer: observer})
+	if err := manager.MarkActiveForHashSlot(ctx, 7, []ActivePatch{
+		{UID: deleteKey.UID, Kind: deleteKey.Kind, ChannelID: deleteKey.ChannelID, ChannelType: uint8(deleteKey.ChannelType), ActiveAtMS: 1_000, MessageSeq: 10},
+		{UID: liveKey.UID, Kind: liveKey.Kind, ChannelID: liveKey.ChannelID, ChannelType: uint8(liveKey.ChannelType), ActiveAtMS: 2_000, MessageSeq: 11},
+	}); err != nil {
+		t.Fatalf("MarkActiveForHashSlot() error = %v", err)
+	}
+	var concurrentErr error
+	store.touchHook = func() {
+		store.touchHook = nil
+		concurrentErr = manager.MarkActiveForHashSlot(ctx, 7, []ActivePatch{{
+			UID: deleteKey.UID, Kind: deleteKey.Kind, ChannelID: deleteKey.ChannelID,
+			ChannelType: uint8(deleteKey.ChannelType), ActiveAtMS: 3_000, MessageSeq: 11,
+		}})
+	}
+
+	result, err := manager.FlushHashSlot(ctx, 7, 2)
+	if concurrentErr != nil {
+		t.Fatalf("concurrent MarkActiveForHashSlot() error = %v", concurrentErr)
+	}
+	if !errors.Is(err, touchErr) {
+		t.Fatalf("FlushHashSlot() error = %v, want %v", err, touchErr)
+	}
+	if result.Selected != 2 || result.DeleteFenced != 1 || result.Requeued != 2 {
+		t.Fatalf("FlushHashSlot() = %+v, want selected=2 delete_fenced=1 requeued=2 after newer activity", result)
+	}
+	newer, ok := manager.EntryForTest(deleteKey.Kind, deleteKey.UID, deleteKey.ChannelID, uint8(deleteKey.ChannelType))
+	if !ok || newer.MessageSeq != 11 || newer.ActiveAtMS != 3_000 {
+		t.Fatalf("newer delete-fenced activity = %+v present=%t, want seq=11 active_at=3000", newer, ok)
+	}
+	if got := manager.DirtyCountForTest(); got != 2 {
+		t.Fatalf("dirty rows = %d, want newer activity and persist-failed live row", got)
+	}
+	observation := observer.lastFlush(t)
+	if observation.DeleteFenced != 1 || observation.Requeued != 2 {
+		t.Fatalf("flush observation = %+v, want delete_fenced=1 requeued=2", observation)
+	}
+	requireCacheIndexConservation(t, manager)
 }
 
 func TestManagerObservesCacheRowsAndDirtyLag(t *testing.T) {

--- a/internal/runtime/conversationactive/types.go
+++ b/internal/runtime/conversationactive/types.go
@@ -20,7 +20,7 @@ type Options struct {
 	NowMS func() int64
 	// Store reads and persists durable active conversation rows that have already flushed to DB.
 	Store ActiveStore
-	// ActiveCooldown skips receiver-only active_at flushes newer than the durable row by less than this duration.
+	// ActiveCooldown suppresses receiver-only dirty work and flushes newer than the durable row by less than this duration.
 	ActiveCooldown time.Duration
 	// MaxCachedRows bounds in-memory active rows across all users; zero disables the bound.
 	MaxCachedRows int
@@ -81,6 +81,8 @@ type MutationObservation struct {
 	BecameDirty int
 	// DirtyUpdated is the number of unique already-dirty rows advanced to a newer version.
 	DirtyUpdated int
+	// CooldownSuppressed is the number of clean receiver rows whose latest view advanced without durable dirty work.
+	CooldownSuppressed int
 	// Unchanged is the number of unique existing rows whose projection and ownership were unchanged.
 	Unchanged int
 	// LockWaitDuration is time spent waiting for the node-local cache lock.
@@ -104,6 +106,8 @@ type FlushObservation struct {
 	Persisted int
 	// Skipped is the number of selected rows routed through the cooldown no-write path after durable-state comparison.
 	Skipped int
+	// DeleteFenced is the number of selected rows rejected by a durable delete barrier without a touch write.
+	DeleteFenced int
 	// Cleared is the number of dirty markers actually cleared after version fencing.
 	Cleared int
 	// VersionConflicts is the number of dirty markers retained because a concurrent update advanced the version.
@@ -160,6 +164,8 @@ type FlushResult struct {
 	Persisted int
 	// Skipped is the number of rows routed through the cooldown no-write path.
 	Skipped int
+	// DeleteFenced is the number of rows rejected by a durable delete barrier without a touch write.
+	DeleteFenced int
 	// Cleared is the number of dirty markers actually cleared after version fencing.
 	Cleared int
 	// VersionConflicts is the number of dirty markers retained after concurrent updates.
@@ -216,8 +222,10 @@ type ActivePatch struct {
 	ChannelID string
 	// ChannelType identifies the active conversation channel type.
 	ChannelType uint8
-	// ActiveAtMS is the maximum observed Unix millisecond activity timestamp.
+	// ActiveAtMS is the latest observed Unix millisecond activity timestamp exposed by the cache view.
 	ActiveAtMS int64
 	// ReadSeq is advanced only for the sender's own conversation row.
 	ReadSeq uint64
+	// MessageSeq is the latest committed channel sequence represented by this activity observation.
+	MessageSeq uint64
 }

--- a/pkg/metrics/conversation.go
+++ b/pkg/metrics/conversation.go
@@ -88,6 +88,8 @@ type ConversationActiveFlushSample struct {
 	Persisted int
 	// Skipped is the number of rows routed through the cooldown no-write path.
 	Skipped int
+	// DeleteFenced is the number of rows rejected by a durable delete barrier without a touch write.
+	DeleteFenced int
 	// Cleared is the number of version-fenced dirty markers actually cleared.
 	Cleared int
 	// VersionConflicts is the number of newer dirty versions retained for retry.
@@ -100,7 +102,7 @@ type ConversationActiveFlushSample struct {
 	LaneWaitDuration time.Duration
 	// SelectDuration is time spent selecting a bounded dirty snapshot.
 	SelectDuration time.Duration
-	// FilterDuration is time spent comparing cooldown candidates with durable state.
+	// FilterDuration is time spent comparing selected rows with durable state for cooldown and delete barriers.
 	FilterDuration time.Duration
 	// PersistDuration is time spent in the store call.
 	PersistDuration time.Duration
@@ -348,13 +350,14 @@ func newConversationMetrics(registry prometheus.Registerer, labels prometheus.La
 // present before the first non-zero observation so measured-window deltas do
 // not silently lose the first flush or mutation event.
 func (m *ConversationMetrics) initializeActiveConservationSeries() {
-	for _, event := range []string{"became_dirty", "dirty_updated", "unchanged"} {
+	for _, event := range []string{"became_dirty", "dirty_updated", "cooldown_suppressed", "unchanged"} {
 		m.activeDirtyMutations.WithLabelValues(event)
 	}
 	for _, labels := range [][3]string{
 		{"ok", "selected", "none"},
 		{"ok", "persisted", "none"},
 		{"ok", "skipped", "active_cooldown"},
+		{"ok", "skipped", "delete_barrier"},
 		{"ok", "cleared", "none"},
 		{"ok", "requeued", "version_conflict"},
 		{"ok", "superseded", "stale_snapshot"},
@@ -475,12 +478,13 @@ func (m *ConversationMetrics) SetActiveCache(sample ConversationActiveCacheSampl
 }
 
 // ObserveActiveMutation records one conversation active cache mutation batch.
-func (m *ConversationMetrics) ObserveActiveMutation(becameDirty, dirtyUpdated, unchanged int) {
+func (m *ConversationMetrics) ObserveActiveMutation(becameDirty, dirtyUpdated, cooldownSuppressed, unchanged int) {
 	if m == nil {
 		return
 	}
 	m.addActiveDirtyMutation("became_dirty", becameDirty)
 	m.addActiveDirtyMutation("dirty_updated", dirtyUpdated)
+	m.addActiveDirtyMutation("cooldown_suppressed", cooldownSuppressed)
 	m.addActiveDirtyMutation("unchanged", unchanged)
 }
 
@@ -515,7 +519,9 @@ func (m *ConversationMetrics) ObserveActiveFlush(sample ConversationActiveFlushS
 	m.observeActiveFlushRows(result, "persisted", "none", sample.Persisted)
 	// Keep the legacy histogram label stable; explicit conservation uses persisted.
 	m.activeFlushRows.WithLabelValues(result, "flushed").Observe(float64(nonNegative(sample.Persisted)))
-	m.observeActiveFlushRows(result, "skipped", "active_cooldown", sample.Skipped)
+	m.activeFlushRows.WithLabelValues(result, "skipped").Observe(float64(nonNegative(sample.Skipped) + nonNegative(sample.DeleteFenced)))
+	m.addActiveFlushRowsTotal(result, "skipped", "active_cooldown", sample.Skipped)
+	m.addActiveFlushRowsTotal(result, "skipped", "delete_barrier", sample.DeleteFenced)
 	m.observeActiveFlushRows(result, "cleared", "none", sample.Cleared)
 	if sample.VersionConflicts > 0 {
 		m.observeActiveFlushRows(result, "requeued", "version_conflict", sample.VersionConflicts)
@@ -548,9 +554,17 @@ func (m *ConversationMetrics) observeActiveFlushRows(result, stage, reason strin
 	stage = conversationActiveFlushRowsKind(stage)
 	reason = conversationActiveFlushReason(reason)
 	m.activeFlushRows.WithLabelValues(result, stage).Observe(float64(rows))
-	if rows > 0 {
-		m.activeFlushRowsTotal.WithLabelValues(result, stage, reason).Add(float64(rows))
+	m.addActiveFlushRowsTotal(result, stage, reason, rows)
+}
+
+func (m *ConversationMetrics) addActiveFlushRowsTotal(result, stage, reason string, rows int) {
+	rows = nonNegative(rows)
+	if rows <= 0 {
+		return
 	}
+	stage = conversationActiveFlushRowsKind(stage)
+	reason = conversationActiveFlushReason(reason)
+	m.activeFlushRowsTotal.WithLabelValues(result, stage, reason).Add(float64(rows))
 }
 
 func (m *ConversationMetrics) observeActiveFlushStage(result, stage string, dur time.Duration) {
@@ -610,7 +624,7 @@ func conversationActiveFlushRowsKind(kind string) string {
 
 func conversationActiveMutationEvent(event string) string {
 	switch event {
-	case "became_dirty", "dirty_updated", "unchanged":
+	case "became_dirty", "dirty_updated", "cooldown_suppressed", "unchanged":
 		return event
 	default:
 		return "other"
@@ -619,7 +633,7 @@ func conversationActiveMutationEvent(event string) string {
 
 func conversationActiveFlushReason(reason string) string {
 	switch reason {
-	case "none", "active_cooldown", "version_conflict", "filter_error", "persist_error", "timeout", "stale_snapshot":
+	case "none", "active_cooldown", "delete_barrier", "version_conflict", "filter_error", "persist_error", "timeout", "stale_snapshot":
 		return reason
 	default:
 		return "other"

--- a/pkg/metrics/registry_test.go
+++ b/pkg/metrics/registry_test.go
@@ -2262,6 +2262,7 @@ func TestConversationMetricsPreinitializeActiveConservationBaselines(t *testing.
 		{"result": "ok", "stage": "selected", "reason": "none"},
 		{"result": "ok", "stage": "persisted", "reason": "none"},
 		{"result": "ok", "stage": "skipped", "reason": "active_cooldown"},
+		{"result": "ok", "stage": "skipped", "reason": "delete_barrier"},
 		{"result": "ok", "stage": "cleared", "reason": "none"},
 		{"result": "ok", "stage": "requeued", "reason": "version_conflict"},
 		{"result": "ok", "stage": "superseded", "reason": "stale_snapshot"},
@@ -2271,9 +2272,11 @@ func TestConversationMetricsPreinitializeActiveConservationBaselines(t *testing.
 		require.Zero(t, findMetricByLabels(t, flushRows, labels).GetCounter().GetValue())
 	}
 	dirtyMutations := requireMetricFamily(t, families, "wukongim_conversation_active_dirty_mutations_total")
-	require.Zero(t, findMetricByLabels(t, dirtyMutations, map[string]string{
-		"node_id": "11", "node_name": "node-11", "event": "became_dirty",
-	}).GetCounter().GetValue())
+	for _, event := range []string{"became_dirty", "cooldown_suppressed"} {
+		require.Zero(t, findMetricByLabels(t, dirtyMutations, map[string]string{
+			"node_id": "11", "node_name": "node-11", "event": event,
+		}).GetCounter().GetValue())
+	}
 	pressureEvents := requireMetricFamily(t, families, "wukongim_conversation_active_pressure_events_total")
 	require.Zero(t, findMetricByLabels(t, pressureEvents, map[string]string{
 		"node_id": "11", "node_name": "node-11", "event": "signal_received",
@@ -2288,13 +2291,14 @@ func TestConversationMetricsTrackActiveCacheAndFlush(t *testing.T) {
 		OldestDirtyAge: 2 * time.Second, PressureDraining: true,
 		NormalRows: 8, NormalDirtyRows: 2, CMDRows: 4, CMDDirtyRows: 3,
 	})
-	reg.Conversation.ObserveActiveMutation(4, 2, 1)
+	reg.Conversation.ObserveActiveMutation(4, 2, 3, 1)
 	reg.Conversation.ObserveActiveMutationLock("ok", time.Millisecond, 2*time.Millisecond, 3*time.Millisecond)
 	reg.Conversation.ObserveActiveFlush(ConversationActiveFlushSample{
 		Result:                "ok",
-		Selected:              4,
+		Selected:              6,
 		Persisted:             3,
 		Skipped:               1,
+		DeleteFenced:          2,
 		Cleared:               2,
 		VersionConflicts:      1,
 		Superseded:            1,
@@ -2315,6 +2319,16 @@ func TestConversationMetricsTrackActiveCacheAndFlush(t *testing.T) {
 		Requeued:       2,
 		FilterDuration: time.Millisecond,
 		Duration:       time.Millisecond,
+	})
+	reg.Conversation.ObserveActiveFlush(ConversationActiveFlushSample{
+		Result:          "error",
+		FailureStage:    "persist",
+		Selected:        2,
+		DeleteFenced:    1,
+		Requeued:        1,
+		FilterDuration:  time.Millisecond,
+		PersistDuration: time.Millisecond,
+		Duration:        2 * time.Millisecond,
 	})
 	reg.Conversation.ObserveActivePressure("signal_received", 6*time.Millisecond)
 
@@ -2384,7 +2398,7 @@ func TestConversationMetricsTrackActiveCacheAndFlush(t *testing.T) {
 	}).GetCounter().GetValue())
 
 	flushRows := requireMetricFamily(t, families, "wukongim_conversation_active_flush_rows")
-	require.Equal(t, float64(4), findMetricByLabels(t, flushRows, map[string]string{
+	require.Equal(t, float64(6), findMetricByLabels(t, flushRows, map[string]string{
 		"node_id":   "11",
 		"node_name": "node-11",
 		"result":    "ok",
@@ -2397,6 +2411,34 @@ func TestConversationMetricsTrackActiveCacheAndFlush(t *testing.T) {
 		"result":    "ok",
 		"stage":     "persisted",
 		"reason":    "none",
+	}).GetCounter().GetValue())
+	require.Equal(t, float64(1), findMetricByLabels(t, flushRowsTotal, map[string]string{
+		"node_id":   "11",
+		"node_name": "node-11",
+		"result":    "ok",
+		"stage":     "skipped",
+		"reason":    "active_cooldown",
+	}).GetCounter().GetValue())
+	require.Equal(t, float64(2), findMetricByLabels(t, flushRowsTotal, map[string]string{
+		"node_id":   "11",
+		"node_name": "node-11",
+		"result":    "ok",
+		"stage":     "skipped",
+		"reason":    "delete_barrier",
+	}).GetCounter().GetValue())
+	require.Equal(t, float64(1), findMetricByLabels(t, flushRowsTotal, map[string]string{
+		"node_id":   "11",
+		"node_name": "node-11",
+		"result":    "error",
+		"stage":     "skipped",
+		"reason":    "delete_barrier",
+	}).GetCounter().GetValue())
+	require.Equal(t, float64(1), findMetricByLabels(t, flushRowsTotal, map[string]string{
+		"node_id":   "11",
+		"node_name": "node-11",
+		"result":    "error",
+		"stage":     "requeued",
+		"reason":    "persist_error",
 	}).GetCounter().GetValue())
 	require.Equal(t, float64(1), findMetricByLabels(t, flushRowsTotal, map[string]string{
 		"node_id":   "11",

--- a/wukongim.toml.example
+++ b/wukongim.toml.example
@@ -140,6 +140,10 @@ authority_cache_max_rows_per_uid = 4096
 authority_cache_max_rows = 100000
 authority_list_db_window_max = 1000
 authority_handoff_timeout = "3s"
+# Coalesces receiver-only active_at persistence while keeping the latest
+# activity visible in the UID authority cache. Delete barriers invalidate the
+# cached durable baseline before any later message can reuse this cooldown.
+authority_active_cooldown = "2h"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
 # Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.


### PR DESCRIPTION
## What changed

- route independent canonical-channel groups with bounded intra-batch concurrency while preserving item order, per-leader outbound limits, fresh-route retries, and fail-fast cross-batch backpressure
- suppress receiver-only conversation dirty churn inside the durable activity cooldown and retain the latest cache-visible activity/sequence
- add strict delete-barrier fencing across local/remote authority routing, partial proposal failures, cache hydration, flushes, authority activation, and handoff
- replace full-cache clean-row purge scans with an exact hash-slot index and defer cache observers until lifecycle locks are released
- split cooldown and delete-barrier flush accounting so pressure diagnostics preserve two-stage row conservation
- keep local and remote hide limits and cancellation/deadline semantics consistent

## Root cause

Cloud Medium saturated around 2k ingress/s because one gateway batch submitted independent channel groups sequentially. At the same time, receiver activity repeatedly re-dirtied conversation rows much faster than bounded persistence could clear them. This filled the active cache, increased post-commit backlog, and amplified gateway dispatch wait and SENDACK latency.

The first cache-index fix removed the long cache lock but did not remove the repeated dirty work. The complete fix bounds routing concurrency, coalesces safe receiver activity against a confirmed durable baseline, and fences delete/authority transitions without losing newer activity.

## Impact

- independent channel groups can use available node CPU concurrently without unbounded goroutine or per-leader fan-out
- receiver activity inside the cooldown stays visible without generating redundant durable writes
- authority moves and conversation deletes cannot expose stale cache rows or erase newer activity
- hash-slot activation purge falls from a 100k-row scan and multi-megabyte allocation to target-slot-only, zero-allocation work
- Prometheus distinguishes `active_cooldown` from `delete_barrier` and reports actual dirty rows retained after failed flushes

## Validation

- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- focused affected-package tests repeated 3-100 times
- race tests for conversation cache, authority lifecycle/RPC, and channel router concurrency
- `GOWORK=off go vet ./internal/runtime/conversationactive ./internal/runtime/channelappend ./internal/access/node ./internal/infra/cluster ./internal/app ./pkg/metrics`
- 100k-row purge benchmark: about 24ms / 4.8MB per operation before, about 0.17ms / 0 allocations after
- 128-row production-cooldown flush benchmarks cover receiver skip, sender persistence, missing durable rows, and delete barriers
