### PR TITLE
Balance channel reactors and harden cloud analysis

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -23,6 +23,7 @@
 - `internal` webhook delivery is a node-local best-effort post-commit side effect with bounded queues and finite retry. Large offline fanout should use batch observer/chunking, and webhook failure must not affect SENDACK, durable append, conversation active admission, or owner delivery.
 - Channelappend post-commit pool admission and per-channel backlog must stay bounded and independent from foreground append admission; saturation is observed and dropped so best-effort conversation/delivery work cannot pin writer-advance workers, delay durable SEND/SENDACK, or return `ErrChannelBusy` for an otherwise admissible send.
 - Conversation-active cache churn may evict clean rows during memory-only admission; dirty persistence stays exclusively on periodic, pressure-woken, or handoff flush workers.
+- Local Cloud Analysis should use the run's Cloud View `RemoteAddr` as a best-effort same-destination egress hint; transparent routing can give public echo services another IPv4. Keep pinned-TLS MCP health authoritative and preserve the echo fallback for runs without Cloud View.
 
 ## Gateway Runtime
 
@@ -30,6 +31,7 @@
 
 ## Channel Runtime
 
+- Node-local Channel reactor routing must avalanche stable hashes before a power-of-two modulus; raw FNV-64a low bits collapse sequential canonical person-channel IDs onto a subset of reactors. Reactor partitions are not cluster hash slots or persisted ownership.
 - Channel runtime data replicas are selected by Channel placement, not by Slot metadata peers; Slot route peers describe metadata ownership only.
 
 ### Conversation working set

