### PR TITLE
fix cloud medium conversation pressure drain

### DIFF
--- a/.github/workflows/cloud-sim-analyze.yml
+++ b/.github/workflows/cloud-sim-analyze.yml
@@ -146,12 +146,14 @@ jobs:
       - name: Open temporary runner exchange window
         id: ingress
         if: steps.preflight.outputs.state == 'live'
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
-          runner_ip="$(curl --fail --silent --show-error --proto '=https' --tlsv1.2 https://api.ipify.org)"
+          runner_ip="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 --proto '=https' --tlsv1.2 https://api.ipify.org)"
           until="$(date -u -d '+10 minutes' +%Y-%m-%dT%H:%M:%SZ)"
-          ./wkcloudsim --provider alibaba --provider-config provider.json open-analysis "$RUN_ID" \
+          echo "attempted=true" >>"$GITHUB_OUTPUT"
+          timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json open-analysis "$RUN_ID" \
             --source "${runner_ip}/32" --until "$until" >/dev/null
           echo "opened=true" >>"$GITHUB_OUTPUT"
       - name: Encrypt handoff and move ingress to local Codex
@@ -199,8 +201,8 @@ jobs:
           cp pinned-ca.pem session/pinned-ca.pem
           ca_fingerprint="sha256:$(openssl x509 -in pinned-ca.pem -outform DER | sha256sum | awk '{print $1}')"
 
-          ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis "$RUN_ID"
-          ./wkcloudsim --provider alibaba --provider-config provider.json open-analysis "$RUN_ID" \
+          timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis "$RUN_ID"
+          timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json open-analysis "$RUN_ID" \
             --source "${CLIENT_IPV4}/32" --until "$expires_at" >/dev/null
           jq -n --arg run_id "$RUN_ID" --arg request_id "$REQUEST_ID" \
             --arg source_sha '${{ steps.locator.outputs.source_sha }}' \
@@ -238,10 +240,10 @@ jobs:
             '{schema:"wukongim/cloud-simulation-analysis-session/v1",state:$state,run_id:$run_id,
               request_id:$request_id,message:$message}' >session/session.json
       - name: Close failed temporary exchange window
-        if: always() && steps.ingress.outputs.opened == 'true' && steps.handoff.outputs.client_window != 'true'
+        if: always() && steps.ingress.outputs.attempted == 'true' && steps.handoff.outputs.client_window != 'true'
         continue-on-error: true
         shell: bash
-        run: ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis "$RUN_ID"
+        run: timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis "$RUN_ID"
       - name: Upload encrypted one-day local handoff
         if: always() && hashFiles('session/session.json') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -321,4 +323,4 @@ jobs:
         run: |
           set -euo pipefail
           go build -trimpath -o wkcloudsim ./cmd/wkcloudsim
-          ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis "$RUN_ID"
+          timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis "$RUN_ID"

--- a/cmd/wukongim/config_test.go
+++ b/cmd/wukongim/config_test.go
@@ -1489,6 +1489,9 @@ func TestLoadConfigExampleFile(t *testing.T) {
 	if cfg.Observability.DebugAPIEnabled {
 		t.Fatalf("Observability.DebugAPIEnabled = true, want false")
 	}
+	if cfg.Conversation.AuthorityFlushBatchRows != 512 {
+		t.Fatalf("Conversation.AuthorityFlushBatchRows = %d, want 512", cfg.Conversation.AuthorityFlushBatchRows)
+	}
 	assertExampleDiagnostics(t, cfg.Observability.Diagnostics)
 }
 
@@ -1508,6 +1511,9 @@ func TestLoadConfigRootExampleFile(t *testing.T) {
 	}
 	if cfg.Bench.APIEnabled {
 		t.Fatalf("Bench.APIEnabled = true, want false")
+	}
+	if cfg.Conversation.AuthorityFlushBatchRows != 512 {
+		t.Fatalf("Conversation.AuthorityFlushBatchRows = %d, want 512", cfg.Conversation.AuthorityFlushBatchRows)
 	}
 	assertExampleDiagnostics(t, cfg.Observability.Diagnostics)
 }
