### PR TITLE
fix(cloud-sim): fail fast on terminal bootstrap gates

### DIFF
--- a/.github/workflows/cloud-sim-provision.yml
+++ b/.github/workflows/cloud-sim-provision.yml
@@ -498,7 +498,20 @@ jobs:
         run: |
           set -euo pipefail
           deadline=$(( $(date +%s) + 1200 ))
-          until scripts/cloud-sim/collect-bootstrap-gate.sh && bundle/bin/wkcloudgate --snapshot bootstrap-gate.json --bundle-digest "$BUNDLE_DIGEST"; do
+          while true; do
+            if scripts/cloud-sim/collect-bootstrap-gate.sh; then
+              if bundle/bin/wkcloudgate --snapshot bootstrap-gate.json --bundle-digest "$BUNDLE_DIGEST" | tee bootstrap-gate-result.json; then
+                break
+              fi
+              if ! jq -e '.passed == false and (.retryable | type == "boolean")' bootstrap-gate-result.json >/dev/null; then
+                echo "Bootstrap Gate returned an invalid failure result" >&2
+                exit 1
+              fi
+              if ! jq -e '.retryable == true' bootstrap-gate-result.json >/dev/null; then
+                echo "Bootstrap Gate reported a non-retryable invariant" >&2
+                exit 1
+              fi
+            fi
             test "$(date +%s)" -lt "$deadline"
             sleep 10
           done
@@ -557,9 +570,10 @@ jobs:
 
       - name: Preserve diagnostics or release unusable failed provisioning
         id: preserve_failed_provisioning
-        if: failure() && steps.create.outcome == 'success'
+        if: (failure() || cancelled()) && steps.provider_config.outcome == 'success' && steps.prepare.outcome == 'success'
         shell: bash
         env:
+          BOOTSTRAP_GATE_OUTCOME: ${{ steps.bootstrap_gate.outcome }}
           PUBLIC_OBSERVATION_GATE_OUTCOME: ${{ steps.public_observation.outcome }}
         run: |
           set -euo pipefail
@@ -572,6 +586,10 @@ jobs:
           }
           if [[ "$PUBLIC_OBSERVATION" == "true" && "$PUBLIC_OBSERVATION_GATE_OUTCOME" != "success" ]]; then
             ./wkcloudsim --provider alibaba --provider-config provider.json close-public-view "$RUN_ID" >/dev/null || true
+          fi
+          if [[ "$BOOTSTRAP_GATE_OUTCOME" != "success" ]]; then
+            release_failed_run
+            exit 0
           fi
           if ! status_json="$(./wkcloudsim --provider alibaba --provider-config provider.json status "$RUN_ID")"; then
             release_failed_run

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -236,6 +236,7 @@
 - Cloud Simulation normal completion uses a non-diagnostic Finalization Schedule plus local `finalize.sh`: arm cleanup before bounded GitHub preflight, retry an explicit in-progress workload while the lease permits, survive terminal signals through exact cleanup, then require structured provider-confirmed empty inventory.
 - Cloud Simulation stability topology uses 256 physical hash slots mapped to 10 logical Slot Raft Groups; bootstrap gates both values separately.
 - Cloud Simulation bundles carry a versioned effective-node runtime contract; Bootstrap Gate must match every node's normalized TOML-sourced critical values before starting a paid workload.
+- Bootstrap Gate must parse the rendered YAML shape rather than source-file indentation, retry only convergence failures, and destroy the exact Run on terminal contract failure or workflow cancellation.
 - Omitted Channel store/RPC worker settings stay zero in the loader so the owning Channel runtime derives them; deployment profiles that require a fixed shape must set them explicitly.
 - Local Cloud Medium RC evidence must disable parent `go.work`, resolve the exact `go.mod` toolchain, and use portable temporary/hash commands so macOS and Linux exercise the same committed harness.
 - Cloud Simulation Bootstrap Gate accepts a non-zero actual Slot Raft leader that belongs to the current voter set when quorum and peer sync are healthy; `PreferredLeader` mismatch is placement evidence, not a health failure.

--- a/internal/infra/cloudsim/deploy/bundle_test.go
+++ b/internal/infra/cloudsim/deploy/bundle_test.go
@@ -503,7 +503,7 @@ func TestBootstrapGateFailsClosedAndPassesOnlyCompleteSnapshot(t *testing.T) {
 			"node-3": observedRuntimeContract(t, "medium"),
 		},
 	}