--- a/internal/access/cloudview/FLOW.md
+++ b/internal/access/cloudview/FLOW.md
@@ -28,6 +28,16 @@ annotate-report` reads live simulator-local state and adds the final purity
 verdict to the wkbench report. Missing or degraded state writes `pure=false`
 and fails the systemd post-stop action instead of leaving a pure result.
 
+`GET /cloud-view/status` is a passive control-plane read. It reports the direct
+transport peer as `observed_ipv4` from `RemoteAddr`, ignores forwarded-address
+headers, and does not change benchmark purity. Local Analysis uses that
+same-destination observation to bind its single `/32` ingress rule when a
+transparent VPN or policy router gives public IP echo services another egress.
+The response is `no-store`, and Analysis adds a per-session cache buster. This
+plain-HTTP signal is only a best-effort rebind hint: unavailable, legacy, or
+invalid status falls back to the HTTPS public echo address, while the pinned-TLS
+MCP health check remains the authority for accepting the Analysis endpoint.
+
 For real interactive traffic, the conservative marker is persisted before the
 request is forwarded. If persistence is degraded, Cloud View returns `503` and
 does not execute the Demo/API/WS request or an irreversible Manager operation.

--- a/internal/access/cloudview/limit.go
+++ b/internal/access/cloudview/limit.go
@@ -182,3 +182,13 @@ func requestSource(request *http.Request) string {
 	}
 	return "unknown"
 }
+
+// requestIPv4 returns the canonical transport peer IPv4 and never trusts
+// caller-controlled forwarding headers.
+func requestIPv4(request *http.Request) string {
+	address := net.ParseIP(requestSource(request))
+	if address == nil || address.To4() == nil {
+		return ""
+	}
+	return address.String()
+}

--- a/internal/access/cloudview/server.go
+++ b/internal/access/cloudview/server.go
@@ -33,6 +33,8 @@ type statusResponse struct {
 	cloudviewstate.State
 	// PersistenceHealthy is false while a failed durable projection is retrying.
 	PersistenceHealthy bool `json:"persistence_healthy"`
+	// ObservedIPv4 is the direct transport peer used to reach this Cloud View.
+	ObservedIPv4 string `json:"observed_ipv4"`
 }
 
 // NodeUpstream contains the private endpoints for one WuKongIM cluster node.
@@ -195,10 +197,11 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.URL.Path == "/cloud-view/status" {
+		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Content-Type", "application/json")
 		state, persistenceHealthy := s.state.StatusSnapshot()
 		_ = json.NewEncoder(w).Encode(statusResponse{
-			State: state, PersistenceHealthy: persistenceHealthy,
+			State: state, PersistenceHealthy: persistenceHealthy, ObservedIPv4: requestIPv4(r),
 		})
 		return
 	}

--- a/internal/access/cloudview/server_test.go
+++ b/internal/access/cloudview/server_test.go
@@ -129,6 +129,43 @@ func TestServerRateLimitsHTTPPerSourceIP(t *testing.T) {
 	}
 }
 
+func TestServerStatusReportsRemoteIPv4WithoutChangingRunPurity(t *testing.T) {
+	server, err := New(Options{
+		RunID:         "run-1",
+		PublicBaseURL: "http://198.51.100.20:19443",
+		Nodes: []NodeUpstream{{
+			ID: 1, APIBaseURL: "http://127.0.0.1:1", ManagerBaseURL: "http://127.0.0.1:1", WebSocketBaseURL: "http://127.0.0.1:1",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/cloud-view/status", nil)
+	request.RemoteAddr = "203.0.113.10:50000"
+	request.Header.Set("X-Forwarded-For", "198.51.100.99")
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	var status struct {
+		ObservedIPv4     string `json:"observed_ipv4"`
+		Interactive      bool   `json:"interactive"`
+		OperatorModified bool   `json:"operator_modified"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode cloud view status: %v; body=%q", err, recorder.Body.String())
+	}
+	if recorder.Code != http.StatusOK || status.ObservedIPv4 != "203.0.113.10" {
+		t.Fatalf("cloud view status = %#v code=%d, want transport peer IPv4", status, recorder.Code)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("cloud view status Cache-Control = %q, want no-store", got)
+	}
+	if status.Interactive || status.OperatorModified {
+		t.Fatalf("cloud view status changed run purity: %#v", status)
+	}
+}
+
 func TestServerLimitsConcurrentWebSocketsPerSourceIP(t *testing.T) {
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/readyz" {

--- a/internal/bench/workload/reactor_distribution_test.go
+++ b/internal/bench/workload/reactor_distribution_test.go
@@ -1,0 +1,93 @@
+package workload
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	benchconfig "github.com/WuKongIM/WuKongIM/internal/bench/config"
+	"github.com/WuKongIM/WuKongIM/internal/bench/planner"
+	benchmodel "github.com/WuKongIM/WuKongIM/pkg/bench/model"
+	ch "github.com/WuKongIM/WuKongIM/pkg/channel"
+	"github.com/WuKongIM/WuKongIM/pkg/channel/reactor"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudMediumTrafficBalancesAcrossChannelReactors(t *testing.T) {
+	const (
+		reactorCount = 4
+		// runID preserves the failed Cloud Medium run's group-channel hash seed.
+		runID    = "gh-29845692322-1"
+		workerID = "simulator-worker"
+	)
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	scenario, err := benchconfig.LoadScenario(filepath.Join(filepath.Dir(currentFile), "../../../docker/sim/cloud-medium.yaml"))
+	require.NoError(t, err)
+	scenario.Run.ID = runID
+	plan, err := planner.Build(scenario, []benchmodel.Worker{{ID: workerID, Weight: 1}})
+	require.NoError(t, err)
+	workerPlan, ok := plan.Workers[workerID]
+	require.True(t, ok)
+	require.Equal(t, benchmodel.Range{Start: 0, End: 10_000}, workerPlan.IdentityRange)
+	profiles := make(map[string]benchmodel.ChannelProfile, len(scenario.Channels.Profiles))
+	for _, profile := range scenario.Channels.Profiles {
+		profiles[profile.Name] = profile
+	}
+
+	router, err := reactor.NewRouter(reactorCount)
+	require.NoError(t, err)
+	load := make([]float64, reactorCount)
+	profileLoad := make(map[string][]float64)
+
+	add := func(profileName, channelID string, channelType uint8, qps float64) {
+		key := ch.ChannelKeyForID(ch.ChannelID{ID: channelID, Type: channelType})
+		index := router.PickIndex(key)
+		load[index] += qps
+		if profileLoad[profileName] == nil {
+			profileLoad[profileName] = make([]float64, reactorCount)
+		}
+		profileLoad[profileName][index] += qps
+	}
+	for _, profileName := range plan.ProfileOrder {
+		profile, ok := profiles[profileName]
+		require.True(t, ok, "profile %q", profileName)
+		shard, ok := workerPlan.Profiles[profileName]
+		require.True(t, ok, "profile shard %q", profileName)
+		switch profile.ChannelType {
+		case benchmodel.ChannelTypePerson:
+			require.Equal(t, shard.ChannelRange.Len()*2, shard.ParticipantRange.Len())
+			for offset := 0; offset < shard.ChannelRange.Len(); offset++ {
+				senderIndex := shard.ParticipantRange.Start + offset*2
+				recipientIndex := senderIndex + 1
+				senderUID := indexedBenchID(scenario.Identity.UIDPrefix, senderIndex)
+				recipientUID := indexedBenchID(scenario.Identity.UIDPrefix, recipientIndex)
+				add(profileName, encodeBenchPersonChannel(senderUID, recipientUID), frame.ChannelTypePerson, shard.LocalRate.PerSecond)
+			}
+		case benchmodel.ChannelTypeGroup:
+			for channelIndex := shard.ChannelRange.Start; channelIndex < shard.ChannelRange.End; channelIndex++ {
+				channelID := GroupChannelID(runID, profileName, channelIndex)
+				if profile.Shard.HashSlotSpread {
+					channelID = GroupChannelIDForHashSlot(runID, profileName, channelIndex, profile.Shard.HashSlotCount)
+				}
+				add(profileName, channelID, frame.ChannelTypeGroup, shard.LocalRate.PerSecond)
+			}
+		default:
+			t.Fatalf("unsupported channel type %q", profile.ChannelType)
+		}
+	}
+
+	for profileName, qps := range profileLoad {
+		t.Logf("%s load=%v", profileName, qps)
+	}
+	totalQPS := 0.0
+	for _, qps := range load {
+		totalQPS += qps
+	}
+	require.Equal(t, 5_000.0, scenario.Objectives.IngressQPS.PerSecond)
+	require.InDelta(t, scenario.Objectives.IngressQPS.PerSecond, totalQPS, 0.000001)
+	for index, qps := range load {
+		require.InDelta(t, 1_250, qps, 1_250*0.05, "reactor %d load=%v all=%v", index, qps, load)
+	}
+}

--- a/pkg/channel/reactor/FLOW.md
+++ b/pkg/channel/reactor/FLOW.md
@@ -6,6 +6,12 @@
 reactor goroutine is the writer for each loaded channel runtime. Blocking store
 and RPC work leaves the reactor through bounded worker pools and returns as
 fenced worker completions.
+Channel keys use stable FNV-64a followed by an avalanche mix before the
+node-local reactor modulus. The mix prevents structured person-channel IDs from
+collapsing onto the weak low bits of power-of-two reactor counts. This reactor
+partition is in-memory execution ownership; it is not a cluster hash slot or a
+persisted routing decision, so a restart may remap keys after the reactor count
+or implementation changes.
 Started reactors also open/load channel stores and close detached store handles
 through worker tasks, so metadata activation and runtime eviction do not wait on
 store I/O inside the reactor loop.

--- a/pkg/channel/reactor/router.go
+++ b/pkg/channel/reactor/router.go
@@ -23,5 +23,15 @@ func NewRouter(count int) (Router, error) {
 func (r Router) PickIndex(key ch.ChannelKey) int {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(key))
-	return int(h.Sum64() % uint64(r.count))
+	return int(avalanche64(h.Sum64()) % uint64(r.count))
+}
+
+// avalanche64 mixes weak low bits before a power-of-two reactor modulus.
+func avalanche64(value uint64) uint64 {
+	value ^= value >> 33
+	value *= 0xff51afd7ed558ccd
+	value ^= value >> 33
+	value *= 0xc4ceb9fe1a85ec53
+	value ^= value >> 33
+	return value
 }

--- a/pkg/channel/reactor/router_test.go
+++ b/pkg/channel/reactor/router_test.go
@@ -1,9 +1,12 @@
 package reactor
 
 import (
+	"fmt"
 	"testing"
 
 	ch "github.com/WuKongIM/WuKongIM/pkg/channel"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,4 +19,39 @@ func TestRouterStableAndInBounds(t *testing.T) {
 	}
 	require.GreaterOrEqual(t, first, 0)
 	require.Less(t, first, 4)
+}
+
+func TestRouterDistributesSequentialPersonChannelsAcrossPowerOfTwoReactors(t *testing.T) {
+	for _, reactorCount := range []int{4, 8} {
+		t.Run(fmt.Sprintf("reactors_%d", reactorCount), func(t *testing.T) {
+			router, err := NewRouter(reactorCount)
+			require.NoError(t, err)
+			counts := make([]int, reactorCount)
+			const pairCount = 10_000
+			for pairIndex := 0; pairIndex < pairCount; pairIndex++ {
+				leftUID := fmt.Sprintf("cloud-medium-u-%d", pairIndex*2)
+				rightUID := fmt.Sprintf("cloud-medium-u-%d", pairIndex*2+1)
+				id := ch.ChannelID{
+					ID:   channelid.EncodePersonChannel(leftUID, rightUID),
+					Type: frame.ChannelTypePerson,
+				}
+				counts[router.PickIndex(ch.ChannelKeyForID(id))]++
+			}
+
+			expected := float64(pairCount) / float64(reactorCount)
+			for index, count := range counts {
+				require.InDelta(t, expected, count, expected*0.1, "reactor %d count=%d all=%v", index, count, counts)
+			}
+		})
+	}
+}
+
+func TestRouterPickIndexDoesNotAllocate(t *testing.T) {
+	router, err := NewRouter(4)
+	require.NoError(t, err)
+	key := ch.ChannelKey("1:cloud-medium-u-0@cloud-medium-u-1")
+
+	require.Zero(t, testing.AllocsPerRun(1_000, func() {
+		_ = router.PickIndex(key)
+	}))
 }

--- a/scripts/cloud-sim/analyze.sh
+++ b/scripts/cloud-sim/analyze.sh
@@ -266,6 +266,33 @@ publish_result() {
   result_temp=""
 }
 
+is_valid_ipv4() {
+  local value="$1"
+  local octet
+  local -a octets
+  [[ "$value" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || return 1
+  IFS=. read -r -a octets <<<"$value"
+  ((${#octets[@]} == 4)) || return 1
+  for octet in "${octets[@]}"; do
+    [[ "$octet" == 0 || "$octet" != 0* ]] || return 1
+    ((10#$octet <= 255)) || return 1
+  done
+}
+
+curl_failure_class() {
+  case "$1" in
+    6) printf '%s\n' dns_failure ;;
+    7) printf '%s\n' connect_failure ;;
+    22) printf '%s\n' http_error ;;
+    28) printf '%s\n' timeout ;;
+    35) printf '%s\n' tls_handshake_failure ;;
+    52) printf '%s\n' empty_response ;;
+    56) printf '%s\n' receive_failure ;;
+    60) printf '%s\n' tls_verification_failure ;;
+    *) printf 'curl_exit_%s\n' "$1" ;;
+  esac
+}
+
 analysis_temp="$(mktemp -d "${TMPDIR:-/tmp}/wukongim-cloud-analysis.XXXXXX")"
 private_key="$analysis_temp/client-private.pem"
 public_key="$analysis_temp/client-public.pem"
