### PR TITLE
Fix Cloud Medium ingress bottlenecks

### DIFF
--- a/docker/observability/grafana/dashboards/wukongim-v2-runtime-ops.json
+++ b/docker/observability/grafana/dashboards/wukongim-v2-runtime-ops.json
@@ -242,49 +242,69 @@
       },
       "targets": [
         {
-          "expr": "sum(wukongim_channelappend_writer_admission_depth{node_name=~\"$node_name\"}) by (writer)",
-          "legendFormat": "writer admission depth {{writer}}",
+          "expr": "sum(wukongim_channelappend_writer_admission_depth{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} writer admission depth",
           "refId": "A"
         },
         {
-          "expr": "sum(wukongim_channelappend_writer_admission_capacity{node_name=~\"$node_name\"}) by (writer)",
-          "legendFormat": "writer admission capacity {{writer}}",
+          "expr": "sum(wukongim_channelappend_writer_admission_capacity{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} writer admission capacity",
           "refId": "B"
         },
         {
-          "expr": "sum(wukongim_channelappend_writer_pool_running{node_name=~\"$node_name\"}) by (writer)",
-          "legendFormat": "writer running {{writer}}",
+          "expr": "sum(wukongim_channelappend_writer_pool_running{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} writer running",
           "refId": "C"
         },
         {
-          "expr": "sum(wukongim_channelappend_writer_pool_capacity{node_name=~\"$node_name\"}) by (writer)",
-          "legendFormat": "writer pool capacity {{writer}}",
+          "expr": "sum(wukongim_channelappend_writer_pool_capacity{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} writer pool capacity",
           "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(wukongim_channelappend_writer_state_items_bucket{node_name=~\"$node_name\"}[$__rate_interval])) by (le, state))",
-          "legendFormat": "writer state items p95 {{state}}",
+          "expr": "sum(wukongim_channelappend_writer_state_items{node_name=~\"$node_name\"}) by (node_name, kind)",
+          "legendFormat": "{{node_name}} writer state {{kind}}",
           "refId": "E"
         },
         {
-          "expr": "sum(wukongim_channelappend_effect_pool_inflight{node_name=~\"$node_name\"}) by (pool)",
-          "legendFormat": "effect inflight {{pool}}",
+          "expr": "sum(wukongim_channelappend_effect_pool_inflight{node_name=~\"$node_name\"}) by (node_name, stage)",
+          "legendFormat": "{{node_name}} effect inflight {{stage}}",
           "refId": "F"
         },
         {
-          "expr": "sum(wukongim_channelappend_effect_pool_capacity{node_name=~\"$node_name\"}) by (pool)",
-          "legendFormat": "effect capacity {{pool}}",
+          "expr": "sum(wukongim_channelappend_effect_pool_capacity{node_name=~\"$node_name\"}) by (node_name, stage)",
+          "legendFormat": "{{node_name}} effect capacity {{stage}}",
           "refId": "G"
         },
         {
-          "expr": "sum(wukongim_channelappend_effect_pool_saturated{node_name=~\"$node_name\"}) by (pool)",
-          "legendFormat": "effect saturated {{pool}}",
+          "expr": "sum(wukongim_channelappend_effect_pool_saturated{node_name=~\"$node_name\"}) by (node_name, stage)",
+          "legendFormat": "{{node_name}} effect saturated {{stage}}",
           "refId": "H"
         },
         {
-          "expr": "sum(rate(wukongim_channelappend_effect_pool_submit_total{node_name=~\"$node_name\"}[$__rate_interval])) by (pool, result)",
-          "legendFormat": "effect submit {{pool}} {{result}}",
+          "expr": "sum(rate(wukongim_channelappend_effect_pool_submit_total{node_name=~\"$node_name\"}[$__rate_interval])) by (node_name, stage, result)",
+          "legendFormat": "{{node_name}} effect submit {{stage}} {{result}}",
           "refId": "I"
+        },
+        {
+          "expr": "sum(wukongim_channelappend_post_commit_handoff_depth{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} post-commit handoff depth",
+          "refId": "J"
+        },
+        {
+          "expr": "sum(wukongim_channelappend_post_commit_handoff_capacity{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} post-commit handoff capacity",
+          "refId": "K"
+        },
+        {
+          "expr": "sum(wukongim_channelappend_post_commit_retry_queue_depth{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} post-commit retry queue",
+          "refId": "L"
+        },
+        {
+          "expr": "max(wukongim_channelappend_post_commit_retry_contended{node_name=~\"$node_name\"}) by (node_name)",
+          "legendFormat": "{{node_name}} post-commit retry contended",
+          "refId": "M"
         }
       ],
       "title": "Channel Append Writer And Effect Pool",

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -411,13 +411,12 @@ count with a minimum of four. `ChannelAppend.AdvancePoolSize` is the direct ants
 pool capacity used to activate channelappend writer state machines.
 `ChannelAppend.EffectPoolSize` is the direct ants pool capacity used separately
 by foreground channelappend append effects and post-append recipient effects.
-The post-append pool uses non-blocking saturated admission and drops the
-already-best-effort effect through the scheduler-failure observation instead of
-blocking a channel writer advance worker; the foreground append pool keeps its
-blocking worker admission semantics. Each channel also keeps the post-commit
-backlog separately bounded from foreground append admission; a full side-effect
-backlog records and drops the newest already-durable envelope without returning
-`ErrChannelBusy` to a later SEND.
+The post-append pool uses non-blocking saturated admission and retains an
+already-durable envelope behind a de-duplicated fair retry FIFO instead of
+blocking a channel writer advance worker. A group-wide handoff reservation is
+acquired before durable append; when that bound is full only the not-yet-appended
+item returns `ErrChannelBusy`. The foreground append pool keeps its blocking
+worker admission semantics.
 Prepare runs inline on the writer advance path; append remains the foreground
 durable path that determines SEND/SENDACK throughput.
 `ChannelAppend.RecipientAuthorityDispatchConcurrency` defaults to a bounded
@@ -430,7 +429,15 @@ target fanout and production plan execution capacities therefore remain
 independent. The lookup-shard count controls writer map sharding; effect workers run only blocking effects and never write channel
 state concurrently with another advance for the same channel. The delivery
 observer maps aggregate writer pressure and effect pool observations into
-Prometheus, and also records direct ants/v2 occupancy for the channelappend
+Prometheus. Post-commit pressure uses four fixed per-node gauges:
+`wukongim_channelappend_post_commit_handoff_depth`,
+`wukongim_channelappend_post_commit_handoff_capacity`,
+`wukongim_channelappend_post_commit_retry_queue_depth`, and
+`wukongim_channelappend_post_commit_retry_contended`. They have only the
+registry's constant node labels; no channel, UID, Slot, or authority-target
+label is added. Retry queue depth excludes a writer that already owns the retry
+turn, so a zero queue with contended equal to one is valid. The observer also
+records direct ants/v2 occupancy for the channelappend
 advance/append_effect/post_commit pools in the generic ants pool metrics. The three-node bench
 script summarizes these in `channelappend_metrics_summary.tsv` and
 `ants_pool_usage_summary.tsv`. Per-channel append ordering remains capped
@@ -710,6 +717,7 @@ gateway/API send
        access/node Channel Append RPC forwards the batch
        remote node admits it to its local channel writer
   -> authority writer prepares commands, allocates IDs, and calls cluster ChannelAppender
+     only after reserving one slot from the group-wide post-commit handoff bound
   -> Channel runtime persists messages and returns append result
   -> SENDACK returns to sender
   -> authority writer post-commit effect:
@@ -717,7 +725,10 @@ gateway/API send
        group recipients by UID authority target, including Slot leader term and config epoch, for delivery
        enqueue recipient delivery batch when delivery is enabled
        ConversationAuthorityClient.AdmitActiveBatch as an independent projection