@@ -1576,6 +1582,9 @@ func TestLoadConfigMultiNodeExampleFiles(t *testing.T) {
 			}
 			if len(cfg.Gateway.Listeners) != 2 {
 				t.Fatalf("Gateway.Listeners len = %d, want 2", len(cfg.Gateway.Listeners))
+			}
+			if cfg.Conversation.AuthorityFlushBatchRows != 512 {
+				t.Fatalf("Conversation.AuthorityFlushBatchRows = %d, want 512", cfg.Conversation.AuthorityFlushBatchRows)
 			}
 			if cfg.Observability.DebugAPIEnabled {
 				t.Fatalf("Observability.DebugAPIEnabled = true, want false")

--- a/cmd/wukongim/wukongim-node1.toml.example
+++ b/cmd/wukongim/wukongim-node1.toml.example
@@ -120,7 +120,7 @@ authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
 # Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/cmd/wukongim/wukongim-node2.toml.example
+++ b/cmd/wukongim/wukongim-node2.toml.example
@@ -120,7 +120,7 @@ authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
 # Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/cmd/wukongim/wukongim-node3.toml.example
+++ b/cmd/wukongim/wukongim-node3.toml.example
@@ -120,7 +120,7 @@ authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
 # Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/cmd/wukongim/wukongim.toml.example
+++ b/cmd/wukongim/wukongim.toml.example
@@ -141,7 +141,7 @@ authority_handoff_timeout = "3s"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
 # Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -852,9 +852,14 @@ periodic tick or coalesced cache-pressure wakeup
   -> batch-read durable conversation rows for receiver-only cooldown filtering
   -> skip receiver-only ActiveAt updates inside AuthorityActiveCooldown
   -> store.TouchConversationActiveAtBatch persists remaining ActiveAt/ReadSeq/UpdatedAt
-  -> after a successful pressure-cycle attempt, requeue one wakeup while dirty
-     rows remain above the 70% low watermark and at least one dirty marker was
-     cleared; a zero-progress attempt waits for the next periodic tick
+  -> after a successful pressure-cycle attempt with cleared rows, the Manager
+     requeues one coalesced wakeup while dirty rows remain above the 70% low
+     watermark
+  -> when a selected pressure batch clears no dirty marker while retryable rows
+     remain, the app worker schedules one cancellation-safe delayed retry with
+     bounded exponential backoff from 25ms to 250ms; progress, no work, or an error
+     cancels that retry and returns continuation ownership to the normal
+     Manager pressure signal or periodic tick
 
 cache admission
   -> keep the latest receiver activity visible in cache while suppressing only
@@ -878,7 +883,10 @@ payloads. It only persists dirty active rows already admitted into the
 conversationactive cache, keeping cache visibility immediate while bounding
 eventual durable lag. The capacity-1 pressure channel and single worker goroutine
 coalesce concurrent wakeups; every attempt remains bounded by
-`AuthorityFlushBatchRows` and `AuthorityFlushTimeout`.
+`AuthorityFlushBatchRows` and `AuthorityFlushTimeout`. The worker owns and reuses
+the delayed pressure-retry timer, stops it on cancellation, and never immediately
+re-signals a zero-progress batch, so repeated version conflicts cannot create a
+busy loop.
 
 ## Conversation Authority Handoff
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2907,7 +2907,7 @@ func TestDefaultConversationAuthorityConfig(t *testing.T) {
 		cfg.AuthorityActiveCooldown != 2*time.Hour ||
 		cfg.AuthorityFlushInterval != time.Second ||
 		cfg.AuthorityFlushTimeout != 5*time.Second ||
-		cfg.AuthorityFlushBatchRows != 128 ||
+		cfg.AuthorityFlushBatchRows != 512 ||
 		cfg.AuthorityAdmitBatchRows != 512 ||
 		cfg.AuthorityAdmitConcurrency != 16 {
 		t.Fatalf("conversation authority defaults = %#v", cfg)

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -26,6 +26,8 @@ var (
 	ErrStopped = errors.New("internal/app: stopped")
 )
 
+const defaultConversationAuthorityFlushBatchRows = 512
+
 // Config contains phase-1 internal app configuration.
 type Config struct {
 	// NodeID is the stable cluster node identity.
@@ -692,7 +694,7 @@ func defaultConversationConfig(cfg ConversationConfig) ConversationConfig {
 		cfg.AuthorityFlushTimeout = 5 * time.Second
 	}
 	if cfg.AuthorityFlushBatchRows == 0 {
-		cfg.AuthorityFlushBatchRows = 128
+		cfg.AuthorityFlushBatchRows = defaultConversationAuthorityFlushBatchRows
 	}
 	if cfg.AuthorityAdmitBatchRows == 0 {
 		cfg.AuthorityAdmitBatchRows = 512

--- a/internal/app/conversation_active_flush.go
+++ b/internal/app/conversation_active_flush.go
@@ -25,6 +25,12 @@ type conversationActiveFlushWorkerOptions struct {
 	BatchRows int
 	// PressureSignals receives coalesced dirty-cache pressure wakeups.
 	PressureSignals <-chan conversationactive.PressureSignal
+	// PressureRetryMinDelay is the first delay before retrying a pressure flush
+	// that made no clear progress while retryable rows remain.
+	PressureRetryMinDelay time.Duration
+	// PressureRetryMaxDelay caps exponential pressure retry backoff while
+	// selected rows keep making no clear progress.
+	PressureRetryMaxDelay time.Duration
 	// Observer receives pressure wakeup wait observations from the app-owned worker.
 	Observer conversationactive.Observer
 	// Logger records periodic flush failures.
@@ -49,6 +55,15 @@ func newConversationActiveFlushWorker(opts conversationActiveFlushWorkerOptions)
 	}
 	if opts.BatchRows <= 0 {
 		opts.BatchRows = 512
+	}
+	if opts.PressureRetryMinDelay <= 0 {
+		opts.PressureRetryMinDelay = 25 * time.Millisecond
+	}
+	if opts.PressureRetryMaxDelay <= 0 {
+		opts.PressureRetryMaxDelay = 250 * time.Millisecond
+	}
+	if opts.PressureRetryMaxDelay < opts.PressureRetryMinDelay {
+		opts.PressureRetryMaxDelay = opts.PressureRetryMinDelay
 	}
 	if opts.Logger == nil {
 		opts.Logger = wklog.NewNop()
@@ -112,12 +127,57 @@ func (w *conversationActiveFlushWorker) tick(ctx context.Context) {
 	ticker := time.NewTicker(w.opts.FlushInterval)
 	defer ticker.Stop()
 	pressureSignals := w.opts.PressureSignals
+	var pressureRetryTimer *time.Timer
+	var pressureRetry <-chan time.Time
+	pressureRetryDelay := w.opts.PressureRetryMinDelay
+	stopPressureRetry := func(resetDelay bool) {
+		if pressureRetryTimer != nil {
+			if !pressureRetryTimer.Stop() {
+				select {
+				case <-pressureRetryTimer.C:
+				default:
+				}
+			}
+		}
+		pressureRetry = nil
+		if resetDelay {
+			pressureRetryDelay = w.opts.PressureRetryMinDelay
+		}
+	}
+	defer stopPressureRetry(false)
+	schedulePressureRetry := func() {
+		if pressureRetryTimer == nil {
+			pressureRetryTimer = time.NewTimer(pressureRetryDelay)
+		} else {
+			stopPressureRetry(false)
+			pressureRetryTimer.Reset(pressureRetryDelay)
+		}
+		pressureRetry = pressureRetryTimer.C
+		pressureRetryDelay = nextConversationActivePressureRetryDelay(
+			pressureRetryDelay,
+			w.opts.PressureRetryMaxDelay,
+		)
+	}
+	handlePressureResult := func(result conversationactive.FlushResult, err error) {
+		if err == nil && result.Selected > 0 && result.Cleared == 0 && result.Requeued > 0 {
+			schedulePressureRetry()
+			return
+		}
+		stopPressureRetry(true)
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			_, _ = w.flushOnce(ctx, false)
+			result, err := w.flushOnce(ctx, false)
+			if pressureRetry != nil {
+				handlePressureResult(result, err)
+			}
+		case <-pressureRetry:
+			pressureRetry = nil
+			result, err := w.flushOnce(ctx, false)
+			handlePressureResult(result, err)
 		case signal, ok := <-pressureSignals:
 			if !ok {
 				pressureSignals = nil
@@ -133,9 +193,21 @@ func (w *conversationActiveFlushWorker) tick(ctx context.Context) {
 					WakeupWaitDuration: wait,
 				})
 			}
-			_, _ = w.flushOnce(ctx, false)
+			stopPressureRetry(true)
+			result, err := w.flushOnce(ctx, false)
+			handlePressureResult(result, err)
 		}
 	}
+}
+
+func nextConversationActivePressureRetryDelay(current, maximum time.Duration) time.Duration {
+	if current <= 0 {
+		return maximum
+	}
+	if current >= maximum || current > maximum/2 {
+		return maximum
+	}
+	return current * 2
 }
 
 func (w *conversationActiveFlushWorker) flushFinal(ctx context.Context) error {

--- a/internal/app/conversation_active_flush_test.go
+++ b/internal/app/conversation_active_flush_test.go
@@ -80,6 +80,137 @@ func TestConversationActiveFlushWorkerWakesOnCachePressure(t *testing.T) {
 	}
 }
 
+func TestConversationActiveFlushWorkerRetriesZeroProgressPressureWithoutPeriodicTick(t *testing.T) {
+	pressureSignals := make(chan conversationactive.PressureSignal, 1)
+	flusher := &recordingConversationActiveFlusher{
+		firstFlush: make(chan struct{}),
+		results: []conversationactive.FlushResult{
+			{Selected: 128, Persisted: 128, Requeued: 128, VersionConflicts: 128},
+			{Selected: 128, Persisted: 128, Cleared: 128},
+			{},
+		},
+	}
+	worker := newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
+		Authority:       flusher,
+		FlushInterval:   time.Hour,
+		BatchRows:       128,
+		PressureSignals: pressureSignals,
+	})
+
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := worker.Stop(context.Background()); err != nil {
+			t.Errorf("Stop() error = %v", err)
+		}
+	})
+	pressureSignals <- conversationactive.PressureSignal{EnqueuedAt: time.Now()}
+	select {
+	case <-flusher.firstFlush:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the initial pressure flush")
+	}
+
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for len(flusher.batchRows()) < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := flusher.batchRows(); len(got) < 2 {
+		t.Fatalf("flush batches = %#v, want a bounded retry after zero-progress pressure without waiting for the periodic tick", got)
+	}
+}
+
+func TestConversationActiveFlushWorkerBacksOffRepeatedZeroProgressPressure(t *testing.T) {
+	pressureSignals := make(chan conversationactive.PressureSignal, 1)
+	flusher := &recordingConversationActiveFlusher{
+		firstFlush: make(chan struct{}),
+		results: []conversationactive.FlushResult{
+			{Selected: 128, Persisted: 128, Requeued: 128, VersionConflicts: 128},
+			{Selected: 128, Persisted: 128, Requeued: 128, VersionConflicts: 128},
+			{Selected: 128, Persisted: 128, Requeued: 128, VersionConflicts: 128},
+			{Selected: 128, Persisted: 128, Cleared: 128},
+			{},
+		},
+	}
+	worker := newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
+		Authority:             flusher,
+		FlushInterval:         time.Hour,
+		BatchRows:             128,
+		PressureSignals:       pressureSignals,
+		PressureRetryMinDelay: 20 * time.Millisecond,
+		PressureRetryMaxDelay: 80 * time.Millisecond,
+	})
+
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := worker.Stop(context.Background()); err != nil {
+			t.Errorf("Stop() error = %v", err)
+		}
+	})
+	pressureSignals <- conversationactive.PressureSignal{EnqueuedAt: time.Now()}
+	deadline := time.Now().Add(time.Second)
+	for len(flusher.batchRows()) < 4 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	callTimes := flusher.flushCallTimes()
+	if len(callTimes) != 4 {
+		t.Fatalf("flush calls = %d, want three delayed zero-progress retries followed by progress", len(callTimes))
+	}
+	wantMinimumDelays := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond}
+	for index, wantMinimum := range wantMinimumDelays {
+		if elapsed := callTimes[index+1].Sub(callTimes[index]); elapsed < wantMinimum {
+			t.Fatalf("pressure retry delay[%d] = %v, want at least %v to avoid a busy loop", index, elapsed, wantMinimum)
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := len(flusher.batchRows()); got != 4 {
+		t.Fatalf("flush calls after progress = %d, want retry loop to stop at 4", got)
+	}
+}
+
+func TestConversationActiveFlushWorkerStopCancelsPendingPressureRetry(t *testing.T) {
+	pressureSignals := make(chan conversationactive.PressureSignal, 1)
+	flusher := &recordingConversationActiveFlusher{
+		firstFlush: make(chan struct{}),
+		results: []conversationactive.FlushResult{
+			{Selected: 128, Persisted: 128, Requeued: 128, VersionConflicts: 128},
+			{},
+		},
+	}
+	worker := newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
+		Authority:             flusher,
+		FlushInterval:         time.Hour,
+		BatchRows:             128,
+		PressureSignals:       pressureSignals,
+		PressureRetryMinDelay: 250 * time.Millisecond,
+		PressureRetryMaxDelay: 250 * time.Millisecond,
+	})
+
+	if err := worker.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	pressureSignals <- conversationactive.PressureSignal{EnqueuedAt: time.Now()}
+	select {
+	case <-flusher.firstFlush:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the initial pressure flush")
+	}
+	if err := worker.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if got := len(flusher.batchRows()); got != 2 {
+		t.Fatalf("flush calls after Stop() = %d, want initial pressure attempt plus final empty drain", got)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if got := len(flusher.batchRows()); got != 2 {
+		t.Fatalf("flush calls after pending retry deadline = %d, want canceled retry to stay stopped", got)
+	}
+}
+
 func TestConversationActiveFlushWorkerStopReturnsFinalFlushError(t *testing.T) {
 	flushErr := errors.New("store unavailable")
 	worker := newConversationActiveFlushWorker(conversationActiveFlushWorkerOptions{
@@ -181,6 +312,7 @@ type recordingConversationActiveFlusher struct {
 	err        error
 	results    []conversationactive.FlushResult
 	batches    []int
+	callTimes  []time.Time
 }
 
 type pressureAwareConversationActiveFlusher struct {
@@ -212,6 +344,7 @@ func (f *recordingConversationActiveFlusher) FlushActiveRows(_ context.Context, 
 		result = f.results[len(f.batches)]
 	}
 	f.batches = append(f.batches, batchRows)
+	f.callTimes = append(f.callTimes, time.Now())
 	f.mu.Unlock()
 	f.firstOnce.Do(func() {
 		if f.firstFlush != nil {
@@ -228,6 +361,12 @@ func (f *recordingConversationActiveFlusher) batchRows() []int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]int(nil), f.batches...)
+}
+
+func (f *recordingConversationActiveFlusher) flushCallTimes() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]time.Time(nil), f.callTimes...)
 }
 
 type contextBlockingConversationActiveFlusher struct {

--- a/internal/app/conversation_authority.go
+++ b/internal/app/conversation_authority.go
@@ -202,7 +202,7 @@ func newConversationAuthority(opts conversationAuthorityOptions) *conversationAu
 		opts.MaxRows = 100000
 	}
 	if opts.FlushBatchRows <= 0 {
-		opts.FlushBatchRows = 128
+		opts.FlushBatchRows = defaultConversationAuthorityFlushBatchRows
 	}
 	authority := &conversationAuthority{
 		localNodeID:        opts.LocalNodeID,

--- a/internal/infra/cloudsim/alibaba/openapi.go
+++ b/internal/infra/cloudsim/alibaba/openapi.go
@@ -27,11 +27,13 @@ import (
 )
 
 const (
-	defaultSDKPollInterval = 2 * time.Second
-	defaultSDKWaitTimeout  = 3 * time.Minute
-	maxDiscoveryPages      = 20
-	discoveryPageSize      = 100
-	vpcInventoryPageSize   = 50
+	defaultSDKPollInterval         = 2 * time.Second
+	defaultSDKWaitTimeout          = 3 * time.Minute
+	defaultSDKConnectTimeoutMillis = 10_000
+	defaultSDKReadTimeoutMillis    = 30_000
+	maxDiscoveryPages              = 20
+	discoveryPageSize              = 100
+	vpcInventoryPageSize           = 50
 )
 
 type linuxImageCandidate struct {
@@ -85,6 +87,18 @@ func NewOpenAPIFromDefaultCredential(region string) (*OpenAPI, error) {
 }
 
 func newOpenAPI(config *openapiutil.Config) (*OpenAPI, error) {
+	if config == nil {
+		return nil, ErrInvalidConfig
+	}
+	// Several generated Alibaba methods do not expose a context-aware variant.
+	// Client-level transport deadlines keep those calls bounded even when the
+	// surrounding workflow context is cancelled or the provider stops replying.
+	if config.ConnectTimeout == nil || dara.IntValue(config.ConnectTimeout) <= 0 {
+		config.SetConnectTimeout(defaultSDKConnectTimeoutMillis)
+	}
+	if config.ReadTimeout == nil || dara.IntValue(config.ReadTimeout) <= 0 {
+		config.SetReadTimeout(defaultSDKReadTimeoutMillis)
+	}
 	ecsClient, err := ecs.NewClient(config)
 	if err != nil {
 		return nil, fmt.Errorf("create ECS client: %w", err)

--- a/internal/infra/cloudsim/alibaba/openapi_test.go
+++ b/internal/infra/cloudsim/alibaba/openapi_test.go
@@ -9,8 +9,35 @@ import (
 	"time"
 
 	"github.com/WuKongIM/WuKongIM/internal/usecase/cloudsim"
+	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
+	"github.com/alibabacloud-go/tea/dara"
 	"gopkg.in/yaml.v3"
 )
+
+func TestNewOpenAPIAppliesBoundedTransportTimeouts(t *testing.T) {
+	api, err := newOpenAPI(&openapiutil.Config{
+		AccessKeyId:     dara.String("test-access-key"),
+		AccessKeySecret: dara.String("test-access-secret"),
+		RegionId:        dara.String("cn-hangzhou"),
+	})
+	if err != nil {
+		t.Fatalf("newOpenAPI() error = %v", err)
+	}
+	if api.ecs.ConnectTimeout == nil || *api.ecs.ConnectTimeout <= 0 {
+		t.Fatalf("ECS ConnectTimeout = %v, want a bounded positive timeout", api.ecs.ConnectTimeout)
+	}
+	if api.ecs.ReadTimeout == nil || *api.ecs.ReadTimeout <= 0 {
+		t.Fatalf("ECS ReadTimeout = %v, want a bounded positive timeout", api.ecs.ReadTimeout)
+	}
+	if api.vpc.ConnectTimeout == nil || *api.vpc.ConnectTimeout != *api.ecs.ConnectTimeout ||
+		api.sts.ConnectTimeout == nil || *api.sts.ConnectTimeout != *api.ecs.ConnectTimeout {
+		t.Fatalf("SDK connect timeouts are inconsistent: ECS=%v VPC=%v STS=%v", api.ecs.ConnectTimeout, api.vpc.ConnectTimeout, api.sts.ConnectTimeout)
+	}
+	if api.vpc.ReadTimeout == nil || *api.vpc.ReadTimeout != *api.ecs.ReadTimeout ||
+		api.sts.ReadTimeout == nil || *api.sts.ReadTimeout != *api.ecs.ReadTimeout {
+		t.Fatalf("SDK read timeouts are inconsistent: ECS=%v VPC=%v STS=%v", api.ecs.ReadTimeout, api.vpc.ReadTimeout, api.sts.ReadTimeout)
+	}
+}
 
 func TestCloudInitConfiguresOnlyProviderAssignedSecondaryAddresses(t *testing.T) {
 	content := cloudInit("ssh-ed25519 AAAATEST run", []string{"10.42.0.21", "10.42.0.22"}, 24)

--- a/internal/infra/cloudsim/deploy/workflow_test.go
+++ b/internal/infra/cloudsim/deploy/workflow_test.go
@@ -108,6 +108,13 @@ func TestCloudSimulationWorkflowPrivilegeSeparation(t *testing.T) {
 	if !strings.Contains(prepareSection, "id: handoff\n        if: steps.ingress.outputs.opened == 'true'\n        continue-on-error: true") {
 		t.Fatal("analysis broker cannot materialize an insufficient-evidence handoff after exchange failure")
 	}
+	if !strings.Contains(prepareSection, "id: ingress\n        if: steps.preflight.outputs.state == 'live'\n        continue-on-error: true") {
+		t.Fatal("analysis broker cannot materialize an insufficient-evidence session after bounded ingress failure")
+	}
+	if !strings.Contains(prepareSection, `echo "attempted=true" >>"$GITHUB_OUTPUT"`) ||
+		!strings.Contains(prepareSection, "steps.ingress.outputs.attempted == 'true' && steps.handoff.outputs.client_window != 'true'") {
+		t.Fatal("analysis broker cannot revoke a possibly-created exchange rule after a timed-out ingress command")
+	}
 	for _, forbidden := range []string{"OPENAI_API_KEY", "openai/codex-action", "environment: cloud-sim-remediation", "contents: write", "WK_ANALYSIS_MCP_TOKEN="} {
 		if strings.Contains(analysis, forbidden) {
 			t.Fatalf("analysis broker contains forbidden credential or repository-write capability %q", forbidden)

--- a/internal/runtime/conversationactive/FLOW.md
+++ b/internal/runtime/conversationactive/FLOW.md
@@ -38,10 +38,13 @@ Current flow:
    `MessageSeq` is reconciled out of cache instead of treating the store's
    idempotent no-op as a confirmed active baseline. Successful attempts requeue one
    wakeup while dirty rows remain above the 70% low watermark and the attempt
-   cleared at least one dirty marker. A zero-progress attempt keeps the drain
-   active but waits for the periodic worker tick instead of forming a tight
-   wakeup loop. Retained clean rows form an immediately evictable reserve for
-   later admissions.
+   cleared at least one dirty marker. The manager does not immediately
+   self-signal after a zero-progress attempt. Instead, the app-owned worker
+   keeps the drain active with a cancellation-safe delayed retry and bounded
+   exponential backoff from 25ms to 250ms; progress, no work, or an error ends
+   that retry chain. This avoids both a tight wakeup loop and a one-second
+   periodic-tick stall under continuous version conflicts. Retained clean rows
+   form an immediately evictable reserve for later admissions.
 6. Active view reads carry each cache row's `MessageSeq` while merging the
    latest cached view with durable `(uid, kind)` active-index pages and primary
    row hydration. A durable `DeletedToSeq` hides an unknown or older cached

--- a/pkg/cluster/FLOW.md
+++ b/pkg/cluster/FLOW.md
@@ -504,9 +504,14 @@ Kind-aware UID-owned conversation rows are the active recent-conversation path.
 `HideConversationsBatch` route each row by `RouteKey(uid)`, group rows by
 physical Slot, and submit bounded Slot FSM commands that carry each row's real
 UID hash slot plus its `ConversationKind`. `TouchConversationActiveAtBatch`
-marks those proposals as background admission work because they are retryable
-active-cache projection flushes; user-facing UID metadata writes keep the
-default foreground class. The Slot FSM then applies each conversation state,
+resolves the patch UIDs against one route snapshot, then submits independent
+physical-Slot groups with at most four proposals in flight. Chunks for the same
+physical Slot remain ordered, and errors are returned in sorted Slot order after
+all admitted groups finish. Active patches are monotonic and idempotent, so a
+caller may retry the full batch after a partial cross-Slot failure without
+requiring cross-Slot atomicity. The proposals use background admission because
+they are retryable active-cache projection flushes; user-facing UID metadata
+writes keep the default foreground class. The Slot FSM then applies each conversation state,
 active patch, or delete barrier to that UID-owned hash slot and logical kind,
 preserving `SparseActive`, read/delete visibility floors, and the active
 ordering anchor in one metadata mutation. Hide requests advance `DeletedToSeq`
@@ -516,7 +521,9 @@ and clear `active_at` through the same Slot ownership path. Reads such as
 `ConversationKind` so normal and CMD projections stay isolated. Active pages
 scan the local conversation active index for that UID hash slot and selected
 kind with the `(active_at, channel_id, channel_type)` cursor; kind is part of
-the scan scope, not the cursor. Legacy `channel_latest` remains a channel-owned
+the scan scope, not the cursor. `GetConversationStates` resolves all requested
+UIDs against one route snapshot before issuing hash-slot-local point reads.
+Legacy `channel_latest` remains a channel-owned
 projection for old callers and is not the recent-conversation active path.
 
 ## Channel runtime Flow

--- a/pkg/cluster/node_meta.go
+++ b/pkg/cluster/node_meta.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/WuKongIM/WuKongIM/pkg/cluster/propose"
@@ -12,8 +13,9 @@ import (
 )
 
 const (
-	maxChannelLatestBatchItems = 512
-	maxConversationBatchItems  = 512
+	maxChannelLatestBatchItems          = 512
+	maxConversationBatchItems           = 512
+	maxConversationTouchSlotConcurrency = 4
 )
 
 // CreateUserMetadata persists durable UID metadata through Slot ownership.
@@ -739,36 +741,7 @@ func (n *Node) TouchConversationActiveAtBatch(ctx context.Context, patches []met
 	if err != nil {
 		return err
 	}
-	for _, slotID := range sortedConversationSlotIDs(groups) {
-		group := groups[slotID]
-		for start := 0; start < len(group.patchItems); start += maxConversationBatchItems {
-			end := start + maxConversationBatchItems
-			if end > len(group.patchItems) {
-				end = len(group.patchItems)
-			}
-			items := group.patchItems[start:end]
-			command, err := metafsm.EncodeTouchConversationActiveAtBatchCommandChecked(n.cfg.Slots.HashSlotCount, items)
-			if err != nil {
-				return err
-			}
-			routeHashSlot := group.routeHashSlot
-			if len(items) > 0 {
-				routeHashSlot = items[0].HashSlot
-			}
-			if err := n.Propose(ctx, ProposeRequest{
-				Command: command,
-				Target: ProposeTarget{
-					SlotID:      slotID,
-					HasSlotID:   true,
-					HashSlot:    routeHashSlot,
-					HasHashSlot: true,
-				},
-			}); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return n.touchConversationSlotBatches(ctx, groups)
 }
 
 // GetConversationState reads one UID-owned conversation row from Slot metadata storage.
@@ -807,12 +780,17 @@ func (n *Node) GetConversationStates(ctx context.Context, keys []metadb.Conversa
 	if n.defaultSlotMetaDB == nil {
 		return nil, ErrNotStarted
 	}
+	uids := make([]string, len(keys))
+	for i := range keys {
+		uids[i] = keys[i].UID
+	}
+	routes, err := n.RouteKeys(uids)
+	if err != nil {
+		return nil, err
+	}
 	states := make(map[metadb.ConversationStateKey]metadb.ConversationState, len(keys))
-	for _, key := range keys {
-		route, err := n.RouteKey(key.UID)
-		if err != nil {
-			return nil, err
-		}
+	for i, key := range keys {
+		route := routes[i]
 		state, err := n.defaultSlotMetaDB.ForHashSlot(route.HashSlot).GetConversationState(ctx, key.Kind, key.UID, key.ChannelID, key.ChannelType)
 		if err != nil {
 			if errors.Is(err, metadb.ErrNotFound) {
@@ -911,15 +889,20 @@ func (n *Node) groupConversationStatesBySlot(states []metadb.ConversationState) 
 }
 
 func (n *Node) groupConversationPatchesBySlot(patches []metadb.ConversationActivePatch) (map[uint32]conversationSlotBatch, error) {
-	groups := make(map[uint32]conversationSlotBatch)
-	for _, patch := range patches {
+	uids := make([]string, len(patches))
+	for i, patch := range patches {
 		if patch.UID == "" || patch.ChannelID == "" || patch.ChannelType == 0 {
 			return nil, metadb.ErrInvalidArgument
 		}
-		route, err := n.RouteKey(patch.UID)
-		if err != nil {
-			return nil, err
-		}
+		uids[i] = patch.UID
+	}
+	routes, err := n.RouteKeys(uids)
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[uint32]conversationSlotBatch)
+	for i, patch := range patches {
+		route := routes[i]
 		group := groups[route.SlotID]
 		if len(group.stateItems) == 0 && len(group.patchItems) == 0 && len(group.deleteItems) == 0 {
 			group.routeHashSlot = route.HashSlot
@@ -931,6 +914,81 @@ func (n *Node) groupConversationPatchesBySlot(patches []metadb.ConversationActiv
 		groups[route.SlotID] = group
 	}
 	return groups, nil
+}
+
+// touchConversationSlotBatches persists independent physical Slot groups with
+// bounded concurrency. Commands for one Slot remain ordered because one worker
+// owns the complete group, while errors are selected in sorted Slot order.
+func (n *Node) touchConversationSlotBatches(ctx context.Context, groups map[uint32]conversationSlotBatch) error {
+	slotIDs := sortedConversationSlotIDs(groups)
+	if len(slotIDs) == 0 {
+		return nil
+	}
+	if len(slotIDs) == 1 {
+		return n.touchConversationSlotBatch(ctx, slotIDs[0], groups[slotIDs[0]])
+	}
+
+	workerCount := len(slotIDs)
+	if workerCount > maxConversationTouchSlotConcurrency {
+		workerCount = maxConversationTouchSlotConcurrency
+	}
+	jobs := make(chan int)
+	errs := make([]error, len(slotIDs))
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for worker := 0; worker < workerCount; worker++ {
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				slotID := slotIDs[index]
+				errs[index] = n.touchConversationSlotBatch(ctx, slotID, groups[slotID])
+			}
+		}()
+	}
+	for index := range slotIDs {
+		jobs <- index
+	}
+	close(jobs)
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// touchConversationSlotBatch preserves proposal order for chunks that mutate
+// the same physical Slot. Conversation active patches are monotonic and
+// idempotent, so callers may safely retry the full batch after a partial error.
+func (n *Node) touchConversationSlotBatch(ctx context.Context, slotID uint32, group conversationSlotBatch) error {
+	for start := 0; start < len(group.patchItems); start += maxConversationBatchItems {
+		end := start + maxConversationBatchItems
+		if end > len(group.patchItems) {
+			end = len(group.patchItems)
+		}
+		items := group.patchItems[start:end]
+		command, err := metafsm.EncodeTouchConversationActiveAtBatchCommandChecked(n.cfg.Slots.HashSlotCount, items)
+		if err != nil {
+			return err
+		}
+		routeHashSlot := group.routeHashSlot
+		if len(items) > 0 {
+			routeHashSlot = items[0].HashSlot
+		}
+		if err := n.Propose(ctx, ProposeRequest{
+			Command: command,
+			Target: ProposeTarget{
+				SlotID:      slotID,
+				HasSlotID:   true,
+				HashSlot:    routeHashSlot,
+				HasHashSlot: true,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (n *Node) groupConversationDeletesBySlot(deletes []metadb.ConversationDelete) (map[uint32]conversationSlotBatch, error) {

--- a/pkg/cluster/node_meta_conversation_test.go
+++ b/pkg/cluster/node_meta_conversation_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -155,6 +156,219 @@ func TestTouchConversationActiveAtBatchMarksProposalBackground(t *testing.T) {
 	if got := propose.ProposalClassFromContext(proposer.ctx); got != propose.ProposalClassBackground {
 		t.Fatalf("proposal class = %q, want %q", got, propose.ProposalClassBackground)
 	}
+}
+
+func TestTouchConversationActiveAtBatchProposesIndependentSlotsConcurrently(t *testing.T) {
+	proposer := newBlockingConversationProposer(3)
+	node := newConversationProposalTestNode(t, 3, proposer)
+
+	patches := make([]metadb.ConversationActivePatch, 0, 3)
+	for hashSlot := uint16(0); hashSlot < 3; hashSlot++ {
+		patches = append(patches, metadb.ConversationActivePatch{
+			UID:         uidForHashSlot(t, 3, hashSlot),
+			Kind:        metadb.ConversationKindNormal,
+			ChannelID:   fmt.Sprintf("g-%d", hashSlot),
+			ChannelType: 2,
+			ActiveAt:    10,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- node.TouchConversationActiveAtBatch(ctx, patches)
+	}()
+	defer proposer.releaseAll()
+
+	entered := make(map[uint32]struct{}, 3)
+	for len(entered) < 3 {
+		select {
+		case slotID := <-proposer.entered:
+			entered[slotID] = struct{}{}
+		case <-time.After(250 * time.Millisecond):
+			t.Fatalf("proposal slots entered before release = %v, want all independent slots; proposals are serialized", entered)
+		}
+	}
+	proposer.releaseAll()
+	if err := <-done; err != nil {
+		t.Fatalf("TouchConversationActiveAtBatch() error = %v", err)
+	}
+}
+
+func TestTouchConversationActiveAtBatchBoundsSlotConcurrency(t *testing.T) {
+	const slotCount = uint16(6)
+	proposer := newBlockingConversationProposer(int(slotCount))
+	node := newConversationProposalTestNode(t, slotCount, proposer)
+	patches := make([]metadb.ConversationActivePatch, 0, slotCount)
+	for hashSlot := uint16(0); hashSlot < slotCount; hashSlot++ {
+		patches = append(patches, metadb.ConversationActivePatch{
+			UID:         uidForHashSlot(t, slotCount, hashSlot),
+			Kind:        metadb.ConversationKindNormal,
+			ChannelID:   fmt.Sprintf("g-%d", hashSlot),
+			ChannelType: 2,
+			ActiveAt:    10,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- node.TouchConversationActiveAtBatch(ctx, patches)
+	}()
+	defer proposer.releaseAll()
+
+	entered := make(map[uint32]struct{}, maxConversationTouchSlotConcurrency)
+	for len(entered) < maxConversationTouchSlotConcurrency {
+		select {
+		case slotID := <-proposer.entered:
+			entered[slotID] = struct{}{}
+		case <-time.After(250 * time.Millisecond):
+			t.Fatalf("proposal slots entered before release = %v, want %d", entered, maxConversationTouchSlotConcurrency)
+		}
+	}
+	select {
+	case slotID := <-proposer.entered:
+		t.Fatalf("proposal slot %d exceeded concurrency limit %d", slotID, maxConversationTouchSlotConcurrency)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	proposer.releaseAll()
+	if err := <-done; err != nil {
+		t.Fatalf("TouchConversationActiveAtBatch() error = %v", err)
+	}
+}
+
+func TestTouchConversationActiveAtBatchPreservesSameSlotChunkOrder(t *testing.T) {
+	proposer := newBlockingConversationProposer(2)
+	node := newConversationProposalTestNode(t, 1, proposer)
+	uid := uidForHashSlot(t, 1, 0)
+	patches := make([]metadb.ConversationActivePatch, 0, maxConversationBatchItems+1)
+	for i := 0; i < maxConversationBatchItems+1; i++ {
+		patches = append(patches, metadb.ConversationActivePatch{
+			UID:         uid,
+			Kind:        metadb.ConversationKindNormal,
+			ChannelID:   fmt.Sprintf("g-%d", i),
+			ChannelType: 2,
+			ActiveAt:    int64(i + 1),
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- node.TouchConversationActiveAtBatch(ctx, patches)
+	}()
+	defer proposer.releaseAll()
+
+	select {
+	case <-proposer.entered:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("first same-Slot proposal did not start")
+	}
+	select {
+	case slotID := <-proposer.entered:
+		t.Fatalf("second same-Slot proposal entered before the first completed: slot=%d", slotID)
+	case <-time.After(100 * time.Millisecond):
+	}
+	proposer.releaseAll()
+	if err := <-done; err != nil {
+		t.Fatalf("TouchConversationActiveAtBatch() error = %v", err)
+	}
+	select {
+	case slotID := <-proposer.entered:
+		if slotID != 1 {
+			t.Fatalf("second proposal slot = %d, want 1", slotID)
+		}
+	default:
+		t.Fatal("second same-Slot chunk was not proposed")
+	}
+}
+
+func TestTouchConversationActiveAtBatchReturnsLowestSlotErrorDeterministically(t *testing.T) {
+	errSlot1 := errors.New("slot 1 failed")
+	errSlot2 := errors.New("slot 2 failed")
+	proposer := newControlledConversationProposer(map[uint32]error{1: errSlot1, 2: errSlot2})
+	node := newConversationProposalTestNode(t, 2, proposer)
+	patches := []metadb.ConversationActivePatch{
+		{UID: uidForHashSlot(t, 2, 0), Kind: metadb.ConversationKindNormal, ChannelID: "g-0", ChannelType: 2, ActiveAt: 10},
+		{UID: uidForHashSlot(t, 2, 1), Kind: metadb.ConversationKindNormal, ChannelID: "g-1", ChannelType: 2, ActiveAt: 10},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- node.TouchConversationActiveAtBatch(context.Background(), patches)
+	}()
+	for entered := 0; entered < 2; entered++ {
+		select {
+		case <-proposer.entered:
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("independent Slot proposals did not start")
+		}
+	}
+	close(proposer.release[2])
+	select {
+	case err := <-done:
+		t.Fatalf("TouchConversationActiveAtBatch() returned before all Slot groups completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(proposer.release[1])
+	if err := <-done; !errors.Is(err, errSlot1) {
+		t.Fatalf("TouchConversationActiveAtBatch() error = %v, want lowest Slot error %v", err, errSlot1)
+	}
+}
+
+func BenchmarkTouchConversationActiveAtBatchTenSlots128Rows(b *testing.B) {
+	const slotCount = uint16(10)
+	node := newConversationProposalTestNode(b, slotCount, delayedConversationProposer{delay: time.Millisecond})
+	uids := make([]string, slotCount)
+	for hashSlot := uint16(0); hashSlot < slotCount; hashSlot++ {
+		uids[hashSlot] = uidForHashSlot(b, slotCount, hashSlot)
+	}
+	patches := make([]metadb.ConversationActivePatch, 0, 128)
+	for i := 0; i < 128; i++ {
+		patches = append(patches, metadb.ConversationActivePatch{
+			UID:         uids[i%int(slotCount)],
+			Kind:        metadb.ConversationKindNormal,
+			ChannelID:   fmt.Sprintf("g-%d", i),
+			ChannelType: 2,
+			ActiveAt:    int64(i + 1),
+		})
+	}
+	b.Run("serial_reference", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(patches)), "rows/op")
+		for i := 0; i < b.N; i++ {
+			if err := touchConversationActiveAtBatchSerialReference(node, patches); err != nil {
+				b.Fatalf("serial TouchConversationActiveAtBatch() error = %v", err)
+			}
+		}
+	})
+	b.Run("bounded_parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(patches)), "rows/op")
+		for i := 0; i < b.N; i++ {
+			if err := node.TouchConversationActiveAtBatch(context.Background(), patches); err != nil {
+				b.Fatalf("TouchConversationActiveAtBatch() error = %v", err)
+			}
+		}
+	})
+}
+
+func touchConversationActiveAtBatchSerialReference(node *Node, patches []metadb.ConversationActivePatch) error {
+	ctx := propose.WithProposalClass(context.Background(), propose.ProposalClassBackground)
+	groups, err := node.groupConversationPatchesBySlot(patches)
+	if err != nil {
+		return err
+	}
+	for _, slotID := range sortedConversationSlotIDs(groups) {
+		if err := node.touchConversationSlotBatch(ctx, slotID, groups[slotID]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func TestClusterHideConversationsBatchRoutesByUID(t *testing.T) {
@@ -332,4 +546,121 @@ func conversationRouteKeyForHashSlot(t testing.TB, node *Node, want uint16) stri
 	}
 	t.Fatalf("could not find route key for hash slot %d", want)
 	return ""
+}
+
+type blockingConversationProposer struct {
+	entered chan uint32
+	release chan struct{}
+}
+
+type controlledConversationProposer struct {
+	entered chan uint32
+	release map[uint32]chan struct{}
+	errs    map[uint32]error
+}
+
+func newControlledConversationProposer(errs map[uint32]error) *controlledConversationProposer {
+	release := make(map[uint32]chan struct{}, len(errs))
+	for slotID := range errs {
+		release[slotID] = make(chan struct{})
+	}
+	return &controlledConversationProposer{
+		entered: make(chan uint32, len(errs)),
+		release: release,
+		errs:    errs,
+	}
+}
+
+func (p *controlledConversationProposer) Propose(ctx context.Context, req propose.Request) error {
+	p.entered <- req.Target.SlotID
+	select {
+	case <-p.release[req.Target.SlotID]:
+		return p.errs[req.Target.SlotID]
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type delayedConversationProposer struct {
+	delay time.Duration
+}
+
+func (p delayedConversationProposer) Propose(ctx context.Context, _ propose.Request) error {
+	timer := time.NewTimer(p.delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func newConversationProposalTestNode(t testing.TB, slotCount uint16, proposer interface {
+	Propose(context.Context, propose.Request) error
+}) *Node {
+	t.Helper()
+	cfg := Config{NodeID: 1, ListenAddr: "127.0.0.1:0", DataDir: t.TempDir()}
+	cfg.Slots.InitialSlotCount = uint32(slotCount)
+	cfg.Slots.HashSlotCount = slotCount
+	cfg.Slots.ReplicaCount = 1
+	node, err := New(cfg, WithProposer(proposer))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	slots := make([]control.SlotAssignment, 0, slotCount)
+	ranges := make([]control.HashSlotRange, 0, slotCount)
+	statuses := make([]routing.SlotStatus, 0, slotCount)
+	for hashSlot := uint16(0); hashSlot < slotCount; hashSlot++ {
+		slotID := uint32(hashSlot) + 1
+		slots = append(slots, control.SlotAssignment{SlotID: slotID, DesiredPeers: []uint64{1}, ConfigEpoch: 1, PreferredLeader: 1})
+		ranges = append(ranges, control.HashSlotRange{From: hashSlot, To: hashSlot, SlotID: slotID})
+		statuses = append(statuses, routing.SlotStatus{SlotID: slotID, Leader: 1})
+	}
+	snapshot := control.Snapshot{
+		Revision:     1,
+		ControllerID: 1,
+		Nodes: []control.Node{
+			{NodeID: 1, Addr: "127.0.0.1:1001", Roles: []control.Role{control.RoleData}, Status: control.NodeAlive},
+		},
+		Slots:     slots,
+		HashSlots: control.HashSlotTable{Revision: 1, Count: slotCount, Ranges: ranges},
+	}
+	if err := node.router.UpdateControlSnapshot(snapshot); err != nil {
+		t.Fatalf("UpdateControlSnapshot() error = %v", err)
+	}
+	node.router.UpdateSlotLeaders(statuses)
+	node.snapshot = Snapshot{NodeID: 1, RoutesReady: true, SlotsReady: true, ChannelsReady: true, SlotCount: uint32(slotCount), HashSlotCount: slotCount}
+	node.started.Store(true)
+	return node
+}
+
+func newBlockingConversationProposer(capacity int) *blockingConversationProposer {
+	return &blockingConversationProposer{
+		entered: make(chan uint32, capacity),
+		release: make(chan struct{}),
+	}
+}
+
+func (p *blockingConversationProposer) Propose(ctx context.Context, req propose.Request) error {
+	select {
+	case p.entered <- req.Target.SlotID:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-p.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *blockingConversationProposer) releaseAll() {
+	select {
+	case <-p.release:
+		return
+	default:
+		close(p.release)
+	}
 }

--- a/scripts/cloud_sim_workflows_test.go
+++ b/scripts/cloud_sim_workflows_test.go
@@ -261,6 +261,15 @@ func TestCloudSimulationWorkflowsPersistAndReuseDiscoveredProviderConfig(t *test
 	if got := strings.Count(analyze, "resolve-exact-provider-config.sh"); got != 2 {
 		t.Fatalf("analysis provider config selector count = %d, want 2", got)
 	}
+	if got := strings.Count(analyze, "timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json open-analysis"); got != 2 {
+		t.Fatalf("bounded analysis ingress count = %d, want 2", got)
+	}
+	if got := strings.Count(analyze, "timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis"); got != 3 {
+		t.Fatalf("bounded analysis ingress cleanup count = %d, want 3", got)
+	}
+	if !strings.Contains(analyze, `curl --fail --silent --show-error --connect-timeout 5 --max-time 10 --proto '=https' --tlsv1.2 https://api.ipify.org`) {
+		t.Fatal("analysis runner public-IP discovery is not bounded")
+	}
 	if strings.Contains(analyze, "\n      PROVIDER_CONFIG_JSON: ${{ vars.ALIBABA_CLOUD_SIM_CONFIG_JSON }}") {
 		t.Fatal("analysis workflow still requires the setup-created provider config variable")
 	}

--- a/scripts/wukongim/wukongim-node1.toml
+++ b/scripts/wukongim/wukongim-node1.toml
@@ -250,7 +250,7 @@ authority_flush_interval = "1s"
 
 authority_flush_timeout = "5s"
 
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 
 authority_admit_batch_rows = 512
 

--- a/scripts/wukongim/wukongim-node2.toml
+++ b/scripts/wukongim/wukongim-node2.toml
@@ -250,7 +250,7 @@ authority_flush_interval = "1s"
 
 authority_flush_timeout = "5s"
 
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 
 authority_admit_batch_rows = 512
 

--- a/scripts/wukongim/wukongim-node3.toml
+++ b/scripts/wukongim/wukongim-node3.toml
@@ -250,7 +250,7 @@ authority_flush_interval = "1s"
 
 authority_flush_timeout = "5s"
 
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 
 authority_admit_batch_rows = 512
 

--- a/scripts/wukongim/wukongim.toml
+++ b/scripts/wukongim/wukongim.toml
@@ -248,7 +248,7 @@ authority_flush_interval = "1s"
 
 authority_flush_timeout = "5s"
 
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 
 authority_admit_batch_rows = 512
 

--- a/scripts/wukongim_config_test.go
+++ b/scripts/wukongim_config_test.go
@@ -78,6 +78,9 @@ func TestScriptWukongIMTOMLConfigsLoad(t *testing.T) {
 			if len(cfg.Gateway.Listeners) != 2 {
 				t.Fatalf("Gateway.Listeners len = %d, want 2", len(cfg.Gateway.Listeners))
 			}
+			if cfg.Conversation.AuthorityFlushBatchRows != 512 {
+				t.Fatalf("Conversation.AuthorityFlushBatchRows = %d, want 512", cfg.Conversation.AuthorityFlushBatchRows)
+			}
 		})
 	}
 }

--- a/wukongim.toml.example
+++ b/wukongim.toml.example
@@ -147,7 +147,7 @@ authority_active_cooldown = "2h"
 authority_flush_interval = "1s"
 authority_flush_timeout = "5s"
 # Maximum dirty active rows persisted by one periodic, pressure-woken, or authority-handoff flush attempt.
-authority_flush_batch_rows = 128
+authority_flush_batch_rows = 512
 authority_admit_batch_rows = 512
 authority_admit_concurrency = 16
 


### PR DESCRIPTION
## What changed

- keep conversation-active pressure draining after zero-clear version-conflict batches with cancellation-safe 25–250 ms backoff
- raise the global authority flush batch default from 128 to 512 while keeping the 100,000-row cache bound
- route one batch snapshot and submit independent physical Slot groups with at most four proposals in flight while preserving same-Slot order
- bound Alibaba SDK connect/read waits and every Analysis ingress mutation; preserve insufficient-evidence artifacts and best-effort rollback after partial timeouts

## Root cause

The failed Cloud Medium run filled node 2's 100,000-row active cache because the durable drain could persist only one 128-row, cross-Slot-serialized batch at a time. When continuous updates caused a batch to clear zero version-fenced rows, the pressure cycle stopped until the next one-second periodic tick. In parallel, generated Alibaba methods without context-aware variants inherited no transport deadline, so `open-analysis` could consume the whole 15-minute workflow timeout.

## Impact

Conversation projection persistence now keeps making bounded progress without a busy loop, and independent Slots no longer create avoidable head-of-line blocking. Analysis session setup fails with bounded evidence instead of hanging, and a possibly-created temporary ingress rule is actively closed with expiry/Sweep as the final backstop.

## Validation

- repository unit gate: `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1` (PASS, 324.53s)
- focused app and cluster race tests (PASS)
- focused config, Alibaba provider, workflow, and script tests with repeat counts (PASS)
- `go vet` on changed Go packages (PASS)
- 10-Slot/128-row proposal benchmark: about 11.7 ms serial to 3.4–3.8 ms bounded parallel
- workflow YAML parse and `git diff --check` (PASS)