@@ -282,12 +309,12 @@ for ip_echo_url in https://api.ipify.org https://api-ipv4.ip.sb/ip; do
     --proto '=https' --tlsv1.2 "$ip_echo_url" 2>/dev/null || true)"
   candidate_ipv4="${candidate_ipv4//$'\r'/}"
   candidate_ipv4="${candidate_ipv4//$'\n'/}"
-  if [[ "$candidate_ipv4" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+  if is_valid_ipv4 "$candidate_ipv4"; then
     client_ipv4="$candidate_ipv4"
     break
   fi
 done
-[[ "$client_ipv4" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || \
+is_valid_ipv4 "$client_ipv4" || \
   fail "cannot determine the direct public IPv4 used to reach the Analysis MCP"
 request_id="local-$(openssl rand -hex 8)"
 
@@ -346,35 +373,124 @@ dispatch_session_operation() {
   printf '%s\n' "$workflow_run"
 }
 
-prepare_run="$(dispatch_session_operation prepare)"
-gh run download "$prepare_run" --repo "$repository" \
-  --name "cloud-sim-analysis-session-$request_id" --dir "$session_dir"
-
 session_json="$session_dir/session.json"
-[[ -f "$session_json" ]] || fail "analysis workflow returned no session descriptor"
-jq -e --arg run_id "$run_id" --arg request_id "$request_id" '
-  .schema == "wukongim/cloud-simulation-analysis-session/v1" and
-  .run_id == $run_id and .request_id == $request_id and
-  (.state == "live" or .state == "released" or .state == "unknown_run" or .state == "insufficient_evidence")
-' "$session_json" >/dev/null || fail "analysis workflow returned an invalid session descriptor"
+prepare_analysis_session() {
+  local prepare_run session_state session_message
+  # Once prepare is dispatched, a lost local workflow watch or artifact can no
+  # longer prove whether the client /32 opened. Conservatively own cleanup
+  # before dispatch so the EXIT trap closes every ambiguous handoff.
+  session_open=true
+  prepare_run="$(dispatch_session_operation prepare)"
+  rm -rf "$session_dir"
+  mkdir -p "$session_dir"
+  gh run download "$prepare_run" --repo "$repository" \
+    --name "cloud-sim-analysis-session-$request_id" --dir "$session_dir"
 
-session_state="$(jq -er .state "$session_json")"
-case "$session_state" in
-  released)
-    publish_result released
-    printf 'Simulation Run %s 已由云厂商确认自动销毁，当前没有可分析的实时数据；分析已终止。\n' "$run_id"
-    exit 0
-    ;;
-  unknown_run)
-    fail "no unique retained Run Locator exists for $run_id"
-    ;;
-  insufficient_evidence)
-    session_message="$(jq -er '.message | strings | select(length > 0 and length <= 512)' "$session_json")" || \
-      fail "analysis session broker returned insufficient evidence without a valid explanation"
-    fail "$session_message"
-    ;;
-  live) session_open=true ;;
-esac
+  [[ -f "$session_json" ]] || fail "analysis workflow returned no session descriptor"
+  jq -e --arg run_id "$run_id" --arg request_id "$request_id" '
+    .schema == "wukongim/cloud-simulation-analysis-session/v1" and
+    .run_id == $run_id and .request_id == $request_id and
+    (.state == "live" or .state == "released" or .state == "unknown_run" or .state == "insufficient_evidence")
+  ' "$session_json" >/dev/null || fail "analysis workflow returned an invalid session descriptor"
+
+  session_state="$(jq -er .state "$session_json")"
+  case "$session_state" in
+    released)
+      session_open=false
+      publish_result released
+      printf 'Simulation Run %s 已由云厂商确认自动销毁，当前没有可分析的实时数据；分析已终止。\n' "$run_id"
+      exit 0
+      ;;
+    unknown_run)
+      session_open=false
+      fail "no unique retained Run Locator exists for $run_id"
+      ;;
+    insufficient_evidence)
+      session_message="$(jq -er '.message | strings | select(length > 0 and length <= 512)' "$session_json")" || \
+        fail "analysis session broker returned insufficient evidence without a valid explanation"
+      fail "$session_message"
+      ;;
+    live) ;;
+  esac
+}
+
+observed_ipv4=""
+observed_ipv4_error=""
+probe_same_host_ipv4() {
+  local endpoint_url="$1"
+  local endpoint_host status_url status_json curl_status error_file candidate
+  endpoint_host="${endpoint_url#https://}"
+  endpoint_host="${endpoint_host%%:*}"
+  is_valid_ipv4 "$endpoint_host" || {
+    observed_ipv4_error=invalid_analysis_endpoint
+    return 1
+  }
+  status_url="http://${endpoint_host}:19443/cloud-view/status?request_id=${request_id}"
+  error_file="$analysis_temp/cloud-view-source-probe.err"
+  if status_json="$(curl --noproxy '*' --fail --silent --show-error --connect-timeout 5 --max-time 10 \
+    --header 'Cache-Control: no-cache' --proto '=http' "$status_url" 2>"$error_file")"; then
+    if ! jq -e . <<<"$status_json" >/dev/null 2>&1; then
+      observed_ipv4_error=invalid_response
+      return 1
+    fi
+    if ! jq -e --arg run_id "$run_id" 'select(.run_id == $run_id)' \
+      <<<"$status_json" >/dev/null 2>&1; then
+      observed_ipv4_error=identity_mismatch
+      return 1
+    fi
+    if ! jq -e 'select(.persistence_healthy == true)' <<<"$status_json" >/dev/null 2>&1; then
+      observed_ipv4_error=persistence_unhealthy
+      return 1
+    fi
+    candidate="$(jq -er '.observed_ipv4 | strings' <<<"$status_json" 2>/dev/null || true)"
+    if [[ -z "$candidate" ]]; then
+      observed_ipv4_error=unsupported
+      return 2
+    fi
+    if ! is_valid_ipv4 "$candidate"; then
+      observed_ipv4_error=invalid_response
+      return 1
+    fi
+    observed_ipv4="$candidate"
+    observed_ipv4_error=""
+    return 0
+  else
+    curl_status=$?
+    observed_ipv4_error="$(curl_failure_class "$curl_status")"
+    return 2
+  fi
+}
+
+prepare_analysis_session
+mcp_url="$(jq -er '.mcp_url | select(test("^https://[0-9.]+:19092/mcp$"))' "$session_json")" || \
+  fail "invalid Analysis MCP URL"
+initial_mcp_url="$mcp_url"
+same_host_probe_ready=false
+if probe_same_host_ipv4 "$mcp_url"; then
+  same_host_probe_ready=true
+else
+  if [[ "$observed_ipv4_error" == invalid_analysis_endpoint ]]; then
+    fail "cannot verify the same-host Analysis egress IPv4: $observed_ipv4_error"
+  fi
+  printf 'Cloud View cannot provide a trustworthy same-host Analysis egress IPv4 (%s); using public echo IPv4 %s.\n' \
+    "$observed_ipv4_error" "$client_ipv4" >&2
+fi
+if [[ "$same_host_probe_ready" == true && "$observed_ipv4" != "$client_ipv4" ]]; then
+  printf 'Cloud View observed Analysis egress IPv4 %s instead of public echo IPv4 %s; rebinding once.\n' \
+    "$observed_ipv4" "$client_ipv4" >&2
+  dispatch_session_operation close >/dev/null
+  session_open=false
+  client_ipv4="$observed_ipv4"
+  request_id="${request_id}-rebind"
+  prepare_analysis_session
+  mcp_url="$(jq -er '.mcp_url | select(test("^https://[0-9.]+:19092/mcp$"))' "$session_json")" || \
+    fail "invalid Analysis MCP URL after rebind"
+  [[ "$mcp_url" == "$initial_mcp_url" ]] || fail "Analysis MCP endpoint changed during egress rebind"
+  probe_same_host_ipv4 "$mcp_url" || \
+    fail "cannot verify the same-host Analysis egress IPv4 after rebind: $observed_ipv4_error"
+  [[ "$observed_ipv4" == "$client_ipv4" ]] || \
+    fail "same-host Analysis egress IPv4 changed again after one rebind"
+fi
 
 ensure_go_on_path || fail "go is required"
 for command in git perl; do