-       drop the in-memory post-commit envelope after one enqueue attempt
+       when the nonblocking effect pool is full, retain the committed envelope
+       and enter the fair retry FIFO instead of dropping already-durable work
+       after one terminal recipient/conversation attempt, release the handoff
+       reservation and prune the in-memory committed envelope
 ```
 
 The bench presence snapshot controller aggregates `online.Registry.Snapshot`
@@ -767,7 +778,16 @@ Stop(ctx)
   -> prometheus.Stop(ctx)
   -> manager.Stop(ctx)
   -> api.Stop(ctx)
-  -> channel append group Stop(ctx): close admission and drain accepted appends plus post-commit effects
+  -> top.Stop(ctx)
+  -> channel append group Stop(ctx): close admission and wait for its single
+     background graceful drain of accepted appends, handoff reservations,
+     post-commit effects, and retry ownership
+     if this caller's context expires before that drain completes:
+       return the stop error immediately
+       keep delivery, webhook, plugin, conversation, presence, seed-join, cluster,
+       and controller-task-audit dependencies running
+       retain their started flags so a later Stop(newCtx) waits for the same
+       channel append drain and then resumes this dependency shutdown sequence
   -> delivery worker group Stop(ctx): recipient delivery worker drains before async manager and retry scheduler
   -> webhook runtime Stop(ctx): stop accepting new webhook side effects after producers drain
   -> plugin PersistAfter worker Stop(ctx): stop accepting new side effects after channel append drains
@@ -784,6 +804,10 @@ Stop(ctx)
 `Start` and `Stop` are serialized by a lifecycle mutex. If API, manager, Prometheus, or gateway
 startup fails after the cluster starts, `Start` attempts rollback in reverse
 order; if rollback fails, state remains retryable so a later `Stop` can clean up.
+Rollback uses the same channel-append drain boundary as ordinary Stop: a rollback
+deadline at that boundary returns without closing post-commit dependencies, and
+a later Stop with a fresh context continues the existing drain before closing
+them. Entry runtimes already stopped before the boundary remain stopped.
 The startup console is presentation-only: it is disabled with `Log.Console=false`,
 does not add a configuration surface, and does not replace structured lifecycle
 events in rolling files. API, Demo (`/demo/` on the API listener), manager, metrics,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6619,6 +6619,120 @@ func TestStopOrderIncludesAPIBeforeCluster(t *testing.T) {
 	}
 }
 
+func TestStopDeadlineKeepsChannelAppendDependenciesRunningUntilRetryDrain(t *testing.T) {
+	calls := make([]string, 0, 12)
+	appender := newLifecycleBlockingChannelAppender()
+	t.Cleanup(appender.release)
+	channelAppends := channelappend.New(channelappend.Options{
+		LocalNodeID: 1,
+		MessageID:   &lifecycleMessageIDAllocator{next: 100},
+		Appender:    appender,
+	})
+	app := &App{
+		cluster:                    &fakeCluster{calls: &calls},
+		conversationRouteLifecycle: &recordingWorkerRuntime{name: "conversation_route", calls: &calls},
+		conversationActiveWorker:   &recordingWorkerRuntime{name: "conversation_active", calls: &calls},
+		deliveryWorker:             &recordingWorkerRuntime{name: "delivery", calls: &calls},
+		channelAppends:             channelAppends,
+	}
+	if err := app.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	future, err := submitLifecycleBlockedAppend(channelAppends)
+	if err != nil {
+		t.Fatalf("SubmitLocal() error = %v", err)
+	}
+	appender.waitStarted(t)
+
+	firstStopCtx, cancelFirstStop := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelFirstStop()
+	if err := app.Stop(firstStopCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first Stop() error = %v, want context deadline exceeded", err)
+	}
+	if got := joinCalls(calls); got != "cluster.start,conversation_route.start,conversation_active.start,delivery.start" {
+		t.Fatalf("calls after timed-out Stop = %s, want channel append dependencies still running", got)
+	}
+
+	appender.release()
+	secondStopCtx, cancelSecondStop := context.WithTimeout(context.Background(), time.Second)
+	defer cancelSecondStop()
+	if err := app.Stop(secondStopCtx); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
+	}
+	results, err := future.Wait(secondStopCtx)
+	if err != nil {
+		t.Fatalf("Future.Wait() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Err != nil || results[0].Result.Reason != channelappend.ReasonSuccess {
+		t.Fatalf("append results = %#v, want one success", results)
+	}
+	if got := joinCalls(calls); got != "cluster.start,conversation_route.start,conversation_active.start,delivery.start,delivery.stop,conversation_active.stop,conversation_route.stop,cluster.stop" {
+		t.Fatalf("calls after retry drain = %s, want dependencies stopped after channel append", got)
+	}
+}
+
+func TestRollbackDeadlineKeepsChannelAppendDependenciesRunningUntilStopRetry(t *testing.T) {
+	calls := make([]string, 0, 12)
+	appender := newLifecycleBlockingChannelAppender()
+	t.Cleanup(appender.release)
+	channelAppends := channelappend.New(channelappend.Options{
+		LocalNodeID: 1,
+		MessageID:   &lifecycleMessageIDAllocator{next: 200},
+		Appender:    appender,
+	})
+	startFailure := errors.New("top start failed")
+	var future *channelappend.Future
+	var submitErr error
+	top := &recordingWorkerRuntime{
+		name:     "top",
+		calls:    &calls,
+		startErr: startFailure,
+		onStart: func() {
+			future, submitErr = submitLifecycleBlockedAppend(channelAppends)
+			if submitErr != nil {
+				t.Fatalf("SubmitLocal() error = %v", submitErr)
+			}
+			appender.waitStarted(t)
+		},
+	}
+	app := &App{
+		cluster:                    &fakeCluster{calls: &calls},
+		conversationRouteLifecycle: &recordingWorkerRuntime{name: "conversation_route", calls: &calls},
+		conversationActiveWorker:   &recordingWorkerRuntime{name: "conversation_active", calls: &calls},
+		deliveryWorker:             &recordingWorkerRuntime{name: "delivery", calls: &calls},
+		channelAppends:             channelAppends,
+		top:                        top,
+	}
+
+	startCtx, cancelStart := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancelStart()
+	err := app.Start(startCtx)
+	if !errors.Is(err, startFailure) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start() error = %v, want start failure and rollback deadline", err)
+	}
+	if got := joinCalls(calls); got != "cluster.start,conversation_route.start,conversation_active.start,delivery.start,top.start" {
+		t.Fatalf("calls after timed-out rollback = %s, want channel append dependencies still running", got)
+	}
+
+	appender.release()
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), time.Second)
+	defer cancelStop()
+	if err := app.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() retry error = %v", err)
+	}
+	results, err := future.Wait(stopCtx)
+	if err != nil {
+		t.Fatalf("Future.Wait() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Err != nil || results[0].Result.Reason != channelappend.ReasonSuccess {
+		t.Fatalf("append results = %#v, want one success", results)
+	}
+	if got := joinCalls(calls); got != "cluster.start,conversation_route.start,conversation_active.start,delivery.start,top.start,delivery.stop,conversation_active.stop,conversation_route.stop,cluster.stop" {
+		t.Fatalf("calls after Stop retry = %s, want dependencies stopped after channel append", got)
+	}
+}
+
 func TestConcurrentStartStopCannotLeaveGatewayRunningAfterStopReturns(t *testing.T) {
 	cluster := newBlockingCluster()
 	gateway := newStateGateway()
@@ -6793,6 +6907,82 @@ type fakeCluster struct {
 	clusterID  string
 	listenAddr string
 	nodeCount  int
+}
+
+type lifecycleMessageIDAllocator struct {
+	mu   sync.Mutex
+	next uint64
+}
+
+func (a *lifecycleMessageIDAllocator) Next() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.next++
+	return a.next
+}
+
+type lifecycleBlockingChannelAppender struct {
+	started     chan struct{}
+	releaseCh   chan struct{}
+	releaseOnce sync.Once
+}
+
+func newLifecycleBlockingChannelAppender() *lifecycleBlockingChannelAppender {
+	return &lifecycleBlockingChannelAppender{
+		started:   make(chan struct{}, 1),
+		releaseCh: make(chan struct{}),
+	}
+}
+
+func (a *lifecycleBlockingChannelAppender) AppendBatch(ctx context.Context, req channelappend.AppendBatchRequest) (channelappend.AppendBatchResult, error) {
+	select {
+	case a.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-a.releaseCh:
+	case <-ctx.Done():
+		return channelappend.AppendBatchResult{}, ctx.Err()
+	}
+	items := make([]channelappend.AppendBatchItemResult, 0, len(req.Messages))
+	for index, message := range req.Messages {
+		items = append(items, channelappend.AppendBatchItemResult{
+			MessageID:  message.MessageID,
+			MessageSeq: uint64(index + 1),
+			Message:    message,
+		})
+	}
+	return channelappend.AppendBatchResult{Items: items}, nil
+}
+
+func (a *lifecycleBlockingChannelAppender) waitStarted(t *testing.T) {
+	t.Helper()
+	select {
+	case <-a.started:
+	case <-time.After(time.Second):
+		t.Fatal("channel append did not start")
+	}
+}
+
+func (a *lifecycleBlockingChannelAppender) release() {
+	a.releaseOnce.Do(func() { close(a.releaseCh) })
+}
+
+func submitLifecycleBlockedAppend(group *channelappend.Group) (*channelappend.Future, error) {
+	return group.SubmitLocal(context.Background(), channelappend.AuthorityTarget{
+		ChannelID:    channelappend.ChannelID{ID: "lifecycle-room", Type: 2},
+		ChannelKey:   "lifecycle-room",
+		LeaderNodeID: 1,
+	}, []channelappend.SendBatchItem{{
+		Command: channelappend.SendCommand{
+			FromUID:     "lifecycle-u1",
+			ClientMsgNo: "lifecycle-message-1",
+			ChannelID:   "lifecycle-room",
+			ChannelType: 2,
+			ChannelKey:  "lifecycle-room",
+			Payload:     []byte("lifecycle payload"),
+		},
+	}})
 }
 
 func (f *fakeCluster) Start(context.Context) error {

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -158,6 +158,10 @@ func (o deliveryMessageObserver) SetChannelAppendWriterPressure(event channelapp
 		event.PendingAppendItems,
 		event.AppendInflightItems,
 		event.PostCommitBacklog,
+		event.PostCommitHandoffDepth,
+		event.PostCommitHandoffCapacity,
+		event.PostCommitRetryQueueDepth,
+		event.PostCommitRetryContended,
 	)
 }
 

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -401,6 +401,10 @@ func (a *App) Stop(ctx context.Context) error {
 		if stopErr := a.channelAppends.Stop(ctx); stopErr != nil {
 			a.logLifecycleWarn("channel_append", "stop", stopErr)
 			err = errors.Join(err, stopErr)
+			// Channel append keeps the same graceful drain alive after a caller
+			// deadline. Its delivery, conversation, plugin, webhook, and cluster
+			// dependencies must remain running until a later Stop finishes that drain.
+			return errors.Join(err, a.syncLogger())
 		} else {
 			a.channelAppendStarted = false
 		}
@@ -533,6 +537,10 @@ func (a *App) rollbackStarted(ctx context.Context) error {
 		if stopErr := a.channelAppends.Stop(ctx); stopErr != nil {
 			a.logLifecycleWarn("channel_append", "rollback_stop", stopErr)
 			err = errors.Join(err, stopErr)
+			// Keep already-started post-commit dependencies available for the
+			// channel append drain. App remains retryable because started and the
+			// component flags are cleared only after a complete later Stop.
+			return err
 		} else {
 			a.channelAppendStarted = false
 		}

--- a/internal/app/observability_test.go
+++ b/internal/app/observability_test.go
@@ -2615,6 +2615,34 @@ func TestDeliveryMessageObserverMapsRecipientDeliveryWorkerMetrics(t *testing.T)
 	}
 }
 
+func TestDeliveryMessageObserverMapsChannelAppendPostCommitPressure(t *testing.T) {
+	reg := obsmetrics.New(1, "n1")
+	observer := deliveryMessageObserver{app: &App{metrics: reg}}
+
+	observer.SetChannelAppendWriterPressure(channelappend.WriterPressureObservation{
+		PostCommitHandoffDepth:    11,
+		PostCommitHandoffCapacity: 17,
+		PostCommitRetryQueueDepth: 3,
+		PostCommitRetryContended:  true,
+	})
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	assertGauge := func(name string, want float64) {
+		t.Helper()
+		family := requireAppMetricFamily(t, families, name)
+		if got := findAppMetricByLabels(t, family, nil).GetGauge().GetValue(); got != want {
+			t.Fatalf("%s = %v, want %v", name, got, want)
+		}
+	}
+	assertGauge("wukongim_channelappend_post_commit_handoff_depth", 11)
+	assertGauge("wukongim_channelappend_post_commit_handoff_capacity", 17)
+	assertGauge("wukongim_channelappend_post_commit_retry_queue_depth", 3)
+	assertGauge("wukongim_channelappend_post_commit_retry_contended", 1)
+}
+
 func TestDeliveryMessageObserverLogsChannelAppendPostCommitFailure(t *testing.T) {
 	logger := &recordingAppLogger{}
 	app := &App{logger: logger}

--- a/internal/infra/cluster/FLOW.md
+++ b/internal/infra/cluster/FLOW.md
@@ -627,6 +627,12 @@ and background Slot proposal backpressure within a small bounded fresh-route
 window. Only aligned failed groups or failed UID route items are resolved
 again; successful siblings are never issued twice. Continued failure is
 returned to the caller so the post-commit path remains bounded.
+The normal one-batch path coalesces UIDs and recipient roles once, counts each
+exact target group before allocation, and fills disjoint capacity-limited
+slices from one shared recipient backing store. This avoids per-target growth
+and intermediate retry copies for high-fanout admissions. A failed target is
+cloned before retry so retaining one failed subset cannot retain the whole
+happy-path backing allocation.
 Delete-barrier writes group rows by UID and use the same fresh-target retry
 loop as authority reads. The actual Slot write runs on the resolved authority
 leader, which reconciles its cache and revalidates the exact target before it

--- a/internal/infra/cluster/conversation_authority.go
+++ b/internal/infra/cluster/conversation_authority.go
@@ -132,7 +132,7 @@ func (c *ConversationAuthorityClient) AdmitActiveBatch(ctx context.Context, batc
 				continue
 			}
 			if attempt+1 < conversationAdmissionRetryAttempts && shouldRetryConversationAdmission(result.Err) {
-				failed = append(failed, groups[index].batch)
+				failed = append(failed, cloneConversationActiveBatchForRetry(groups[index].batch))
 				continue
 			}
 			if terminalErr == nil {
@@ -275,6 +275,9 @@ func (c *ConversationAuthorityClient) groupActiveBatchesByTargetPartial(batches 
 	if c == nil || c.node == nil {
 		return nil, nil, conversationusecase.ErrRouteNotReady
 	}
+	if len(batches) == 1 {
+		return c.groupSingleActiveBatchByTargetPartial(batches[0])
+	}
 	uids := make([]string, 0)
 	uidIndex := make(map[string]int)
 	addUID := func(uid string) {
@@ -366,6 +369,159 @@ func (c *ConversationAuthorityClient) groupActiveBatchesByTargetPartial(batches 
 		}
 	}
 	return groups, failures, nil
+}
+
+// singleActiveRouteItem coalesces one UID's sender and recipient roles before
+// the single bulk route snapshot is resolved.
+type singleActiveRouteItem struct {
+	uid              string
+	recipient        conversationactive.ActiveEntry
+	hasRecipient     bool
+	recipientEmitted bool
+	isSender         bool
+}
+
+// singleActiveTargetGroup records exact capacity needed for one routed target.
+type singleActiveTargetGroup struct {
+	target         conversationusecase.RouteTarget
+	recipientCount int
+	senderUID      string
+}
+
+// groupSingleActiveBatchByTargetPartial avoids the retry-path intermediate
+// copies on the normal one-batch admission path. It preserves first-appearance
+// ordering, duplicate-recipient IsSender OR semantics, and aligned route
+// failures while allocating recipient groups at their exact sizes.
+func (c *ConversationAuthorityClient) groupSingleActiveBatchByTargetPartial(batch conversationactive.ActiveBatch) ([]conversationAuthorityActiveBatchGroup, []conversationAuthorityActiveBatchFailure, error) {
+	itemCapacity := len(batch.Recipients) + 1
+	items := make([]singleActiveRouteItem, 0, itemCapacity)
+	uids := make([]string, 0, itemCapacity)
+	itemIndex := make(map[string]int, itemCapacity)
+	addItem := func(uid string, sender bool, recipient *conversationactive.ActiveEntry) {
+		if uid == "" {
+			return
+		}
+		index, ok := itemIndex[uid]
+		if !ok {
+			index = len(items)
+			itemIndex[uid] = index
+			items = append(items, singleActiveRouteItem{uid: uid})
+			uids = append(uids, uid)
+		}
+		items[index].isSender = items[index].isSender || sender
+		if recipient == nil {
+			return
+		}
+		if items[index].hasRecipient {
+			items[index].recipient.IsSender = items[index].recipient.IsSender || recipient.IsSender
+			return
+		}
+		items[index].recipient = *recipient
+		items[index].hasRecipient = true
+	}
+	addItem(batch.SenderUID, true, nil)
+	for index := range batch.Recipients {
+		recipient := &batch.Recipients[index]
+		addItem(recipient.UID, false, recipient)
+	}
+	if len(items) == 0 {
+		return nil, nil, nil
+	}
+
+	routes, err := c.node.RouteKeysPartial(uids)
+	if err != nil {
+		return nil, nil, mapConversationRouteError(err)
+	}
+	if len(routes) != len(items) {
+		return nil, nil, fmt.Errorf("%w: aligned route result count %d does not match UID count %d", conversationusecase.ErrRouteNotReady, len(routes), len(items))
+	}
+
+	targetCapacity := len(items)
+	if targetCapacity > 256 {
+		targetCapacity = 256
+	}
+	targetIndex := make(map[conversationusecase.RouteTarget]int, targetCapacity)
+	targetGroups := make([]singleActiveTargetGroup, 0, targetCapacity)
+	var failures []conversationAuthorityActiveBatchFailure
+	totalRecipientCount := 0
+	for index, result := range routes {
+		item := items[index]
+		routeErr := result.Err
+		if routeErr == nil && result.Route.Leader == 0 {
+			routeErr = fmt.Errorf("%w: route leader is unknown", conversationusecase.ErrRouteNotReady)
+		}
+		if routeErr != nil {
+			failed := conversationActiveBatchMetadata(batch)
+			if item.isSender {
+				failed.SenderUID = item.uid
+			}
+			if item.hasRecipient {
+				failed.Recipients = append(failed.Recipients, item.recipient)
+			}
+			failures = append(failures, conversationAuthorityActiveBatchFailure{
+				batch: failed,
+				err:   mapConversationRouteError(routeErr),
+			})
+			continue
+		}
+		target := conversationRouteTargetFromClusterRoute(result.Route)
+		groupIndex, ok := targetIndex[target]
+		if !ok {
+			groupIndex = len(targetGroups)
+			targetIndex[target] = groupIndex
+			targetGroups = append(targetGroups, singleActiveTargetGroup{target: target})
+		}
+		if item.isSender {
+			targetGroups[groupIndex].senderUID = item.uid
+		}
+		if item.hasRecipient {
+			targetGroups[groupIndex].recipientCount++
+			totalRecipientCount++
+		}
+	}
+
+	groups := make([]conversationAuthorityActiveBatchGroup, len(targetGroups))
+	recipientStorage := make([]conversationactive.ActiveEntry, totalRecipientCount)
+	recipientOffset := 0
+	for index, targetGroup := range targetGroups {
+		groupBatch := conversationActiveBatchMetadata(batch)
+		groupBatch.SenderUID = targetGroup.senderUID
+		if targetGroup.recipientCount > 0 {
+			recipientEnd := recipientOffset + targetGroup.recipientCount
+			groupBatch.Recipients = recipientStorage[recipientOffset:recipientOffset:recipientEnd]
+			recipientOffset = recipientEnd
+		}
+		groups[index] = conversationAuthorityActiveBatchGroup{
+			target: targetGroup.target,
+			batch:  groupBatch,
+		}
+	}
+	for _, recipient := range batch.Recipients {
+		itemPosition, ok := itemIndex[recipient.UID]
+		if !ok {
+			continue
+		}
+		item := &items[itemPosition]
+		if !item.hasRecipient || item.recipientEmitted {
+			continue
+		}
+		result := routes[itemPosition]
+		if result.Err != nil || result.Route.Leader == 0 {
+			continue
+		}
+		target := conversationRouteTargetFromClusterRoute(result.Route)
+		groupIndex := targetIndex[target]
+		groups[groupIndex].batch.Recipients = append(groups[groupIndex].batch.Recipients, item.recipient)
+		item.recipientEmitted = true
+	}
+	return groups, failures, nil
+}
+
+// cloneConversationActiveBatchForRetry detaches a failed group from shared
+// happy-path recipient storage before the next route attempt retains it.
+func cloneConversationActiveBatchForRetry(batch conversationactive.ActiveBatch) conversationactive.ActiveBatch {
+	batch.Recipients = append([]conversationactive.ActiveEntry(nil), batch.Recipients...)
+	return batch
 }
 
 func coalesceConversationActiveRecipients(recipients []conversationactive.ActiveEntry) []conversationactive.ActiveEntry {

--- a/internal/infra/cluster/conversation_authority_benchmark_test.go
+++ b/internal/infra/cluster/conversation_authority_benchmark_test.go
@@ -1,0 +1,162 @@
+package cluster
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/runtime/conversationactive"
+	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
+	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
+)
+
+var (
+	benchmarkConversationAuthorityGroups   []conversationAuthorityActiveBatchGroup
+	benchmarkConversationAuthorityFailures []conversationAuthorityActiveBatchFailure
+)
+
+// benchmarkConversationAuthorityNode returns precomputed aligned routes without
+// adding the recording and input-copy allocations used by correctness fakes.
+type benchmarkConversationAuthorityNode struct {
+	routes []clusterpkg.RouteKeyResult
+}
+
+func (n *benchmarkConversationAuthorityNode) NodeID() uint64 {
+	return 1
+}
+
+func (n *benchmarkConversationAuthorityNode) RouteKey(string) (clusterpkg.Route, error) {
+	panic("RouteKey must not be called by the bulk grouping benchmark")
+}
+
+func (n *benchmarkConversationAuthorityNode) RouteKeysPartial(uids []string) ([]clusterpkg.RouteKeyResult, error) {
+	if len(uids) != len(n.routes) {
+		panic("unexpected aligned UID count")
+	}
+	return n.routes, nil
+}
+
+func (n *benchmarkConversationAuthorityNode) CallRPC(context.Context, uint64, uint8, []byte) ([]byte, error) {
+	panic("CallRPC must not be called by the grouping benchmark")
+}
+
+func (n *benchmarkConversationAuthorityNode) RegisterRPC(uint8, clusterpkg.NodeRPCHandler) {
+	panic("RegisterRPC must not be called by the grouping benchmark")
+}
+
+func (n *benchmarkConversationAuthorityNode) WatchRouteAuthorities() <-chan clusterpkg.RouteAuthorityEvent {
+	panic("WatchRouteAuthorities must not be called by the grouping benchmark")
+}
+
+func BenchmarkConversationAuthorityGroupActiveBatchesByTargetPartial(b *testing.B) {
+	b.Run("unique_512_recipients_256_targets", func(b *testing.B) {
+		const (
+			recipientCount = 512
+			hashSlotCount  = 256
+			logicalSlots   = 10
+			leaderCount    = 3
+		)
+
+		recipients := make([]conversationactive.ActiveEntry, 0, recipientCount)
+		routes := make([]clusterpkg.RouteKeyResult, recipientCount+1)
+		routes[0].Route = benchmarkConversationAuthorityRoute(0, logicalSlots, leaderCount)
+		for index := 0; index < recipientCount; index++ {
+			recipients = append(recipients, conversationactive.ActiveEntry{UID: "recipient-" + strconv.Itoa(index)})
+			routes[index+1].Route = benchmarkConversationAuthorityRoute(index%hashSlotCount, logicalSlots, leaderCount)
+		}
+
+		client := &ConversationAuthorityClient{
+			node: &benchmarkConversationAuthorityNode{routes: routes},
+		}
+		batches := []conversationactive.ActiveBatch{{
+			Kind:        metadb.ConversationKindNormal,
+			SenderUID:   "sender",
+			ChannelID:   "benchmark-channel",
+			ChannelType: 2,
+			MessageSeq:  1,
+			ActiveAtMS:  1,
+			Recipients:  recipients,
+		}}
+
+		groups, failures, err := client.groupActiveBatchesByTargetPartial(batches)
+		if err != nil {
+			b.Fatalf("groupActiveBatchesByTargetPartial() setup error = %v", err)
+		}
+		assertConversationAuthorityBenchmarkShape(b, groups, failures, recipientCount, hashSlotCount, logicalSlots, leaderCount)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for index := 0; index < b.N; index++ {
+			groups, failures, err = client.groupActiveBatchesByTargetPartial(batches)
+			if err != nil {
+				b.Fatalf("groupActiveBatchesByTargetPartial() error = %v", err)
+			}
+			benchmarkConversationAuthorityGroups = groups
+			benchmarkConversationAuthorityFailures = failures
+		}
+		b.StopTimer()
+
+		assertConversationAuthorityBenchmarkShape(b, benchmarkConversationAuthorityGroups, benchmarkConversationAuthorityFailures, recipientCount, hashSlotCount, logicalSlots, leaderCount)
+	})
+}
+
+func benchmarkConversationAuthorityRoute(hashSlot, logicalSlots, leaderCount int) clusterpkg.Route {
+	logicalSlot := hashSlot % logicalSlots
+	return clusterpkg.Route{
+		HashSlot:       uint16(hashSlot),
+		SlotID:         uint32(logicalSlot),
+		Leader:         uint64(logicalSlot%leaderCount + 1),
+		LeaderTerm:     7,
+		ConfigEpoch:    9,
+		Revision:       11,
+		AuthorityEpoch: 13,
+	}
+}
+
+func assertConversationAuthorityBenchmarkShape(
+	b *testing.B,
+	groups []conversationAuthorityActiveBatchGroup,
+	failures []conversationAuthorityActiveBatchFailure,
+	recipientCount int,
+	hashSlotCount int,
+	logicalSlotCount int,
+	leaderCount int,
+) {
+	b.Helper()
+	if len(failures) != 0 {
+		b.Fatalf("route failures = %d, want 0", len(failures))
+	}
+	if len(groups) != hashSlotCount {
+		b.Fatalf("exact target groups = %d, want %d", len(groups), hashSlotCount)
+	}
+
+	hashSlots := make(map[uint16]struct{}, hashSlotCount)
+	logicalSlots := make(map[uint32]struct{}, logicalSlotCount)
+	leaders := make(map[uint64]struct{}, leaderCount)
+	recipientRows := 0
+	senderGroups := 0
+	for _, group := range groups {
+		hashSlots[group.target.HashSlot] = struct{}{}
+		logicalSlots[group.target.SlotID] = struct{}{}
+		leaders[group.target.LeaderNodeID] = struct{}{}
+		recipientRows += len(group.batch.Recipients)
+		if group.batch.SenderUID != "" {
+			senderGroups++
+		}
+	}
+	if len(hashSlots) != hashSlotCount {
+		b.Fatalf("hash slots = %d, want %d", len(hashSlots), hashSlotCount)
+	}
+	if len(logicalSlots) != logicalSlotCount {
+		b.Fatalf("logical slots = %d, want %d", len(logicalSlots), logicalSlotCount)
+	}
+	if len(leaders) != leaderCount {
+		b.Fatalf("leaders = %d, want %d", len(leaders), leaderCount)
+	}
+	if recipientRows != recipientCount {
+		b.Fatalf("recipient rows = %d, want %d", recipientRows, recipientCount)
+	}
+	if senderGroups != 1 {
+		b.Fatalf("sender groups = %d, want 1", senderGroups)
+	}
+}

--- a/internal/infra/cluster/conversation_authority_test.go
+++ b/internal/infra/cluster/conversation_authority_test.go
@@ -121,8 +121,8 @@ func TestConversationAuthorityClientAdmitActiveBatchKeepsSenderWithSameTargetRec
 	}
 	client := NewConversationAuthorityClient(node, local)
 	recipients := []conversationactive.ActiveEntry{
-		{UID: "sender", IsSender: true},
 		{UID: "receiver"},
+		{UID: "sender", IsSender: true},
 	}
 
 	err := client.AdmitActiveBatch(context.Background(), conversationactive.ActiveBatch{

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -114,9 +114,12 @@ single-writer ordering for the channel key.
 `Group.Start` opens local admission and prepares isolated worker pools. Writers
 are created lazily on accepted local submissions and reclaimed opportunistically
 after they have stayed fully idle past `WriterIdleRetention`. `Group.Stop`
-closes admission, cancels the runtime context used by append and post-commit
-work, and waits for already accepted writers to drain until the caller context
-expires. A stopped group is not restarted.
+closes admission and starts one background graceful drain. The drain preserves
+accepted futures, durable append state, global post-commit handoff reservations,
+and fair retry ownership until they finish; only then does it release worker
+pools and cancel the runtime context. A caller context bounds only that caller's
+wait. A timed-out Stop does not cancel or clear work, and a later Stop continues
+waiting for the same drain. A stopped group is not restarted.
 
 ## Writer Execution
 
@@ -159,7 +162,16 @@ authority ownership by returning an older successful result. Matching prepared
 items enter the writer state's pending queue in input order only when the
 state's pending plus in-flight item count is below
 `ChannelBacklogHighWatermark`; saturated channels complete those items with
-`ErrChannelBusy` before they reach the append port.
+`ErrChannelBusy` before they reach the append port. When any post-commit port is
+configured, every durable prepared item must also reserve one slot from the
+group-wide `PostCommitHandoffCapacity` before append. An item that cannot reserve
+a slot completes with `ErrChannelBusy` and is never passed to `Appender`; append
+failure or terminal post-commit completion returns the slot. The default is the
+larger of `ChannelBacklogHighWatermark` and
+`EffectPoolSize * commitBatchMaxEvents`.
+Both worker-pool sizes are capped at the maximum positive int32 capacity used by
+ants/v2, preventing oversized configuration values from wrapping into an
+unbounded or permanently full pool.
 Prepared command-style `NoPersist` items also receive one message id and server
 timestamp, but they do not enter the durable pending queue. The writer schedules
 them as realtime effects and completes their future only after the recipient
@@ -215,8 +227,9 @@ immutable envelope by reference through the delivery worker and owner-push
 planning. Concrete owner push adapters copy or serialize at their boundary.
 Success prunes the payload-bearing envelope from the backlog. Recipient route or
 delivery enqueue failure is logged through `PostCommitFailureObserver`, counted
-through effect metrics, and then the envelope is dropped without retry so one
-bad recipient side effect cannot block later messages on the same channel.
+through effect metrics, and then the envelope reaches its terminal attempt
+without retry so one bad recipient side effect cannot block later messages on
+the same channel.
 Conversation-active projection failures are recorded independently and do not
 turn a successful delivery enqueue into a failed item completion. Failure
 observations carry a precise post-commit phase plus
@@ -224,11 +237,33 @@ sampled recipient, target, and dispatch context so route-resolution failures
 can be distinguished from conversation active admission and delivery enqueue
 failures in logs. Each channel keeps only one committed envelope in flight at a
 time, and concurrency inside that envelope is limited to recipient authority
-targets. Foreground append admission and the post-commit backlog use separate
-bounds derived from `ChannelBacklogHighWatermark`. When the best-effort bound
-is full, the newest already-durable envelope is reported as an admission-phase
-post-commit failure and dropped; it never turns a later foreground SEND into
-`ErrChannelBusy`.
+targets. The global pre-append reservation is the post-commit backlog bound, so
+every newly acknowledged durable envelope already owns capacity for its FIFO
+handoff. A full handoff rejects only the not-yet-appended item with
+`ErrChannelBusy`; an already-durable envelope is never dropped at scheduler
+admission.
+
+Post-commit pool admission remains non-blocking. If the pool is full, the writer
+cancels only transient dispatch ownership, keeps the committed envelopes in
+`channelState`, and enters a de-duplicated global FIFO retry scheduler. While
+that FIFO is contended, newer writers join behind it instead of probing the pool
+directly. A queued writer may prepare newly received inbox work, but it parks
+that append work until its older durable commit owns the retry turn. The selected
+writer's pass admits only the old commit; normal append-first ordering resumes
+on its next pass. The scheduler consumes a turn only when the pool reports free
+logical task capacity. Task completion releases that logical reservation before
+publishing the capacity wakeup, so coalesced wakeups refill every free worker
+without depending on ants' idle-worker count. If ants is still returning the
+just-completed worker to its idle queue, the logical capacity owner completes
+that short handoff rather than reporting a false overload. A real overload
+returns the writer to the FIFO tail and waits for the next capacity signal or
+bounded timer tick. Queue compaction clears truncated writer pointers from the
+backing array. This preserves fair retry without a busy scheduler spin, stale
+writer retention, or terminal scheduler drop, while each admitted effect still
+processes at most `commitBatchMaxEvents` envelopes.
+Realtime work shares the effect pool but does not overtake a contended durable
+retry FIFO; it fails fast with backpressure while an older durable writer owns
+or awaits the retry turn.
 
 When a PersistAfter enqueuer is configured, each successful durable committed
 envelope is cloned into the configured side-effect sinks from the same
@@ -350,21 +385,42 @@ by the writer as items move between queues. Append effects run on a foreground
 append pool, while post-commit and realtime recipient effects run on an
 isolated post-commit pool so best-effort side effects cannot occupy durable
 append workers. Post-commit pool admission is bounded and non-blocking: a full
-pool produces the normal scheduler failure observation and drops that committed
-envelope, so saturated best-effort work cannot pin writer-advance workers or
-delay later durable appends. The writer pressure observer reports the local
-writer group aggregate rather than a per-channel event loop. When the observer supports ants
-pool samples, the group also emits direct ants/v2 running/capacity/waiting
-observations for the advance, append_effect, and post_commit pools; benchmark
-scripts use these samples for the per-node peak `used/cap` ants pool summary.
+pool retains the committed envelope and sends its writer through the fair retry
+FIFO, so saturated side effects cannot pin writer-advance workers or lose an
+acknowledged durable handoff. Exhausting the global pre-append reservation
+returns item-local `ErrChannelBusy` and emits a post-commit backpressure effect
+observation. The writer pressure observer reports the local
+writer group aggregate rather than a per-channel event loop. It also reports
+the global post-commit handoff depth/capacity and the fair-retry FIFO depth plus
+its contended bit. Handoff depth counts durable messages holding reservations;
+retry depth counts de-duplicated writers still waiting in the FIFO and excludes
+the writer that already owns the selected retry turn. Consequently retry depth
+may be zero while contended remains true. These snapshots read only atomics and
+never acquire the retry scheduler mutex on the append hot path. Concurrent
+publication requests use a non-blocking, coalesced wakeup for one group-local
+publisher goroutine. It invokes callbacks serially, so a delayed old callback
+cannot overwrite a newer snapshot, while a slow observer never pins an append or
+commit goroutine. Group shutdown performs one final serialized publication after
+writer and retry state drain, making the terminal zero state observable without
+requiring later traffic or a hot-path global mutex. Reservation release, FIFO
+enqueue/pop, and retry-turn completion request pressure publication only after
+their state transition. None of these observations carries a channel, UID, Slot,
+or authority-target label. When the observer supports pool
+samples, the group also emits running/capacity/waiting observations for the
+advance, append_effect, and post_commit pools. The first two report direct
+ants/v2 worker state; post_commit reports logical admitted tasks so retained idle
+ants workers are not mistaken for active work. Benchmark scripts use these
+samples for the per-node peak `used/cap` pool summary.
 
 Before a post-commit effect enters the asynchronous pool, it copies the
 committed-envelope slice into effect-owned storage. The envelopes themselves
-remain immutable values, while the independent slice ownership allows shutdown
-to clear queued writer backlog without racing an already-running effect.
+remain immutable values, while the independent slice ownership lets the writer
+retain and retry its queued backing store without racing an already-running
+effect.
 
-`Stop` cancels the runtime context passed to append and post-commit effects
-before waiting for writers to drain. Once cancellation is observed, writers do
-not schedule more queued post-commit backlog, avoiding a one-by-one walk of
-canceled work during shutdown. Ports must respect their context promptly for
-Stop to complete without waiting for the caller's timeout.
+`Stop` first closes admission and waits for shard admission ownership, append
+state, handoff reservations, committed backlog, and retry FIFO ownership to
+drain. This includes accepted realtime sends, whose futures retain shard
+admission until their effect completes. The runtime context is canceled only
+after the drain and worker-pool release complete. A Stop deadline therefore
+returns only a waiting error; it does not alter the ongoing graceful drain.

--- a/internal/runtime/channelappend/append_test.go
+++ b/internal/runtime/channelappend/append_test.go
@@ -585,8 +585,8 @@ func TestAppendRecordsObserverAndSendtraceFromCompletion(t *testing.T) {
 	}
 }
 
-func TestStopCancelsBlockedAppendWorkerAndFuture(t *testing.T) {
-	appender := newContextBlockingAppenderForAppendTest()
+func TestStopDeadlineDoesNotCancelBlockedAppendWorkerOrFuture(t *testing.T) {
+	appender := newBlockingAppenderForAppendTest()
 	group := New(Options{
 		LocalNodeID: 1,
 		MessageID:   newSequenceIDsForPrepare(800),
@@ -598,23 +598,23 @@ func TestStopCancelsBlockedAppendWorkerAndFuture(t *testing.T) {
 	target := localTargetForAppendTest("room")
 
 	submitC := submitNoWaitForAppendTest(group, target, appendSendItemForTest("u1", "room", "payload"))
-	appender.waitStarted(t)
+	started := appender.waitStarted(t)
 	submit := receiveSubmitResult(t, submitC)
 	if submit.err != nil {
 		t.Fatalf("SubmitLocal() error = %v", submit.err)
 	}
 
-	stopCtx, cancelStop := context.WithTimeout(context.Background(), time.Second)
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancelStop()
-	if err := group.Stop(stopCtx); err != nil {
-		t.Fatalf("Stop() error = %v", err)
+	if err := group.Stop(stopCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop() error = %v, want context deadline exceeded", err)
 	}
-	if !appender.wasCanceled() {
-		t.Fatalf("appender did not observe context cancellation")
-	}
-	results := waitFutureForTest(t, submit.future)
-	if !errors.Is(results[0].Err, context.Canceled) {
-		t.Fatalf("future error = %v, want context.Canceled", results[0].Err)
+	started.Release()
+	requireAppendSuccess(t, waitFutureForTest(t, submit.future), 0, 800, 1)
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), time.Second)
+	defer cancelDrain()
+	if err := group.Stop(drainCtx); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
 	}
 }
 

--- a/internal/runtime/channelappend/commit.go
+++ b/internal/runtime/channelappend/commit.go
@@ -125,17 +125,6 @@ func commitPanicCompletion(effect commitEffect, recovered any) commitCompletedEv
 	return commitErrorCompletion(effect, effectPanicError(effectStagePostCommit, recovered), PostCommitFailureDetail{Phase: "panic"})
 }
 
-func commitScheduleErrorCompletion(effect commitEffect, scheduleErr error) commitCompletedEvent {
-	return commitErrorCompletion(effect, effectScheduleError(effectStagePostCommit, scheduleErr), PostCommitFailureDetail{Phase: "scheduler"})
-}
-
-// postCommitAdmissionFailure records an already-durable envelope that could
-// not enter the separately bounded best-effort backlog.
-func postCommitAdmissionFailure(event CommittedEnvelope) PostCommitFailureObservation {
-	err := fmt.Errorf("%w: post-commit backlog admission: %w", ErrCommitEffectFailed, ErrBackpressured)
-	return PostCommitFailureDetail{Phase: "admission"}.toObservation(event, 0, errorClass(err), err)
-}
-
 func commitErrorCompletion(effect commitEffect, err error, detail PostCommitFailureDetail) commitCompletedEvent {
 	completion := commitCompletedEvent{
 		key:     effect.key,

--- a/internal/runtime/channelappend/commit_test.go
+++ b/internal/runtime/channelappend/commit_test.go
@@ -189,6 +189,8 @@ func TestAppendSuccessEnqueuesCommittedEventsAndSendackCompletesBeforeRecipientE
 	if committed[0].MessageID != 900 || committed[0].MessageSeq != 1 {
 		t.Fatalf("committed id/seq = %d/%d, want 900/1", committed[0].MessageID, committed[0].MessageSeq)
 	}
+	enqueuer.release()
+	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
 }
 
 func TestNoopPostCommitPortsDoNotScheduleCommitEffect(t *testing.T) {
@@ -671,7 +673,7 @@ func TestLargeGroupSubscribersRemainPagedPerCommittedMessage(t *testing.T) {
 	}
 }
 
-func TestBlockedCommitBacklogDropsBestEffortWorkWithoutBackpressuringLaterSubmit(t *testing.T) {
+func TestBlockedCommitBacklogRetainsDurableEnvelopeUntilDeliveryAdmission(t *testing.T) {
 	enqueuer := newBlockingRecipientDeliveryEnqueuerForCommitTest()
 	t.Cleanup(enqueuer.release)
 	observer := &recordingPostCommitFailureObserverForTest{}
@@ -684,6 +686,7 @@ func TestBlockedCommitBacklogDropsBestEffortWorkWithoutBackpressuringLaterSubmit
 		RecipientDeliveryEnqueuer:   enqueuer,
 		RecipientBatchSize:          16,
 		ChannelBacklogHighWatermark: 1,
+		PostCommitHandoffCapacity:   2,
 	})
 	target := localTargetForAppendTest("room")
 	first := appendSendItemForTest("u1", "room", "one")
@@ -703,19 +706,156 @@ func TestBlockedCommitBacklogDropsBestEffortWorkWithoutBackpressuringLaterSubmit
 		t.Fatalf("second SubmitLocal() error = %v", err)
 	}
 	requireAppendSuccess(t, waitFutureForTest(t, secondFuture), 0, 1201, 2)
-	observer.waitFailures(t, 1)
-	observer.mu.Lock()
-	failure := observer.failures[0]
-	observer.mu.Unlock()
-	if failure.MessageID != 1201 || failure.Phase != "admission" || failure.Result != channelAppendResultBackpressured {
-		t.Fatalf("post-commit failure = %#v, want bounded admission drop for message 1201", failure)
+	enqueuer.release()
+	enqueuer.waitCalls(t, 2)
+	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+	if got := enqueuer.messageIDs(); !reflect.DeepEqual(got, []uint64{1200, 1201}) {
+		t.Fatalf("recipient delivery message ids = %#v, want both durable commits in order", got)
 	}
-	if calls := enqueuer.callCount(); calls != 1 {
-		t.Fatalf("recipient delivery calls = %d, want only the already in-flight post-commit effect", calls)
+	observer.mu.Lock()
+	defer observer.mu.Unlock()
+	for _, failure := range observer.failures {
+		if failure.MessageID == 1201 && failure.Phase == "admission" {
+			t.Fatalf("durable message 1201 was dropped at post-commit admission: %#v", failure)
+		}
 	}
 }
 
-func TestStopDoesNotWalkCanceledCommitBacklog(t *testing.T) {
+func TestPostCommitHandoffRejectsBeforeAppendAndReturnsTokenAfterDrain(t *testing.T) {
+	enqueuer := newBlockingRecipientDeliveryEnqueuerForCommitTest()
+	t.Cleanup(enqueuer.release)
+	appender := newRecordingAppenderForAppendTest()
+	group := newStartedTestGroup(t, Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(1500),
+		Appender:                   appender,
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  enqueuer,
+		RecipientBatchSize:         16,
+		PostCommitHandoffCapacity:  1,
+	})
+	target := localTargetForAppendTest("room")
+
+	first := appendSendItemForTest("u1", "room", "one")
+	first.Command.MessageScopedUIDs = []string{"u2"}
+	firstFuture, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{first})
+	if err != nil {
+		t.Fatalf("first SubmitLocal() error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, firstFuture), 0, 1500, 1)
+	enqueuer.waitStarted(t)
+
+	second := appendSendItemForTest("u1", "room", "two")
+	second.Command.MessageScopedUIDs = []string{"u3"}
+	secondFuture, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{second})
+	if err != nil {
+		t.Fatalf("second SubmitLocal() error = %v", err)
+	}
+	secondResults := waitFutureForTest(t, secondFuture)
+	if !errors.Is(secondResults[0].Err, ErrChannelBusy) {
+		t.Fatalf("second item error = %v, want ErrChannelBusy", secondResults[0].Err)
+	}
+	if got := appender.Calls(); got != 1 {
+		t.Fatalf("appender calls while handoff full = %d, want 1", got)
+	}
+	if depth := group.handoff.depth(); depth != 1 {
+		t.Fatalf("handoff depth while delivery blocked = %d, want 1", depth)
+	}
+
+	enqueuer.release()
+	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+	waitHandoffDepthForTest(t, group, 0)
+	third := appendSendItemForTest("u1", "room", "three")
+	third.Command.MessageScopedUIDs = []string{"u4"}
+	thirdFuture, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{third})
+	if err != nil {
+		t.Fatalf("third SubmitLocal() error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, thirdFuture), 0, 1502, 2)
+	enqueuer.waitCalls(t, 2)
+	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+	if got := enqueuer.messageIDs(); !reflect.DeepEqual(got, []uint64{1500, 1502}) {
+		t.Fatalf("recipient delivery message ids = %#v, want only appended messages", got)
+	}
+}
+
+func TestAppendPartialAndShortResultsReturnUnusedHandoffTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*recordingAppenderForAppendTest)
+		wantSecond error
+	}{
+		{
+			name: "partial error",
+			configure: func(appender *recordingAppenderForAppendTest) {
+				appender.itemErrs = []error{nil, ErrAppendFailed}
+			},
+		},
+		{
+			name: "short result",
+			configure: func(appender *recordingAppenderForAppendTest) {
+				appender.resultLimit = 1
+			},
+			wantSecond: ErrAppendResultMissing,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appender := newRecordingAppenderForAppendTest()
+			tt.configure(appender)
+			persistAfter := &recordingPersistAfterEnqueuerForCommitTest{}
+			group := newStartedTestGroup(t, Options{
+				LocalNodeID:               1,
+				MessageID:                 newSequenceIDsForPrepare(1600),
+				Appender:                  appender,
+				PersistAfterEnqueuer:      persistAfter,
+				PostCommitHandoffCapacity: 2,
+			})
+			target := localTargetForAppendTest("room")
+			future, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{
+				appendSendItemForTest("u1", "room", "one"),
+				appendSendItemForTest("u1", "room", "two"),
+			})
+			if err != nil {
+				t.Fatalf("SubmitLocal() error = %v", err)
+			}
+			results := waitFutureForTest(t, future)
+			requireAppendSuccess(t, results, 0, 1600, 1)
+			if tt.wantSecond != nil && !errors.Is(results[1].Err, tt.wantSecond) {
+				t.Fatalf("second result error = %v, want %v", results[1].Err, tt.wantSecond)
+			}
+			if tt.wantSecond == nil && results[1].Result.Reason == ReasonSuccess {
+				t.Fatalf("second result = %#v, want item-local append failure", results[1])
+			}
+			requireEventuallyEqualInt(t, time.Second, persistAfter.callCount, 1, "persist-after calls")
+			waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+			waitHandoffDepthForTest(t, group, 0)
+
+			appender.mu.Lock()
+			appender.itemErrs = nil
+			appender.resultLimit = 0
+			appender.mu.Unlock()
+			next, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{
+				appendSendItemForTest("u1", "room", "three"),
+				appendSendItemForTest("u1", "room", "four"),
+			})
+			if err != nil {
+				t.Fatalf("second SubmitLocal() error = %v", err)
+			}
+			nextResults := waitFutureForTest(t, next)
+			requireResultReason(t, nextResults, 0, ReasonSuccess)
+			requireResultReason(t, nextResults, 1, ReasonSuccess)
+			requireEventuallyEqualInt(t, time.Second, persistAfter.callCount, 3, "persist-after calls after token reuse")
+			waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+			waitHandoffDepthForTest(t, group, 0)
+			if got := persistAfter.messageIDs(); !reflect.DeepEqual(got, []uint64{1600, 1602, 1603}) {
+				t.Fatalf("persist-after message ids = %#v, want successful durable items exactly once", got)
+			}
+		})
+	}
+}
+
+func TestStopDeadlineRetainsCommitBacklogForNextDrain(t *testing.T) {
 	enqueuer := newBlockingRecipientDeliveryEnqueuerForCommitTest()
 	t.Cleanup(enqueuer.release)
 	group := New(Options{
@@ -745,13 +885,32 @@ func TestStopDoesNotWalkCanceledCommitBacklog(t *testing.T) {
 	_ = waitFutureForTest(t, future)
 	enqueuer.waitStarted(t)
 
-	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-	if err := group.Stop(stopCtx); err != nil {
-		t.Fatalf("Stop() error = %v", err)
+	if err := group.Stop(stopCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop() error = %v, want context deadline exceeded", err)
 	}
 	if got := enqueuer.callCount(); got != 1 {
-		t.Fatalf("recipient delivery enqueue calls after stop = %d, want only in-flight commit", got)
+		t.Fatalf("recipient delivery enqueue calls after timed-out stop = %d, want one in-flight call", got)
+	}
+	if backlog := commitBacklogForTest(group, target.ChannelID); backlog != 3 {
+		t.Fatalf("commit backlog after timed-out stop = %d, want 3 retained envelopes", backlog)
+	}
+	if depth := group.handoff.depth(); depth != 3 {
+		t.Fatalf("handoff depth after timed-out stop = %d, want 3 retained reservations", depth)
+	}
+	enqueuer.release()
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), time.Second)
+	defer cancelDrain()
+	if err := group.Stop(drainCtx); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
+	}
+	enqueuer.waitCalls(t, 3)
+	if got := enqueuer.messageIDs(); !reflect.DeepEqual(got, []uint64{1300, 1301, 1302}) {
+		t.Fatalf("recipient delivery message ids = %#v, want all retained envelopes in order", got)
+	}
+	if depth := group.handoff.depth(); depth != 0 {
+		t.Fatalf("handoff depth after drain = %d, want 0", depth)
 	}
 }
 
@@ -856,6 +1015,117 @@ func TestNoPersistSyncOnceDispatchesRealtimeWithoutAppendOrActiveConversation(t 
 		t.Fatalf("realtime payload = %q, want cmd-payload", payload)
 	}
 	waitCommitBacklogForTest(t, group, target.ChannelID, 0)
+}
+
+func TestRealtimeDoesNotOvertakeContendedDurableRetryFIFO(t *testing.T) {
+	delivery := newBlockingRecipientDeliveryEnqueuerForCommitTest()
+	t.Cleanup(delivery.release)
+	group := newStartedTestGroup(t, Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(1700),
+		Appender:                   newRecordingAppenderForAppendTest(),
+		EffectPoolSize:             1,
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  delivery,
+		RecipientBatchSize:         16,
+	})
+
+	firstTarget := localTargetForAppendTest("durable-first")
+	firstItem := appendSendItemForTest("u1", firstTarget.ChannelID.ID, "first")
+	firstItem.Command.MessageScopedUIDs = []string{"u2"}
+	first, err := group.SubmitLocal(context.Background(), firstTarget, []SendBatchItem{firstItem})
+	if err != nil {
+		t.Fatalf("SubmitLocal(first) error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, first), 0, 1700, 1)
+	delivery.waitStarted(t)
+
+	secondTarget := localTargetForAppendTest("durable-second")
+	secondItem := appendSendItemForTest("u1", secondTarget.ChannelID.ID, "second")
+	secondItem.Command.MessageScopedUIDs = []string{"u3"}
+	second, err := group.SubmitLocal(context.Background(), secondTarget, []SendBatchItem{secondItem})
+	if err != nil {
+		t.Fatalf("SubmitLocal(second) error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, second), 0, 1701, 2)
+	deadline := time.Now().Add(time.Second)
+	for !group.postCommitRetries.isContended() {
+		if time.Now().After(deadline) {
+			t.Fatal("durable retry FIFO did not become contended")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	commandChannelID := runtimechannelid.ToCommandChannel("realtime")
+	realtimeTarget := localTargetForAppendTest(commandChannelID)
+	realtimeItem := appendSendItemForTest("u1", "realtime", "transient")
+	realtimeItem.Command.NoPersist = true
+	realtimeItem.Command.SyncOnce = true
+	realtimeItem.Command.MessageScopedUIDs = []string{"u4"}
+	realtime, err := group.SubmitLocal(context.Background(), realtimeTarget, []SendBatchItem{realtimeItem})
+	if err != nil {
+		t.Fatalf("SubmitLocal(realtime) error = %v", err)
+	}
+	realtimeResults := waitFutureForTest(t, realtime)
+	if !errors.Is(realtimeResults[0].Err, ErrBackpressured) {
+		t.Fatalf("realtime result error = %v, want ErrBackpressured behind durable retry", realtimeResults[0].Err)
+	}
+	if got := delivery.callCount(); got != 1 {
+		t.Fatalf("delivery calls before releasing durable effect = %d, want 1", got)
+	}
+
+	delivery.release()
+	delivery.waitCalls(t, 2)
+	waitCommitBacklogForTest(t, group, secondTarget.ChannelID, 0)
+	if got := delivery.messageIDs(); !reflect.DeepEqual(got, []uint64{1700, 1701}) {
+		t.Fatalf("delivery message ids = %#v, want only durable FIFO messages", got)
+	}
+}
+
+func TestStopWaitsForAcceptedRealtimeEffectBeforeCancel(t *testing.T) {
+	delivery := newBlockingRecipientDeliveryEnqueuerForCommitTest()
+	t.Cleanup(delivery.release)
+	group := New(Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(1800),
+		Appender:                   newRecordingAppenderForAppendTest(),
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  delivery,
+		RecipientBatchSize:         16,
+	})
+	if err := group.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	commandChannelID := runtimechannelid.ToCommandChannel("realtime-stop")
+	target := localTargetForAppendTest(commandChannelID)
+	item := appendSendItemForTest("u1", "realtime-stop", "transient")
+	item.Command.NoPersist = true
+	item.Command.SyncOnce = true
+	item.Command.MessageScopedUIDs = []string{"u2"}
+	future, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{item})
+	if err != nil {
+		t.Fatalf("SubmitLocal() error = %v", err)
+	}
+	delivery.waitStarted(t)
+
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), time.Second)
+	defer cancelStop()
+	stopC := make(chan error, 1)
+	go func() { stopC <- group.Stop(stopCtx) }()
+	select {
+	case err := <-stopC:
+		t.Fatalf("Stop() returned before accepted realtime effect drained: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	if _, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{item}); !errors.Is(err, ErrRouteNotReady) {
+		t.Fatalf("SubmitLocal() while stopping error = %v, want ErrRouteNotReady", err)
+	}
+
+	delivery.release()
+	if err := <-stopC; err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	requireAppendSuccess(t, waitFutureForTest(t, future), 0, 1800, 0)
 }
 
 func TestNoPersistRealtimeDoesNotEnqueuePersistAfter(t *testing.T) {
@@ -1063,7 +1333,7 @@ type blockingRecipientDeliveryEnqueuerForCommitTest struct {
 	once     sync.Once
 	releaseO sync.Once
 	mu       sync.Mutex
-	calls    int
+	batches  []RecipientBatch
 }
 
 func newBlockingRecipientDeliveryEnqueuerForCommitTest() *blockingRecipientDeliveryEnqueuerForCommitTest {
@@ -1073,12 +1343,12 @@ func newBlockingRecipientDeliveryEnqueuerForCommitTest() *blockingRecipientDeliv
 	}
 }
 
-func (r *blockingRecipientDeliveryEnqueuerForCommitTest) EnqueueRecipientBatch(ctx context.Context, _ RecipientAuthorityTarget, _ RecipientBatch) error {
+func (r *blockingRecipientDeliveryEnqueuerForCommitTest) EnqueueRecipientBatch(ctx context.Context, _ RecipientAuthorityTarget, batch RecipientBatch) error {
 	r.once.Do(func() {
 		close(r.started)
 	})
 	r.mu.Lock()
-	r.calls++
+	r.batches = append(r.batches, batch.Clone())
 	r.mu.Unlock()
 	select {
 	case <-r.releaseC:
@@ -1106,7 +1376,45 @@ func (r *blockingRecipientDeliveryEnqueuerForCommitTest) release() {
 func (r *blockingRecipientDeliveryEnqueuerForCommitTest) callCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.calls
+	return len(r.batches)
+}
+
+func (r *blockingRecipientDeliveryEnqueuerForCommitTest) waitCalls(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if got := r.callCount(); got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("recipient delivery enqueue calls = %d, want %d", r.callCount(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func (r *blockingRecipientDeliveryEnqueuerForCommitTest) messageIDs() []uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]uint64, 0, len(r.batches))
+	for _, batch := range r.batches {
+		out = append(out, batch.Event.MessageID)
+	}
+	return out
+}
+
+func waitHandoffDepthForTest(t *testing.T, group *Group, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if got := group.handoff.depth(); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("handoff depth = %d, want %d", group.handoff.depth(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 type scriptedRecipientDeliveryEnqueuerForCommitTest struct {

--- a/internal/runtime/channelappend/group.go
+++ b/internal/runtime/channelappend/group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -18,12 +17,16 @@ type Group struct {
 	appendPool *workerPool
 	// postCommitPool runs best-effort post-commit and realtime recipient effects.
 	postCommitPool *workerPool
+	// handoff bounds durable messages that still own post-commit work.
+	handoff *postCommitHandoff
+	// postCommitRetries fairly retries writers rejected by the non-blocking effect pool.
+	postCommitRetries *postCommitRetryScheduler
 
 	runtimeCtx    context.Context
 	runtimeCancel context.CancelFunc
-	// runtimeStopped is the hot-path stop signal checked by channel writers.
-	runtimeStopped atomic.Bool
-	metrics        groupMetrics
+	metrics       groupMetrics
+	stopOnce      sync.Once
+	stopDone      chan struct{}
 
 	mu       sync.RWMutex
 	started  bool
@@ -38,15 +41,23 @@ func New(opts Options) *Group {
 	advancePool := newWorkerPool(opts.AdvancePoolSize)
 	appendPool := newWorkerPool(opts.EffectPoolSize)
 	postCommitPool := newNonblockingWorkerPool(opts.EffectPoolSize)
+	handoff := newPostCommitHandoff(opts.PostCommitHandoffCapacity)
+	postCommitRetries := newPostCommitRetryScheduler()
+	postCommitRetries.capacityAvailable = func() bool {
+		return postCommitPool.running() < postCommitPool.capacity()
+	}
 	runtimeCtx, runtimeCancel := context.WithCancel(context.Background())
 	group := &Group{
-		opts:           opts,
-		advancePool:    advancePool,
-		appendPool:     appendPool,
-		postCommitPool: postCommitPool,
-		shards:         make([]*shard, opts.AuthorityShardCount),
-		runtimeCtx:     runtimeCtx,
-		runtimeCancel:  runtimeCancel,
+		opts:              opts,
+		advancePool:       advancePool,
+		appendPool:        appendPool,
+		postCommitPool:    postCommitPool,
+		handoff:           handoff,
+		postCommitRetries: postCommitRetries,
+		shards:            make([]*shard, opts.AuthorityShardCount),
+		runtimeCtx:        runtimeCtx,
+		runtimeCancel:     runtimeCancel,
+		stopDone:          make(chan struct{}),
 	}
 	for i := range group.shards {
 		group.shards[i] = newShard(limits, int64(opts.AdmissionCapacityPerShard), opts.WriterIdleRetention)
@@ -60,6 +71,8 @@ func New(opts Options) *Group {
 			appendPool:        appendPool,
 			postCommitPool:    postCommitPool,
 			advancePool:       advancePool,
+			handoff:           handoff,
+			postCommitRetries: postCommitRetries,
 		}
 		metrics = &group.metrics
 	}
@@ -69,9 +82,10 @@ func New(opts Options) *Group {
 		commit:         commitPortsFromOptions(opts),
 		appendPool:     appendPool,
 		postCommitPool: postCommitPool,
+		handoff:        handoff,
+		commitRetries:  postCommitRetries,
 		schedule:       group.schedule,
 		runtimeCtx:     runtimeCtx,
-		stopped:        &group.runtimeStopped,
 		metrics:        metrics,
 
 		inboxCoalesceWindow:   opts.InboxCoalesceWindow,
@@ -98,18 +112,25 @@ func (g *Group) Start(ctx context.Context) error {
 		return err
 	}
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	if g.stopping || g.stopped {
+		g.mu.Unlock()
 		return ErrBackpressured
 	}
 	if g.started {
+		g.mu.Unlock()
 		return nil
 	}
+	g.metrics.startPressurePublisher()
+	g.postCommitRetries.start()
 	g.started = true
+	g.mu.Unlock()
+	g.metrics.observePressure()
 	return nil
 }
 
-// Stop closes admission, drains accepted writer work, and releases the pool.
+// Stop closes admission, drains accepted work, and only then cancels the
+// runtime and releases its pools. A deadline preserves all unfinished state so
+// a later Stop call can continue the same drain.
 func (g *Group) Stop(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -120,27 +141,32 @@ func (g *Group) Stop(ctx context.Context) error {
 		return nil
 	}
 	g.stopping = true
-	g.runtimeStopped.Store(true)
-	g.runtimeCancel()
 	g.mu.Unlock()
+	g.stopOnce.Do(func() { go g.finishStop() })
+	select {
+	case <-g.stopDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
-	if err := g.drainWriters(ctx); err != nil {
-		return err
-	}
-	if err := g.advancePool.stop(ctx); err != nil {
-		return err
-	}
-	if err := g.appendPool.stop(ctx); err != nil {
-		return err
-	}
-	if err := g.postCommitPool.stop(ctx); err != nil {
-		return err
-	}
+// finishStop owns the one-way background drain. Caller deadlines only stop
+// waiting; they never cancel accepted work or discard retry ownership.
+func (g *Group) finishStop() {
+	background := context.Background()
+	_ = g.drainWriters(background)
+	_ = g.postCommitRetries.stopAndWait(background)
+	_ = g.metrics.stopPressurePublisher(background)
+	_ = g.advancePool.stop(background)
+	_ = g.appendPool.stop(background)
+	_ = g.postCommitPool.stop(background)
 
+	g.runtimeCancel()
 	g.mu.Lock()
 	g.stopped = true
 	g.mu.Unlock()
-	return nil
+	close(g.stopDone)
 }
 
 // drainWriters waits until every writer has no pending work and is not scheduled.
@@ -160,7 +186,13 @@ func (g *Group) drainWriters(ctx context.Context) error {
 }
 
 func (g *Group) writersIdle() bool {
+	if g.postCommitRetries.pending() > 0 || g.handoff.depth() > 0 {
+		return false
+	}
 	for _, s := range g.shards {
+		if s.admissionUsed.Load() > 0 {
+			return false
+		}
 		s.mu.RLock()
 		for _, w := range s.writers {
 			if w.scheduled.Load() {

--- a/internal/runtime/channelappend/group_test.go
+++ b/internal/runtime/channelappend/group_test.go
@@ -193,7 +193,7 @@ func TestSubmitLocalAdmissionCapacityIsShardLocal(t *testing.T) {
 	if firstFuture == nil {
 		t.Fatalf("first future is nil")
 	}
-	_ = appender.waitStarted(t)
+	firstStarted := appender.waitStarted(t)
 
 	if _, err := group.SubmitLocal(context.Background(), first, []SendBatchItem{testSendItem("u2", first.ChannelID.ID)}); !errors.Is(err, ErrBackpressured) {
 		t.Fatalf("same-shard SubmitLocal() error = %v, want ErrBackpressured", err)
@@ -205,6 +205,11 @@ func TestSubmitLocalAdmissionCapacityIsShardLocal(t *testing.T) {
 	if secondFuture == nil {
 		t.Fatalf("second future is nil")
 	}
+	firstStarted.Release()
+	secondStarted := appender.waitStarted(t)
+	secondStarted.Release()
+	requireAppendSuccess(t, waitFutureForTest(t, firstFuture), 0, 1, 1)
+	requireAppendSuccess(t, waitFutureForTest(t, secondFuture), 0, 2, 2)
 }
 
 func TestSubmitLocalFutureCompletesWithAppendResults(t *testing.T) {
@@ -250,7 +255,7 @@ func differentShardTargetForTest(t *testing.T, group *Group, first AuthorityTarg
 	return AuthorityTarget{}
 }
 
-func TestStopCancelsAcceptedAppendAndClosesAdmission(t *testing.T) {
+func TestStopWaitsForAcceptedAppendAndClosesAdmission(t *testing.T) {
 	appender := newBlockingAppenderForAppendTest()
 	group := New(Options{LocalNodeID: 1, AdmissionCapacityPerShard: 1, MessageID: newSequenceIDsForPrepare(1), Appender: appender})
 	if err := group.Start(context.Background()); err != nil {
@@ -261,12 +266,16 @@ func TestStopCancelsAcceptedAppendAndClosesAdmission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubmitLocal() error = %v", err)
 	}
-	_ = appender.waitStarted(t)
+	started := appender.waitStarted(t)
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := group.Stop(stopCtx); err != nil {
-		t.Fatalf("Stop() error = %v", err)
+	stopC := make(chan error, 1)
+	go func() { stopC <- group.Stop(stopCtx) }()
+	select {
+	case err := <-stopC:
+		t.Fatalf("Stop() returned before accepted append drained: %v", err)
+	case <-time.After(20 * time.Millisecond):
 	}
 	if err := group.Start(context.Background()); !errors.Is(err, ErrBackpressured) {
 		t.Fatalf("Start() error = %v, want ErrBackpressured", err)
@@ -274,14 +283,14 @@ func TestStopCancelsAcceptedAppendAndClosesAdmission(t *testing.T) {
 	if _, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{testSendItem("u2", "room")}); !errors.Is(err, ErrRouteNotReady) {
 		t.Fatalf("SubmitLocal() error = %v, want ErrRouteNotReady", err)
 	}
-
-	results := waitFutureForTest(t, future)
-	if !errors.Is(results[0].Err, context.Canceled) {
-		t.Fatalf("future error = %v, want context.Canceled", results[0].Err)
+	started.Release()
+	if err := <-stopC; err != nil {
+		t.Fatalf("Stop() error = %v", err)
 	}
+	requireAppendSuccess(t, waitFutureForTest(t, future), 0, 1, 1)
 }
 
-func TestSubmitLocalFullMailboxReturnsBackpressureAndDoesNotBlockStop(t *testing.T) {
+func TestSubmitLocalFullMailboxReturnsBackpressureAndStopDrainsAcceptedWork(t *testing.T) {
 	appender := newBlockingAppenderForAppendTest()
 	group := New(Options{LocalNodeID: 1, AdmissionCapacityPerShard: 1, MessageID: newSequenceIDsForPrepare(1), Appender: appender})
 	if err := group.Start(context.Background()); err != nil {
@@ -292,7 +301,7 @@ func TestSubmitLocalFullMailboxReturnsBackpressureAndDoesNotBlockStop(t *testing
 	if err != nil {
 		t.Fatalf("queued SubmitLocal() error = %v", err)
 	}
-	_ = appender.waitStarted(t)
+	started := appender.waitStarted(t)
 
 	fullFuture, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{testSendItem("u2", "room")})
 	if !errors.Is(err, ErrBackpressured) {
@@ -302,6 +311,8 @@ func TestSubmitLocalFullMailboxReturnsBackpressureAndDoesNotBlockStop(t *testing
 		t.Fatalf("full mailbox future = %v, want nil", fullFuture)
 	}
 
+	started.Release()
+	requireAppendSuccess(t, waitFutureForTest(t, queuedFuture), 0, 1, 1)
 	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := group.Stop(stopCtx); err != nil {
@@ -310,14 +321,9 @@ func TestSubmitLocalFullMailboxReturnsBackpressureAndDoesNotBlockStop(t *testing
 	if _, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{testSendItem("u3", "room")}); !errors.Is(err, ErrRouteNotReady) {
 		t.Fatalf("SubmitLocal() after Stop error = %v, want ErrRouteNotReady", err)
 	}
-
-	results := waitFutureForTest(t, queuedFuture)
-	if !errors.Is(results[0].Err, context.Canceled) {
-		t.Fatalf("queued future error = %v, want context.Canceled", results[0].Err)
-	}
 }
 
-func TestStopKeepsAdmissionClosedAfterCancelingAcceptedWork(t *testing.T) {
+func TestStopDeadlineKeepsAdmissionClosedAndPreservesAcceptedWork(t *testing.T) {
 	appender := newBlockingAppenderForAppendTest()
 	group := New(Options{LocalNodeID: 1, MessageID: newSequenceIDsForPrepare(1), Appender: appender})
 	if err := group.Start(context.Background()); err != nil {
@@ -328,12 +334,12 @@ func TestStopKeepsAdmissionClosedAfterCancelingAcceptedWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubmitLocal() error = %v", err)
 	}
-	_ = appender.waitStarted(t)
+	started := appender.waitStarted(t)
 
-	stopCtx, cancelStop := context.WithTimeout(context.Background(), time.Second)
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancelStop()
-	if err := group.Stop(stopCtx); err != nil {
-		t.Fatalf("Stop() error = %v", err)
+	if err := group.Stop(stopCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop() error = %v, want context deadline exceeded", err)
 	}
 	if err := group.Start(context.Background()); !errors.Is(err, ErrBackpressured) {
 		t.Fatalf("Start() error = %v, want ErrBackpressured", err)
@@ -342,9 +348,12 @@ func TestStopKeepsAdmissionClosedAfterCancelingAcceptedWork(t *testing.T) {
 		t.Fatalf("SubmitLocal() error = %v, want ErrRouteNotReady", err)
 	}
 
-	results := waitFutureForTest(t, future)
-	if !errors.Is(results[0].Err, context.Canceled) {
-		t.Fatalf("future error = %v, want context.Canceled", results[0].Err)
+	started.Release()
+	requireAppendSuccess(t, waitFutureForTest(t, future), 0, 1, 1)
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), time.Second)
+	defer cancelDrain()
+	if err := group.Stop(drainCtx); err != nil {
+		t.Fatalf("second Stop() error = %v", err)
 	}
 	if err := group.Start(context.Background()); !errors.Is(err, ErrBackpressured) {
 		t.Fatalf("Start() after drain error = %v, want ErrBackpressured", err)

--- a/internal/runtime/channelappend/metrics.go
+++ b/internal/runtime/channelappend/metrics.go
@@ -1,6 +1,10 @@
 package channelappend
 
-import "sync/atomic"
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
 
 // groupMetrics tracks aggregate channel-writer pressure without scanning shards.
 type groupMetrics struct {
@@ -11,10 +15,20 @@ type groupMetrics struct {
 	appendPool        *workerPool
 	postCommitPool    *workerPool
 	advancePool       *workerPool
+	handoff           *postCommitHandoff
+	postCommitRetries *postCommitRetryScheduler
 
 	pendingAppendItems  atomic.Int64
 	appendInflightItems atomic.Int64
 	postCommitBacklog   atomic.Int64
+
+	pressureWake      chan struct{}
+	pressureStop      chan struct{}
+	pressureDone      chan struct{}
+	pressureStarted   atomic.Bool
+	pressureStopped   atomic.Bool
+	pressureStartOnce sync.Once
+	pressureStopOnce  sync.Once
 }
 
 func (m *groupMetrics) addPendingAppendItems(delta int) {
@@ -39,26 +53,97 @@ func (m *groupMetrics) addPostCommitBacklog(delta int) {
 }
 
 func (m *groupMetrics) observePressure() {
-	if m == nil {
+	if m == nil || m.observer == nil {
 		return
 	}
-	if m.observer == nil {
+	if !m.pressureStarted.Load() {
+		// Directly constructed metrics values used by focused tests and
+		// benchmarks retain synchronous observation. Production Groups start the
+		// coalescing publisher before opening admission.
+		m.publishPressureSnapshot()
 		return
 	}
+	if m.pressureStopped.Load() {
+		return
+	}
+	select {
+	case m.pressureWake <- struct{}{}:
+	default:
+	}
+}
+
+// startPressurePublisher serializes pressure callbacks on one coalescing
+// goroutine. Hot-path transitions only perform a non-blocking wakeup, so a slow
+// observer cannot pin append or commit execution.
+func (m *groupMetrics) startPressurePublisher() {
+	if m == nil || m.observer == nil {
+		return
+	}
+	m.pressureStartOnce.Do(func() {
+		m.pressureWake = make(chan struct{}, 1)
+		m.pressureStop = make(chan struct{})
+		m.pressureDone = make(chan struct{})
+		m.pressureStarted.Store(true)
+		go m.runPressurePublisher()
+	})
+}
+
+func (m *groupMetrics) runPressurePublisher() {
+	defer close(m.pressureDone)
+	for {
+		select {
+		case <-m.pressureWake:
+			m.publishPressureSnapshot()
+		case <-m.pressureStop:
+			// Stop is called after writer and retry state has drained. This final
+			// serialized sample makes the terminal zero state observable even if
+			// an earlier wakeup was coalesced.
+			m.publishPressureSnapshot()
+			return
+		}
+	}
+}
+
+func (m *groupMetrics) stopPressurePublisher(ctx context.Context) error {
+	if m == nil || !m.pressureStarted.Load() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.pressureStopOnce.Do(func() {
+		m.pressureStopped.Store(true)
+		close(m.pressureStop)
+	})
+	select {
+	case <-m.pressureDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *groupMetrics) publishPressureSnapshot() {
 	admissionUsed := m.admissionDepth()
 	workerUsed, workerCapacity := 0, 0
 	if m.appendPool != nil {
 		workerUsed = m.appendPool.running()
 		workerCapacity = m.appendPool.capacity()
 	}
+	handoffDepth, handoffCapacity := m.handoff.snapshot()
+	retryQueueDepth, retryContended := m.postCommitRetries.snapshot()
 	m.observer.SetChannelAppendWriterPressure(WriterPressureObservation{
-		AdmissionDepth:      admissionUsed,
-		AdmissionCapacity:   int(m.admissionCapacity),
-		WorkerRunning:       workerUsed,
-		WorkerCapacity:      workerCapacity,
-		PendingAppendItems:  int(m.pendingAppendItems.Load()),
-		AppendInflightItems: int(m.appendInflightItems.Load()),
-		PostCommitBacklog:   int(m.postCommitBacklog.Load()),
+		AdmissionDepth:            admissionUsed,
+		AdmissionCapacity:         int(m.admissionCapacity),
+		WorkerRunning:             workerUsed,
+		WorkerCapacity:            workerCapacity,
+		PendingAppendItems:        int(m.pendingAppendItems.Load()),
+		AppendInflightItems:       int(m.appendInflightItems.Load()),
+		PostCommitBacklog:         int(m.postCommitBacklog.Load()),
+		PostCommitHandoffDepth:    handoffDepth,
+		PostCommitHandoffCapacity: handoffCapacity,
+		PostCommitRetryQueueDepth: retryQueueDepth,
+		PostCommitRetryContended:  retryContended,
 	})
 	antsObserver, ok := m.observer.(AntsPoolObserver)
 	if !ok || antsObserver == nil {

--- a/internal/runtime/channelappend/options.go
+++ b/internal/runtime/channelappend/options.go
@@ -9,6 +9,9 @@ import (
 )
 
 const (
+	// maxWorkerPoolSize is the largest capacity ants/v2 can represent. Its
+	// internal pool capacity is int32 even on 64-bit hosts.
+	maxWorkerPoolSize                  = int(^uint32(0) >> 1)
 	defaultAuthorityShardCount         = 1
 	defaultAdvancePoolSize             = 1
 	defaultAdmissionCapacityPerShard   = 1024
@@ -122,6 +125,14 @@ type WriterPressureObservation struct {
 	AppendInflightItems int
 	// PostCommitBacklog is the total committed post-commit backlog count.
 	PostCommitBacklog int
+	// PostCommitHandoffDepth is the number of durable messages that currently own a post-commit reservation.
+	PostCommitHandoffDepth int
+	// PostCommitHandoffCapacity is the configured durable-message reservation capacity.
+	PostCommitHandoffCapacity int
+	// PostCommitRetryQueueDepth is the number of de-duplicated channel writers waiting in the retry FIFO.
+	PostCommitRetryQueueDepth int
+	// PostCommitRetryContended reports whether an older retry writer is waiting for or owns the retry turn.
+	PostCommitRetryContended bool
 }
 
 // WriterPressureObserver receives local writer-group pressure gauges.
@@ -150,11 +161,13 @@ type EffectPoolObserver interface {
 	ObserveChannelAppendEffectPool(EffectPoolObservation)
 }
 
-// AntsPoolObservation describes one direct ants/v2 pool occupancy sample.
+// AntsPoolObservation describes one bounded worker-pool occupancy sample.
 type AntsPoolObservation struct {
 	// Pool is the stable pool name within channelappend.
 	Pool string
-	// Running is the current number of executing workers.
+	// Running is the current executing-worker count. For the non-blocking
+	// post_commit pool it is the logical admitted-task count, which excludes
+	// idle ants workers that have not been purged.
 	Running int
 	// Capacity is the configured worker capacity.
 	Capacity int
@@ -162,9 +175,9 @@ type AntsPoolObservation struct {
 	Waiting int
 }
 
-// AntsPoolObserver receives direct ants/v2 pool occupancy samples.
+// AntsPoolObserver receives bounded worker-pool occupancy samples.
 type AntsPoolObserver interface {
-	// ObserveChannelAppendAntsPool records one direct ants/v2 pool occupancy sample.
+	// ObserveChannelAppendAntsPool records one worker-pool occupancy sample.
 	ObserveChannelAppendAntsPool(AntsPoolObservation)
 }
 
@@ -388,12 +401,14 @@ type Options struct {
 	SenderFence SenderFenceValidator
 	// AuthorityShardCount is the number of channel-key lookup shards. Values <= 0 use one shard.
 	AuthorityShardCount int
-	// AdvancePoolSize is the direct ants pool size used to activate writer state machines. Values <= 0 use a conservative default.
+	// AdvancePoolSize is the direct ants pool size used to activate writer state machines. Values <= 0 use a conservative default; larger values are capped at the ants/v2 int32 capacity limit.
 	AdvancePoolSize int
 	// AdmissionCapacityPerShard bounds admitted-but-incomplete items per shard. Values <= 0 use a conservative bounded default.
 	AdmissionCapacityPerShard int
-	// ChannelBacklogHighWatermark independently bounds per-channel foreground append admission and best-effort post-commit backlog. Values <= 0 use a bounded default.
+	// ChannelBacklogHighWatermark bounds per-channel foreground append admission. Values <= 0 use a bounded default.
 	ChannelBacklogHighWatermark int
+	// PostCommitHandoffCapacity globally bounds durable messages whose required post-commit work has not reached a terminal attempt. Admission reserves one slot before append so an acknowledged durable message is never dropped between append and post-commit scheduling. Values <= 0 derive a capacity from the foreground backlog and effect-pool batch throughput.
+	PostCommitHandoffCapacity int
 	// AppendInflightBatchesPerChannel bounds same-channel append batches in flight. Values <= 0 use the runtime default.
 	AppendInflightBatchesPerChannel int
 	// InboxCoalesceWindow is the bounded delay a scheduled writer may wait to merge near-simultaneous same-channel submissions. A negative value disables coalescing; zero uses the runtime default.
@@ -402,7 +417,7 @@ type Options struct {
 	InboxCoalesceMaxItems int
 	// WriterIdleRetention keeps drained channel writers available for reuse before shard cleanup may reclaim them. Values <= 0 use a conservative default.
 	WriterIdleRetention time.Duration
-	// EffectPoolSize is the direct ants pool size used separately for blocking append calls and post-append recipient effects. Values <= 0 use a conservative default.
+	// EffectPoolSize is the direct ants pool size used separately for blocking append calls and post-append recipient effects. Values <= 0 use a conservative default; larger values are capped at the ants/v2 int32 capacity limit.
 	EffectPoolSize int
 	// Observer receives non-fatal append observations.
 	Observer AppendObserver
@@ -438,6 +453,8 @@ func applyDefaults(opts Options) Options {
 	}
 	if opts.AdvancePoolSize <= 0 {
 		opts.AdvancePoolSize = defaultAdvancePoolSize
+	} else if opts.AdvancePoolSize > maxWorkerPoolSize {
+		opts.AdvancePoolSize = maxWorkerPoolSize
 	}
 	if opts.AdmissionCapacityPerShard <= 0 {
 		opts.AdmissionCapacityPerShard = defaultAdmissionCapacityPerShard
@@ -464,6 +481,19 @@ func applyDefaults(opts Options) Options {
 	}
 	if opts.EffectPoolSize <= 0 {
 		opts.EffectPoolSize = defaultEffectPoolSize
+	} else if opts.EffectPoolSize > maxWorkerPoolSize {
+		opts.EffectPoolSize = maxWorkerPoolSize
+	}
+	if opts.PostCommitHandoffCapacity <= 0 {
+		maxInt := int(^uint(0) >> 1)
+		if opts.EffectPoolSize > maxInt/commitBatchMaxEvents {
+			opts.PostCommitHandoffCapacity = maxInt
+		} else {
+			opts.PostCommitHandoffCapacity = opts.EffectPoolSize * commitBatchMaxEvents
+		}
+		if opts.PostCommitHandoffCapacity < opts.ChannelBacklogHighWatermark {
+			opts.PostCommitHandoffCapacity = opts.ChannelBacklogHighWatermark
+		}
 	}
 	if opts.SubscriberScanPageSize <= 0 {
 		opts.SubscriberScanPageSize = defaultSubscriberScanPageSize
@@ -517,8 +547,7 @@ func commitPortsFromOptions(opts Options) commitPorts {
 
 func stateLimitsFromOptions(opts Options) channelStateLimits {
 	return channelStateLimits{
-		pendingItemHighWatermark:       opts.ChannelBacklogHighWatermark,
-		postCommitBacklogHighWatermark: opts.ChannelBacklogHighWatermark,
-		appendInflightLimit:            opts.AppendInflightBatchesPerChannel,
+		pendingItemHighWatermark: opts.ChannelBacklogHighWatermark,
+		appendInflightLimit:      opts.AppendInflightBatchesPerChannel,
 	}
 }

--- a/internal/runtime/channelappend/options_test.go
+++ b/internal/runtime/channelappend/options_test.go
@@ -13,6 +13,18 @@ func TestDefaultAppendInflightBatchesPerChannelIsTen(t *testing.T) {
 	}
 }
 
+func TestDefaultPostCommitHandoffCapacityUsesLargerSafetyBound(t *testing.T) {
+	fromPool := applyDefaults(Options{EffectPoolSize: 2000, ChannelBacklogHighWatermark: 1024})
+	if fromPool.PostCommitHandoffCapacity != 2000*commitBatchMaxEvents {
+		t.Fatalf("pool-derived PostCommitHandoffCapacity = %d, want %d", fromPool.PostCommitHandoffCapacity, 2000*commitBatchMaxEvents)
+	}
+
+	fromBacklog := applyDefaults(Options{EffectPoolSize: 1, ChannelBacklogHighWatermark: 4096})
+	if fromBacklog.PostCommitHandoffCapacity != 4096 {
+		t.Fatalf("backlog-derived PostCommitHandoffCapacity = %d, want 4096", fromBacklog.PostCommitHandoffCapacity)
+	}
+}
+
 func TestDefaultInboxCoalesceOptionsAreConservative(t *testing.T) {
 	opts := applyDefaults(Options{})
 

--- a/internal/runtime/channelappend/pool.go
+++ b/internal/runtime/channelappend/pool.go
@@ -2,13 +2,20 @@ package channelappend
 
 import (
 	"context"
+	"runtime"
+	"sync/atomic"
 
 	"github.com/panjf2000/ants/v2"
 )
 
 // workerPool runs channel append work off the caller stack.
 type workerPool struct {
-	pool *ants.Pool
+	pool        *ants.Pool
+	nonblocking bool
+	// logicalInflight reserves non-blocking task capacity until the task body
+	// has returned. It excludes idle ants workers, whose Running count is not a
+	// usable admission signal when worker purging is disabled.
+	logicalInflight atomic.Int64
 }
 
 func newWorkerPool(size int) *workerPool {
@@ -24,21 +31,85 @@ func newNonblockingWorkerPool(size int) *workerPool {
 func newWorkerPoolWithAdmission(size int, nonblocking bool) *workerPool {
 	if size <= 0 {
 		size = 1
+	} else if size > maxWorkerPoolSize {
+		size = maxWorkerPoolSize
 	}
 	pool, err := ants.NewPool(size, ants.WithNonblocking(nonblocking), ants.WithDisablePurge(true))
 	if err != nil {
 		panic("channelappend: create worker pool: " + err.Error())
 	}
-	return &workerPool{pool: pool}
+	return &workerPool{pool: pool, nonblocking: nonblocking}
 }
 
 // submit runs fn on a pooled goroutine. It blocks briefly if all workers are busy.
 func (p *workerPool) submit(fn func()) error {
-	return p.pool.Submit(fn)
+	return p.submitWithCompletion(fn, nil)
 }
 
-// running reports the number of currently executing pool workers.
+// submitWithCompletion runs onDone after logical non-blocking capacity is
+// released. A just-completed ants worker may not yet have returned to its idle
+// queue, so the capacity owner retries that tiny handoff window instead of
+// reporting a false overload to the durable retry scheduler.
+func (p *workerPool) submitWithCompletion(fn func(), onDone func()) error {
+	if !p.nonblocking {
+		if onDone == nil {
+			return p.pool.Submit(fn)
+		}
+		return p.pool.Submit(func() {
+			defer onDone()
+			fn()
+		})
+	}
+	if !p.tryAcquireLogicalCapacity() {
+		return ants.ErrPoolOverload
+	}
+	wrapped := func() {
+		defer func() {
+			remaining := p.logicalInflight.Add(-1)
+			if remaining < 0 {
+				panic("channelappend: worker pool logical inflight underflow")
+			}
+			if onDone != nil {
+				onDone()
+			}
+		}()
+		fn()
+	}
+	for {
+		err := p.pool.Submit(wrapped)
+		if err == nil {
+			return nil
+		}
+		if err == ants.ErrPoolOverload {
+			// logical capacity proves a prior task has returned; ants only needs
+			// to finish putting that worker back on its idle queue.
+			runtime.Gosched()
+			continue
+		}
+		p.logicalInflight.Add(-1)
+		return err
+	}
+}
+
+func (p *workerPool) tryAcquireLogicalCapacity() bool {
+	capacity := int64(p.pool.Cap())
+	for {
+		inflight := p.logicalInflight.Load()
+		if inflight >= capacity {
+			return false
+		}
+		if p.logicalInflight.CompareAndSwap(inflight, inflight+1) {
+			return true
+		}
+	}
+}
+
+// running reports logical admitted tasks for a non-blocking pool and currently
+// executing ants workers for a blocking pool.
 func (p *workerPool) running() int {
+	if p.nonblocking {
+		return int(p.logicalInflight.Load())
+	}
 	return p.pool.Running()
 }
 

--- a/internal/runtime/channelappend/post_commit_handoff.go
+++ b/internal/runtime/channelappend/post_commit_handoff.go
@@ -1,0 +1,304 @@
+package channelappend
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const postCommitRetryInterval = time.Millisecond
+
+type postCommitRetryTurnResult uint8
+
+const (
+	postCommitRetryTurnProgress postCommitRetryTurnResult = iota
+	postCommitRetryTurnOverloaded
+)
+
+// postCommitHandoff bounds the number of durable messages that own unfinished
+// post-commit work. A reservation is acquired before append and released only
+// after append fails or one terminal post-commit attempt completes.
+type postCommitHandoff struct {
+	capacity int64
+	used     atomic.Int64
+}
+
+func newPostCommitHandoff(capacity int) *postCommitHandoff {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &postCommitHandoff{capacity: int64(capacity)}
+}
+
+func (h *postCommitHandoff) tryAcquire() bool {
+	if h == nil {
+		return true
+	}
+	for {
+		used := h.used.Load()
+		if used >= h.capacity {
+			return false
+		}
+		if h.used.CompareAndSwap(used, used+1) {
+			return true
+		}
+	}
+}
+
+func (h *postCommitHandoff) release(count int) {
+	if h == nil || count <= 0 {
+		return
+	}
+	remaining := h.used.Add(-int64(count))
+	if remaining < 0 {
+		panic("channelappend: post-commit handoff reservation underflow")
+	}
+}
+
+func (h *postCommitHandoff) depth() int {
+	depth, _ := h.snapshot()
+	return depth
+}
+
+// snapshot returns the current reservation depth and immutable capacity
+// without taking a scheduler or writer lock.
+func (h *postCommitHandoff) snapshot() (depth int, capacity int) {
+	if h == nil {
+		return 0, 0
+	}
+	return int(h.used.Load()), int(h.capacity)
+}
+
+// postCommitRetryScheduler owns a de-duplicated FIFO of channel writers whose
+// committed work could not enter the non-blocking post-commit worker pool.
+// One wakeup starts a fair refill burst that stops at the next real overload.
+type postCommitRetryScheduler struct {
+	// admissionMu linearizes a non-blocking pool probe with establishing the
+	// FIFO gate after rejection, closing the only newer-writer overtake window.
+	admissionMu sync.Mutex
+	mu          sync.Mutex
+	queue       []*channelWriter
+	head        int
+
+	wake      chan struct{}
+	capacity  chan struct{}
+	retryDone chan postCommitRetryTurnResult
+	stop      chan struct{}
+	done      chan struct{}
+	contended atomic.Bool
+	// queueDepth projects the number of waiting FIFO writers without exposing
+	// the scheduler mutex to hot-path pressure observation.
+	queueDepth atomic.Int64
+	// retryInterval bounds how long a real overload waits when no capacity
+	// completion signal arrives. Tests may widen it to make burst refills
+	// deterministic without changing the production default.
+	retryInterval time.Duration
+	// capacityAvailable reports logical post-commit task capacity. The Group
+	// installs it before Start so an early worker-completion hint cannot consume
+	// the FIFO turn while the bounded pool is still full.
+	capacityAvailable func() bool
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+func (s *postCommitRetryScheduler) lockAdmission() {
+	if s != nil {
+		s.admissionMu.Lock()
+	}
+}
+
+func (s *postCommitRetryScheduler) unlockAdmission() {
+	if s != nil {
+		s.admissionMu.Unlock()
+	}
+}
+
+func newPostCommitRetryScheduler() *postCommitRetryScheduler {
+	return &postCommitRetryScheduler{
+		wake:          make(chan struct{}, 1),
+		capacity:      make(chan struct{}, 1),
+		retryDone:     make(chan postCommitRetryTurnResult, 1),
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+		retryInterval: postCommitRetryInterval,
+	}
+}
+
+func (s *postCommitRetryScheduler) start() {
+	if s == nil {
+		return
+	}
+	s.startOnce.Do(func() { go s.run() })
+}
+
+func (s *postCommitRetryScheduler) enqueue(writer *channelWriter) {
+	if s == nil || writer == nil {
+		return
+	}
+	s.mu.Lock()
+	wasEmpty := s.head >= len(s.queue)
+	s.queue = append(s.queue, writer)
+	s.contended.Store(true)
+	s.queueDepth.Add(1)
+	s.mu.Unlock()
+	if wasEmpty {
+		select {
+		case s.wake <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// isContended reports whether an older writer owns or awaits the fair retry
+// turn. New durable commits join the FIFO instead of bypassing that writer.
+func (s *postCommitRetryScheduler) isContended() bool {
+	return s != nil && s.contended.Load()
+}
+
+// snapshot returns waiting FIFO writers and contention ownership using only
+// atomics. The selected active retry turn is excluded from queueDepth.
+func (s *postCommitRetryScheduler) snapshot() (queueDepth int, contended bool) {
+	if s == nil {
+		return 0, false
+	}
+	return int(s.queueDepth.Load()), s.contended.Load()
+}
+
+// finishRetryTurn hands the single active retry turn back to the scheduler and
+// reports whether that turn reached the real worker-pool overload boundary.
+func (s *postCommitRetryScheduler) finishRetryTurn(result postCommitRetryTurnResult) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.head >= len(s.queue) {
+		s.contended.Store(false)
+	}
+	s.mu.Unlock()
+	select {
+	case s.retryDone <- result:
+	default:
+	}
+}
+
+func (s *postCommitRetryScheduler) notifyCapacity() {
+	if s == nil {
+		return
+	}
+	select {
+	case s.capacity <- struct{}{}:
+	default:
+	}
+}
+
+func (s *postCommitRetryScheduler) pending() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.queue) - s.head
+}
+
+func (s *postCommitRetryScheduler) canRetryNow() bool {
+	return s == nil || s.capacityAvailable == nil || s.capacityAvailable()
+}
+
+func (s *postCommitRetryScheduler) run() {
+	defer close(s.done)
+	var timer *time.Timer
+	waitForCapacity := true
+	for {
+		if s.pending() == 0 {
+			select {
+			case <-s.wake:
+				waitForCapacity = true
+				continue
+			case <-s.stop:
+				return
+			}
+		}
+		if !s.canRetryNow() {
+			waitForCapacity = true
+		}
+		for waitForCapacity && !s.canRetryNow() {
+			if timer == nil {
+				timer = time.NewTimer(s.retryInterval)
+			} else {
+				timer.Reset(s.retryInterval)
+			}
+			select {
+			case <-s.capacity:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+			case <-timer.C:
+			case <-s.stop:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return
+			}
+		}
+		writer := s.pop()
+		if writer != nil {
+			writer.retryPostCommit()
+			select {
+			case result := <-s.retryDone:
+				waitForCapacity = result == postCommitRetryTurnOverloaded
+			case <-s.stop:
+				return
+			}
+		}
+	}
+}
+
+func (s *postCommitRetryScheduler) pop() *channelWriter {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.head >= len(s.queue) {
+		return nil
+	}
+	writer := s.queue[s.head]
+	s.queue[s.head] = nil
+	s.head++
+	if remaining := s.queueDepth.Add(-1); remaining < 0 {
+		panic("channelappend: post-commit retry queue depth underflow")
+	}
+	if s.head == len(s.queue) {
+		s.queue = s.queue[:0]
+		s.head = 0
+	} else if s.head >= 1024 && s.head*2 >= len(s.queue) {
+		oldLen := len(s.queue)
+		remaining := oldLen - s.head
+		copy(s.queue, s.queue[s.head:])
+		clear(s.queue[remaining:oldLen])
+		s.queue = s.queue[:remaining]
+		s.head = 0
+	}
+	return writer
+}
+
+func (s *postCommitRetryScheduler) stopAndWait(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.stopOnce.Do(func() { close(s.stop) })
+	select {
+	case <-s.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/runtime/channelappend/post_commit_handoff_test.go
+++ b/internal/runtime/channelappend/post_commit_handoff_test.go
@@ -1,0 +1,43 @@
+package channelappend
+
+import "testing"
+
+func TestPostCommitRetrySchedulerCompactionClearsBackingTail(t *testing.T) {
+	const writerCount = 2048
+
+	scheduler := newPostCommitRetryScheduler()
+	writers := make([]channelWriter, writerCount)
+	for i := range writers {
+		scheduler.enqueue(&writers[i])
+	}
+
+	for i := 0; i < writerCount/2; i++ {
+		if got := scheduler.pop(); got != &writers[i] {
+			t.Fatalf("pop %d = %p, want %p", i, got, &writers[i])
+		}
+	}
+	assertPostCommitRetryBackingTailCleared(t, scheduler)
+
+	for i := writerCount / 2; i < writerCount; i++ {
+		if got := scheduler.pop(); got != &writers[i] {
+			t.Fatalf("pop %d = %p, want %p", i, got, &writers[i])
+		}
+	}
+	assertPostCommitRetryBackingTailCleared(t, scheduler)
+	if depth, _ := scheduler.snapshot(); depth != 0 {
+		t.Fatalf("retry queue depth = %d, want 0", depth)
+	}
+}
+
+func assertPostCommitRetryBackingTailCleared(t *testing.T, scheduler *postCommitRetryScheduler) {
+	t.Helper()
+
+	scheduler.mu.Lock()
+	defer scheduler.mu.Unlock()
+	backing := scheduler.queue[:cap(scheduler.queue)]
+	for i := len(scheduler.queue); i < len(backing); i++ {
+		if backing[i] != nil {
+			t.Fatalf("retry queue backing[%d] = %p beyond visible len %d, want nil", i, backing[i], len(scheduler.queue))
+		}
+	}
+}

--- a/internal/runtime/channelappend/prepare.go
+++ b/internal/runtime/channelappend/prepare.go
@@ -28,6 +28,10 @@ type preparedSend struct {
 	// ServerTimestampMS is the server timestamp assigned exactly once during prepare.
 	ServerTimestampMS int64
 	future            *Future
+	// postCommitReserved reports that this item owns one global handoff slot.
+	// It is transferred to committed state on append success and released on
+	// append failure or terminal post-commit completion.
+	postCommitReserved bool
 }
 
 type preparePorts struct {

--- a/internal/runtime/channelappend/pressure_test.go
+++ b/internal/runtime/channelappend/pressure_test.go
@@ -2,18 +2,32 @@ package channelappend
 
 import (
 	"context"
+	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 type capturePressureObserver struct {
-	mu        sync.Mutex
-	seen      bool
-	last      WriterPressureObservation
-	antsSeen  map[string]AntsPoolObservation
-	antsReady chan struct{}
-	ready     chan struct{}
+	mu                          sync.Mutex
+	seen                        bool
+	last                        WriterPressureObservation
+	maxPostCommitHandoffDepth   int
+	maxPostCommitRetryQueue     int
+	sawPostCommitRetryContended bool
+	antsSeen                    map[string]AntsPoolObservation
+	antsReady                   chan struct{}
+	ready                       chan struct{}
+}
+
+type blockingPressureObserverForTest struct {
+	mu           sync.Mutex
+	first        bool
+	firstStarted chan struct{}
+	releaseFirst chan struct{}
+	releaseOnce  sync.Once
+	events       []WriterPressureObservation
 }
 
 func newCapturePressureObserver() *capturePressureObserver {
@@ -24,16 +38,62 @@ func newCapturePressureObserver() *capturePressureObserver {
 	}
 }
 
+func newBlockingPressureObserverForTest() *blockingPressureObserverForTest {
+	return &blockingPressureObserverForTest{
+		firstStarted: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+}
+
+func (o *blockingPressureObserverForTest) SetChannelAppendWriterPressure(event WriterPressureObservation) {
+	o.mu.Lock()
+	first := !o.first
+	if first {
+		o.first = true
+	}
+	o.mu.Unlock()
+	if first {
+		close(o.firstStarted)
+		<-o.releaseFirst
+	}
+	o.mu.Lock()
+	o.events = append(o.events, event)
+	o.mu.Unlock()
+}
+
+func (o *blockingPressureObserverForTest) snapshot() []WriterPressureObservation {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]WriterPressureObservation(nil), o.events...)
+}
+
+func (o *blockingPressureObserverForTest) release() {
+	o.releaseOnce.Do(func() { close(o.releaseFirst) })
+}
+
 func (c *capturePressureObserver) AppendFinished(string, error, time.Duration) {}
 
 func (c *capturePressureObserver) SetChannelAppendWriterPressure(event WriterPressureObservation) {
 	c.mu.Lock()
 	c.last = event
+	if event.PostCommitHandoffDepth > c.maxPostCommitHandoffDepth {
+		c.maxPostCommitHandoffDepth = event.PostCommitHandoffDepth
+	}
+	if event.PostCommitRetryQueueDepth > c.maxPostCommitRetryQueue {
+		c.maxPostCommitRetryQueue = event.PostCommitRetryQueueDepth
+	}
+	c.sawPostCommitRetryContended = c.sawPostCommitRetryContended || event.PostCommitRetryContended
 	if !c.seen && (event.PendingAppendItems > 0 || event.AppendInflightItems > 0) {
 		c.seen = true
 		close(c.ready)
 	}
 	c.mu.Unlock()
+}
+
+func (c *capturePressureObserver) postCommitSnapshot() (WriterPressureObservation, int, int, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last, c.maxPostCommitHandoffDepth, c.maxPostCommitRetryQueue, c.sawPostCommitRetryContended
 }
 
 func (c *capturePressureObserver) ObserveChannelAppendAntsPool(event AntsPoolObservation) {
@@ -63,7 +123,28 @@ func TestGroupEmitsAggregatePressure(t *testing.T) {
 	if err := group.Start(context.Background()); err != nil {
 		t.Fatalf("Start error = %v", err)
 	}
+	var futures []*Future
 	t.Cleanup(func() {
+		releaseDone := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case started := <-appender.startedC:
+					started.Release()
+				case <-releaseDone:
+					return
+				}
+			}
+		}()
+		defer close(releaseDone)
+		for _, future := range futures {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			_, err := future.Wait(ctx)
+			cancel()
+			if err != nil {
+				t.Fatalf("Future.Wait() during cleanup error = %v", err)
+			}
+		}
 		for {
 			select {
 			case started := <-appender.startedC:
@@ -81,9 +162,11 @@ func TestGroupEmitsAggregatePressure(t *testing.T) {
 
 	target := benchmarkAuthorityTarget("p1")
 	for i := 0; i < 5; i++ {
-		if _, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{benchmarkSendItem("p1")}); err != nil {
+		future, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{benchmarkSendItem("p1")})
+		if err != nil {
 			t.Fatalf("SubmitLocal error = %v", err)
 		}
+		futures = append(futures, future)
 	}
 
 	select {
@@ -109,6 +192,65 @@ func TestGroupEmitsAggregatePressure(t *testing.T) {
 	observer.mu.Unlock()
 	if advance.Capacity == 0 || appendEffect.Capacity != 5 || postCommit.Capacity != 5 {
 		t.Fatalf("ants pool observations = advance %#v append_effect %#v post_commit %#v, want advance, append_effect, and post_commit pools", advance, appendEffect, postCommit)
+	}
+}
+
+func TestWriterPressurePublicationCannotOverwriteDrainWithOlderSnapshot(t *testing.T) {
+	observer := newBlockingPressureObserverForTest()
+	handoff := newPostCommitHandoff(1)
+	if !handoff.tryAcquire() {
+		t.Fatal("tryAcquire() = false, want initial handoff reservation")
+	}
+	metrics := &groupMetrics{
+		observer:          observer,
+		handoff:           handoff,
+		postCommitRetries: newPostCommitRetryScheduler(),
+	}
+	metrics.startPressurePublisher()
+	t.Cleanup(func() {
+		observer.release()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := metrics.stopPressurePublisher(ctx); err != nil {
+			t.Errorf("stopPressurePublisher() error = %v", err)
+		}
+	})
+
+	metrics.observePressure()
+	select {
+	case <-observer.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first pressure publication did not start")
+	}
+
+	handoff.release(1)
+	updatesDone := make(chan struct{})
+	go func() {
+		for range 10_000 {
+			metrics.observePressure()
+		}
+		close(updatesDone)
+	}()
+	select {
+	case <-updatesDone:
+	case <-time.After(time.Second):
+		t.Fatal("pressure updates blocked behind a slow observer")
+	}
+	observer.release()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		events := observer.snapshot()
+		if len(events) >= 2 {
+			last := events[len(events)-1]
+			if last.PostCommitHandoffDepth == 0 && last.PostCommitRetryQueueDepth == 0 && !last.PostCommitRetryContended {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pressure publications = %#v, want old snapshot followed by drained zero state", events)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -150,7 +292,8 @@ func TestPostCommitEffectDoesNotBlockDurableAppendPool(t *testing.T) {
 	waitCommitBacklogForTest(t, group, postCommitTarget.ChannelID, 0)
 }
 
-func TestPostCommitSaturationDoesNotBlockForegroundAppend(t *testing.T) {
+func TestPostCommitSaturationRetainsDurableEffectsWithoutBlockingForegroundAppend(t *testing.T) {
+	observer := newCapturePressureObserver()
 	delivery := newBlockingRecipientDeliveryEnqueuerForCommitTest()
 	group := newStartedTestGroup(t, Options{
 		LocalNodeID:                1,
@@ -158,9 +301,11 @@ func TestPostCommitSaturationDoesNotBlockForegroundAppend(t *testing.T) {
 		Appender:                   newRecordingAppenderForAppendTest(),
 		AdvancePoolSize:            1,
 		EffectPoolSize:             1,
+		PostCommitHandoffCapacity:  8,
 		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
 		RecipientDeliveryEnqueuer:  delivery,
 		RecipientBatchSize:         16,
+		Observer:                   observer,
 	})
 	t.Cleanup(delivery.release)
 
@@ -183,13 +328,12 @@ func TestPostCommitSaturationDoesNotBlockForegroundAppend(t *testing.T) {
 	}
 	requireAppendSuccess(t, waitFutureForTest(t, second), 0, 11, 2)
 
-	deadline := time.Now().Add(time.Second)
-	for group.postCommitPool.waiting() == 0 && commitBacklogForTest(group, secondTarget.ChannelID) > 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("second post-commit effect neither waited nor completed")
-		}
-		time.Sleep(time.Millisecond)
+	if backlog := commitBacklogForTest(group, secondTarget.ChannelID); backlog != 1 {
+		t.Fatalf("second post-commit backlog = %d, want retained durable effect while pool is saturated", backlog)
 	}
+	waitPostCommitPressureForTest(t, observer, func(_ WriterPressureObservation, maxHandoff int, maxRetryQueue int, sawContended bool) bool {
+		return maxHandoff >= 2 && maxRetryQueue >= 1 && sawContended
+	}, "handoff depth >= 2, retry queue >= 1, and contended retry ownership")
 
 	foregroundTarget := localTargetForAppendTest("foreground")
 	foregroundItem := appendSendItemForTest("u1", foregroundTarget.ChannelID.ID, "foreground")
@@ -199,8 +343,262 @@ func TestPostCommitSaturationDoesNotBlockForegroundAppend(t *testing.T) {
 		t.Fatalf("SubmitLocal(foreground) error = %v", foregroundResult.err)
 	}
 	requireAppendSuccess(t, waitFutureForTest(t, foregroundResult.future), 0, 12, 3)
+	delivery.release()
+	delivery.waitCalls(t, 3)
 	waitCommitBacklogForTest(t, group, secondTarget.ChannelID, 0)
 	waitCommitBacklogForTest(t, group, foregroundTarget.ChannelID, 0)
+	if got := delivery.messageIDs(); !reflect.DeepEqual(got, []uint64{10, 11, 12}) {
+		t.Fatalf("recipient delivery message ids = %#v, want durable messages in FIFO order exactly once", got)
+	}
+	waitPostCommitPressureForTest(t, observer, func(last WriterPressureObservation, _ int, _ int, _ bool) bool {
+		return last.PostCommitHandoffDepth == 0 &&
+			last.PostCommitHandoffCapacity == 8 &&
+			last.PostCommitRetryQueueDepth == 0 &&
+			!last.PostCommitRetryContended
+	}, "handoff and retry pressure returned to zero")
+}
+
+func waitPostCommitPressureForTest(
+	t *testing.T,
+	observer *capturePressureObserver,
+	ready func(WriterPressureObservation, int, int, bool) bool,
+	want string,
+) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		last, maxHandoff, maxRetryQueue, sawContended := observer.postCommitSnapshot()
+		if ready(last, maxHandoff, maxRetryQueue, sawContended) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("post-commit pressure did not reach %s: last=%#v max_handoff=%d max_retry_queue=%d saw_contended=%t", want, last, maxHandoff, maxRetryQueue, sawContended)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestPostCommitRetryBurstRefillsFreedWorkersBeforeFallbackTimer(t *testing.T) {
+	const (
+		poolSize       = 4
+		queuedWriters  = 8
+		firstMessageID = 2000
+	)
+	delivery := newBurstRefillRecipientEnqueuerForPressureTest(firstMessageID + poolSize)
+	group := New(Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(firstMessageID),
+		Appender:                   newRecordingAppenderForAppendTest(),
+		EffectPoolSize:             poolSize,
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  delivery,
+		RecipientBatchSize:         16,
+	})
+	group.postCommitRetries.retryInterval = 500 * time.Millisecond
+	if err := group.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		delivery.releaseAll()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := group.Stop(ctx); err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	submit := func(channel string) {
+		t.Helper()
+		item := appendSendItemForTest("u1", channel, "payload")
+		item.Command.MessageScopedUIDs = []string{"u2"}
+		future, err := group.SubmitLocal(context.Background(), localTargetForAppendTest(channel), []SendBatchItem{item})
+		if err != nil {
+			t.Fatalf("SubmitLocal(%q) error = %v", channel, err)
+		}
+		requireResultReason(t, waitFutureForTest(t, future), 0, ReasonSuccess)
+	}
+	for i := 0; i < poolSize; i++ {
+		submit("burst-occupier-" + string(rune('a'+i)))
+	}
+	delivery.waitInitialStarted(t, poolSize)
+	for i := 0; i < queuedWriters; i++ {
+		submit("burst-waiter-" + string(rune('a'+i)))
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for group.postCommitRetries.pending() != queuedWriters {
+		if time.Now().After(deadline) {
+			t.Fatalf("retry FIFO pending = %d, want %d sparse writers", group.postCommitRetries.pending(), queuedWriters)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	delivery.releaseInitial()
+
+	deadline = time.Now().Add(100 * time.Millisecond)
+	for delivery.retryStartedCount() < poolSize {
+		if time.Now().After(deadline) {
+			t.Fatalf("retry burst started = %d, want %d freed workers refilled before fallback timer", delivery.retryStartedCount(), poolSize)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	delivery.releaseRetries()
+	waitHandoffDepthForTest(t, group, 0)
+}
+
+func TestPostCommitRetryTurnParksNewAppendAndRefillsNextWriterWhileAppendPoolSaturated(t *testing.T) {
+	delivery := newBlockingRecipientDeliveryEnqueuerForCommitTest()
+	appender := newPostCommitIsolationAppenderForPressureTest("append-blocker")
+	group := New(Options{
+		LocalNodeID:                1,
+		MessageID:                  newSequenceIDsForPrepare(3000),
+		Appender:                   appender,
+		AdvancePoolSize:            4,
+		EffectPoolSize:             1,
+		PostCommitHandoffCapacity:  16,
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForCommitTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  delivery,
+		RecipientBatchSize:         16,
+	})
+	// Keep the retry FIFO stable until the real capacity completion below wakes it.
+	group.postCommitRetries.retryInterval = 10 * time.Second
+	if err := group.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := group.Stop(ctx); err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	submitDurable := func(target AuthorityTarget, payload string) *Future {
+		t.Helper()
+		item := appendSendItemForTest("u1", target.ChannelID.ID, payload)
+		item.Command.MessageScopedUIDs = []string{"u2"}
+		future, err := group.SubmitLocal(context.Background(), target, []SendBatchItem{item})
+		if err != nil {
+			t.Fatalf("SubmitLocal(%q) error = %v", target.ChannelID.ID, err)
+		}
+		return future
+	}
+
+	occupierTarget := localTargetForAppendTest("retry-occupier")
+	requireResultReason(t, waitFutureForTest(t, submitDurable(occupierTarget, "occupier")), 0, ReasonSuccess)
+	delivery.waitStarted(t)
+
+	firstRetryTarget := localTargetForAppendTest("retry-first")
+	requireResultReason(t, waitFutureForTest(t, submitDurable(firstRetryTarget, "first-old")), 0, ReasonSuccess)
+	waitPostCommitRetryPendingForPressureTest(t, group, 1)
+	secondRetryTarget := localTargetForAppendTest("retry-second")
+	requireResultReason(t, waitFutureForTest(t, submitDurable(secondRetryTarget, "second-old")), 0, ReasonSuccess)
+	waitPostCommitRetryPendingForPressureTest(t, group, 2)
+
+	blockerTarget := localTargetForAppendTest("append-blocker")
+	blockerFuture := submitDurable(blockerTarget, "blocker")
+	blockedAppend := appender.waitBlockedAppendStarted(t)
+	var releaseAppendOnce sync.Once
+	t.Cleanup(func() {
+		releaseAppendOnce.Do(blockedAppend.Release)
+		delivery.release()
+	})
+
+	newFirstFuture := submitDurable(firstRetryTarget, "first-new")
+	waitQueuedWriterAppendParkedOrBlockedForPressureTest(t, group, firstRetryTarget)
+	if got := delivery.callCount(); got != 1 {
+		t.Fatalf("delivery calls before freeing post-commit worker = %d, want only occupier", got)
+	}
+
+	delivery.release()
+	deadline := time.Now().Add(time.Second)
+	for group.postCommitPool.running() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("post-commit pool running = %d, want 0 after occupier release", group.postCommitPool.running())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// The first selected writer must admit its old commit before its new append,
+	// then hand the FIFO turn to the second writer while appendPool is still full.
+	delivery.waitCalls(t, 3)
+	if got := delivery.messageIDs(); !reflect.DeepEqual(got, []uint64{3000, 3001, 3002}) {
+		t.Fatalf("delivery message ids before append release = %#v, want occupier and both retry commits in FIFO order", got)
+	}
+	if got := group.appendPool.running(); got != 1 {
+		t.Fatalf("append pool running = %d, want blocker still occupying the only worker", got)
+	}
+
+	releaseAppendOnce.Do(blockedAppend.Release)
+	requireResultReason(t, waitFutureForTest(t, blockerFuture), 0, ReasonSuccess)
+	requireResultReason(t, waitFutureForTest(t, newFirstFuture), 0, ReasonSuccess)
+	waitHandoffDepthForTest(t, group, 0)
+}
+
+func waitPostCommitRetryPendingForPressureTest(t *testing.T, group *Group, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for group.postCommitRetries.pending() != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("retry FIFO pending = %d, want %d", group.postCommitRetries.pending(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func waitQueuedWriterAppendParkedOrBlockedForPressureTest(t *testing.T, group *Group, target AuthorityTarget) {
+	t.Helper()
+	writer := group.writerForTest(target.ChannelID)
+	if writer == nil {
+		t.Fatalf("writer for %q is nil", target.ChannelID.ID)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		writer.mu.Lock()
+		queued := writer.commitRetryQueued
+		hasAppend := len(writer.inbox) > 0 || len(writer.state.pendingItems) > 0 || writer.state.appendInflight > 0
+		writer.mu.Unlock()
+		parked := !writer.scheduled.Load()
+		blocked := group.appendPool.waiting() > 0
+		if queued && hasAppend && (parked || blocked) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("queued writer did not park or block append: queued=%t has_append=%t scheduled=%t append_waiting=%d", queued, hasAppend, writer.scheduled.Load(), group.appendPool.waiting())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestApplyDefaultsClampsWorkerPoolsToAntsCapacity(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+
+	opts := applyDefaults(Options{
+		AdvancePoolSize:             maxInt,
+		EffectPoolSize:              maxInt,
+		ChannelBacklogHighWatermark: 1024,
+	})
+
+	if opts.AdvancePoolSize != maxWorkerPoolSize || opts.EffectPoolSize != maxWorkerPoolSize {
+		t.Fatalf("worker pool sizes = advance %d effect %d, want ants capacity %d", opts.AdvancePoolSize, opts.EffectPoolSize, maxWorkerPoolSize)
+	}
+	wantHandoff := maxInt
+	if maxWorkerPoolSize <= maxInt/commitBatchMaxEvents {
+		wantHandoff = maxWorkerPoolSize * commitBatchMaxEvents
+	}
+	if opts.PostCommitHandoffCapacity != wantHandoff {
+		t.Fatalf("pool-derived PostCommitHandoffCapacity = %d, want %d", opts.PostCommitHandoffCapacity, wantHandoff)
+	}
+
+	pool := newNonblockingWorkerPool(maxInt)
+	if got := pool.capacity(); got != maxWorkerPoolSize {
+		t.Fatalf("worker pool capacity = %d, want %d", got, maxWorkerPoolSize)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := pool.stop(ctx); err != nil {
+		t.Fatalf("worker pool stop error = %v", err)
+	}
 }
 
 func TestGroupDisablesWriterPressureMetricsWithoutObserver(t *testing.T) {
@@ -223,6 +621,68 @@ type postCommitIsolationAppenderForPressureTest struct {
 	blockedChannel string
 	blocked        *blockingAppenderForAppendTest
 	recording      *recordingAppenderForAppendTest
+}
+
+type burstRefillRecipientEnqueuerForPressureTest struct {
+	firstRetryMessageID uint64
+	initialStarted      atomic.Int64
+	retryStarted        atomic.Int64
+	initialRelease      chan struct{}
+	retryRelease        chan struct{}
+	initialOnce         sync.Once
+	retryOnce           sync.Once
+}
+
+func newBurstRefillRecipientEnqueuerForPressureTest(firstRetryMessageID uint64) *burstRefillRecipientEnqueuerForPressureTest {
+	return &burstRefillRecipientEnqueuerForPressureTest{
+		firstRetryMessageID: firstRetryMessageID,
+		initialRelease:      make(chan struct{}),
+		retryRelease:        make(chan struct{}),
+	}
+}
+
+func (e *burstRefillRecipientEnqueuerForPressureTest) EnqueueRecipientBatch(ctx context.Context, _ RecipientAuthorityTarget, batch RecipientBatch) error {
+	release := e.retryRelease
+	if batch.Event.MessageID < e.firstRetryMessageID {
+		e.initialStarted.Add(1)
+		release = e.initialRelease
+	} else {
+		e.retryStarted.Add(1)
+	}
+	select {
+	case <-release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (e *burstRefillRecipientEnqueuerForPressureTest) waitInitialStarted(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for int(e.initialStarted.Load()) < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("initial post-commit effects started = %d, want %d", e.initialStarted.Load(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func (e *burstRefillRecipientEnqueuerForPressureTest) retryStartedCount() int {
+	return int(e.retryStarted.Load())
+}
+
+func (e *burstRefillRecipientEnqueuerForPressureTest) releaseInitial() {
+	e.initialOnce.Do(func() { close(e.initialRelease) })
+}
+
+func (e *burstRefillRecipientEnqueuerForPressureTest) releaseRetries() {
+	e.retryOnce.Do(func() { close(e.retryRelease) })
+}
+
+func (e *burstRefillRecipientEnqueuerForPressureTest) releaseAll() {
+	e.releaseInitial()
+	e.releaseRetries()
 }
 
 func newPostCommitIsolationAppenderForPressureTest(blockedChannel string) *postCommitIsolationAppenderForPressureTest {

--- a/internal/runtime/channelappend/state.go
+++ b/internal/runtime/channelappend/state.go
@@ -9,14 +9,13 @@ const (
 type channelState struct {
 	target AuthorityTarget
 
-	pendingItemHighWatermark       int
-	postCommitBacklogHighWatermark int
-	appendInflightLimit            int
-	pendingItems                   []preparedSend
-	appendInflight                 int
-	appendInflightItems            int
-	nextAppendSeq                  uint64
-	nextAppendDrainSeq             uint64
+	pendingItemHighWatermark int
+	appendInflightLimit      int
+	pendingItems             []preparedSend
+	appendInflight           int
+	appendInflightItems      int
+	nextAppendSeq            uint64
+	nextAppendDrainSeq       uint64
 	// readyAppendCompletion stores the next in-order append completion without allocating the out-of-order map.
 	readyAppendCompletion appendCompletedEvent
 	// hasReadyAppendCompletion reports whether readyAppendCompletion is populated.
@@ -34,9 +33,8 @@ type channelState struct {
 }
 
 type channelStateLimits struct {
-	pendingItemHighWatermark       int
-	postCommitBacklogHighWatermark int
-	appendInflightLimit            int
+	pendingItemHighWatermark int
+	appendInflightLimit      int
 }
 
 // subscriberCache is a versioned non-large channel subscriber snapshot.
@@ -51,10 +49,9 @@ type subscriberCache struct {
 
 func newChannelState(target AuthorityTarget, limits channelStateLimits) *channelState {
 	return &channelState{
-		target:                         target,
-		pendingItemHighWatermark:       limits.pendingItemHighWatermark,
-		postCommitBacklogHighWatermark: limits.postCommitBacklogHighWatermark,
-		appendInflightLimit:            limits.appendInflightLimit,
+		target:                   target,
+		pendingItemHighWatermark: limits.pendingItemHighWatermark,
+		appendInflightLimit:      limits.appendInflightLimit,
 	}
 }
 
@@ -200,15 +197,10 @@ func (s *channelState) popNextAppendCompletion() (appendCompletedEvent, bool) {
 	return event, true
 }
 
-// enqueueCommitted admits best-effort post-commit work through a bound that is
-// independent from foreground append admission. A saturated side-effect lane
-// drops the newest envelope instead of rejecting a durable SEND.
-func (s *channelState) enqueueCommitted(event CommittedEnvelope) bool {
-	if s.postCommitBacklogHighWatermark > 0 && s.commitBacklog() >= s.postCommitBacklogHighWatermark {
-		return false
-	}
+// enqueueCommitted transfers an already-reserved durable envelope into the
+// per-channel FIFO. Global handoff admission bounds this queue before append.
+func (s *channelState) enqueueCommitted(event CommittedEnvelope) {
 	s.committed = append(s.committed, event)
-	return true
 }
 
 func (s *channelState) nextCommitEffect(key string, out *commitEffect) bool {
@@ -272,10 +264,6 @@ func (s *channelState) cancelCommitDispatch() {
 	}
 }
 
-func (s *channelState) dropCurrentCommit() {
-	s.dropCommitted(1)
-}
-
 func (s *channelState) dropCommitted(count int) {
 	if count <= 0 {
 		s.commitAttempts = 0
@@ -295,25 +283,6 @@ func (s *channelState) dropCommitted(count int) {
 	s.commitCursor = end
 	s.commitAttempts = 0
 	s.pruneCommittedPrefixIfNeeded()
-}
-
-func (s *channelState) dropCommitBacklog() int {
-	backlog := s.commitBacklog()
-	if backlog == 0 {
-		s.commitInflight = false
-		s.commitInflightEvents = 0
-		s.commitAttempts = 0
-		return 0
-	}
-	for i := s.commitCursor; i < len(s.committed); i++ {
-		s.committed[i] = CommittedEnvelope{}
-	}
-	s.committed = nil
-	s.commitCursor = 0
-	s.commitInflight = false
-	s.commitInflightEvents = 0
-	s.commitAttempts = 0
-	return backlog
 }
 
 func (s *channelState) commitBacklog() int {

--- a/internal/runtime/channelappend/state_test.go
+++ b/internal/runtime/channelappend/state_test.go
@@ -12,9 +12,8 @@ func TestNewChannelStateCapturesAuthorityIdentityAndLimits(t *testing.T) {
 	}
 
 	state := newChannelState(target, channelStateLimits{
-		pendingItemHighWatermark:       8,
-		postCommitBacklogHighWatermark: 8,
-		appendInflightLimit:            2,
+		pendingItemHighWatermark: 8,
+		appendInflightLimit:      2,
 	})
 
 	if state.target != target {
@@ -22,9 +21,6 @@ func TestNewChannelStateCapturesAuthorityIdentityAndLimits(t *testing.T) {
 	}
 	if state.pendingItemHighWatermark != 8 {
 		t.Fatalf("pendingItemHighWatermark = %d, want 8", state.pendingItemHighWatermark)
-	}
-	if state.postCommitBacklogHighWatermark != 8 {
-		t.Fatalf("postCommitBacklogHighWatermark = %d, want 8", state.postCommitBacklogHighWatermark)
 	}
 	if state.appendInflightLimit != 2 {
 		t.Fatalf("appendInflightLimit = %d, want 2", state.appendInflightLimit)
@@ -91,28 +87,6 @@ func TestChannelStateNextAppendBatchDoesNotAllocatePendingCopy(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("nextAppendBatch allocations = %.1f, want 0", allocs)
-	}
-}
-
-func TestChannelStateDropCurrentCommitAdvancesCursorWithoutMovingBacklog(t *testing.T) {
-	state := newChannelState(AuthorityTarget{ChannelID: ChannelID{ID: "room", Type: 2}}, channelStateLimits{})
-	state.enqueueCommitted(CommittedEnvelope{MessageID: 1})
-	state.enqueueCommitted(CommittedEnvelope{MessageID: 2})
-	state.enqueueCommitted(CommittedEnvelope{MessageID: 3})
-
-	state.dropCurrentCommit()
-
-	if state.commitCursor != 1 {
-		t.Fatalf("commitCursor = %d, want 1 without compacting every committed item", state.commitCursor)
-	}
-	if len(state.committed) != 3 {
-		t.Fatalf("committed len = %d, want original backing queue retained after one drop", len(state.committed))
-	}
-	if state.committed[0].MessageID != 0 || state.committed[1].MessageID != 2 || state.committed[2].MessageID != 3 {
-		t.Fatalf("committed queue = %#v, want first slot cleared and remaining slots unmoved", state.committed)
-	}
-	if backlog := state.commitBacklog(); backlog != 2 {
-		t.Fatalf("commitBacklog() = %d, want 2", backlog)
 	}
 }
 

--- a/internal/runtime/channelappend/writer.go
+++ b/internal/runtime/channelappend/writer.go
@@ -25,6 +25,12 @@ type channelWriter struct {
 	state *channelState
 	// inbox holds submitted batches not yet drained into the channelState pending queue.
 	inbox []submittedBatch
+	// commitRetryQueued is guarded by mu and de-duplicates this writer in the
+	// global post-commit retry FIFO.
+	commitRetryQueued bool
+	// commitRetryTurn lets the FIFO-selected writer attempt pool admission while
+	// all newer durable commits remain queued behind the contended gate.
+	commitRetryTurn bool
 }
 
 // submittedBatch is one admitted SubmitLocal call awaiting prepare+append.
@@ -52,9 +58,10 @@ type writerPorts struct {
 	commit         commitPorts
 	appendPool     *workerPool
 	postCommitPool *workerPool
+	handoff        *postCommitHandoff
+	commitRetries  *postCommitRetryScheduler
 	schedule       func(*channelWriter)
 	runtimeCtx     context.Context
-	stopped        *atomic.Bool
 	metrics        *groupMetrics
 
 	inboxCoalesceWindow   time.Duration
@@ -104,7 +111,14 @@ func (w *channelWriter) deactivateLocked() bool {
 }
 
 func (w *channelWriter) hasRunnableWorkLocked() bool {
-	return len(w.inbox) > 0 || w.state.hasRunnableWork(w.ports.commit.hasPostCommitWork())
+	if w.commitRetryQueued {
+		// A queued durable commit owns the channel's next retry turn. New append
+		// work may be prepared, but it parks until that turn is selected instead
+		// of pinning a blocking appendPool submit ahead of the old commit.
+		return false
+	}
+	includeCommit := w.ports.commit.hasPostCommitWork() && !w.commitRetryQueued
+	return len(w.inbox) > 0 || w.state.hasRunnableWork(includeCommit)
 }
 
 func (w *channelWriter) inboxItemCountLocked() int {
@@ -207,13 +221,26 @@ func (w *channelWriter) advance() {
 			w.mu.Unlock()
 			prepared := w.prepareInbox(inbox)
 			w.mu.Lock()
-			realtime := w.admitPreparedInboxLocked(prepared)
+			realtime, handoffRejected := w.admitPreparedInboxLocked(prepared)
 			w.mu.Unlock()
+			w.observeHandoffRejection(handoffRejected)
 			w.runRealtimeDispatches(realtime)
 			w.mu.Lock()
 		}
-		hasAppend := w.nextAppendLocked(&appendEff)
-		hasCommit := w.nextCommitLocked(&commitEff)
+		retryTurn := w.commitRetryTurn
+		hasAppend := false
+		hasCommit := false
+		if retryTurn {
+			// The FIFO-selected writer admits only its old durable commit in this
+			// pass. A later ordinary pass resumes append-first processing.
+			hasCommit = w.nextCommitLocked(&commitEff)
+			if !hasCommit {
+				hasAppend = w.nextAppendLocked(&appendEff)
+			}
+		} else if !w.commitRetryQueued {
+			hasAppend = w.nextAppendLocked(&appendEff)
+			hasCommit = w.nextCommitLocked(&commitEff)
+		}
 		if !hasAppend && !hasCommit {
 			more := w.deactivateLocked()
 			w.mu.Unlock()
@@ -243,8 +270,9 @@ func (w *channelWriter) advanceAppendOnly() {
 			w.mu.Unlock()
 			prepared := w.prepareInbox(inbox)
 			w.mu.Lock()
-			realtime := w.admitPreparedInboxLocked(prepared)
+			realtime, handoffRejected := w.admitPreparedInboxLocked(prepared)
 			w.mu.Unlock()
+			w.observeHandoffRejection(handoffRejected)
 			w.runRealtimeDispatches(realtime)
 			w.mu.Lock()
 		}
@@ -289,17 +317,21 @@ func (w *channelWriter) prepareInbox(inbox []submittedBatch) []preparedInboxBatc
 }
 
 // admitPreparedInboxLocked moves prepared work into channelState while w.mu is held.
-func (w *channelWriter) admitPreparedInboxLocked(prepared []preparedInboxBatch) []realtimeDispatch {
+func (w *channelWriter) admitPreparedInboxLocked(prepared []preparedInboxBatch) ([]realtimeDispatch, int) {
 	var realtime []realtimeDispatch
+	handoffRejected := 0
 	for _, item := range prepared {
-		realtime = append(realtime, w.admitPreparedLocked(item.batch, item.outcome)...)
+		dispatches, rejected := w.admitPreparedLocked(item.batch, item.outcome)
+		realtime = append(realtime, dispatches...)
+		handoffRejected += rejected
 	}
-	return realtime
+	return realtime, handoffRejected
 }
 
 // admitPreparedLocked applies prepare results: completes terminal items on the
 // future immediately and enqueues append-bound items, honoring canAdmit backpressure.
-func (w *channelWriter) admitPreparedLocked(batch submittedBatch, outcome prepareOutcome) []realtimeDispatch {
+func (w *channelWriter) admitPreparedLocked(batch submittedBatch, outcome prepareOutcome) ([]realtimeDispatch, int) {
+	handoffRejected := 0
 	for _, item := range outcome.canonicalResults {
 		if !preparedCommandMatchesTarget(batch.target, item.command) {
 			outcome.results[item.index] = SendBatchItemResult{Err: ErrStaleRoute}
@@ -330,8 +362,21 @@ func (w *channelWriter) admitPreparedLocked(batch submittedBatch, outcome prepar
 	if len(matching) > 0 {
 		w.state.refreshTargetMetadata(batch.target)
 		if w.state.canAdmit(len(matching)) {
-			w.state.enqueuePrepared(matching)
-			w.ports.metrics.addPendingAppendItems(len(matching))
+			admitted := matching[:0]
+			for _, item := range matching {
+				if w.ports.commit.hasPostCommitWork() {
+					if !w.ports.handoff.tryAcquire() {
+						delete(pendingIndex, item.Index)
+						outcome.results[item.Index] = SendBatchItemResult{Err: ErrChannelBusy}
+						handoffRejected++
+						continue
+					}
+					item.postCommitReserved = true
+				}
+				admitted = append(admitted, item)
+			}
+			w.state.enqueuePrepared(admitted)
+			w.ports.metrics.addPendingAppendItems(len(admitted))
 			w.ports.metrics.observePressure()
 		} else {
 			for _, item := range matching {
@@ -345,9 +390,20 @@ func (w *channelWriter) admitPreparedLocked(batch submittedBatch, outcome prepar
 		return !pending
 	})
 	if len(realtimeItems) == 0 {
-		return nil
+		return nil, handoffRejected
 	}
-	return []realtimeDispatch{{target: batch.target, items: realtimeItems}}
+	return []realtimeDispatch{{target: batch.target, items: realtimeItems}}, handoffRejected
+}
+
+func (w *channelWriter) observeHandoffRejection(items int) {
+	if items <= 0 {
+		return
+	}
+	observeEffect(w.ports.append.observer, EffectObservation{
+		Stage:  effectStagePostCommit,
+		Result: channelAppendResultBackpressured,
+		Items:  items,
+	})
 }
 
 func (w *channelWriter) nextAppendLocked(out *appendEffect) bool {
@@ -367,11 +423,22 @@ func (w *channelWriter) nextAppendLocked(out *appendEffect) bool {
 
 func (w *channelWriter) runAppend(effect *appendEffect) {
 	snapshot := *effect
-	_ = w.ports.appendPool.submit(func() {
-		completion := snapshot.run(w.ports.runtimeCtx, w.ports.append)
+	err := w.ports.appendPool.submit(func() {
+		completion := func() (completion appendCompletedEvent) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					completion = appendPanicCompletion(snapshot, recovered)
+				}
+			}()
+			return snapshot.run(w.ports.runtimeCtx, w.ports.append)
+		}()
 		w.applyAppendCompletion(completion)
 		w.rescheduleIfNeeded()
 	})
+	if err != nil {
+		w.applyAppendCompletion(appendScheduleErrorCompletion(snapshot, err))
+		w.rescheduleIfNeeded()
+	}
 }
 
 func (w *channelWriter) runRealtimeDispatches(dispatches []realtimeDispatch) {
@@ -385,21 +452,45 @@ func (w *channelWriter) runRealtimeDispatch(dispatch realtimeDispatch) {
 		return
 	}
 	effect := realtimeEffect{target: dispatch.target, items: dispatch.items}
-	if err := w.ports.postCommitPool.submit(func() {
-		for _, completion := range effect.run(w.ports.runtimeCtx, w.ports.commit) {
+	w.ports.commitRetries.lockAdmission()
+	if w.ports.commitRetries.isContended() {
+		w.ports.commitRetries.unlockAdmission()
+		w.completeRealtimeScheduleError(dispatch.items, ErrBackpressured)
+		return
+	}
+	err := w.ports.postCommitPool.submitWithCompletion(func() {
+		completions := func() (completions []realtimeItemCompletion) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					err := effectPanicError(effectStageRealtime, recovered)
+					completions = make([]realtimeItemCompletion, 0, len(effect.items))
+					for _, item := range effect.items {
+						completions = append(completions, realtimeItemCompletion{item: item, result: SendBatchItemResult{Err: err}})
+					}
+				}
+			}()
+			return effect.run(w.ports.runtimeCtx, w.ports.commit)
+		}()
+		for _, completion := range completions {
 			completion.item.future.completeItem(completion.item.Index, completion.result)
 		}
-	}); err != nil {
-		result := SendBatchItemResult{Err: effectScheduleError(effectStageRealtime, err)}
-		for _, item := range dispatch.items {
-			item.future.completeItem(item.Index, result)
-		}
+	}, w.ports.commitRetries.notifyCapacity)
+	w.ports.commitRetries.unlockAdmission()
+	if err != nil {
+		w.completeRealtimeScheduleError(dispatch.items, err)
+	}
+}
+
+func (w *channelWriter) completeRealtimeScheduleError(items []preparedSend, err error) {
+	result := SendBatchItemResult{Err: effectScheduleError(effectStageRealtime, err)}
+	for _, item := range items {
+		item.future.completeItem(item.Index, result)
 	}
 }
 
 func (w *channelWriter) applyAppendCompletion(event appendCompletedEvent) {
 	var dispatch []appendCompletionDispatchItem
-	var postCommitFailures []PostCommitFailureObservation
+	releaseReservations := 0
 	w.mu.Lock()
 	w.state.recordAppendCompletion(event)
 	for {
@@ -410,31 +501,26 @@ func (w *channelWriter) applyAppendCompletion(event appendCompletedEvent) {
 		w.state.finishAppend(len(next.items))
 		w.ports.metrics.addAppendInflightItems(-len(next.items))
 		for _, completion := range next.items {
+			handedOff := false
 			if w.ports.commit.hasPostCommitWork() &&
 				completion.committed &&
 				completion.traceErr == nil &&
 				completion.result.Err == nil &&
 				completion.result.Result.Reason == ReasonSuccess {
 				envelope := committedEnvelopeForAppend(completion.item, completion.appended)
-				if w.state.enqueueCommitted(envelope) {
-					w.ports.metrics.addPostCommitBacklog(1)
-				} else {
-					postCommitFailures = append(postCommitFailures, postCommitAdmissionFailure(envelope))
-				}
+				w.state.enqueueCommitted(envelope)
+				w.ports.metrics.addPostCommitBacklog(1)
+				handedOff = true
+			}
+			if completion.item.postCommitReserved && !handedOff {
+				releaseReservations++
 			}
 			dispatch = append(dispatch, appendCompletionDispatchItem{completion: completion, duration: next.duration})
 		}
 	}
-	w.ports.metrics.observePressure()
 	w.mu.Unlock()
-	for _, failure := range postCommitFailures {
-		observeEffect(w.ports.append.observer, EffectObservation{
-			Stage:  effectStagePostCommit,
-			Result: failure.Result,
-			Items:  1,
-		})
-		observePostCommitFailure(w.ports.append.observer, failure)
-	}
+	w.ports.handoff.release(releaseReservations)
+	w.ports.metrics.observePressure()
 	for _, item := range dispatch {
 		w.dispatchAppendItemCompletion(item.completion, item.duration)
 	}
@@ -452,10 +538,7 @@ func (w *channelWriter) dispatchAppendItemCompletion(completion appendItemComple
 }
 
 func (w *channelWriter) nextCommitLocked(out *commitEffect) bool {
-	if w.runtimeStopped() {
-		dropped := w.state.dropCommitBacklog()
-		w.ports.metrics.addPostCommitBacklog(-dropped)
-		w.ports.metrics.observePressure()
+	if w.commitRetryQueued {
 		return false
 	}
 	return w.state.nextCommitEffect(w.key, out)
@@ -463,32 +546,116 @@ func (w *channelWriter) nextCommitLocked(out *commitEffect) bool {
 
 func (w *channelWriter) runCommit(effect *commitEffect) {
 	snapshot := *effect
-	if err := w.ports.postCommitPool.submit(func() {
-		completion := snapshot.run(w.ports.runtimeCtx, w.ports.commit)
+	w.ports.commitRetries.lockAdmission()
+	w.mu.Lock()
+	retryTurn := w.commitRetryTurn
+	contended := w.ports.commitRetries.isContended()
+	w.mu.Unlock()
+	if contended && !retryTurn {
+		w.deferPostCommitRetry()
+		w.ports.commitRetries.unlockAdmission()
+		return
+	}
+	err := w.ports.postCommitPool.submitWithCompletion(func() {
+		completion := func() (completion commitCompletedEvent) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					completion = commitPanicCompletion(snapshot, recovered)
+				}
+			}()
+			return snapshot.run(w.ports.runtimeCtx, w.ports.commit)
+		}()
 		w.applyCommitCompletion(completion)
 		w.rescheduleIfNeeded()
-	}); err != nil {
-		w.applyCommitCompletion(commitScheduleErrorCompletion(snapshot, err))
-		w.rescheduleIfNeeded()
+	}, w.ports.commitRetries.notifyCapacity)
+	if err != nil {
+		w.deferPostCommitRetry()
+	} else if retryTurn {
+		w.mu.Lock()
+		w.commitRetryTurn = false
+		w.mu.Unlock()
+		w.ports.commitRetries.finishRetryTurn(postCommitRetryTurnProgress)
+		w.ports.metrics.observePressure()
 	}
+	w.ports.commitRetries.unlockAdmission()
+}
+
+// deferPostCommitRetry restores the current commit to queued state and adds
+// this writer to the de-duplicated global FIFO after transient pool overload.
+func (w *channelWriter) deferPostCommitRetry() {
+	defer w.ports.metrics.observePressure()
+	w.mu.Lock()
+	w.state.cancelCommitDispatch()
+	retryTurn := w.commitRetryTurn
+	w.commitRetryTurn = false
+	enqueue := !w.commitRetryQueued
+	w.commitRetryQueued = true
+	w.mu.Unlock()
+	if !enqueue {
+		if retryTurn {
+			w.ports.commitRetries.finishRetryTurn(postCommitRetryTurnOverloaded)
+		}
+		return
+	}
+	if w.ports.commitRetries != nil {
+		w.ports.commitRetries.enqueue(w)
+		if retryTurn {
+			w.ports.commitRetries.finishRetryTurn(postCommitRetryTurnOverloaded)
+		}
+		return
+	}
+	time.AfterFunc(postCommitRetryInterval, w.retryPostCommit)
+}
+
+// retryPostCommit returns FIFO ownership to the writer state machine. If the
+// writer is already active, its current advance loop observes the cleared flag.
+func (w *channelWriter) retryPostCommit() {
+	defer w.ports.metrics.observePressure()
+	w.mu.Lock()
+	if !w.commitRetryQueued {
+		w.mu.Unlock()
+		return
+	}
+	w.commitRetryQueued = false
+	hasRetryCommit := !w.state.commitInflight && w.state.commitBacklog() > 0
+	w.commitRetryTurn = hasRetryCommit
+	more := w.hasRunnableWorkLocked()
+	if !hasRetryCommit {
+		w.commitRetryTurn = false
+	}
+	w.mu.Unlock()
+	if !hasRetryCommit {
+		w.ports.commitRetries.finishRetryTurn(postCommitRetryTurnProgress)
+	}
+	if !more {
+		return
+	}
+	if !w.tryActivate() {
+		return
+	}
+	if w.ports.schedule != nil {
+		w.ports.schedule(w)
+		return
+	}
+	go w.advance()
 }
 
 func (w *channelWriter) applyCommitCompletion(event commitCompletedEvent) {
 	failures := append([]commitCompletedItem(nil), event.failures...)
+	releaseReservations := 0
 	w.mu.Lock()
 	backlogBefore := w.state.commitBacklog()
 	if len(event.items) > 0 {
 		w.state.recordSubscriberCache(event.subscriberCache)
 		w.state.finishCommit(len(event.items))
+		releaseReservations = len(event.items)
 	} else {
 		w.state.finishCommitFailure()
 	}
-	if w.runtimeStopped() {
-		w.state.dropCommitBacklog()
-	}
 	w.ports.metrics.addPostCommitBacklog(w.state.commitBacklog() - backlogBefore)
-	w.ports.metrics.observePressure()
 	w.mu.Unlock()
+	w.ports.handoff.release(releaseReservations)
+	w.ports.metrics.observePressure()
 	for _, item := range event.items {
 		if item.err != nil {
 			failures = append(failures, item)
@@ -497,10 +664,6 @@ func (w *channelWriter) applyCommitCompletion(event commitCompletedEvent) {
 	for _, item := range failures {
 		observePostCommitFailure(w.ports.append.observer, postCommitFailureFromItem(event, item))
 	}
-}
-
-func (w *channelWriter) runtimeStopped() bool {
-	return w != nil && w.ports.stopped != nil && w.ports.stopped.Load()
 }
 
 // rescheduleIfNeeded re-activates the writer only when completion handling made

--- a/pkg/metrics/channelappend.go
+++ b/pkg/metrics/channelappend.go
@@ -10,23 +10,27 @@ var channelAppendItemBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 
 
 // ChannelAppendMetrics exposes internal channel authority writer metrics.
 type ChannelAppendMetrics struct {
-	routerTotal         *prometheus.CounterVec
-	routerDuration      *prometheus.HistogramVec
-	routerItems         *prometheus.HistogramVec
-	localAdmissionTotal *prometheus.CounterVec
-	localAdmissionItems *prometheus.HistogramVec
-	writerAdmission     *prometheus.GaugeVec
-	writerAdmissionCap  *prometheus.GaugeVec
-	writerPoolRunning   *prometheus.GaugeVec
-	writerPoolCap       *prometheus.GaugeVec
-	writerStateItems    *prometheus.GaugeVec
-	effectPoolSubmit    *prometheus.CounterVec
-	effectPoolInflight  *prometheus.GaugeVec
-	effectPoolCap       *prometheus.GaugeVec
-	effectPoolSaturated *prometheus.GaugeVec
-	effectTotal         *prometheus.CounterVec
-	effectDuration      *prometheus.HistogramVec
-	effectItems         *prometheus.HistogramVec
+	routerTotal              *prometheus.CounterVec
+	routerDuration           *prometheus.HistogramVec
+	routerItems              *prometheus.HistogramVec
+	localAdmissionTotal      *prometheus.CounterVec
+	localAdmissionItems      *prometheus.HistogramVec
+	writerAdmission          *prometheus.GaugeVec
+	writerAdmissionCap       *prometheus.GaugeVec
+	writerPoolRunning        *prometheus.GaugeVec
+	writerPoolCap            *prometheus.GaugeVec
+	writerStateItems         *prometheus.GaugeVec
+	postCommitHandoff        *prometheus.GaugeVec
+	postCommitHandoffCap     *prometheus.GaugeVec
+	postCommitRetryQueue     *prometheus.GaugeVec
+	postCommitRetryContended *prometheus.GaugeVec
+	effectPoolSubmit         *prometheus.CounterVec
+	effectPoolInflight       *prometheus.GaugeVec
+	effectPoolCap            *prometheus.GaugeVec
+	effectPoolSaturated      *prometheus.GaugeVec
+	effectTotal              *prometheus.CounterVec
+	effectDuration           *prometheus.HistogramVec
+	effectItems              *prometheus.HistogramVec
 }
 
 func newChannelAppendMetrics(registry prometheus.Registerer, labels prometheus.Labels) *ChannelAppendMetrics {
@@ -84,6 +88,26 @@ func newChannelAppendMetrics(registry prometheus.Registerer, labels prometheus.L
 			Help:        "Current channel append state item counts by kind.",
 			ConstLabels: labels,
 		}, []string{"kind"}),
+		postCommitHandoff: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "wukongim_channelappend_post_commit_handoff_depth",
+			Help:        "Current durable messages owning a channel append post-commit reservation.",
+			ConstLabels: labels,
+		}, nil),
+		postCommitHandoffCap: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "wukongim_channelappend_post_commit_handoff_capacity",
+			Help:        "Configured durable-message reservation capacity for channel append post-commit work.",
+			ConstLabels: labels,
+		}, nil),
+		postCommitRetryQueue: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "wukongim_channelappend_post_commit_retry_queue_depth",
+			Help:        "Current de-duplicated channel writers waiting in the post-commit retry FIFO.",
+			ConstLabels: labels,
+		}, nil),
+		postCommitRetryContended: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "wukongim_channelappend_post_commit_retry_contended",
+			Help:        "Whether an older post-commit retry writer is waiting for or owns the retry turn.",
+			ConstLabels: labels,
+		}, nil),
 		effectPoolSubmit: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name:        "wukongim_channelappend_effect_pool_submit_total",
 			Help:        "Total internal channel append effect pool submit attempts by stage and result.",
@@ -126,6 +150,10 @@ func newChannelAppendMetrics(registry prometheus.Registerer, labels prometheus.L
 	for _, kind := range []string{"pending_append", "append_inflight", "post_commit_backlog"} {
 		m.writerStateItems.WithLabelValues(kind).Set(0)
 	}
+	m.postCommitHandoff.WithLabelValues().Set(0)
+	m.postCommitHandoffCap.WithLabelValues().Set(0)
+	m.postCommitRetryQueue.WithLabelValues().Set(0)
+	m.postCommitRetryContended.WithLabelValues().Set(0)
 	// Materialize the append/ok histogram without recording a synthetic observation.
 	_ = m.effectItems.WithLabelValues("append", "ok")
 
@@ -140,6 +168,10 @@ func newChannelAppendMetrics(registry prometheus.Registerer, labels prometheus.L
 		m.writerPoolRunning,
 		m.writerPoolCap,
 		m.writerStateItems,
+		m.postCommitHandoff,
+		m.postCommitHandoffCap,
+		m.postCommitRetryQueue,
+		m.postCommitRetryContended,
 		m.effectPoolSubmit,
 		m.effectPoolInflight,
 		m.effectPoolCap,
@@ -178,7 +210,7 @@ func (m *ChannelAppendMetrics) ObserveLocalAdmission(result string, items int) {
 }
 
 // SetWriterPressure sets current local writer-group pressure gauges.
-func (m *ChannelAppendMetrics) SetWriterPressure(admissionDepth int, admissionCapacity int, workerRunning int, workerCapacity int, pendingAppendItems int, appendInflightItems int, postCommitBacklog int) {
+func (m *ChannelAppendMetrics) SetWriterPressure(admissionDepth int, admissionCapacity int, workerRunning int, workerCapacity int, pendingAppendItems int, appendInflightItems int, postCommitBacklog int, postCommitHandoffDepth int, postCommitHandoffCapacity int, postCommitRetryQueueDepth int, postCommitRetryContended bool) {
 	if m == nil {
 		return
 	}
@@ -189,6 +221,14 @@ func (m *ChannelAppendMetrics) SetWriterPressure(admissionDepth int, admissionCa
 	m.writerStateItems.WithLabelValues("pending_append").Set(float64(pendingAppendItems))
 	m.writerStateItems.WithLabelValues("append_inflight").Set(float64(appendInflightItems))
 	m.writerStateItems.WithLabelValues("post_commit_backlog").Set(float64(postCommitBacklog))
+	m.postCommitHandoff.WithLabelValues().Set(float64(postCommitHandoffDepth))
+	m.postCommitHandoffCap.WithLabelValues().Set(float64(postCommitHandoffCapacity))
+	m.postCommitRetryQueue.WithLabelValues().Set(float64(postCommitRetryQueueDepth))
+	if postCommitRetryContended {
+		m.postCommitRetryContended.WithLabelValues().Set(1)
+		return
+	}
+	m.postCommitRetryContended.WithLabelValues().Set(0)
 }
 
 // ObserveEffectPool records effect pool admission and pressure.

--- a/pkg/metrics/registry_test.go
+++ b/pkg/metrics/registry_test.go
@@ -1659,6 +1659,18 @@ func TestRegistryExposesIdleChannelAppendWriterState(t *testing.T) {
 			"kind":      kind,
 		}).GetGauge().GetValue())
 	}
+	for _, name := range []string{
+		"wukongim_channelappend_post_commit_handoff_depth",
+		"wukongim_channelappend_post_commit_handoff_capacity",
+		"wukongim_channelappend_post_commit_retry_queue_depth",
+		"wukongim_channelappend_post_commit_retry_contended",
+	} {
+		family := requireMetricFamily(t, families, name)
+		require.Equal(t, float64(0), findMetricByLabels(t, family, map[string]string{
+			"node_id":   "12",
+			"node_name": "node-12",
+		}).GetGauge().GetValue())
+	}
 	effectItems := requireMetricFamily(t, families, "wukongim_channelappend_effect_items")
 	require.Equal(t, float64(0), findMetricByLabels(t, effectItems, map[string]string{
 		"node_id":   "12",
@@ -1674,7 +1686,7 @@ func TestRegistryExposesChannelAppendMetrics(t *testing.T) {
 	reg.ChannelAppend.ObserveRouter("remote", "backpressured", 4, 5*time.Millisecond)
 	reg.ChannelAppend.ObserveLocalAdmission("accepted", 8)
 	reg.ChannelAppend.ObserveLocalAdmission("backpressured", 4)
-	reg.ChannelAppend.SetWriterPressure(3, 1024, 9, 1024, 7, 2, 5)
+	reg.ChannelAppend.SetWriterPressure(3, 1024, 9, 1024, 7, 2, 5, 11, 64, 3, true)
 	reg.ChannelAppend.ObserveEffectPool("append", "submitted", 8, 16, false)
 	reg.ChannelAppend.ObserveEffectPool("append", "full", 16, 16, true)
 	reg.ChannelAppend.ObserveEffect("append", "ok", 8, 4*time.Millisecond)
@@ -1703,6 +1715,27 @@ func TestRegistryExposesChannelAppendMetrics(t *testing.T) {
 		"node_id":   "12",
 		"node_name": "node-12",
 		"kind":      "post_commit_backlog",
+	}).GetGauge().GetValue())
+
+	handoffDepth := requireMetricFamily(t, families, "wukongim_channelappend_post_commit_handoff_depth")
+	require.Equal(t, float64(11), findMetricByLabels(t, handoffDepth, map[string]string{
+		"node_id":   "12",
+		"node_name": "node-12",
+	}).GetGauge().GetValue())
+	handoffCapacity := requireMetricFamily(t, families, "wukongim_channelappend_post_commit_handoff_capacity")
+	require.Equal(t, float64(64), findMetricByLabels(t, handoffCapacity, map[string]string{
+		"node_id":   "12",
+		"node_name": "node-12",
+	}).GetGauge().GetValue())
+	retryQueue := requireMetricFamily(t, families, "wukongim_channelappend_post_commit_retry_queue_depth")
+	require.Equal(t, float64(3), findMetricByLabels(t, retryQueue, map[string]string{
+		"node_id":   "12",
+		"node_name": "node-12",
+	}).GetGauge().GetValue())
+	retryContended := requireMetricFamily(t, families, "wukongim_channelappend_post_commit_retry_contended")
+	require.Equal(t, float64(1), findMetricByLabels(t, retryContended, map[string]string{
+		"node_id":   "12",
+		"node_name": "node-12",
 	}).GetGauge().GetValue())
 
 	effect := requireMetricFamily(t, families, "wukongim_channelappend_effect_total")
@@ -1742,7 +1775,7 @@ func TestRegistryExposesChannelAppendMetrics(t *testing.T) {
 		"stage":     "append",
 	}).GetGauge().GetValue())
 
-	for _, family := range []*dto.MetricFamily{router, admission, state, effect, poolSubmit, poolInflight, poolCapacity, poolSaturated} {
+	for _, family := range []*dto.MetricFamily{router, admission, state, handoffDepth, handoffCapacity, retryQueue, retryContended, effect, poolSubmit, poolInflight, poolCapacity, poolSaturated} {
 		for _, metric := range family.GetMetric() {
 			requireNoMetricLabel(t, metric, "uid")
 			requireNoMetricLabel(t, metric, "channel_id")

--- a/pkg/raftlog/memory_test.go
+++ b/pkg/raftlog/memory_test.go
@@ -19,6 +19,16 @@ func mustMarshalConfChange(t *testing.T, cc raftpb.ConfChange) []byte {
 	return data
 }
 
+func mustMarshalConfChangeV2(t *testing.T, cc raftpb.ConfChangeV2) []byte {
+	t.Helper()
+
+	data, err := cc.Marshal()
+	if err != nil {
+		t.Fatalf("ConfChangeV2.Marshal() error = %v", err)
+	}
+	return data
+}
+
 func TestMemoryInitialStateIsEmpty(t *testing.T) {
 	store := NewMemory()
 

--- a/pkg/raftlog/meta_test.go
+++ b/pkg/raftlog/meta_test.go
@@ -88,3 +88,73 @@ func TestReplaceEntriesFromIndexClonesIncomingPayloads(t *testing.T) {
 		t.Fatalf("incoming payload was not cloned: %q", got[1].Data)
 	}
 }
+
+func TestReplaceEntriesFromIndexClearsDroppedTailPayloads(t *testing.T) {
+	existing := make([]raftpb.Entry, 4, 8)
+	for i, payload := range []string{"one", "two", "three", "four"} {
+		existing[i] = raftpb.Entry{
+			Index: uint64(i + 1),
+			Term:  1,
+			Data:  []byte(payload),
+		}
+	}
+	incoming := []raftpb.Entry{{
+		Index: 2,
+		Term:  2,
+		Data:  []byte("replacement"),
+	}}
+
+	got := replaceEntriesFromIndex(existing, 2, incoming)
+	if len(got) != 2 {
+		t.Fatalf("len(replaced) = %d, want 2", len(got))
+	}
+	if string(got[1].Data) != "replacement" {
+		t.Fatalf("replacement payload = %q, want replacement", got[1].Data)
+	}
+
+	backing := existing[:cap(existing)]
+	for i := 2; i < 4; i++ {
+		if backing[i].Index != 0 || backing[i].Term != 0 || backing[i].Data != nil {
+			t.Fatalf("dropped tail entry %d was not cleared: index=%d term=%d data=%q", i, backing[i].Index, backing[i].Term, backing[i].Data)
+		}
+	}
+}
+
+func TestReplaceCachedEntriesFromIndexReusesTailCapacityForPureAppend(t *testing.T) {
+	existing := make([]raftpb.Entry, 2, 4)
+	existing[0] = raftpb.Entry{Index: 1, Term: 1}
+	existing[1] = raftpb.Entry{Index: 2, Term: 1}
+	firstEntry := &existing[0]
+	incoming := []raftpb.Entry{{
+		Index: 3,
+		Term:  2,
+		Type:  raftpb.EntryNormal,
+		Data:  []byte("normal payload is not cached"),
+	}}
+
+	got := replaceCachedEntriesFromIndex(existing, 3, incoming)
+	if len(got) != 3 {
+		t.Fatalf("len(appended) = %d, want 3", len(got))
+	}
+	if &got[0] != firstEntry {
+		t.Fatal("pure append replaced the cached entries backing")
+	}
+	if got[2].Index != 3 || got[2].Term != 2 || got[2].Data != nil {
+		t.Fatalf("appended cached entry = %#v, want index=3 term=2 metadata only", got[2])
+	}
+}
+
+func TestCloneCachedEntryDropsZeroLengthPayloadBacking(t *testing.T) {
+	payload := make([]byte, 0, 1<<20)
+	entry := raftpb.Entry{
+		Index: 4,
+		Term:  2,
+		Type:  raftpb.EntryConfChangeV2,
+		Data:  payload,
+	}
+
+	cached := cloneCachedEntry(entry)
+	if cached.Data != nil {
+		t.Fatalf("cached zero-length payload = len %d cap %d, want nil", len(cached.Data), cap(cached.Data))
+	}
+}

--- a/pkg/raftlog/pebble_test.go
+++ b/pkg/raftlog/pebble_test.go
@@ -1703,7 +1703,230 @@ func TestPebbleMarkAppliedMetadataWriteKeepsCachedEntriesBacking(t *testing.T) {
 	}
 }
 
-func TestPebbleAppendKeepsCachedRetainedEntryPayloads(t *testing.T) {
+func TestPebbleWriteStateCacheRetainsOnlyConfChangePayloads(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "raft")
+	db, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	normalPayload := bytes.Repeat([]byte("normal-payload-"), 4096)
+	confChange := raftpb.ConfChange{Type: raftpb.ConfChangeAddNode, NodeID: 1}
+	confChangePayload := mustMarshalConfChange(t, confChange)
+	entries := []raftpb.Entry{
+		{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: normalPayload},
+		{Index: 2, Term: 1, Type: raftpb.EntryConfChange, Data: confChangePayload},
+	}
+	hs := raftpb.HardState{Term: 1, Commit: 2}
+	store := db.ForSlot(54)
+	if err := store.Save(ctx, multiraft.PersistentState{
+		HardState: &hs,
+		Entries:   entries,
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	cached := db.stateCache[SlotScope(54)].entries
+	if len(cached) != len(entries) {
+		t.Fatalf("len(cached entries) = %d, want %d", len(cached), len(entries))
+	}
+	if cached[0].Data != nil {
+		t.Errorf("normal cached entry retained %d payload bytes, want nil", len(cached[0].Data))
+	}
+	if !bytes.Equal(cached[1].Data, confChangePayload) {
+		t.Fatalf("conf-change cached payload = %x, want %x", cached[1].Data, confChangePayload)
+	}
+	var decoded raftpb.ConfChange
+	if err := decoded.Unmarshal(cached[1].Data); err != nil {
+		t.Fatalf("ConfChange.Unmarshal(cached payload) error = %v", err)
+	}
+	if decoded.Type != confChange.Type || decoded.NodeID != confChange.NodeID {
+		t.Fatalf("decoded cached ConfChange = %#v, want %#v", decoded, confChange)
+	}
+
+	got, err := store.Entries(ctx, 1, 3, 0)
+	if err != nil {
+		t.Fatalf("Entries() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, entries) {
+		t.Fatalf("Entries() = %#v, want %#v", got, entries)
+	}
+}
+
+func TestPebbleWriteStateCacheCompactsPayloadsLoadedAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "raft")
+	db, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open(first) error = %v", err)
+	}
+
+	confChangePayload := mustMarshalConfChange(t, raftpb.ConfChange{
+		Type:   raftpb.ConfChangeAddNode,
+		NodeID: 2,
+	})
+	store := db.ForSlot(55)
+	if err := store.Save(ctx, multiraft.PersistentState{Entries: []raftpb.Entry{
+		{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: bytes.Repeat([]byte("payload"), 8192)},
+		{Index: 2, Term: 1, Type: raftpb.EntryConfChange, Data: confChangePayload},
+	}}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close(first) error = %v", err)
+	}
+
+	db, err = Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open(second) error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close(second) error = %v", err)
+		}
+	})
+	store = db.ForSlot(55)
+	if err := store.MarkApplied(ctx, 1); err != nil {
+		t.Fatalf("MarkApplied() error = %v", err)
+	}
+
+	cached := db.stateCache[SlotScope(55)].entries
+	if len(cached) != 2 {
+		t.Fatalf("len(cached entries) = %d, want 2", len(cached))
+	}
+	if cached[0].Data != nil {
+		t.Fatalf("reloaded normal entry retained %d payload bytes, want nil", len(cached[0].Data))
+	}
+	if !bytes.Equal(cached[1].Data, confChangePayload) {
+		t.Fatalf("reloaded conf-change payload = %x, want %x", cached[1].Data, confChangePayload)
+	}
+}
+
+func TestPebbleWriteStateCacheRetainsConfChangeV2AcrossRestartAndSnapshotTrim(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "raft")
+	db, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open(first) error = %v", err)
+	}
+
+	addNode2Payload := mustMarshalConfChangeV2(t, raftpb.ConfChangeV2{
+		Changes: []raftpb.ConfChangeSingle{{Type: raftpb.ConfChangeAddNode, NodeID: 2}},
+	})
+	addLearner3Payload := mustMarshalConfChangeV2(t, raftpb.ConfChangeV2{
+		Changes: []raftpb.ConfChangeSingle{{Type: raftpb.ConfChangeAddLearnerNode, NodeID: 3}},
+	})
+	entries := []raftpb.Entry{
+		{
+			Index: 1,
+			Term:  1,
+			Type:  raftpb.EntryConfChange,
+			Data:  mustMarshalConfChange(t, raftpb.ConfChange{Type: raftpb.ConfChangeAddNode, NodeID: 1}),
+		},
+		{Index: 2, Term: 1, Type: raftpb.EntryConfChangeV2, Data: addNode2Payload},
+		{Index: 3, Term: 1, Type: raftpb.EntryNormal, Data: bytes.Repeat([]byte("normal"), 4096)},
+		{Index: 4, Term: 1, Type: raftpb.EntryConfChangeV2, Data: addLearner3Payload},
+	}
+	hs := raftpb.HardState{Term: 1, Commit: 4}
+	store := db.ForSlot(57)
+	if err := store.Save(ctx, multiraft.PersistentState{HardState: &hs, Entries: entries}); err != nil {
+		t.Fatalf("Save(initial) error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close(first) error = %v", err)
+	}
+
+	db, err = Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open(second) error = %v", err)
+	}
+	store = db.ForSlot(57)
+	if err := store.MarkApplied(ctx, 1); err != nil {
+		t.Fatalf("MarkApplied(after first restart) error = %v", err)
+	}
+	cached := db.stateCache[SlotScope(57)].entries
+	if len(cached) != len(entries) {
+		t.Fatalf("len(cached entries after restart) = %d, want %d", len(cached), len(entries))
+	}
+	if !bytes.Equal(cached[1].Data, addNode2Payload) || !bytes.Equal(cached[3].Data, addLearner3Payload) {
+		t.Fatalf("ConfChangeV2 payloads were not retained after restart: %#v", cached)
+	}
+	if cached[2].Data != nil {
+		t.Fatalf("normal cached entry retained %d payload bytes after restart, want nil", len(cached[2].Data))
+	}
+
+	snap := raftpb.Snapshot{
+		Data: []byte("snapshot-through-index-2"),
+		Metadata: raftpb.SnapshotMetadata{
+			Index:     2,
+			Term:      1,
+			ConfState: raftpb.ConfState{Voters: []uint64{1, 2}},
+		},
+	}
+	if err := store.Save(ctx, multiraft.PersistentState{Snapshot: &snap}); err != nil {
+		t.Fatalf("Save(snapshot) error = %v", err)
+	}
+	cached = db.stateCache[SlotScope(57)].entries
+	if len(cached) != 2 || cached[0].Index != 3 || cached[1].Index != 4 {
+		t.Fatalf("cached entries after snapshot trim = %#v, want indexes 3 and 4", cached)
+	}
+	if cached[0].Data != nil {
+		t.Fatalf("trimmed normal cached entry retained %d payload bytes, want nil", len(cached[0].Data))
+	}
+	if !bytes.Equal(cached[1].Data, addLearner3Payload) {
+		t.Fatalf("post-snapshot ConfChangeV2 payload = %x, want %x", cached[1].Data, addLearner3Payload)
+	}
+	if got := mustEntries(t, store, 3, 5, 0); !reflect.DeepEqual(got, entries[2:]) {
+		t.Fatalf("Entries() after snapshot trim = %#v, want %#v", got, entries[2:])
+	}
+	wantConfState := raftpb.ConfState{Voters: []uint64{1, 2}, Learners: []uint64{3}}
+	state, err := store.InitialState(ctx)
+	if err != nil {
+		t.Fatalf("InitialState(after snapshot trim) error = %v", err)
+	}
+	if !reflect.DeepEqual(state.ConfState, wantConfState) {
+		t.Fatalf("ConfState after snapshot trim = %#v, want %#v", state.ConfState, wantConfState)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close(second) error = %v", err)
+	}
+
+	db, err = Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open(third) error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close(third) error = %v", err)
+		}
+	})
+	store = db.ForSlot(57)
+	state, err = store.InitialState(ctx)
+	if err != nil {
+		t.Fatalf("InitialState(after second restart) error = %v", err)
+	}
+	if !reflect.DeepEqual(state.ConfState, wantConfState) {
+		t.Fatalf("ConfState after second restart = %#v, want %#v", state.ConfState, wantConfState)
+	}
+	if got := mustEntries(t, store, 3, 5, 0); !reflect.DeepEqual(got, entries[2:]) {
+		t.Fatalf("Entries() after second restart = %#v, want %#v", got, entries[2:])
+	}
+	if err := store.MarkApplied(ctx, 2); err != nil {
+		t.Fatalf("MarkApplied(after second restart) error = %v", err)
+	}
+	cached = db.stateCache[SlotScope(57)].entries
+	if len(cached) != 2 || cached[0].Data != nil || !bytes.Equal(cached[1].Data, addLearner3Payload) {
+		t.Fatalf("cached entries after second restart = %#v, want normal metadata plus retained ConfChangeV2", cached)
+	}
+}
+
+func TestPebbleAppendKeepsRetainedNormalEntriesMetadataOnly(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "raft")
 	db, err := Open(path, Options{})
@@ -1724,9 +1947,9 @@ func TestPebbleAppendKeepsCachedRetainedEntryPayloads(t *testing.T) {
 	}
 
 	scope := SlotScope(53)
-	before := cachedEntryDataPtr(db.stateCache[scope].entries, 0)
-	if before == 0 {
-		t.Fatal("cached entry data pointer = 0")
+	before := db.stateCache[scope].entries
+	if len(before) != 4 || before[0].Data != nil {
+		t.Fatalf("initial cached entries = %#v, want four metadata-only normal entries", before)
 	}
 
 	if err := store.Save(ctx, multiraft.PersistentState{
@@ -1735,9 +1958,109 @@ func TestPebbleAppendKeepsCachedRetainedEntryPayloads(t *testing.T) {
 		t.Fatalf("Save(append) error = %v", err)
 	}
 
-	after := cachedEntryDataPtr(db.stateCache[scope].entries, 0)
-	if after != before {
-		t.Fatalf("retained cached entry payload was cloned during append: got %x want %x", after, before)
+	after := db.stateCache[scope].entries
+	if len(after) != 5 {
+		t.Fatalf("len(cached entries) = %d, want 5", len(after))
+	}
+	for i, entry := range after {
+		if entry.Data != nil {
+			t.Fatalf("cached normal entry %d retained %d payload bytes, want nil", i, len(entry.Data))
+		}
+	}
+}
+
+func TestPebbleFailedTailReplaceDoesNotPolluteWriteStateCache(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "raft")
+	db, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	entries := []raftpb.Entry{
+		{
+			Index: 1,
+			Term:  1,
+			Type:  raftpb.EntryConfChange,
+			Data:  mustMarshalConfChange(t, raftpb.ConfChange{Type: raftpb.ConfChangeAddNode, NodeID: 1}),
+		},
+		{Index: 2, Term: 1, Type: raftpb.EntryNormal, Data: []byte("original-normal")},
+		{
+			Index: 3,
+			Term:  1,
+			Type:  raftpb.EntryConfChange,
+			Data:  mustMarshalConfChange(t, raftpb.ConfChange{Type: raftpb.ConfChangeAddNode, NodeID: 2}),
+		},
+	}
+	hs := raftpb.HardState{Term: 1, Commit: 3}
+	store := db.ForSlot(56)
+	if err := store.Save(ctx, multiraft.PersistentState{HardState: &hs, Entries: entries}); err != nil {
+		t.Fatalf("Save(initial) error = %v", err)
+	}
+
+	scope := SlotScope(56)
+	cachedBefore := make([]raftpb.Entry, 0, len(db.stateCache[scope].entries))
+	for _, entry := range db.stateCache[scope].entries {
+		cachedBefore = append(cachedBefore, cloneEntry(entry))
+	}
+	wantConfState := raftpb.ConfState{Voters: []uint64{1, 2}}
+
+	injected := errors.New("injected tail-replace commit failure")
+	db.writeCommitTestHook = func() error { return injected }
+	err = store.Save(ctx, multiraft.PersistentState{Entries: []raftpb.Entry{{
+		Index: 2,
+		Term:  2,
+		Type:  raftpb.EntryNormal,
+		Data:  []byte("uncommitted-replacement"),
+	}}})
+	db.writeCommitTestHook = nil
+	if !errors.Is(err, injected) {
+		t.Fatalf("Save(failed tail replace) error = %v, want %v", err, injected)
+	}
+
+	if got := db.stateCache[scope].entries; !reflect.DeepEqual(got, cachedBefore) {
+		t.Errorf("cached entries changed after failed tail replace: got %#v want %#v", got, cachedBefore)
+	}
+	if got := mustEntries(t, store, 1, 4, 0); !reflect.DeepEqual(got, entries) {
+		t.Errorf("Entries() after failed tail replace = %#v, want %#v", got, entries)
+	}
+	state, err := store.InitialState(ctx)
+	if err != nil {
+		t.Fatalf("InitialState(after failed tail replace) error = %v", err)
+	}
+	if !reflect.DeepEqual(state.ConfState, wantConfState) {
+		t.Errorf("ConfState after failed tail replace = %#v, want %#v", state.ConfState, wantConfState)
+	}
+
+	nextHardState := raftpb.HardState{Term: 2, Vote: 1, Commit: 3}
+	if err := store.Save(ctx, multiraft.PersistentState{HardState: &nextHardState}); err != nil {
+		t.Fatalf("Save(HardState-only) error = %v", err)
+	}
+	if got := mustEntries(t, store, 1, 4, 0); !reflect.DeepEqual(got, entries) {
+		t.Errorf("Entries() after HardState-only save = %#v, want %#v", got, entries)
+	}
+	state, err = store.InitialState(ctx)
+	if err != nil {
+		t.Fatalf("InitialState(after HardState-only save) error = %v", err)
+	}
+	if !reflect.DeepEqual(state.ConfState, wantConfState) {
+		t.Errorf("ConfState after HardState-only save = %#v, want %#v", state.ConfState, wantConfState)
+	}
+	first, err := store.FirstIndex(ctx)
+	if err != nil {
+		t.Fatalf("FirstIndex() error = %v", err)
+	}
+	last, err := store.LastIndex(ctx)
+	if err != nil {
+		t.Fatalf("LastIndex() error = %v", err)
+	}
+	if first != 1 || last != 3 {
+		t.Errorf("first/last index after HardState-only save = %d/%d, want 1/3", first, last)
 	}
 }
 
@@ -1777,18 +2100,68 @@ func TestPebbleMetadataTracksTailReplaceAndSnapshotTrim(t *testing.T) {
 	}
 }
 
+func TestPebbleFailedPureAppendClearsHiddenCachedConfChangePayload(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "raft")
+	db, err := Open(path, Options{})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	store := db.ForSlot(58)
+	initial := raftpb.Entry{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: []byte("initial")}
+	if err := store.Save(ctx, multiraft.PersistentState{Entries: []raftpb.Entry{initial}}); err != nil {
+		t.Fatalf("Save(initial) error = %v", err)
+	}
+
+	scope := SlotScope(58)
+	cached := db.stateCache[scope]
+	withTail := make([]raftpb.Entry, len(cached.entries), len(cached.entries)+2)
+	copy(withTail, cached.entries)
+	cached.entries = withTail
+	db.stateCache[scope] = cached
+
+	payload := mustMarshalConfChangeV2(t, raftpb.ConfChangeV2{
+		Changes: []raftpb.ConfChangeSingle{{Type: raftpb.ConfChangeAddNode, NodeID: 2}},
+	})
+	injected := errors.New("injected pure-append commit failure")
+	db.writeCommitTestHook = func() error { return injected }
+	err = store.Save(ctx, multiraft.PersistentState{Entries: []raftpb.Entry{{
+		Index: 2,
+		Term:  1,
+		Type:  raftpb.EntryConfChangeV2,
+		Data:  payload,
+	}}})
+	db.writeCommitTestHook = nil
+	if !errors.Is(err, injected) {
+		t.Fatalf("Save(failed pure append) error = %v, want %v", err, injected)
+	}
+
+	visible := db.stateCache[scope].entries
+	if len(visible) != 1 || visible[0].Index != 1 {
+		t.Fatalf("visible cached entries after failure = %#v, want only index 1", visible)
+	}
+	backing := visible[:cap(visible)]
+	for index := len(visible); index < len(backing); index++ {
+		if backing[index].Data != nil {
+			t.Fatalf("hidden cached entry %d retained %d payload bytes after failed append", index, len(backing[index].Data))
+		}
+	}
+	if got := mustEntries(t, store, 1, 2, 0); !reflect.DeepEqual(got, []raftpb.Entry{initial}) {
+		t.Fatalf("Entries() after failed pure append = %#v, want initial entry", got)
+	}
+}
+
 func cachedEntriesBackingPtr(entries []raftpb.Entry) uintptr {
 	if len(entries) == 0 {
 		return 0
 	}
 	return uintptr(unsafe.Pointer(unsafe.SliceData(entries)))
-}
-
-func cachedEntryDataPtr(entries []raftpb.Entry, index int) uintptr {
-	if index < 0 || index >= len(entries) || len(entries[index].Data) == 0 {
-		return 0
-	}
-	return uintptr(unsafe.Pointer(unsafe.SliceData(entries[index].Data)))
 }
 
 func TestPebbleReturnsClonedData(t *testing.T) {

--- a/pkg/raftlog/pebble_writer.go
+++ b/pkg/raftlog/pebble_writer.go
@@ -128,6 +128,12 @@ func (db *DB) flushWriteRequests(reqs []*writeRequest) error {
 	defer batch.Close()
 
 	stateCache := make(map[Scope]*scopeWriteState, len(reqs))
+	committed := false
+	defer func() {
+		if !committed {
+			db.clearFailedWriteCacheTails(stateCache)
+		}
+	}()
 	for _, req := range reqs {
 		state, err := db.loadScopeWriteState(stateCache, req.scope)
 		if err != nil {
@@ -151,7 +157,21 @@ func (db *DB) flushWriteRequests(reqs []*writeRequest) error {
 	for scope, state := range stateCache {
 		db.stateCache[scope] = cloneScopeWriteState(*state, false)
 	}
+	committed = true
 	return nil
+}
+
+// clearFailedWriteCacheTails releases configuration-change payloads that a
+// failed pure append may have written beyond a committed cache slice's visible
+// length. Clearing hidden capacity cannot change the committed entry sequence.
+func (db *DB) clearFailedWriteCacheTails(states map[Scope]*scopeWriteState) {
+	for scope := range states {
+		cached, ok := db.stateCache[scope]
+		if !ok || len(cached.entries) == cap(cached.entries) {
+			continue
+		}
+		clear(cached.entries[len(cached.entries):cap(cached.entries)])
+	}
 }
 
 func (db *DB) loadScopeWriteState(cache map[Scope]*scopeWriteState, scope Scope) (*scopeWriteState, error) {
@@ -160,8 +180,10 @@ func (db *DB) loadScopeWriteState(cache map[Scope]*scopeWriteState, scope Scope)
 	}
 
 	if cached, ok := db.stateCache[scope]; ok {
-		// Save operations replace the entries slice copy-on-write, so cached
-		// entry payloads can be retained without deep-copying every append.
+		// Tail replacements copy the visible entries before mutation, while pure
+		// appends may reuse capacity beyond the committed slice length. This keeps
+		// failed writes from changing the committed cache without deep-copying
+		// every append.
 		state := cloneScopeWriteState(cached, false)
 		cache[scope] = &state
 		return &state, nil
@@ -183,6 +205,7 @@ func (db *DB) loadScopeWriteState(cache map[Scope]*scopeWriteState, scope Scope)
 	if err != nil {
 		return nil, err
 	}
+	compactCachedEntryPayloads(entries)
 
 	state := &scopeWriteState{
 		hardState: hardState,
@@ -260,7 +283,7 @@ func (op saveOp) apply(batch *pebble.Batch, state *scopeWriteState, store *pebbl
 		}
 		state.snapshot = raftpb.Snapshot{Metadata: cloneSnapshotMetadata(*st.Snapshot)}
 		state.snapshotManifest = cloneSnapshotManifestPtr(st.SnapshotManifest)
-		state.entries = trimEntriesAfterSnapshot(state.entries, st.Snapshot.Index)
+		state.entries = trimCachedEntriesAfterSnapshot(state.entries, st.Snapshot.Index)
 		snapshotIndex = st.Snapshot.Index
 	}
 
@@ -282,7 +305,7 @@ func (op saveOp) apply(batch *pebble.Batch, state *scopeWriteState, store *pebbl
 				return err
 			}
 		}
-		state.entries = replaceEntriesFromIndex(state.entries, first, entries)
+		state.entries = replaceCachedEntriesFromIndex(state.entries, first, entries)
 	}
 
 	if persistHardState {
@@ -300,6 +323,69 @@ func (op saveOp) apply(batch *pebble.Batch, state *scopeWriteState, store *pebbl
 		return err
 	}
 	return store.setMeta(batch, state.meta)
+}
+
+// cloneCachedEntry keeps only the entry bytes needed to derive committed
+// membership state. Normal Raft command payloads remain durable in Pebble and
+// must not be retained by the writer's long-lived metadata cache.
+func cloneCachedEntry(entry raftpb.Entry) raftpb.Entry {
+	cached := entry
+	cached.Data = nil
+	switch entry.Type {
+	case raftpb.EntryConfChange, raftpb.EntryConfChangeV2:
+		if len(entry.Data) > 0 {
+			cached.Data = append([]byte(nil), entry.Data...)
+		}
+	default:
+		cached.Data = nil
+	}
+	return cached
+}
+
+// compactCachedEntryPayloads releases normal command payloads loaded from
+// Pebble while retaining configuration changes required by deriveConfState.
+func compactCachedEntryPayloads(entries []raftpb.Entry) {
+	for i := range entries {
+		if entries[i].Type != raftpb.EntryConfChange && entries[i].Type != raftpb.EntryConfChangeV2 {
+			entries[i].Data = nil
+		}
+	}
+}
+
+// replaceCachedEntriesFromIndex updates the writer metadata cache without
+// retaining normal command payloads. Tail replacements copy the retained
+// prefix so a failed write cannot mutate the committed cache; pure appends keep
+// the capacity-reuse fast path because they do not change its visible entries.
+func replaceCachedEntriesFromIndex(existing []raftpb.Entry, first uint64, incoming []raftpb.Entry) []raftpb.Entry {
+	cut := len(existing)
+	for i, entry := range existing {
+		if entry.Index >= first {
+			cut = i
+			break
+		}
+	}
+	result := existing
+	if cut < len(existing) {
+		result = make([]raftpb.Entry, cut, cut+len(incoming))
+		copy(result, existing[:cut])
+	}
+	for _, entry := range incoming {
+		result = append(result, cloneCachedEntry(entry))
+	}
+	return result
+}
+
+// trimCachedEntriesAfterSnapshot removes compacted metadata-cache entries and
+// preserves only configuration payloads above the snapshot index.
+func trimCachedEntriesAfterSnapshot(existing []raftpb.Entry, snapshotIndex uint64) []raftpb.Entry {
+	result := make([]raftpb.Entry, 0, len(existing))
+	for _, entry := range existing {
+		if entry.Index <= snapshotIndex {
+			continue
+		}
+		result = append(result, cloneCachedEntry(entry))
+	}
+	return result
 }
 
 func (op markAppliedOp) apply(batch *pebble.Batch, state *scopeWriteState, store *pebbleStore) error {


### PR DESCRIPTION
## Summary

- preserve already-durable channel append post-commit work with bounded handoff reservations and a fair FIFO retry scheduler
- reduce Cloud Medium hot-path allocation in conversation authority grouping and prevent ordinary Raft entry payloads from remaining in the long-lived state cache
- make channel append shutdown retryable, publish bounded pressure metrics, and add Grafana visibility for handoff/retry pressure

## Root cause

The last Cloud Medium run reached only 3339 QPS and failed latency/error gates without simulator or infrastructure saturation. Three product-side amplifiers were identified:

1. durable append results could lose required post-commit work when per-channel admission or the nonblocking effect pool was saturated;
2. recipient authority grouping repeatedly cloned large backing sets, causing about 147 GB of cumulative allocation in the run;
3. the Raft state cache retained ordinary entry payloads, leaving about 786 MB of flat retained memory per node.

Final adversarial review also found that synchronous pressure publication could spin indefinitely under continuous updates and that oversized worker-pool settings could wrap the `ants/v2` internal `int32` capacity.

## Changes

- reserve a global bounded post-commit handoff slot before append and release it only after append failure or a terminal post-commit attempt
- retry saturated durable post-commit work through a deduplicated FIFO scheduler without allowing newer work to overtake it
- keep caller timeouts from cancelling the one-way graceful drain; application dependencies remain live until a later Stop observes completion
- publish pressure through one coalescing goroutine per Group so observers cannot block append/commit hot paths
- clamp worker-pool capacities at the `ants/v2` representable limit
- group recipient authority targets with a two-pass, shared-backing algorithm while preserving exact target order and retry isolation
- drop normal Raft entry payloads from the long-lived cache while retaining configuration-change payloads required for ConfState derivation
- expose handoff/retry gauges and update the runtime Grafana dashboard

## Validation

- repository Go gate: passed in full once
- second repository gate: all changed packages passed; one unrelated cluster readiness test timed out under full parallel load and then passed in isolation with `-count=5`
- channelappend full package and full race suite: passed
- critical retry/pressure regressions: passed with `-count=20`
- critical retry/pressure race regressions: passed with `-count=10`
- new application shutdown race regressions: passed with `-count=20`
- conversation authority and Raft log focused/race tests: passed
- `git diff --check`, gofmt verification, and Grafana JSON parsing: passed

The existing local `.gitignore` edit is intentionally excluded from this PR.