-	if result := EvaluateBootstrapGate(snapshot, digest); !result.Passed {
+	if result := EvaluateBootstrapGate(snapshot, digest); !result.Passed || result.Retryable {
 		t.Fatalf("complete gate = %#v", result)
 	}
 	snapshot.SlotGroupCount = 256
@@ -532,13 +532,18 @@ func TestBootstrapGateFailsClosedAndPassesOnlyCompleteSnapshot(t *testing.T) {
 	driftedExpected := snapshot.ExpectedNodeRuntimeContract
 	driftedExpected.ChannelRPCWorkers = 49
 	snapshot.ExpectedNodeRuntimeContract = driftedExpected
-	if result := EvaluateBootstrapGate(snapshot, digest); result.Passed || !slices.Contains(result.Failures, "node-1 effective runtime contract mismatch") {
+	if result := EvaluateBootstrapGate(snapshot, digest); result.Passed || result.Retryable || !slices.Contains(result.Failures, "node-1 effective runtime contract mismatch") {
 		t.Fatalf("sealed runtime contract drift gate = %#v, want observed mismatch", result)
 	}
 	snapshot.ExpectedNodeRuntimeContract = expectedRuntimeContract(t, "medium")
+	snapshot.RuntimeScale = ""
+	if result := EvaluateBootstrapGate(snapshot, digest); result.Passed || result.Retryable || !slices.Contains(result.Failures, `sealed effective runtime contract scale mismatch: contract="medium" scenario=""`) {
+		t.Fatalf("missing rendered scenario scale gate = %#v, want terminal mismatch", result)
+	}
+	snapshot.RuntimeScale = "medium"
 	snapshot.PendingControllerTask = 1
-	if result := EvaluateBootstrapGate(snapshot, digest); result.Passed || len(result.Failures) == 0 {
-		t.Fatalf("incomplete gate = %#v, want fail closed", result)
+	if result := EvaluateBootstrapGate(snapshot, digest); result.Passed || !result.Retryable || len(result.Failures) == 0 {
+		t.Fatalf("incomplete gate = %#v, want retryable fail closed result", result)
 	}
 }
 

--- a/internal/infra/cloudsim/deploy/gate.go
+++ b/internal/infra/cloudsim/deploy/gate.go
@@ -51,16 +51,19 @@ type BootstrapSnapshot struct {
 type GateResult struct {
 	// Passed is true only when every bootstrap invariant holds.
 	Passed bool `json:"passed"`
+	// Retryable is true only when every failed invariant can still converge without changing the sealed bundle or node configuration.
+	Retryable bool `json:"retryable"`
 	// Failures contains every bounded failed invariant.
 	Failures []string `json:"failures"`
 }
 
 // EvaluateBootstrapGate checks the exact three-node, 256-hash-slot cloud contract.
 func EvaluateBootstrapGate(snapshot BootstrapSnapshot, expectedDigest string) GateResult {
-	result := GateResult{Failures: make([]string, 0)}
+	result := GateResult{Retryable: true, Failures: make([]string, 0)}
 	for _, role := range []string{"node-1", "node-2", "node-3", "sim"} {
 		if snapshot.BundleDigests[role] != expectedDigest {
 			result.Failures = append(result.Failures, fmt.Sprintf("%s bundle digest mismatch", role))
+			result.Retryable = false
 		}
 	}
 	required := map[string][]string{
@@ -115,18 +118,29 @@ func EvaluateBootstrapGate(snapshot BootstrapSnapshot, expectedDigest string) Ga
 	if snapshot.PublicViewEnabled && !snapshot.CloudViewSelfCheck {
 		result.Failures = append(result.Failures, "Cloud View self-check failed")
 	}
-	if !snapshot.WKBenchValidate || !snapshot.WKBenchDoctor {
-		result.Failures = append(result.Failures, "wkbench validate or doctor failed")
+	if !snapshot.WKBenchValidate {
+		result.Failures = append(result.Failures, "wkbench validate failed")
+		result.Retryable = false
+	}
+	if !snapshot.WKBenchDoctor {
+		result.Failures = append(result.Failures, "wkbench doctor failed")
 	}
 	expectedRuntime := snapshot.ExpectedNodeRuntimeContract
-	if expectedRuntime.Schema != EffectiveNodeRuntimeContractSchemaV1 ||
-		expectedRuntime.Scale != snapshot.RuntimeScale {
-		result.Failures = append(result.Failures, "sealed effective runtime contract is invalid")
+	if expectedRuntime.Schema != EffectiveNodeRuntimeContractSchemaV1 {
+		result.Failures = append(result.Failures, "sealed effective runtime contract schema is invalid")
+		result.Retryable = false
+	} else if expectedRuntime.Scale != snapshot.RuntimeScale {
+		result.Failures = append(result.Failures, fmt.Sprintf(
+			"sealed effective runtime contract scale mismatch: contract=%q scenario=%q",
+			expectedRuntime.Scale, snapshot.RuntimeScale,
+		))
+		result.Retryable = false
 	} else {
 		for _, role := range []string{"node-1", "node-2", "node-3"} {
 			observed, ok := snapshot.NodeRuntimeContracts[role]
 			if !ok || !runtimeContractValuesEqual(observed, expectedRuntime) {
 				result.Failures = append(result.Failures, fmt.Sprintf("%s effective runtime contract mismatch", role))
+				result.Retryable = false
 				continue
 			}
 			sourcesMatch := true
@@ -138,9 +152,13 @@ func EvaluateBootstrapGate(snapshot BootstrapSnapshot, expectedDigest string) Ga
 			}
 			if !sourcesMatch {
 				result.Failures = append(result.Failures, fmt.Sprintf("%s effective runtime contract source is not toml", role))
+				result.Retryable = false
 			}
 		}
 	}
 	result.Passed = len(result.Failures) == 0
+	if result.Passed {
+		result.Retryable = false
+	}
 	return result
 }

--- a/internal/infra/cloudsim/deploy/workflow_test.go
+++ b/internal/infra/cloudsim/deploy/workflow_test.go
@@ -545,6 +545,27 @@ func TestCloudSimulationWorkflowMapsReviewedScaleAliasesAndConfirmsWeekCost(t *t
 	}
 }
 
+func TestCloudSimulationWorkflowFailsFastOnTerminalBootstrapGateAndCleansCancellation(t *testing.T) {
+	provision := readWorkflowText(t, repositoryRoot(t), "cloud-sim-provision.yml")
+	for _, required := range []string{
+		`bundle/bin/wkcloudgate --snapshot bootstrap-gate.json --bundle-digest "$BUNDLE_DIGEST" | tee bootstrap-gate-result.json`,
+		`'.passed == false and (.retryable | type == "boolean")'`,
+		`'.retryable == true'`,
+		`Bootstrap Gate reported a non-retryable invariant`,
+		`if: (failure() || cancelled()) && steps.provider_config.outcome == 'success' && steps.prepare.outcome == 'success'`,
+		`BOOTSTRAP_GATE_OUTCOME: ${{ steps.bootstrap_gate.outcome }}`,
+		`if [[ "$BOOTSTRAP_GATE_OUTCOME" != "success" ]]`,
+		`release_failed_run`,
+	} {
+		if !strings.Contains(provision, required) {
+			t.Fatalf("provision workflow missing terminal Bootstrap Gate handling %q", required)
+		}
+	}
+	if strings.Contains(provision, `until scripts/cloud-sim/collect-bootstrap-gate.sh && bundle/bin/wkcloudgate`) {
+		t.Fatal("provision workflow still retries every Bootstrap Gate failure until the deadline")
+	}
+}
+
 func TestCloudSimulationWorkflowRequiresEmpiricalStorageCalibrationForStandardRuns(t *testing.T) {
 	provision := readWorkflowText(t, repositoryRoot(t), "cloud-sim-provision.yml")
 	for _, required := range []string{

--- a/scripts/cloud-sim/collect-bootstrap-gate.sh
+++ b/scripts/cloud-sim/collect-bootstrap-gate.sh
@@ -95,7 +95,7 @@ manager_token="$(ssh_sim "curl --fail --silent --show-error --max-time 10 -H 'Co
 nodes_json="$(ssh_sim "curl --fail --silent --show-error --max-time 10 -H 'Authorization: Bearer ${manager_token}' '${manager_base}/manager/nodes'")"
 slots_json="$(ssh_sim "curl --fail --silent --show-error --max-time 15 -H 'Authorization: Bearer ${manager_token}' '${manager_base}/manager/slots'")"
 tasks_json="$(ssh_sim "curl --fail --silent --show-error --max-time 10 -H 'Authorization: Bearer ${manager_token}' '${manager_base}/manager/controller/tasks?limit=50'")"
-runtime_scale="$(ssh_sim "sudo awk '/^objectives:/{inside=1; next} inside && /^  scale:/{print \$2; exit} inside && /^[^ ]/{exit}' /etc/wukongim/scenario.yaml")"
+runtime_scale="$(ssh_sim "sudo cat /etc/wukongim/scenario.yaml" | awk -f "$(dirname "$0")/read-scenario-scale.awk")"
 expected_node_runtime_contract="$(ssh_sim "sudo cat /etc/wukongim/effective-node-runtime-contract.json" | jq -ce .)"
 
 node_runtime_contract() {

--- a/scripts/cloud-sim/read-scenario-scale.awk
+++ b/scripts/cloud-sim/read-scenario-scale.awk
@@ -1,0 +1,32 @@
+BEGIN {
+  in_objectives = 0
+  found = 0
+}
+
+/^objectives:[[:space:]]*(#.*)?$/ {
+  in_objectives = 1
+  next
+}
+
+in_objectives && /^[^[:space:]]/ {
+  exit 1
+}
+
+in_objectives && /^[[:space:]]+scale:[[:space:]]*/ {
+  value = $0
+  sub(/^[[:space:]]+scale:[[:space:]]*/, "", value)
+  sub(/[[:space:]]*(#.*)?$/, "", value)
+  gsub(/^["']|["']$/, "", value)
+  if (value !~ /^(small|medium|large)$/) {
+    exit 1
+  }
+  print value
+  found = 1
+  exit 0
+}
+
+END {
+  if (!found) {
+    exit 1
+  }
+}

--- a/scripts/cloud_sim_bootstrap_gate_test.go
+++ b/scripts/cloud_sim_bootstrap_gate_test.go
@@ -92,8 +92,9 @@ func TestCloudSimulationBootstrapCollectorCapturesEffectiveRuntimeContract(t *te
 		`/manager/nodes/${node_id}/config`,
 		`--argjson node_id "$node_id"`,
 		`bootstrap-runtime-contract.jq`,
-		`sudo awk`,
+		`sudo cat /etc/wukongim/scenario.yaml`,
 		`sudo cat /etc/wukongim/effective-node-runtime-contract.json`,
+		`read-scenario-scale.awk`,
 		`effective-node-runtime-contract/v1`,
 		`WK_CLUSTER_HASH_SLOT_COUNT`,
 		`WK_CLUSTER_INITIAL_SLOT_COUNT`,
@@ -112,6 +113,43 @@ func TestCloudSimulationBootstrapCollectorCapturesEffectiveRuntimeContract(t *te
 	} {
 		if !strings.Contains(text, required) {
 			t.Fatalf("Bootstrap Gate collector missing effective runtime contract %q", required)
+		}
+	}
+}
+
+func TestCloudSimulationBootstrapScenarioScaleParserAcceptsRenderedIndentation(t *testing.T) {
+	program := filepath.Join(repoRoot(t), "scripts", "cloud-sim", "read-scenario-scale.awk")
+	for _, testCase := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "source two spaces", input: "version: wkbench/v1\nobjectives:\n  scale: medium\nlimits: {}\n", want: "medium\n"},
+		{name: "yaml v3 four spaces", input: "version: wkbench/v1\nobjectives:\n    scale: medium\n    standard: true\nlimits: {}\n", want: "medium\n"},
+		{name: "quoted with comment", input: "objectives:\n    scale: 'large' # reviewed\n", want: "large\n"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			command := exec.Command("awk", "-f", program)
+			command.Stdin = strings.NewReader(testCase.input)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("parse scale: %v\n%s", err, output)
+			}
+			if string(output) != testCase.want {
+				t.Fatalf("scale output = %q, want %q", output, testCase.want)
+			}
+		})
+	}
+
+	for _, input := range []string{
+		"objectives:\n    standard: true\n",
+		"objectives:\n    scale: unsupported\n",
+		"objectives:\nlimits: {}\n",
+	} {
+		command := exec.Command("awk", "-f", program)
+		command.Stdin = strings.NewReader(input)
+		if output, err := command.CombinedOutput(); err == nil {
+			t.Fatalf("invalid scale unexpectedly passed: output=%q input=%q", output, input)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- parse the deployed, yaml.v3-rendered scenario scale without depending on source indentation
- classify Bootstrap Gate failures as retryable convergence failures or terminal sealed/configuration failures
- fail immediately on terminal gate results instead of retrying for 20 minutes
- release the exact Run on terminal Bootstrap Gate failure or workflow cancellation, including partial resource creation

## Root cause and cost evidence

Provision [29985985148](https://github.com/WuKongIM/WuKongIM/actions/runs/29985985148) rendered `objectives.scale` with four-space indentation, while `collect-bootstrap-gate.sh` accepted exactly two spaces. The collector therefore emitted an empty runtime scale and the gate reported a sealed contract mismatch. The workflow retried every gate error until its 1200-second deadline, even though this invariant could not converge.

The failed Run `gh-29985985148-1` was canceled to stop billable runtime and exact Cleanup [29987509646](https://github.com/WuKongIM/WuKongIM/actions/runs/29987509646) succeeded, proving `state=released` and `resources.length=0`.

## Validation

- focused Bootstrap Gate/workflow/script tests
- focused race tests
- full `./scripts` package: 147.006s
- repository explicit-root Go gate (`./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/...`) split to avoid rerunning scripts: all passed
- `bash -n scripts/cloud-sim/collect-bootstrap-gate.sh`
- `git diff --check`

No new Alibaba Cloud Provision will be dispatched until this PR, required CI, and Nightly are green.