@@ -424,19 +540,35 @@ rm -f "$private_key" "$encrypted_token"
 # much shorter MCP initialization deadline.
 health_url="${mcp_url%/mcp}/healthz"
 mcp_reachable=false
+health_failure=not_attempted
+health_error_file="$analysis_temp/analysis-health.err"
 for ((attempt = 1; attempt <= 12; attempt += 1)); do
   if health_json="$(curl --noproxy '*' --fail --silent --show-error --connect-timeout 5 --max-time 10 \
-    --cacert "$pinned_ca" "$health_url" 2>/dev/null)" &&
-    jq -e --arg run_id "$run_id" \
+    --cacert "$pinned_ca" "$health_url" 2>"$health_error_file")"; then
+    if jq -e --arg run_id "$run_id" \
       '.status == "ok" and .run_id == $run_id and .run_state == "running"' \
-      <<<"$health_json" >/dev/null; then
-    mcp_reachable=true
-    break
+      <<<"$health_json" >/dev/null 2>&1; then
+      mcp_reachable=true
+      break
+    fi
+    if jq -e . <<<"$health_json" >/dev/null 2>&1; then
+      health_failure=identity_mismatch
+    else
+      health_failure=invalid_response
+    fi
+    printf 'Analysis MCP health attempt %d/12 failed: %s\n' "$attempt" "$health_failure" >&2
+  else
+    curl_status=$?
+    health_failure="$(curl_failure_class "$curl_status")"
+    printf 'Analysis MCP health attempt %d/12 failed: %s (curl exit %d)\n' \
+      "$attempt" "$health_failure" "$curl_status" >&2
   fi
-  sleep 5
+  if ((attempt < 12)); then
+    sleep 5
+  fi
 done
 [[ "$mcp_reachable" == true ]] || \
-  fail "Analysis MCP did not become reachable from local IPv4 $client_ipv4 before its access window deadline"
+  fail "Analysis MCP did not become reachable from local IPv4 $client_ipv4 before its access window deadline; last failure: $health_failure"
 
 source_sha="$(jq -er '.source_sha | select(test("^[0-9a-f]{40}$"))' "$session_json")" || fail "invalid source SHA"
 scenario_digest="$(jq -er '.scenario_digest | select(test("^sha256:[0-9a-f]{64}$"))' "$session_json")" || fail "invalid scenario digest"

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -163,6 +163,9 @@ exit 89
 		t.Fatal(err)
 	}
 	callText := string(calls)
+	if got := strings.Count(callText, "-f operation=prepare"); got != 1 {
+		t.Fatalf("prepare dispatches = %d, want one when same-host IPv4 matches public echo:\n%s", got, calls)
+	}
 	for _, fragment := range []string{
 		"codex login status",
 		"gh workflow run cloud-sim-analyze.yml --repo example/project --ref main -f operation=prepare",
@@ -197,6 +200,302 @@ exit 89
 	}
 	if strings.Contains(callText, "gh run watch 999") {
 		t.Fatalf("analysis selected a concurrent decoy workflow run:\n%s", calls)
+	}
+}
+
+func TestCloudSimulationAnalyzeRepreparesForSameHostObservedIPv4(t *testing.T) {
+	root := repoRoot(t)
+	temp := t.TempDir()
+	bin := filepath.Join(temp, "bin")
+	stateDir := filepath.Join(temp, "state")
+	callLog := filepath.Join(temp, "calls.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAnalyzeFakes(t, bin)
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+		"run-live", "--repository", "example/project")
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"WK_ANALYZE_CALL_LOG="+callLog,
+		"WK_ANALYZE_STATE_DIR="+stateDir,
+		"WK_ANALYZE_SESSION_STATE=live",
+		"WK_ANALYZE_OBSERVED_IPV4=198.51.100.8",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		calls, _ := os.ReadFile(callLog)
+		t.Fatalf("analyze: %v\n%s\ncalls:\n%s", err, output, calls)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callText := string(calls)
+	if got := strings.Count(callText, "-f operation=prepare"); got != 2 {
+		t.Fatalf("prepare dispatches = %d, want one initial prepare and one reprepare:\n%s", got, calls)
+	}
+	operations := make([]string, 0, 4)
+	for _, line := range strings.Split(callText, "\n") {
+		if !strings.HasPrefix(line, "gh workflow run cloud-sim-analyze.yml ") {
+			continue
+		}
+		switch {
+		case strings.Contains(line, "-f operation=prepare"):
+			operations = append(operations, "prepare")
+		case strings.Contains(line, "-f operation=close"):
+			operations = append(operations, "close")
+		}
+	}
+	if got := strings.Join(operations, ","); got != "prepare,close,prepare,close" {
+		t.Fatalf("Analysis window operations = %q, want prepare,close,prepare,close:\n%s", got, calls)
+	}
+	if !strings.Contains(callText, "-f request_id=local-0123456789abcdef-rebind") {
+		t.Fatalf("second prepare did not use a unique rebind request correlation:\n%s", calls)
+	}
+	first := strings.Index(callText, "-f client_ipv4=203.0.113.7")
+	second := strings.LastIndex(callText, "-f client_ipv4=198.51.100.8")
+	if first < 0 || second <= first {
+		t.Fatalf("analysis did not replace public echo IPv4 with same-host observation:\n%s", calls)
+	}
+	if got := strings.Count(callText, "http://198.51.100.20:19443/cloud-view/status"); got != 2 {
+		t.Fatalf("same-host IPv4 probes = %d, want one per prepared session:\n%s", got, calls)
+	}
+}
+
+func TestCloudSimulationAnalyzeFallsBackWhenSameHostObservationIsUnavailable(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		env  string
+	}{
+		{name: "public view closed", env: "WK_ANALYZE_CLOUD_VIEW_CURL_EXIT=7"},
+		{name: "legacy status response", env: "WK_ANALYZE_OMIT_OBSERVED_IPV4=true"},
+		{name: "malformed status response", env: "WK_ANALYZE_INVALID_CLOUD_VIEW_JSON=true"},
+		{name: "unhealthy status persistence", env: "WK_ANALYZE_CLOUD_VIEW_PERSISTENCE_UNHEALTHY=true"},
+		{name: "mismatched status identity", env: "WK_ANALYZE_CLOUD_VIEW_RUN_ID_MISMATCH=true"},
+		{name: "invalid observed IPv4", env: "WK_ANALYZE_OBSERVED_IPV4=999.1.1.1"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := repoRoot(t)
+			temp := t.TempDir()
+			bin := filepath.Join(temp, "bin")
+			stateDir := filepath.Join(temp, "state")
+			callLog := filepath.Join(temp, "calls.log")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeAnalyzeFakes(t, bin)
+
+			command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+				"run-live", "--repository", "example/project")
+			command.Dir = root
+			command.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"WK_ANALYZE_CALL_LOG="+callLog,
+				"WK_ANALYZE_STATE_DIR="+stateDir,
+				"WK_ANALYZE_SESSION_STATE=live",
+				testCase.env,
+			)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				calls, _ := os.ReadFile(callLog)
+				t.Fatalf("analyze: %v\n%s\ncalls:\n%s", err, output, calls)
+			}
+			if !strings.Contains(string(output), "using public echo IPv4 203.0.113.7") {
+				t.Fatalf("analysis output missing compatible fallback:\n%s", output)
+			}
+			calls, err := os.ReadFile(callLog)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Count(string(calls), "-f operation=prepare"); got != 1 {
+				t.Fatalf("prepare dispatches = %d, want one fallback session:\n%s", got, calls)
+			}
+			if !strings.Contains(string(calls), "Cache-Control: no-cache") ||
+				!strings.Contains(string(calls), "/cloud-view/status?request_id=local-0123456789abcdef") {
+				t.Fatalf("same-host probe was cacheable:\n%s", calls)
+			}
+		})
+	}
+}
+
+func TestCloudSimulationAnalyzeClosesWindowWhenPrepareHandoffFails(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		env  string
+	}{
+		{name: "workflow watch", env: "WK_ANALYZE_PREPARE_WATCH_EXIT=72"},
+		{name: "session artifact download", env: "WK_ANALYZE_DOWNLOAD_EXIT=71"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := repoRoot(t)
+			temp := t.TempDir()
+			bin := filepath.Join(temp, "bin")
+			stateDir := filepath.Join(temp, "state")
+			callLog := filepath.Join(temp, "calls.log")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeAnalyzeFakes(t, bin)
+
+			command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+				"run-live", "--repository", "example/project")
+			command.Dir = root
+			command.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"WK_ANALYZE_CALL_LOG="+callLog,
+				"WK_ANALYZE_STATE_DIR="+stateDir,
+				"WK_ANALYZE_SESSION_STATE=live",
+				testCase.env,
+			)
+			output, err := command.CombinedOutput()
+			if err == nil {
+				t.Fatalf("analysis accepted a failed prepare handoff:\n%s", output)
+			}
+			calls, readErr := os.ReadFile(callLog)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			callText := string(calls)
+			operations := make([]string, 0, 2)
+			for _, line := range strings.Split(callText, "\n") {
+				if !strings.HasPrefix(line, "gh workflow run cloud-sim-analyze.yml ") {
+					continue
+				}
+				switch {
+				case strings.Contains(line, "-f operation=prepare"):
+					operations = append(operations, "prepare")
+				case strings.Contains(line, "-f operation=close"):
+					operations = append(operations, "close")
+				}
+			}
+			if got := strings.Join(operations, ","); got != "prepare,close" {
+				t.Fatalf("Analysis window operations = %q, want prepare,close:\n%s", got, calls)
+			}
+			if strings.Contains(callText, "codex login status") || strings.Contains(callText, "codex exec") {
+				t.Fatalf("prepare handoff failure started Codex:\n%s", calls)
+			}
+		})
+	}
+}
+
+func TestCloudSimulationAnalyzeFailsClosedWhenSameHostIPv4ChangesAgain(t *testing.T) {
+	root := repoRoot(t)
+	temp := t.TempDir()
+	bin := filepath.Join(temp, "bin")
+	stateDir := filepath.Join(temp, "state")
+	callLog := filepath.Join(temp, "calls.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAnalyzeFakes(t, bin)
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+		"run-live", "--repository", "example/project")
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"WK_ANALYZE_CALL_LOG="+callLog,
+		"WK_ANALYZE_STATE_DIR="+stateDir,
+		"WK_ANALYZE_SESSION_STATE=live",
+		"WK_ANALYZE_OBSERVED_IPV4_SEQUENCE=198.51.100.8,192.0.2.44",
+	)
+	output, err := command.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "same-host Analysis egress IPv4 changed again after one rebind") {
+		t.Fatalf("analyze error = %v, want second-change failure:\n%s", err, output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	callText := string(calls)
+	if got := strings.Count(callText, "-f operation=prepare"); got != 2 {
+		t.Fatalf("prepare dispatches = %d, want bounded two attempts:\n%s", got, calls)
+	}
+	if !strings.Contains(callText, "-f operation=close") {
+		t.Fatalf("failed rebind did not close the live Analysis window:\n%s", calls)
+	}
+}
+
+func TestCloudSimulationAnalyzeFailsClosedOnInvalidSameHostIPv4(t *testing.T) {
+	root := repoRoot(t)
+	temp := t.TempDir()
+	bin := filepath.Join(temp, "bin")
+	stateDir := filepath.Join(temp, "state")
+	callLog := filepath.Join(temp, "calls.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAnalyzeFakes(t, bin)
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+		"run-live", "--repository", "example/project")
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"WK_ANALYZE_CALL_LOG="+callLog,
+		"WK_ANALYZE_STATE_DIR="+stateDir,
+		"WK_ANALYZE_SESSION_STATE=live",
+		"WK_ANALYZE_OBSERVED_IPV4_SEQUENCE=198.51.100.8,999.1.1.1",
+	)
+	output, err := command.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "cannot verify the same-host Analysis egress IPv4 after rebind: invalid_response") {
+		t.Fatalf("analyze error = %v, want invalid-source failure:\n%s", err, output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	callText := string(calls)
+	if got := strings.Count(callText, "-f operation=prepare"); got != 2 {
+		t.Fatalf("prepare dispatches = %d, want bounded two attempts:\n%s", got, calls)
+	}
+	if !strings.Contains(callText, "-f operation=close") {
+		t.Fatalf("invalid rebind did not close the live Analysis window:\n%s", calls)
+	}
+}
+
+func TestCloudSimulationAnalyzeClassifiesHealthCurlFailure(t *testing.T) {
+	root := repoRoot(t)
+	temp := t.TempDir()
+	bin := filepath.Join(temp, "bin")
+	stateDir := filepath.Join(temp, "state")
+	callLog := filepath.Join(temp, "calls.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAnalyzeFakes(t, bin)
+	writeSetupExecutable(t, filepath.Join(bin, "sleep"), `#!/usr/bin/env bash
+exit 0
+`)
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
+		"run-live", "--repository", "example/project")
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"WK_ANALYZE_CALL_LOG="+callLog,
+		"WK_ANALYZE_STATE_DIR="+stateDir,
+		"WK_ANALYZE_SESSION_STATE=live",
+		"WK_ANALYZE_HEALTH_CURL_EXIT=28",
+	)
+	output, err := command.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "Analysis MCP health attempt 1/12 failed: timeout (curl exit 28)") ||
+		!strings.Contains(string(output), "last failure: timeout") {
+		t.Fatalf("analyze error = %v, want bounded curl failure classification:\n%s", err, output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	callText := string(calls)
+	if got := strings.Count(callText, ":19092/healthz"); got != 12 {
+		t.Fatalf("health attempts = %d, want 12:\n%s", got, calls)
+	}
+	if !strings.Contains(callText, "-f operation=close") {
+		t.Fatalf("health failure did not close the live Analysis window:\n%s", calls)
 	}
 }
 
@@ -506,6 +805,9 @@ func TestCloudSimulationAnalyzeReportsBrokerInsufficientEvidenceBeforeCodex(t *t
 	if strings.Contains(string(calls), "codex login status") || strings.Contains(string(calls), "codex exec") {
 		t.Fatalf("broker failure started Codex:\n%s", calls)
 	}
+	if !strings.Contains(string(calls), "-f operation=close") {
+		t.Fatalf("broker failure did not conservatively close possible Analysis access:\n%s", calls)
+	}
 }
 
 func TestCloudSimulationAnalyzeCreatesTestedDraftPRAfterClosingLiveSession(t *testing.T) {
@@ -595,7 +897,40 @@ func writeAnalyzeFakes(t *testing.T, bin string) {
 set -euo pipefail
 printf 'curl %s\n' "$*" >>"$WK_ANALYZE_CALL_LOG"
 if [[ "$*" == *'/healthz'* ]]; then
+	if [[ -n "${WK_ANALYZE_HEALTH_CURL_EXIT:-}" ]]; then
+		exit "$WK_ANALYZE_HEALTH_CURL_EXIT"
+	fi
   printf '%s\n' '{"status":"ok","run_id":"run-live","run_state":"running"}'
+  exit 0
+fi
+if [[ "$*" == *':19443/cloud-view/status'* ]]; then
+	if [[ -n "${WK_ANALYZE_CLOUD_VIEW_CURL_EXIT:-}" ]]; then
+		exit "$WK_ANALYZE_CLOUD_VIEW_CURL_EXIT"
+	fi
+	if [[ "${WK_ANALYZE_INVALID_CLOUD_VIEW_JSON:-}" == true ]]; then
+		printf '%s\n' '{'
+		exit 0
+	fi
+	if [[ "${WK_ANALYZE_OMIT_OBSERVED_IPV4:-}" == true ]]; then
+		printf '%s\n' '{"run_id":"run-live","interactive":false,"operator_modified":false,"persistence_healthy":true}'
+		exit 0
+	fi
+	status_run_id=run-live
+	status_persistence_healthy=true
+	if [[ "${WK_ANALYZE_CLOUD_VIEW_RUN_ID_MISMATCH:-}" == true ]]; then status_run_id=run-other; fi
+	if [[ "${WK_ANALYZE_CLOUD_VIEW_PERSISTENCE_UNHEALTHY:-}" == true ]]; then status_persistence_healthy=false; fi
+	observed_ipv4="${WK_ANALYZE_OBSERVED_IPV4:-203.0.113.7}"
+	if [[ -n "${WK_ANALYZE_OBSERVED_IPV4_SEQUENCE:-}" ]]; then
+		counter_file="$WK_ANALYZE_STATE_DIR/observed-ipv4-count"
+		counter="$(cat "$counter_file" 2>/dev/null || printf '0')"
+		IFS=, read -r -a observed_values <<<"$WK_ANALYZE_OBSERVED_IPV4_SEQUENCE"
+		if ((counter >= ${#observed_values[@]})); then counter=$((${#observed_values[@]} - 1)); fi
+		observed_ipv4="${observed_values[$counter]}"
+		printf '%s' "$((counter + 1))" >"$counter_file"
+	fi
+  jq -cn --arg run_id "$status_run_id" --arg observed_ipv4 "$observed_ipv4" \
+    --argjson persistence_healthy "$status_persistence_healthy" \
+    '{run_id:$run_id,interactive:false,operator_modified:false,persistence_healthy:$persistence_healthy,observed_ipv4:$observed_ipv4}'
   exit 0
 fi
 printf '%s\n' '203.0.113.7'
@@ -741,8 +1076,14 @@ case "$1" in
           [{databaseId:999,displayTitle:"Cloud Simulation Analysis prepare another-request"},
            {databaseId:$current,displayTitle:("Cloud Simulation Analysis " + $operation + " " + $request_id)}]'
         ;;
-      watch) exit 0 ;;
+      watch)
+        if [[ -n "${WK_ANALYZE_PREPARE_WATCH_EXIT:-}" && "$(cat "$WK_ANALYZE_STATE_DIR/operation")" == prepare ]]; then
+          exit "$WK_ANALYZE_PREPARE_WATCH_EXIT"
+        fi
+        exit 0
+        ;;
       download)
+        if [[ -n "${WK_ANALYZE_DOWNLOAD_EXIT:-}" ]]; then exit "$WK_ANALYZE_DOWNLOAD_EXIT"; fi
         destination=""
         while (($#)); do if [[ "$1" == --dir ]]; then destination="$2"; break; fi; shift; done
         test -n "$destination"

--- a/scripts/cloud_sim_workflows_test.go
+++ b/scripts/cloud_sim_workflows_test.go
@@ -292,6 +292,17 @@ func TestCloudSimulationWorkflowsPersistAndReuseDiscoveredProviderConfig(t *test
 	if got := strings.Count(analyze, "timeout 90s ./wkcloudsim --provider alibaba --provider-config provider.json close-analysis"); got != 3 {
 		t.Fatalf("bounded analysis ingress cleanup count = %d, want 3", got)
 	}
+	handoffStart := strings.Index(analyze, "      - name: Encrypt handoff and move ingress to local Codex")
+	handoffEnd := strings.Index(analyze, "      - name: Materialize terminal session state")
+	if handoffStart < 0 || handoffEnd <= handoffStart {
+		t.Fatal("analysis workflow does not retain the bounded handoff step")
+	}
+	handoff := analyze[handoffStart:handoffEnd]
+	closeIndex := strings.Index(handoff, `close-analysis "$RUN_ID"`)
+	openIndex := strings.Index(handoff, `open-analysis "$RUN_ID"`)
+	if closeIndex < 0 || openIndex <= closeIndex {
+		t.Fatal("analysis handoff does not close the previous /32 before opening its replacement")
+	}
 	if !strings.Contains(analyze, `curl --fail --silent --show-error --connect-timeout 5 --max-time 10 --proto '=https' --tlsv1.2 https://api.ipify.org`) {
 		t.Fatal("analysis runner public-IP discovery is not bounded")
 	}


### PR DESCRIPTION
## What changed

- avalanche the stable Channel reactor hash before the power-of-two modulus
- add a real Cloud Medium scenario regression that plans the configured 5,000 ingress QPS and checks all four reactors
- report the Cloud View transport peer without trusting forwarding headers or changing run purity
- make local Analysis use a bounded same-destination egress hint, unique rebind correlation, non-cacheable status probes, classified health failures, and conservative access-window cleanup
- document the node-local reactor and Analysis egress contracts

## Root cause

Raw FNV-64a low bits are not well mixed for sequential canonical person-channel IDs. Modulo four routed a 10,000-pair sample as `[0, 7272, 0, 2728]`, overloading one Channel reactor mailbox and producing backpressure/SENDACK failures while other reactors remained idle. The previous Analysis helper also trusted a public echo address that can differ from the direct simulator route under transparent policy routing, and ambiguous prepare handoffs could leave a temporary `/32` window until expiry.

## Impact

The Cloud Medium traffic plan now distributes about 1,209-1,270 QPS per reactor for its 5,000 QPS objective. Reactor assignment remains node-local and non-persistent; cluster hash slots, logical Slot Raft groups, and durability semantics are unchanged. Analysis keeps pinned TLS health authoritative and supports runs without public Cloud View.

## Validation

- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- focused Channel reactor, Cloud View, workload, and Analysis tests
- focused `-race` tests
- focused `go vet`
- `bash -n scripts/cloud-sim/analyze.sh`
- `git diff --check`