### PR TITLE
perf: remove recipient hot-path amplification

### DIFF
--- a/cmd/wkanalysis/config.go
+++ b/cmd/wkanalysis/config.go
@@ -211,6 +211,7 @@ func defaultMetricQueries() map[string]string {
 		"append_error_rate":                                       `sum(rate(wukongim_message_append_errors_total[1m])) by (path, class)`,
 		"gateway_queue_depth":                                     `sum(wukongim_gateway_async_send_queue_depth)`,
 		"runtime_queue_pressure":                                  `max(wukongim_runtime_pool_queue_depth / (wukongim_runtime_pool_queue_capacity > 0))`,
+		"runtime_queue_pressure_by_pool":                          `max by (instance, node_id, node_name, component, pool, queue, priority) (wukongim_runtime_pool_queue_depth{job="wukongim"} / (wukongim_runtime_pool_queue_capacity{job="wukongim"} > 0))`,
 		"storage_commit_queue_depth":                              `sum by (instance, node_name, store) (wukongim_storage_commit_queue_depth{job="wukongim"})`,
 		"storage_commit_request_p99":                              `histogram_quantile(0.99, sum by (instance, node_name, store, lane, result, le) (rate(wukongim_storage_commit_request_duration_seconds_bucket{job="wukongim"}[1m])))`,
 		"storage_commit_batch_stage_p99":                          `histogram_quantile(0.99, sum by (instance, node_name, store, stage, result, le) (rate(wukongim_storage_commit_batch_duration_seconds_bucket{job="wukongim"}[1m])))`,

--- a/cmd/wkanalysis/config_test.go
+++ b/cmd/wkanalysis/config_test.go
@@ -85,6 +85,14 @@ func TestDefaultMetricQueriesExcludeZeroCapacityRuntimeQueues(t *testing.T) {
 	}
 }
 
+func TestDefaultMetricQueriesIncludePerPoolRuntimeQueuePressure(t *testing.T) {
+	got := defaultMetricQueries()["runtime_queue_pressure_by_pool"]
+	want := `max by (instance, node_id, node_name, component, pool, queue, priority) (wukongim_runtime_pool_queue_depth{job="wukongim"} / (wukongim_runtime_pool_queue_capacity{job="wukongim"} > 0))`
+	if got != want {
+		t.Fatalf("runtime_queue_pressure_by_pool = %q, want %q", got, want)
+	}
+}
+
 func TestDefaultMetricQueriesIncludeRecipientDeliveryAndPostCommitEvidence(t *testing.T) {
 	queries := defaultMetricQueries()
 	want := map[string]string{

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -22,6 +22,7 @@
 - `internal/runtime/delivery` is the no-gateway/no-cluster benchmark boundary for online fanout, owner push batching, and recipient-owner recvack tracking.
 - `internal` webhook delivery is a node-local best-effort post-commit side effect with bounded queues and finite retry. Large offline fanout should use batch observer/chunking, and webhook failure must not affect SENDACK, durable append, conversation active admission, or owner delivery.
 - Channelappend post-commit pool admission and per-channel backlog must stay bounded and independent from foreground append admission; saturation is observed and dropped so best-effort conversation/delivery work cannot pin writer-advance workers, delay durable SEND/SENDACK, or return `ErrChannelBusy` for an otherwise admissible send.
+- Channelappend writer activation must pass through the dedicated dispatcher; callers or append/effect workers must never block while submitting back into the bounded advance pool, or saturated advance/append pools can form a cross-pool deadlock.
 - Conversation-active cache churn may evict clean rows during memory-only admission; dirty persistence stays exclusively on periodic, pressure-woken, or handoff flush workers.
 - Local Cloud Analysis should use the run's Cloud View `RemoteAddr` as a best-effort same-destination egress hint; transparent routing can give public echo services another IPv4. Keep pinned-TLS MCP health authoritative and preserve the echo fallback for runs without Cloud View.
 
@@ -49,6 +50,7 @@
 - Conversation active pressure uses one coalesced async worker wakeup, bounded flush attempts, and 80%/70% high/dirty-low watermarks; clean rows below the dirty watermark are the reusable eviction reserve.
 - Conversation active projection failure is observed independently and must not block recipient delivery, later large-channel pages, or subscriber snapshot caching.
 - Recipient delivery plans preserve complete UID-authority fences and batch presence RPC by actual leader; only stale/not-ready groups may batch-resolve fresh targets and retry once, without replaying successful siblings.
+- Cloud Medium recipient pages are bounded at 512 rows: authority normalization uses an inline UID index and exact 256-physical-hash-slot grouping while preserving all 10 logical Slot and leader/config fences; do not replace it with per-message UID/target maps.
 - Deleting a conversation clears current active visibility through `DeletedToSeq`; a later message with a larger sequence must be allowed to reactivate it.
 - Delete without an explicit message sequence must first resolve the latest Channel Log sequence; if no sequence is available, do not install a zero delete barrier.
 - Duplicate/stale delete barriers must not clear an `ActiveAt` written by a newer message.
@@ -200,6 +202,7 @@
 - Plugin runtime is node-local and disabled by default; plugin-user bindings are Slot Raft metadata keyed by UID.
 - Phase 1 supports `.wkp`/go-pdk core methods and host RPCs, but stream RPCs return explicit unimplemented errors.
 - Plugin sends must go through `message.App.Send`; PersistAfter runs only on the channel owner node.
+- Offline Receive observation enters the plugin worker as one message-scoped UID batch with one owned payload copy; candidate discovery runs once per batch and skips UID binding reads when no running Receive plugin exists.
 - Plugin migration changes should rerun the microbenchmark baseline in `docs/development/PLUGIN_BENCHMARK_BASELINE.md`, especially Send hook selection, host RPC mapping, PersistAfter, HTTP forward, and NoPersist realtime delivery.
 - Plugin wire contracts live in `pkg/plugin/pluginproto`; keep protobuf field numbers compatible with `github.com/WuKongIM/go-pdk` and do not add new imports of old `internal/usecase/plugin/pluginproto`.
 - The node-local plugin process host lives in `pkg/plugin/pluginhost`; internal app wiring adapts it to `internal/usecase/plugin` without depending on old plugin runtime code.

--- a/docs/superpowers/reports/2026-07-23-cloud-medium-recipient-hotpath-rc.md
+++ b/docs/superpowers/reports/2026-07-23-cloud-medium-recipient-hotpath-rc.md
@@ -1,0 +1,137 @@
+# Cloud Medium Recipient Hot-Path Release Candidate
+
+Date: 2026-07-23
+
+Base: `origin/main` at `3d68536984a0205125a213834f63ebd216e8b0bc`
+
+Failed cloud evidence: Run `gh-29989526911-1`
+
+## Decision
+
+**NO-GO for paid Cloud Medium validation.**
+
+The integrated benchmark now includes the real offline plugin observer, bounded
+plugin worker, and no-running-Receive-plugin usecase exit. It processes the
+complete 5,000-message/s-equivalent 50ms recipient volume in a 5.85ms local
+median in the original serial admission mode. A stronger full-slice burst gate
+then exposed a deterministic cross-pool deadlock: all advance workers could
+wait for append workers while append completions waited to resubmit into the
+advance pool. The pre-fix candidate timed out after 20 seconds with both sides
+of that cycle in the goroutine dump. A dedicated activation dispatcher breaks
+the cycle; the same burst completes in a 5.72ms local median.
+
+This is strong evidence for a repository-owned liveness defect that can produce
+the observed multi-second queueing. It still does not include the real network,
+Raft, Pebble, and socket backpressure. The final repository gates and independent
+reviews passed, but that missing tail-latency coverage keeps paid validation at
+NO-GO.
+
+## Evidence And Scope
+
+The failed run completed without failed workers but reached only 1761.09 ingress
+messages/s and SENDACK P99 15.86s. Simulator headroom, process continuity,
+recipient workers, channelappend handoff, Presence bulk lookup, ACK batching,
+Slot scheduling, and append correctness were excluded. Node-2 allocation
+evidence attributed about 312GB to recipient dispatch, 161GB to routed
+conversation admission, 127GB to offline-recipient observation, and 76.7GB to
+authority grouping. Runtime queue pressure averaged 0.839 and reached 1.0.
+
+This candidate changes that confirmed path as one batch:
+
+- one offline UID page now becomes one plugin-worker admission and one owned
+  payload copy instead of one admission and payload copy per UID;
+- no running Receive plugin returns before UID binding reads or wire mapping;
+- a bound Receive plugin keeps ordered per-UID binding, dedupe, invocation, and
+  independent timeout semantics;
+- authority normalization uses an inline UID index for the normal 512-row page,
+  and exact target grouping uses the 256 physical hash-slot index without
+  weakening the 10 logical Slot or Raft fence semantics;
+- exact-target delivery plans aggregate offline UIDs into one observer event per
+  bounded plan instead of one event per physical authority target;
+- a dedicated activation dispatcher is now the only blocking submitter to the
+  advance pool, eliminating the advance-pool/append-pool circular wait while
+  preserving configured writer concurrency;
+- single-leader Presence target groups borrow the immutable caller slice, the
+  production batch usecase avoids a discarded result allocation, and async
+  delivery plans borrow capacity-limited grouping-owned recipient windows;
+- Analysis exposes queue pressure by node, component, pool, queue, and priority.
+
+## Deterministic Local Benchmarks
+
+Apple M4, `GOWORK=off`, three samples. Values below use representative medians.
+The plugin rows compare scalar and batch implementations in the candidate
+revision. The authority and integrated rows compare captured `origin/main`
+baseline output with the candidate output using the same benchmark definitions.
+
+| Cloud Medium-shaped path | Before | Candidate | Result |
+| --- | ---: | ---: | ---: |
+| Plugin worker admission, 512 UIDs | 76.0µs, 524291B, 512 allocs | 0.833µs, 10496B, 2 allocs | 91x faster; 98.0% fewer bytes |
+| Receive usecase, no plugin, 512 UIDs | 23.3µs, 12288B, 512 allocs | 0.035µs, 24B, 1 alloc | 666x faster; binding reads eliminated |
+| Receive usecase, one bound plugin, 512 UIDs | 331.9µs, 1004168B, 5634 allocs | 238.1µs, 708137B, 2545 allocs | 28.3% faster; 54.8% fewer allocs |
+| Authority snapshot/grouping, 250 messages and 19650 recipient rows | 2.240ms, 13.559MB, 6924 allocs | 1.527ms, 7.377MB, 2810 allocs | 31.8% faster; 45.6% fewer bytes |
+| Presence client, 256 exact targets / 19650 UIDs / one leader | 16.51µs, 58448B, 24 allocs | 9.26µs, 10944B, 2 allocs | 43.9% faster; 81.3% fewer bytes; only aligned result allocations remain |
+| Integrated routing/recipient feedback before adding plugin coverage | 7.44ms, 27.44MB, 66143 allocs | 6.15ms, 17.54MB, 47723 allocs | 17.3% faster; 36.1% fewer bytes; 27.9% fewer allocs |
+| Final integrated feedback including plugin observer/worker/no-plugin exit | Not comparable: `origin/main` had per-UID plugin work and this benchmark did not include it | 5.85ms, 19.84MB, 49738 allocs, 130 plugin batches | complete 250-message / 19650-recipient volume; 8.5x under its 50ms window |
+| Full-slice burst admission with advance/append pool pressure | Timed out after 20s; goroutine dump proved circular pool admission wait | 5.72ms, 20.43MB, 49898 allocs, bounded recipient inflight below capacity, 130 plugin batches | liveness restored; more than 3,400x below the pre-fix timeout bound |
+
+The failed cloud scenario had no running Receive plugin, so the exact no-plugin
+benchmark and final integrated path are directly relevant. The final candidate
+kept recipient queue depth at zero and reduced the physical-target plugin
+amplification to exactly 130 plan-level batches for the 130 group-message plans
+that actually had offline recipients. Burst admission reached 32-51 concurrent
+recipient workers in the primary samples and remained below capacity in
+independent review samples without deadlock or queue loss. The 5.72ms local
+median is not divided
+into 250 and reported as production QPS. It proves the intended batching and
+allocation changes plus removal of the circular scheduling wait. Independent
+review concluded that this proof is not sufficiently faithful to justify a paid
+cloud run.
+
+## Verification
+
+- Focused functional packages: passed.
+- Focused race tests for plugin batch, authority grouping, recipient dispatch,
+  and app composition: passed.
+- Final integrated benchmark includes plugin observer, worker admission, and the
+  real no-running-Receive-plugin usecase path: passed.
+- Burst regression with one advance and one append worker: passed 20
+  repetitions; focused race passed.
+- Full Cloud Medium-shaped burst integration: passed five repetitions and
+  reports exactly 130 plugin batches.
+- Slow first Receive UID timeout does not starve the following UID: passed.
+- `git diff --check`: passed.
+- Repository Go gate with explicit roots and without root `./...`: passed on
+  the final candidate.
+- Independent Standards review: passed with no remaining finding after
+  observer isolation, Presence empty-group alignment, dispatcher pressure
+  publication, queue-tail clearing, and terminal-zero fixes.
+- Independent Spec review: no implementation-semantic finding; paid cloud
+  validation remains NO-GO because the harness does not cover real
+  network/Raft/Pebble/socket tail latency.
+- User `.gitignore` change remains outside this candidate.
+
+The first repository gate exposed one test-harness-only timing race: the fake
+start process could miss a two-second readiness window under full parallel
+load. The test-only window is now ten seconds while its two-second
+delayed-auto-join assertion is unchanged. The exact test passed ten repetitions,
+then the full repository gate passed.
+
+## Remaining Local Work
+
+1. Land the reviewed cohesive correctness/performance batch through required
+   PR CI without starting cloud resources.
+2. Add a higher-fidelity local gate or gather additional repository-owned
+   evidence that exercises the missing network/Raft/Pebble/socket backpressure
+   and can project ingress and SENDACK P99 with meaningful margin.
+3. Continue cohesive local diagnosis and optimization until the written
+   projection supports a GO. Do not Provision merely because the current
+   microbenchmarks and PR gates pass.
+4. Only after a future GO: merge one cohesive PR with required CI and Nightly
+   green, prove there are no live resources, and consider exactly one paid
+   Cloud Medium run.
+
+Cloud acceptance remains: completed/passed/exit 0, no failed worker, ingress
+at least 4500/s, SENDACK error at most 0.01%, RECV error at most 0.1%, connect
+error at most 0.01%, SENDACK P99 at most 1s, RECV P99 at most 2s, pure run,
+7/7 continuous targets, no restart/OOM, simulator memory below 80%, and healthy
+queue/cache/authority/handoff signals.

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -242,7 +242,7 @@ New(Config)
        cluster-authoritative UID plugin bindings when available; attach the
        plugin hook metrics observer
        when metrics are enabled, expose durable commit PersistAfter events to
-       channelappend, expose durable offline recipient candidates to
+       channelappend, expose each durable offline recipient batch to
        channelappend's recipient delivery worker for Receive hooks, and
        register the manager plugin RPC handler when node RPC is available so
        peer managers can inspect or mutate this node's plugin lifecycle state
@@ -833,7 +833,13 @@ When `Plugin.Enable=true` (the default unless `WK_PLUGIN_ENABLE=false` is set),
 the app wires the PDK-compatible node-local plugin
 runtime, desired-state store adapter, minimal lifecycle host RPC adapter, v2
 plugin usecase, and bounded PersistAfter worker before channelappend. The
-channelappend group receives only the PersistAfter enqueue port. Plugin runtime
+channelappend group receives the PersistAfter enqueue port and a batch-capable
+offline-recipient observer. One offline recipient batch becomes one plugin
+worker admission and one owned copy of its payload and UID slice. The plugin
+usecase snapshots eligible running Receive plugins once per batch, returns
+before binding reads when none exist, and then preserves ordered per-UID binding,
+dedupe, and invocation semantics only for bound recipients. The legacy scalar
+observer and worker interfaces remain as compatibility fallbacks. Plugin runtime
 and hook workers start before channelappend and stop after channelappend drains,
 so accepted durable commits can enqueue plugin side effects until the append
 runtime is stopped. Desired plugin config remains node-local in this phase and

--- a/internal/app/cloud_medium_recipient_feedback_test.go
+++ b/internal/app/cloud_medium_recipient_feedback_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/online"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/pluginhook"
 	authoritypresence "github.com/WuKongIM/WuKongIM/internal/runtime/presence"
+	pluginusecase "github.com/WuKongIM/WuKongIM/internal/usecase/plugin"
 	presenceusecase "github.com/WuKongIM/WuKongIM/internal/usecase/presence"
 	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	"github.com/WuKongIM/WuKongIM/pkg/cluster/control"
@@ -72,15 +74,20 @@ var cloudMediumFeedbackProfiles = []struct {
 //   - the bounded recipient delivery queue with 320 workers;
 //   - infra/delivery LocalOwnerPusher and the real pending-ACK state machine, with sessions
 //     returning an immediate RECVACK from inside WriteDelivery.
+//   - the real offline plugin observer, bounded plugin hook worker, and plugin
+//     usecase fast exit when no running Receive plugin exists.
 //
 // The durable appender, Slot/Channel Raft, Pebble, cluster transport, gateway
 // socket, and client protocol loop are deterministic in-process substitutes.
 // Channels and recipient UIDs are unique inside the slice so every counted row
 // is independently conserved; hot-channel cache reuse and overlapping users
 // remain separate focused-test concerns.
-// The slice is not wall-clock paced. Therefore this test proves shape,
-// conservation, bounded drain, and ACK lifecycle correctness; it does not
-// prove production QPS or latency percentiles.
+// The complete slice is admitted before any future is awaited so local
+// channelappend and recipient queues see burst pressure instead of a
+// submit-and-wait serial loop. The slice is not wall-clock paced. Therefore
+// this test proves shape, conservation, bounded drain, ACK lifecycle, and
+// in-process burst handling; it does not prove production QPS or latency
+// percentiles.
 func TestCloudMediumRecipientOneTwentiethSecondFeedback(t *testing.T) {
 	if got := cloudMediumFeedbackMessageCount * int(time.Second/cloudMediumFeedbackSliceDuration); got != cloudMediumFeedbackEquivalentIngressQPS {
 		t.Fatalf("slice ingress = %d messages/s, want %d", got, cloudMediumFeedbackEquivalentIngressQPS)
@@ -139,24 +146,28 @@ func BenchmarkCloudMediumRecipientOneTwentiethSecondFeedback(b *testing.B) {
 		b.ReportMetric(float64(snapshot.maxInflight), "max-inflight/op")
 		b.ReportMetric(cloudMediumFeedbackMessageCount, "messages/op")
 		b.ReportMetric(cloudMediumFeedbackPlanCount, "plans/op")
+		b.ReportMetric(float64(snapshot.pluginReceiveAccepted), "plugin-batches/op")
 		b.ReportMetric(cloudMediumFeedbackRecipientRows, "recipient-rows/op")
 	}
 }
 
 type cloudMediumRecipientFeedbackHarness struct {
-	group        *channelappend.Group
-	worker       *channelappend.RecipientDeliveryWorker
-	observer     *cloudMediumRecipientFeedbackObserver
-	node         *cloudMediumRecipientFeedbackNode
-	source       *cloudMediumRecipientFeedbackSubscribers
-	directory    *authoritypresence.Directory
-	delivery     *runtimedelivery.Manager
-	writes       *atomic.Int64
-	targets      []channelappend.AuthorityTarget
-	items        []channelappend.SendBatchItem
-	closeMu      sync.Mutex
-	groupClosed  bool
-	workerClosed bool
+	group          *channelappend.Group
+	worker         *channelappend.RecipientDeliveryWorker
+	pluginHook     *pluginhook.Worker
+	pluginObserver *cloudMediumPluginHookObserver
+	observer       *cloudMediumRecipientFeedbackObserver
+	node           *cloudMediumRecipientFeedbackNode
+	source         *cloudMediumRecipientFeedbackSubscribers
+	directory      *authoritypresence.Directory
+	delivery       *runtimedelivery.Manager
+	writes         *atomic.Int64
+	targets        []channelappend.AuthorityTarget
+	items          []channelappend.SendBatchItem
+	closeMu        sync.Mutex
+	groupClosed    bool
+	workerClosed   bool
+	pluginClosed   bool
 }
 
 func newCloudMediumRecipientFeedbackHarness() (*cloudMediumRecipientFeedbackHarness, error) {
@@ -311,10 +322,30 @@ func newCloudMediumRecipientFeedbackHarness() (*cloudMediumRecipientFeedbackHarn
 		Online:     onlineRegistry,
 		AckManager: deliveryManager,
 	})
+	plugins, err := pluginusecase.NewApp(pluginusecase.Options{
+		Runtime: &cloudMediumNoPluginRuntime{},
+		Invoker: cloudMediumNoPluginInvoker{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create no-plugin receive usecase: %w", err)
+	}
+	pluginObserver := &cloudMediumPluginHookObserver{}
+	pluginWorker := pluginhook.NewWorker(pluginhook.Options{
+		Usecase:        plugins,
+		ReceiveUsecase: plugins,
+		QueueSize:      32_768,
+		Workers:        8,
+		Timeout:        time.Second,
+		Observer:       pluginObserver,
+	})
+	if err := pluginWorker.Start(context.Background()); err != nil {
+		return nil, fmt.Errorf("start plugin receive worker: %w", err)
+	}
 	processor := channelappend.NewRecipientProcessor(channelappend.RecipientProcessorOptions{
-		PresenceResolver:   deliveryinfra.NewChannelAppendPresenceResolver(presenceApp),
-		OwnerPusher:        channelAppendOwnerPusher{next: localPusher},
-		OwnerPushBatchSize: cloudMediumFeedbackRecipientBatchSize,
+		PresenceResolver:          deliveryinfra.NewChannelAppendPresenceResolver(presenceApp),
+		OwnerPusher:               channelAppendOwnerPusher{next: localPusher},
+		OfflineRecipientsObserver: pluginReceiveObserver{worker: pluginWorker},
+		OwnerPushBatchSize:        cloudMediumFeedbackRecipientBatchSize,
 	})
 	observer := newCloudMediumRecipientFeedbackObserver()
 	worker := channelappend.NewRecipientDeliveryWorker(channelappend.RecipientDeliveryWorkerOptions{
@@ -325,6 +356,9 @@ func newCloudMediumRecipientFeedbackHarness() (*cloudMediumRecipientFeedbackHarn
 		Observer:    observer,
 	})
 	if err := worker.Start(context.Background()); err != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = pluginWorker.Stop(stopCtx)
 		return nil, fmt.Errorf("start recipient delivery worker: %w", err)
 	}
 	group := channelappend.New(channelappend.Options{
@@ -350,19 +384,22 @@ func newCloudMediumRecipientFeedbackHarness() (*cloudMediumRecipientFeedbackHarn
 		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = worker.Stop(stopCtx)
+		_ = pluginWorker.Stop(stopCtx)
 		return nil, fmt.Errorf("start channel append group: %w", err)
 	}
 	return &cloudMediumRecipientFeedbackHarness{
-		group:     group,
-		worker:    worker,
-		observer:  observer,
-		node:      node,
-		source:    source,
-		directory: directory,
-		delivery:  deliveryManager,
-		writes:    writes,
-		targets:   targets,
-		items:     items,
+		group:          group,
+		worker:         worker,
+		pluginHook:     pluginWorker,
+		pluginObserver: pluginObserver,
+		observer:       observer,
+		node:           node,
+		source:         source,
+		directory:      directory,
+		delivery:       deliveryManager,
+		writes:         writes,
+		targets:        targets,
+		items:          items,
 	}, nil
 }
 
@@ -370,11 +407,15 @@ func (h *cloudMediumRecipientFeedbackHarness) run(ctx context.Context) (cloudMed
 	if h == nil || h.group == nil {
 		return cloudMediumRecipientFeedbackSnapshot{}, errors.New("cloud medium feedback harness is not initialized")
 	}
+	futures := make([]*channelappend.Future, len(h.items))
 	for i := range h.items {
 		future, err := h.group.SubmitLocal(ctx, h.targets[i], []channelappend.SendBatchItem{h.items[i]})
 		if err != nil {
 			return cloudMediumRecipientFeedbackSnapshot{}, fmt.Errorf("submit message %d: %w", i, err)
 		}
+		futures[i] = future
+	}
+	for i, future := range futures {
 		results, err := future.Wait(ctx)
 		if err != nil {
 			return cloudMediumRecipientFeedbackSnapshot{}, fmt.Errorf("wait message %d: %w", i, err)
@@ -387,6 +428,9 @@ func (h *cloudMediumRecipientFeedbackHarness) run(ctx context.Context) (cloudMed
 		return cloudMediumRecipientFeedbackSnapshot{}, fmt.Errorf("drain channel append group: %w", err)
 	}
 	if err := h.observer.waitDrained(ctx, cloudMediumFeedbackPlanCount); err != nil {
+		return cloudMediumRecipientFeedbackSnapshot{}, err
+	}
+	if err := h.pluginObserver.waitDrained(ctx); err != nil {
 		return cloudMediumRecipientFeedbackSnapshot{}, err
 	}
 	snapshot := h.snapshot()
@@ -402,7 +446,8 @@ func (h *cloudMediumRecipientFeedbackHarness) close(ctx context.Context) error {
 	}
 	groupErr := h.stopGroup(ctx)
 	workerErr := h.stopWorker(ctx)
-	return errors.Join(groupErr, workerErr)
+	pluginErr := h.stopPluginHook(ctx)
+	return errors.Join(groupErr, workerErr, pluginErr)
 }
 
 func (h *cloudMediumRecipientFeedbackHarness) stopGroup(ctx context.Context) error {
@@ -431,6 +476,19 @@ func (h *cloudMediumRecipientFeedbackHarness) stopWorker(ctx context.Context) er
 	return nil
 }
 
+func (h *cloudMediumRecipientFeedbackHarness) stopPluginHook(ctx context.Context) error {
+	h.closeMu.Lock()
+	defer h.closeMu.Unlock()
+	if h.pluginClosed || h.pluginHook == nil {
+		return nil
+	}
+	if err := h.pluginHook.Stop(ctx); err != nil {
+		return err
+	}
+	h.pluginClosed = true
+	return nil
+}
+
 func (h *cloudMediumRecipientFeedbackHarness) snapshot() cloudMediumRecipientFeedbackSnapshot {
 	snapshot := h.observer.snapshot()
 	snapshot.subscriberPages = int(h.source.pageCalls.Load())
@@ -443,34 +501,40 @@ func (h *cloudMediumRecipientFeedbackHarness) snapshot() cloudMediumRecipientFee
 	snapshot.pendingACKs = h.delivery.PendingAckCount()
 	snapshot.directoryActive = h.directory.Snapshot().Active
 	snapshot.workerCapacity = h.worker.WorkerCapacity()
+	snapshot.pluginReceiveAccepted = int(h.pluginObserver.accepted.Load())
+	snapshot.pluginReceiveInvoked = int(h.pluginObserver.invoked.Load())
+	snapshot.pluginReceiveOther = int(h.pluginObserver.other.Load())
 	return snapshot
 }
 
 type cloudMediumRecipientFeedbackSnapshot struct {
-	appendFinished      int
-	appendErrors        int
-	admissionAccepted   int
-	admissionOther      int
-	processedOK         int
-	processedOther      int
-	processedRecipients int
-	postCommitFailures  int
-	queueDepth          int
-	queueCapacity       int
-	maxQueueDepth       int
-	inflight            int
-	inflightCapacity    int
-	maxInflight         int
-	subscriberPages     int
-	subscriberRows      int
-	authorityBatchCalls int
-	authorityRows       int
-	routeRefreshCalls   int
-	remoteRPCCalls      int
-	onlineWrites        int
-	pendingACKs         int
-	directoryActive     int
-	workerCapacity      int
+	appendFinished        int
+	appendErrors          int
+	admissionAccepted     int
+	admissionOther        int
+	processedOK           int
+	processedOther        int
+	processedRecipients   int
+	postCommitFailures    int
+	queueDepth            int
+	queueCapacity         int
+	maxQueueDepth         int
+	inflight              int
+	inflightCapacity      int
+	maxInflight           int
+	subscriberPages       int
+	subscriberRows        int
+	authorityBatchCalls   int
+	authorityRows         int
+	routeRefreshCalls     int
+	remoteRPCCalls        int
+	onlineWrites          int
+	pendingACKs           int
+	directoryActive       int
+	workerCapacity        int
+	pluginReceiveAccepted int
+	pluginReceiveInvoked  int
+	pluginReceiveOther    int
 }
 
 func (s cloudMediumRecipientFeedbackSnapshot) validate() error {
@@ -501,6 +565,9 @@ func (s cloudMediumRecipientFeedbackSnapshot) validate() error {
 		{name: "owner-local writes", got: s.onlineWrites, want: cloudMediumFeedbackOwnerWrites},
 		{name: "pending ACKs", got: s.pendingACKs, want: 0},
 		{name: "presence directory active routes", got: s.directoryActive, want: cloudMediumFeedbackOnlineRoutes},
+		{name: "plugin receive accepted batches", got: s.pluginReceiveAccepted, want: cloudMediumFeedbackGroupSubscriberPlans},
+		{name: "plugin receive invoked batches", got: s.pluginReceiveInvoked, want: cloudMediumFeedbackGroupSubscriberPlans},
+		{name: "plugin receive non-ok outcomes", got: s.pluginReceiveOther, want: 0},
 	}
 	for _, check := range checks {
 		if check.got != check.want {
@@ -514,6 +581,76 @@ func (s cloudMediumRecipientFeedbackSnapshot) validate() error {
 		return fmt.Errorf("max inflight = %d, want within [1,%d]", s.maxInflight, s.inflightCapacity)
 	}
 	return nil
+}
+
+type cloudMediumNoPluginRuntime struct{}
+
+func (*cloudMediumNoPluginRuntime) RegisterObserved(context.Context, pluginusecase.ObservedPlugin) error {
+	return nil
+}
+
+func (*cloudMediumNoPluginRuntime) MarkClosed(context.Context, string) error {
+	return nil
+}
+
+func (*cloudMediumNoPluginRuntime) List() []pluginusecase.ObservedPlugin {
+	return nil
+}
+
+type cloudMediumNoPluginInvoker struct{}
+
+func (cloudMediumNoPluginInvoker) RequestPlugin(context.Context, string, string, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (cloudMediumNoPluginInvoker) SendPlugin(string, uint32, []byte) error {
+	return nil
+}
+
+type cloudMediumPluginHookObserver struct {
+	accepted atomic.Int64
+	invoked  atomic.Int64
+	other    atomic.Int64
+}
+
+func (*cloudMediumPluginHookObserver) ObservePersistAfterEnqueue(string, time.Duration) {}
+
+func (*cloudMediumPluginHookObserver) ObservePersistAfterInvoke(string, time.Duration) {}
+
+func (o *cloudMediumPluginHookObserver) ObserveReceiveEnqueue(result string, _ time.Duration) {
+	if result == "accepted" {
+		o.accepted.Add(1)
+		return
+	}
+	o.other.Add(1)
+}
+
+func (o *cloudMediumPluginHookObserver) ObserveReceiveInvoke(result string, _ time.Duration) {
+	if result == "ok" {
+		o.invoked.Add(1)
+		return
+	}
+	o.other.Add(1)
+}
+
+func (o *cloudMediumPluginHookObserver) waitDrained(ctx context.Context) error {
+	if o == nil {
+		return errors.New("cloud medium plugin hook observer is nil")
+	}
+	ticker := time.NewTicker(100 * time.Microsecond)
+	defer ticker.Stop()
+	for {
+		accepted := o.accepted.Load()
+		invoked := o.invoked.Load()
+		if accepted > 0 && invoked == accepted {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait plugin receive drain accepted=%d invoked=%d other=%d: %w", accepted, invoked, o.other.Load(), ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 type cloudMediumRecipientFeedbackObserver struct {

--- a/internal/app/plugin.go
+++ b/internal/app/plugin.go
@@ -33,6 +33,11 @@ type pluginReceiveWorker interface {
 	EnqueueReceive(context.Context, pluginevents.ReceiveOffline)
 }
 
+// pluginReceiveBatchWorker accepts one mapped Receive batch for asynchronous processing.
+type pluginReceiveBatchWorker interface {
+	EnqueueReceiveBatch(context.Context, pluginevents.ReceiveOfflineBatch)
+}
+
 // pluginPersistAfterEnqueuer adapts durable channelappend envelopes to plugin PersistAfter events.
 type pluginPersistAfterEnqueuer struct {
 	worker pluginPersistAfterWorker
@@ -354,5 +359,34 @@ func (o pluginReceiveObserver) ObserveOfflineRecipient(ctx context.Context, even
 		SyncOnce:          source.SyncOnce,
 		NoPersist:         source.MessageSeq == 0,
 		MessageScopedUIDs: append([]string(nil), source.MessageScopedUIDs...),
+	})
+}
+
+// ObserveOfflineRecipients converts one committed message recipient batch into one plugin task.
+func (o pluginReceiveObserver) ObserveOfflineRecipients(ctx context.Context, event channelappend.OfflineRecipientsEvent) {
+	if o.worker == nil || len(event.UIDs) == 0 {
+		return
+	}
+	worker, ok := o.worker.(pluginReceiveBatchWorker)
+	if !ok {
+		for _, uid := range event.UIDs {
+			o.ObserveOfflineRecipient(ctx, channelappend.OfflineRecipientEvent{Event: event.Event, UID: uid})
+		}
+		return
+	}
+	source := event.Event
+	worker.EnqueueReceiveBatch(ctx, pluginevents.ReceiveOfflineBatch{
+		MessageID:         source.MessageID,
+		MessageSeq:        source.MessageSeq,
+		ChannelID:         source.ChannelID,
+		ChannelType:       source.ChannelType,
+		FromUID:           source.FromUID,
+		UIDs:              event.UIDs,
+		ClientMsgNo:       source.ClientMsgNo,
+		ServerTimestampMS: source.ServerTimestampMS,
+		Payload:           source.Payload,
+		SyncOnce:          source.SyncOnce,
+		NoPersist:         source.MessageSeq == 0,
+		MessageScopedUIDs: source.MessageScopedUIDs,
 	})
 }

--- a/internal/app/plugin_test.go
+++ b/internal/app/plugin_test.go
@@ -502,6 +502,44 @@ func TestPluginReceiveObserverMapsOfflineRecipientEvent(t *testing.T) {
 	}}, worker.events)
 }
 
+func TestPluginReceiveObserverMapsOfflineRecipientBatchWithoutScalarExpansion(t *testing.T) {
+	worker := &recordingPluginReceiveBatchWorker{}
+	observer := pluginReceiveObserver{worker: worker}
+	source := channelappend.OfflineRecipientsEvent{
+		UIDs: []string{"bot", "bot-2"},
+		Event: channelappend.CommittedEnvelope{
+			MessageID:         101,
+			MessageSeq:        202,
+			ChannelID:         "room-a",
+			ChannelType:       2,
+			FromUID:           "sender-u1",
+			ClientMsgNo:       "client-1",
+			ServerTimestampMS: 123456789,
+			Payload:           []byte("payload"),
+			MessageScopedUIDs: []string{"bot"},
+		},
+	}
+
+	observer.ObserveOfflineRecipients(context.Background(), source)
+	source.UIDs[0] = "mutated"
+	source.Event.Payload[0] = 'X'
+	source.Event.MessageScopedUIDs[0] = "mutated"
+
+	require.Empty(t, worker.events)
+	require.Equal(t, []pluginevents.ReceiveOfflineBatch{{
+		MessageID:         101,
+		MessageSeq:        202,
+		ChannelID:         "room-a",
+		ChannelType:       2,
+		FromUID:           "sender-u1",
+		UIDs:              []string{"bot", "bot-2"},
+		ClientMsgNo:       "client-1",
+		ServerTimestampMS: 123456789,
+		Payload:           []byte("payload"),
+		MessageScopedUIDs: []string{"bot"},
+	}}, worker.batches)
+}
+
 func TestPluginRuntimeAdapterPreservesReceiveMethod(t *testing.T) {
 	runtime := pluginhost.NewRuntime(pluginhost.RuntimeOptions{Registry: pluginhost.NewRegistry()})
 	adapter := pluginRuntimeAdapter{runtime: runtime}
@@ -532,6 +570,15 @@ type recordingPluginReceiveWorker struct {
 
 func (w *recordingPluginReceiveWorker) EnqueueReceive(_ context.Context, event pluginevents.ReceiveOffline) {
 	w.events = append(w.events, event)
+}
+
+type recordingPluginReceiveBatchWorker struct {
+	recordingPluginReceiveWorker
+	batches []pluginevents.ReceiveOfflineBatch
+}
+
+func (w *recordingPluginReceiveBatchWorker) EnqueueReceiveBatch(_ context.Context, event pluginevents.ReceiveOfflineBatch) {
+	w.batches = append(w.batches, event.Clone())
 }
 
 type recordingAppMessageSubmitter struct {

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -35,6 +35,7 @@ type composedPersistAfterEnqueuer struct {
 
 type composedOfflineRecipientsObserver struct {
 	pluginSingle channelappend.OfflineRecipientObserver
+	pluginBatch  channelappend.OfflineRecipientsObserver
 	webhookBatch channelappend.OfflineRecipientsObserver
 }
 
@@ -137,11 +138,20 @@ func composeOfflineRecipientObservers(
 	if pluginSingle == nil || webhookBatch == nil {
 		return pluginSingle, webhookBatch
 	}
-	return pluginSingle, composedOfflineRecipientsObserver{pluginSingle: pluginSingle, webhookBatch: webhookBatch}
+	pluginBatch, _ := pluginSingle.(channelappend.OfflineRecipientsObserver)
+	return pluginSingle, composedOfflineRecipientsObserver{
+		pluginSingle: pluginSingle,
+		pluginBatch:  pluginBatch,
+		webhookBatch: webhookBatch,
+	}
 }
 
 func (o composedOfflineRecipientsObserver) ObserveOfflineRecipients(ctx context.Context, event channelappend.OfflineRecipientsEvent) {
 	o.webhookBatch.ObserveOfflineRecipients(ctx, event)
+	if o.pluginBatch != nil {
+		o.pluginBatch.ObserveOfflineRecipients(ctx, event)
+		return
+	}
 	for _, uid := range event.UIDs {
 		o.pluginSingle.ObserveOfflineRecipient(ctx, channelappend.OfflineRecipientEvent{
 			Event: event.Event,

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -162,6 +162,30 @@ func TestComposeOfflineRecipientObserversKeepsPluginSingleAndWebhookBatch(t *tes
 	require.Equal(t, [][]string{{"u1", "u2"}}, webhook.uidBatches)
 }
 
+func TestComposeOfflineRecipientObserversUsesPluginBatchWhenAvailable(t *testing.T) {
+	plugin := &recordingBatchOfflineRecipientObserverForWebhookTest{}
+	webhook := &recordingOfflineRecipientsObserverForWebhookTest{}
+	single, batch := composeOfflineRecipientObservers(plugin, webhook)
+
+	processor := channelappend.NewRecipientProcessor(channelappend.RecipientProcessorOptions{
+		PresenceResolver:            staticChannelAppendPresenceResolver{},
+		OfflineRecipientObserver:    single,
+		OfflineRecipientsObserver:   batch,
+		DeliveryRetryMaxAttempts:    1,
+		DeliveryRetryInitialBackoff: 1,
+		DeliveryRetryMaxBackoff:     1,
+	})
+	err := processor.ProcessRecipientBatch(context.Background(), channelappend.RecipientBatch{
+		Event:      channelappend.CommittedEnvelope{MessageID: 101, MessageSeq: 1, ChannelID: "g1", ChannelType: 2},
+		Recipients: []channelappend.Recipient{{UID: "u1"}, {UID: "u2"}},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, plugin.singleUIDs)
+	require.Equal(t, [][]string{{"u1", "u2"}}, plugin.uidBatches)
+	require.Equal(t, [][]string{{"u1", "u2"}}, webhook.uidBatches)
+}
+
 func TestWebhookNotifyEnqueuerMapsCommittedEnvelopeAndCopiesSlices(t *testing.T) {
 	runtime := &recordingWebhookRuntime{}
 	enqueuer := webhookNotifyEnqueuer{runtime: runtime}
@@ -324,6 +348,19 @@ func (r *recordingOfflineRecipientObserverForWebhookTest) ObserveOfflineRecipien
 
 type recordingOfflineRecipientsObserverForWebhookTest struct {
 	uidBatches [][]string
+}
+
+type recordingBatchOfflineRecipientObserverForWebhookTest struct {
+	singleUIDs []string
+	uidBatches [][]string
+}
+
+func (r *recordingBatchOfflineRecipientObserverForWebhookTest) ObserveOfflineRecipient(_ context.Context, event channelappend.OfflineRecipientEvent) {
+	r.singleUIDs = append(r.singleUIDs, event.UID)
+}
+
+func (r *recordingBatchOfflineRecipientObserverForWebhookTest) ObserveOfflineRecipients(_ context.Context, event channelappend.OfflineRecipientsEvent) {
+	r.uidBatches = append(r.uidBatches, append([]string(nil), event.UIDs...))
 }
 
 func (r *recordingOfflineRecipientsObserverForWebhookTest) ObserveOfflineRecipients(_ context.Context, event channelappend.OfflineRecipientsEvent) {

--- a/internal/contracts/pluginevents/types.go
+++ b/internal/contracts/pluginevents/types.go
@@ -71,3 +71,58 @@ func (e ReceiveOffline) Clone() ReceiveOffline {
 	e.MessageScopedUIDs = append([]string(nil), e.MessageScopedUIDs...)
 	return e
 }
+
+// ReceiveOfflineBatch carries offline recipient candidates for one committed message into plugin hooks.
+type ReceiveOfflineBatch struct {
+	// MessageID is the durable server message identifier.
+	MessageID uint64
+	// MessageSeq is the committed channel sequence number.
+	MessageSeq uint64
+	// ChannelID is the target channel identifier.
+	ChannelID string
+	// ChannelType is the target channel type.
+	ChannelType uint8
+	// FromUID is the sender user identifier.
+	FromUID string
+	// UIDs contains the offline recipient user identifiers in delivery order.
+	UIDs []string
+	// ClientMsgNo is the client-provided idempotency key.
+	ClientMsgNo string
+	// ServerTimestampMS is the server commit timestamp in milliseconds.
+	ServerTimestampMS int64
+	// Payload is the committed message body shared by all recipients.
+	Payload []byte
+	// NoPersist reports whether the envelope was a transient realtime send.
+	NoPersist bool
+	// SyncOnce reports whether the message should only sync once to recipients.
+	SyncOnce bool
+	// MessageScopedUIDs marks request-scoped messages that must not trigger Receive.
+	MessageScopedUIDs []string
+}
+
+// Clone returns an independent batch copy safe for asynchronous plugin workers.
+func (e ReceiveOfflineBatch) Clone() ReceiveOfflineBatch {
+	e.UIDs = append([]string(nil), e.UIDs...)
+	e.Payload = append([]byte(nil), e.Payload...)
+	e.MessageScopedUIDs = append([]string(nil), e.MessageScopedUIDs...)
+	return e
+}
+
+// ForUID projects one recipient into the scalar compatibility event.
+// Payload and MessageScopedUIDs remain shared with the immutable owned batch.
+func (e ReceiveOfflineBatch) ForUID(uid string) ReceiveOffline {
+	return ReceiveOffline{
+		MessageID:         e.MessageID,
+		MessageSeq:        e.MessageSeq,
+		ChannelID:         e.ChannelID,
+		ChannelType:       e.ChannelType,
+		FromUID:           e.FromUID,
+		UID:               uid,
+		ClientMsgNo:       e.ClientMsgNo,
+		ServerTimestampMS: e.ServerTimestampMS,
+		Payload:           e.Payload,
+		NoPersist:         e.NoPersist,
+		SyncOnce:          e.SyncOnce,
+		MessageScopedUIDs: e.MessageScopedUIDs,
+	}
+}

--- a/internal/contracts/pluginevents/types_test.go
+++ b/internal/contracts/pluginevents/types_test.go
@@ -46,3 +46,57 @@ func TestReceiveOfflineCloneCopiesMutableFields(t *testing.T) {
 	require.Equal(t, []byte("hello"), clone.Payload)
 	require.Equal(t, []string{"u2"}, clone.MessageScopedUIDs)
 }
+
+func TestReceiveOfflineBatchCloneCopiesMutableFields(t *testing.T) {
+	event := ReceiveOfflineBatch{
+		MessageID:         10,
+		MessageSeq:        3,
+		ChannelID:         "room",
+		ChannelType:       2,
+		FromUID:           "u1",
+		UIDs:              []string{"u2", "u3"},
+		ClientMsgNo:       "c1",
+		ServerTimestampMS: 1713859200123,
+		Payload:           []byte("hello"),
+		MessageScopedUIDs: []string{"u2"},
+	}
+	clone := event.Clone()
+	event.UIDs[0] = "changed"
+	event.Payload[0] = 'H'
+	event.MessageScopedUIDs[0] = "changed"
+
+	require.Equal(t, []string{"u2", "u3"}, clone.UIDs)
+	require.Equal(t, []byte("hello"), clone.Payload)
+	require.Equal(t, []string{"u2"}, clone.MessageScopedUIDs)
+}
+
+func TestReceiveOfflineBatchForUIDPreservesSharedMessageFields(t *testing.T) {
+	batch := ReceiveOfflineBatch{
+		MessageID:         10,
+		MessageSeq:        3,
+		ChannelID:         "room",
+		ChannelType:       2,
+		FromUID:           "u1",
+		ClientMsgNo:       "c1",
+		ServerTimestampMS: 1713859200123,
+		Payload:           []byte("hello"),
+		NoPersist:         true,
+		SyncOnce:          true,
+		MessageScopedUIDs: []string{"u2"},
+	}
+
+	require.Equal(t, ReceiveOffline{
+		MessageID:         10,
+		MessageSeq:        3,
+		ChannelID:         "room",
+		ChannelType:       2,
+		FromUID:           "u1",
+		UID:               "u3",
+		ClientMsgNo:       "c1",
+		ServerTimestampMS: 1713859200123,
+		Payload:           []byte("hello"),
+		NoPersist:         true,
+		SyncOnce:          true,
+		MessageScopedUIDs: []string{"u2"},
+	}, batch.ForUID("u3"))
+}

--- a/internal/infra/cluster/FLOW.md
+++ b/internal/infra/cluster/FLOW.md
@@ -868,6 +868,9 @@ Target-aware endpoint lookup consumes those already-resolved target fences. It
 never calls `RouteKey` or `RouteKeysPartial` on the happy path. Multiple exact
 hash-slot targets for the same remote leader share one RPC envelope, so network
 work scales with leader count instead of recipient or hash-slot count.
+When every non-empty exact target belongs to one leader, the client borrows the
+caller-owned immutable group slice directly and preserves identity result
+alignment without constructing another leader map, index slice, or group copy.
 Independent leader envelopes execute concurrently under a fixed bound while
 aligned results remain in original input order. Each leader execution boundary
 also converts a local-authority or remote-client panic into a terminal error for

--- a/internal/infra/cluster/conversation_authority_test.go
+++ b/internal/infra/cluster/conversation_authority_test.go
@@ -56,6 +56,36 @@ func TestConversationAuthorityClientPrefersLightweightPartialRoutes(t *testing.T
 	}
 }
 
+func TestConversationAuthorityClientMultiBatchGroupingDoesNotDuplicateRecipients(t *testing.T) {
+	target := cluster.Route{HashSlot: 2, SlotID: 2, Leader: 1, LeaderTerm: 5, ConfigEpoch: 6, Revision: 11, AuthorityEpoch: 7}
+	node := &fakeConversationAuthorityNode{
+		nodeID: 1,
+		routesByUID: map[string]cluster.Route{
+			"recipient-1": target,
+			"recipient-2": target,
+		},
+	}
+	client := NewConversationAuthorityClient(node, &fakeConversationAuthorityLocal{})
+
+	groups, failures, err := client.groupActiveBatchesByTargetPartial([]conversationactive.ActiveBatch{
+		{ChannelID: "g1", MessageSeq: 1, Recipients: []conversationactive.ActiveEntry{{UID: "recipient-1"}}},
+		{ChannelID: "g2", MessageSeq: 2, Recipients: []conversationactive.ActiveEntry{{UID: "recipient-2"}}},
+	})
+
+	if err != nil {
+		t.Fatalf("groupActiveBatchesByTargetPartial() error = %v", err)
+	}
+	if len(failures) != 0 || len(groups) != 2 {
+		t.Fatalf("groups=%#v failures=%#v, want two successful source batches", groups, failures)
+	}
+	if got := groups[0].batch.Recipients; !reflect.DeepEqual(got, []conversationactive.ActiveEntry{{UID: "recipient-1"}}) {
+		t.Fatalf("first recipients = %#v, want one exact recipient", got)
+	}
+	if got := groups[1].batch.Recipients; !reflect.DeepEqual(got, []conversationactive.ActiveEntry{{UID: "recipient-2"}}) {
+		t.Fatalf("second recipients = %#v, want one exact recipient", got)
+	}
+}
+
 func TestConversationAuthorityClientUsesLocalAuthority(t *testing.T) {
 	local := &fakeConversationAuthorityLocal{}
 	node := &fakeConversationAuthorityNode{nodeID: 1, route: cluster.Route{HashSlot: 7, SlotID: 2, Leader: 1, LeaderTerm: 5, ConfigEpoch: 6, Revision: 3, AuthorityEpoch: 4}}

--- a/internal/infra/cluster/presence.go
+++ b/internal/infra/cluster/presence.go
@@ -330,6 +330,92 @@ func (c *PresenceAuthorityClient) endpointsByTargetsOnce(ctx context.Context, gr
 		groups  []presence.EndpointLookupGroup
 		items   int
 	}
+
+	processLeader := func(leaderNodeID uint64, batch *leaderBatch) {
+		resultIndexes := batch.indexes
+		resultIndex := func(batchIndex int) int {
+			if resultIndexes == nil {
+				return batchIndex
+			}
+			return resultIndexes[batchIndex]
+		}
+		path := ""
+		observer := c.endpointObserver
+		var started time.Time
+		if observer != nil {
+			started = time.Now()
+		}
+		defer func() {
+			if recover() != nil {
+				fillPresenceEndpointLookupErrors(results, resultIndexes, errPresenceEndpointLookupPanic)
+			}
+			if observer != nil {
+				observePresenceEndpointLookupSafely(observer, PresenceEndpointLookupObservation{
+					Path:       path,
+					Outcome:    presenceEndpointLookupOutcome(results, resultIndexes),
+					StaleRetry: staleRetry,
+					Items:      batch.items,
+					Groups:     len(batch.groups),
+					Duration:   time.Since(started),
+				})
+			}
+		}()
+		localNodeID := c.node.NodeID()
+		path = PresenceEndpointLookupPathRemoteBulk
+		if leaderNodeID == localNodeID {
+			path = PresenceEndpointLookupPathLegacyFallback
+			if _, ok := c.local.(accessnode.PresenceTargetBatchAuthority); ok {
+				path = PresenceEndpointLookupPathLocalBulk
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			fillPresenceEndpointLookupErrors(results, resultIndexes, err)
+			return
+		}
+		if leaderNodeID == localNodeID {
+			if targetBatch, ok := c.local.(accessnode.PresenceTargetBatchAuthority); ok {
+				localResults := targetBatch.EndpointsByTargets(ctx, batch.groups)
+				if len(localResults) != len(batch.groups) {
+					err := fmt.Errorf("%w: aligned local endpoint result count %d does not match group count %d", authoritypresence.ErrRouteNotReady, len(localResults), len(batch.groups))
+					fillPresenceEndpointLookupErrors(results, resultIndexes, err)
+					return
+				}
+				for i, result := range localResults {
+					results[resultIndex(i)] = result
+				}
+				return
+			}
+			for i, group := range batch.groups {
+				results[resultIndex(i)] = c.endpointsByExactTarget(ctx, group)
+			}
+			return
+		}
+		if c.remote == nil {
+			fillPresenceEndpointLookupErrors(results, resultIndexes, authoritypresence.ErrRouteNotReady)
+			return
+		}
+		remoteResults, err := c.remote.EndpointsByTargets(ctx, leaderNodeID, batch.groups)
+		if err != nil {
+			fillPresenceEndpointLookupErrors(results, resultIndexes, err)
+			return
+		}
+		if len(remoteResults) != len(batch.groups) {
+			err := fmt.Errorf("%w: aligned endpoint result count %d does not match group count %d", authoritypresence.ErrRouteNotReady, len(remoteResults), len(batch.groups))
+			fillPresenceEndpointLookupErrors(results, resultIndexes, err)
+			return
+		}
+		for i, result := range remoteResults {
+			results[resultIndex(i)] = result
+		}
+	}
+	if leaderNodeID, items, ok := singlePresenceEndpointLeader(groups); ok {
+		processLeader(leaderNodeID, &leaderBatch{
+			groups: groups,
+			items:  items,
+		})
+		return results
+	}
+
 	byLeader := make(map[uint64]*leaderBatch)
 	leaderOrder := make([]uint64, 0)
 	for i, group := range groups {
@@ -350,80 +436,37 @@ func (c *PresenceAuthorityClient) endpointsByTargetsOnce(ctx context.Context, gr
 		batch.groups = append(batch.groups, group)
 		batch.items += countNonEmptyPresenceUIDs(group.UIDs)
 	}
-
-	processLeader := func(leaderNodeID uint64) {
-		batch := byLeader[leaderNodeID]
-		path := ""
-		observer := c.endpointObserver
-		var started time.Time
-		if observer != nil {
-			started = time.Now()
-		}
-		defer func() {
-			if recover() != nil {
-				fillPresenceEndpointLookupErrors(results, batch.indexes, errPresenceEndpointLookupPanic)
-			}
-			if observer != nil {
-				observePresenceEndpointLookupSafely(observer, PresenceEndpointLookupObservation{
-					Path:       path,
-					Outcome:    presenceEndpointLookupOutcome(results, batch.indexes),
-					StaleRetry: staleRetry,
-					Items:      batch.items,
-					Groups:     len(batch.groups),
-					Duration:   time.Since(started),
-				})
-			}
-		}()
-		localNodeID := c.node.NodeID()
-		path = PresenceEndpointLookupPathRemoteBulk
-		if leaderNodeID == localNodeID {
-			path = PresenceEndpointLookupPathLegacyFallback
-			if _, ok := c.local.(accessnode.PresenceTargetBatchAuthority); ok {
-				path = PresenceEndpointLookupPathLocalBulk
-			}
-		}
-		if err := ctx.Err(); err != nil {
-			fillPresenceEndpointLookupErrors(results, batch.indexes, err)
-			return
-		}
-		if leaderNodeID == localNodeID {
-			if targetBatch, ok := c.local.(accessnode.PresenceTargetBatchAuthority); ok {
-				localResults := targetBatch.EndpointsByTargets(ctx, batch.groups)
-				if len(localResults) != len(batch.indexes) {
-					err := fmt.Errorf("%w: aligned local endpoint result count %d does not match group count %d", authoritypresence.ErrRouteNotReady, len(localResults), len(batch.indexes))
-					fillPresenceEndpointLookupErrors(results, batch.indexes, err)
-					return
-				}
-				for i, result := range localResults {
-					results[batch.indexes[i]] = result
-				}
-				return
-			}
-			for i, group := range batch.groups {
-				results[batch.indexes[i]] = c.endpointsByExactTarget(ctx, group)
-			}
-			return
-		}
-		if c.remote == nil {
-			fillPresenceEndpointLookupErrors(results, batch.indexes, authoritypresence.ErrRouteNotReady)
-			return
-		}
-		remoteResults, err := c.remote.EndpointsByTargets(ctx, leaderNodeID, batch.groups)
-		if err != nil {
-			fillPresenceEndpointLookupErrors(results, batch.indexes, err)
-			return
-		}
-		if len(remoteResults) != len(batch.indexes) {
-			err := fmt.Errorf("%w: aligned endpoint result count %d does not match group count %d", authoritypresence.ErrRouteNotReady, len(remoteResults), len(batch.indexes))
-			fillPresenceEndpointLookupErrors(results, batch.indexes, err)
-			return
-		}
-		for i, result := range remoteResults {
-			results[batch.indexes[i]] = result
-		}
-	}
-	runBoundedPresenceLeaderBatches(leaderOrder, defaultPresenceEndpointLeaderConcurrency, processLeader)
+	runBoundedPresenceLeaderBatches(
+		leaderOrder,
+		defaultPresenceEndpointLeaderConcurrency,
+		func(leaderNodeID uint64) {
+			processLeader(leaderNodeID, byLeader[leaderNodeID])
+		},
+	)
 	return results
+}
+
+func singlePresenceEndpointLeader(groups []presence.EndpointLookupGroup) (uint64, int, bool) {
+	if len(groups) == 0 {
+		return 0, 0, false
+	}
+	var leaderNodeID uint64
+	items := 0
+	for _, group := range groups {
+		if len(group.UIDs) == 0 {
+			return 0, 0, false
+		}
+		if group.Target.LeaderNodeID == 0 {
+			return 0, 0, false
+		}
+		if leaderNodeID == 0 {
+			leaderNodeID = group.Target.LeaderNodeID
+		} else if group.Target.LeaderNodeID != leaderNodeID {
+			return 0, 0, false
+		}
+		items += countNonEmptyPresenceUIDs(group.UIDs)
+	}
+	return leaderNodeID, items, leaderNodeID != 0
 }
 
 func observePresenceEndpointLookupSafely(observer PresenceEndpointLookupObserver, event PresenceEndpointLookupObservation) {
@@ -559,15 +602,15 @@ func presenceEndpointLookupOutcome(results []presence.EndpointLookupResult, inde
 	succeeded := 0
 	failed := 0
 	commonFailure := ""
-	for _, index := range indexes {
+	record := func(index int) {
 		if index < 0 || index >= len(results) {
 			failed++
 			commonFailure = PresenceEndpointLookupOutcomeError
-			continue
+			return
 		}
 		if results[index].Err == nil {
 			succeeded++
-			continue
+			return
 		}
 		failed++
 		outcome := presenceEndpointLookupErrorOutcome(results[index].Err)
@@ -575,6 +618,15 @@ func presenceEndpointLookupOutcome(results []presence.EndpointLookupResult, inde
 			commonFailure = outcome
 		} else if commonFailure != outcome {
 			commonFailure = PresenceEndpointLookupOutcomeError
+		}
+	}
+	if indexes == nil {
+		for index := range results {
+			record(index)
+		}
+	} else {
+		for _, index := range indexes {
+			record(index)
 		}
 	}
 	if failed == 0 {

--- a/internal/infra/cluster/presence_benchmark_test.go
+++ b/internal/infra/cluster/presence_benchmark_test.go
@@ -1,0 +1,77 @@
+package cluster
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/usecase/presence"
+)
+
+const (
+	cloudMediumPresenceBenchmarkGroups = 256
+	cloudMediumPresenceBenchmarkItems  = 19_650
+)
+
+var cloudMediumPresenceBenchmarkResultSink []presence.EndpointLookupResult
+
+// benchmarkTargetBatchPresenceAuthority isolates client-side exact-target
+// leader grouping; the production local directory cost has separate coverage.
+type benchmarkTargetBatchPresenceAuthority struct {
+	*fakePresenceAuthority
+	results []presence.EndpointLookupResult
+}
+
+func (a *benchmarkTargetBatchPresenceAuthority) EndpointsByTargets(
+	_ context.Context,
+	_ []presence.EndpointLookupGroup,
+) []presence.EndpointLookupResult {
+	return a.results
+}
+
+func newCloudMediumPresenceBenchmark() (*PresenceAuthorityClient, []presence.EndpointLookupGroup) {
+	groups := make([]presence.EndpointLookupGroup, cloudMediumPresenceBenchmarkGroups)
+	for groupIndex := range groups {
+		groups[groupIndex].Target = testEndpointLookupTarget(uint16(groupIndex), 1)
+	}
+	for itemIndex := 0; itemIndex < cloudMediumPresenceBenchmarkItems; itemIndex++ {
+		groupIndex := itemIndex % len(groups)
+		groups[groupIndex].UIDs = append(groups[groupIndex].UIDs, strconv.Itoa(itemIndex))
+	}
+	local := &benchmarkTargetBatchPresenceAuthority{
+		fakePresenceAuthority: &fakePresenceAuthority{},
+		results:               make([]presence.EndpointLookupResult, len(groups)),
+	}
+	return NewPresenceAuthorityClient(&fakePresenceCluster{nodeID: 1}, local), groups
+}
+
+func TestPresenceAuthorityClientSingleLeaderCloudMediumAllocations(t *testing.T) {
+	client, groups := newCloudMediumPresenceBenchmark()
+	allocations := testing.AllocsPerRun(20, func() {
+		cloudMediumPresenceBenchmarkResultSink = client.EndpointsByTargets(context.Background(), groups)
+	})
+	if got := len(cloudMediumPresenceBenchmarkResultSink); got != len(groups) {
+		t.Fatalf("EndpointsByTargets() len = %d, want %d", got, len(groups))
+	}
+	if allocations > 2 {
+		t.Fatalf("EndpointsByTargets() allocations = %.2f, want at most two aligned result allocations", allocations)
+	}
+}
+
+// BenchmarkPresenceAuthorityClientSingleLeaderCloudMedium measures the normal
+// 256-physical-hash-slot / one-local-leader target grouping overhead for one
+// Cloud Medium-shaped recipient feedback slice.
+func BenchmarkPresenceAuthorityClientSingleLeaderCloudMedium(b *testing.B) {
+	client, groups := newCloudMediumPresenceBenchmark()
+
+	b.ReportAllocs()
+	b.ReportMetric(cloudMediumPresenceBenchmarkGroups, "target-groups/op")
+	b.ReportMetric(cloudMediumPresenceBenchmarkItems, "items/op")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cloudMediumPresenceBenchmarkResultSink = client.EndpointsByTargets(context.Background(), groups)
+		if len(cloudMediumPresenceBenchmarkResultSink) != len(groups) {
+			b.Fatalf("EndpointsByTargets() len = %d, want %d", len(cloudMediumPresenceBenchmarkResultSink), len(groups))
+		}
+	}
+}

--- a/internal/infra/cluster/presence_test.go
+++ b/internal/infra/cluster/presence_test.go
@@ -564,6 +564,30 @@ func TestPresenceAuthorityClientEndpointsByTargetsUsesOneLocalTargetBatchCall(t 
 	})
 }
 
+func TestPresenceAuthorityClientEndpointsByTargetsKeepsEmptyGroupAligned(t *testing.T) {
+	groups := []presence.EndpointLookupGroup{
+		{},
+		{Target: testEndpointLookupTarget(21, 1), UIDs: []string{"second"}},
+	}
+	local := &fakeTargetBatchPresenceAuthority{
+		fakePresenceAuthority: &fakePresenceAuthority{},
+		results: []presence.EndpointLookupResult{{
+			Routes: []presence.Route{testInfraPresenceRoute("second", 2)},
+		}},
+	}
+	client := NewPresenceAuthorityClient(&fakePresenceCluster{nodeID: 1}, local)
+
+	results := client.EndpointsByTargets(context.Background(), groups)
+
+	require.Len(t, local.calls, 1)
+	require.Equal(t, groups[1:], local.calls[0], "empty aligned groups must not reach the authority")
+	require.Len(t, results, 2)
+	require.Empty(t, results[0])
+	require.NoError(t, results[1].Err)
+	require.Len(t, results[1].Routes, 1)
+	require.Equal(t, "second", results[1].Routes[0].UID)
+}
+
 func TestPresenceAuthorityClientEndpointsByTargetsOverlapsRemoteLeadersAndKeepsResultsAligned(t *testing.T) {
 	started := make(chan uint64, 2)
 	releaseC := make(chan struct{})

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -139,6 +139,16 @@ flag guarantees that at most one goroutine advances that channel at a time. The
 group uses shards only for writer lookup and creation; shard locks are not held
 while preparing, appending, or committing messages.
 
+Writer activation first enters one group-local dispatcher queue. Only that
+dispatcher may perform a blocking submit to the bounded advance worker pool;
+`SubmitLocal`, append completions, and post-commit completions never wait for an
+advance worker. The scheduled flag de-duplicates each writer to at most one
+queued or running activation, so dispatcher memory is bounded by active writer
+state rather than SEND rate. This breaks the cross-pool cycle where every
+advance worker could wait for the append pool while every append completion
+waited to resubmit into the advance pool. The configured `AdvancePoolSize`
+still bounds concurrent writer state-machine execution.
+
 Accepted submit events enter a lightweight per-writer inbox. A scheduled writer
 may wait for the tiny runtime-only `InboxCoalesceWindow` before draining a
 small inbox, stopping earlier when the inbox reaches `InboxCoalesceMaxItems`
@@ -284,8 +294,11 @@ is not configured. This observer runs before sender echo suppression so a
 sender's other online sessions do not hide unrelated offline recipients. It is
 limited to durable ordinary commits: zero-sequence realtime envelopes, SyncOnce
 command messages, and request-scoped `MessageScopedUIDs` batches are skipped.
-Batch offline observation avoids per-recipient webhook queue admission for large
-fanout; callers should chunk large batches at the observer boundary if needed.
+Batch offline observation avoids per-recipient webhook or plugin-worker queue
+admission for large fanout. The observer receives one shared committed payload
+plus the ordered UID slice; an asynchronous adapter takes ownership once for the
+whole batch instead of cloning the payload for every UID. Callers should chunk
+large batches at the observer boundary if needed.
 The observer is a best-effort side-effect boundary and must not influence
 SENDACK, append success, conversation active admission, or owner push delivery.
 
@@ -316,6 +329,13 @@ the complete physical hash-slot fence, so the 256 hash slots remain distinct
 even when they map onto only 10 logical Slot Raft Groups. Channelappend then
 enqueues bounded recipient delivery plans and admits one independent
 `conversationactive.ActiveBatch` projection.
+The normal bounded page uses an allocation-free inline UID index to coalesce the
+sender and duplicate recipients while preserving duplicate delivery rows. It
+borrows an already-normalized recipient slice and copies only when empty or
+whitespace-normalized UIDs require compaction. Exact-target grouping uses a
+fixed 256-entry physical-hash-slot index with exact-target comparison; custom
+slot counts or transition collisions fall back to a bounded exact scan rather
+than weakening leader-term, config-epoch, or route-revision fences.
 The batch carries an explicit `metadb.ConversationKind`: normal for ordinary
 channel commits, CMD for one-shot sync commits or command-channel ids. It also
 carries `SenderUID` from the committed event, channel identity, message
@@ -340,7 +360,10 @@ map to route-not-ready before enqueueing. The production plan-capable enqueuer p
 groups into commands whose total recipient count is bounded by the existing
 recipient batch size. This preserves the complete target fence across the queue
 boundary while allowing one subscriber page to be admitted as one plan when it
-fits that bound. A legacy batch-only enqueuer remains supported; only that
+fits that bound. Each target carries a capacity-limited view into the
+grouping-owned normalized recipient storage, so asynchronous admission does not
+repeat the recipient copy and cannot overwrite a sibling target window. A
+legacy batch-only enqueuer remains supported; only that
 compatibility path dispatches different targets concurrently up to
 `RecipientAuthorityDispatchConcurrency`, while batches for the same target stay
 sequential.
@@ -351,12 +374,15 @@ per-group results, so one failed group is observed without suppressing the
 other groups. A legacy presence resolver remains supported by resolving the
 groups individually. A panic while processing one resolved group is converted
 to that group's terminal error and does not prevent later sibling groups from
-running. Successfully resolved groups observe offline recipients and skip only
-the sender's exact accepted session before their routes are coalesced by owner
-across the whole plan. Owner groups retain first-appearance order for stable
-error folding, route order follows target and resolver order, and each owner
-group is split into bounded push chunks. Different owners execute concurrently
-under a fixed bound, while chunks for the same owner remain sequential.
+running. Successfully resolved groups first contribute their deduplicated
+offline UIDs to one plan-level observer event, so plugin and webhook work scales
+with bounded delivery plans rather than 256 physical authority targets. They
+then skip only the sender's exact accepted session before routes are coalesced
+by owner across the whole plan. Owner groups retain first-appearance order for
+stable error folding, route order follows target and resolver order, and each
+owner group is split into bounded push chunks. Different owners execute
+concurrently under a fixed bound, while chunks for the same owner remain
+sequential.
 Retryable results narrow retries to only their returned routes; terminal
 push failures map back only to the exact target groups that contributed those
 routes, while unrelated owners and targets continue. Owner-local concrete
@@ -422,10 +448,12 @@ enqueue/pop, and retry-turn completion request pressure publication only after
 their state transition. None of these observations carries a channel, UID, Slot,
 or authority-target label. When the observer supports pool
 samples, the group also emits running/capacity/waiting observations for the
-advance, append_effect, and post_commit pools. The first two report direct
-ants/v2 worker state; post_commit reports logical admitted tasks so retained idle
-ants workers are not mistaken for active work. Benchmark scripts use these
-samples for the per-node peak `used/cap` pool summary.
+advance, append_effect, and post_commit pools. Advance waiting includes both
+the dispatcher queue and a dispatcher currently blocked on the underlying
+ants/v2 pool; append_effect reports direct ants state. Post_commit reports
+logical admitted tasks so retained idle ants workers are not mistaken for
+active work. Benchmark scripts use these samples for the per-node peak
+`used/cap` pool summary.
 
 Before a post-commit effect enters the asynchronous pool, it copies the
 committed-envelope slice into effect-owned storage. The envelopes themselves

--- a/internal/runtime/channelappend/advance_scheduler.go
+++ b/internal/runtime/channelappend/advance_scheduler.go
@@ -1,0 +1,154 @@
+package channelappend
+
+import "sync"
+
+// writerAdvanceScheduler is the single admission owner for the blocking
+// advance worker pool. Callers and effect-pool completions only append an
+// already de-duplicated writer pointer to this unbounded-in-count but
+// activation-bounded queue; they never wait for an advance worker.
+//
+// A channelWriter may own at most one scheduled activation, so queue memory is
+// bounded by active writer state rather than SEND rate. Keeping blocking pool
+// admission in this dedicated dispatcher breaks the advance<->append pool
+// dependency cycle without bypassing the configured advance concurrency.
+type writerAdvanceScheduler struct {
+	pool *workerPool
+
+	mu    sync.Mutex
+	cond  *sync.Cond
+	queue []*channelWriter
+	head  int
+	// dispatching reports the one writer removed from queue while the
+	// dispatcher is waiting for or handing it to an advance worker.
+	dispatching bool
+	started     bool
+	stopping    bool
+	done        chan struct{}
+
+	onStateChange func()
+}
+
+func newWriterAdvanceScheduler(pool *workerPool) *writerAdvanceScheduler {
+	s := &writerAdvanceScheduler{
+		pool: pool,
+		done: make(chan struct{}),
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+func (s *writerAdvanceScheduler) start() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.mu.Unlock()
+	go s.run()
+}
+
+func (s *writerAdvanceScheduler) schedule(writer *channelWriter) {
+	if s == nil || writer == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.stopping {
+		s.mu.Unlock()
+		return
+	}
+	s.queue = append(s.queue, writer)
+	s.cond.Signal()
+	s.mu.Unlock()
+	s.notifyStateChange()
+}
+
+func (s *writerAdvanceScheduler) run() {
+	defer close(s.done)
+	for {
+		s.mu.Lock()
+		for s.head == len(s.queue) && !s.stopping {
+			s.cond.Wait()
+		}
+		if s.head == len(s.queue) && s.stopping {
+			s.mu.Unlock()
+			return
+		}
+		writer := s.queue[s.head]
+		s.queue[s.head] = nil
+		s.head++
+		if s.head == len(s.queue) {
+			s.queue = s.queue[:0]
+			s.head = 0
+		} else {
+			s.compactQueueLocked()
+		}
+		s.dispatching = true
+		s.mu.Unlock()
+		s.notifyStateChange()
+
+		if err := s.pool.submit(func() { writer.advance() }); err != nil {
+			// The pool is stopped only after the writer drain and scheduler
+			// stop. Running inline is a final fail-safe that preserves accepted
+			// work if that lifecycle invariant is ever violated.
+			writer.advance()
+		}
+		s.mu.Lock()
+		s.dispatching = false
+		s.mu.Unlock()
+		s.notifyStateChange()
+	}
+}
+
+func (s *writerAdvanceScheduler) waiting() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	waiting := len(s.queue) - s.head
+	if s.dispatching {
+		waiting++
+	}
+	return waiting
+}
+
+func (s *writerAdvanceScheduler) compactQueueLocked() {
+	if s.head < 1024 || s.head*2 < len(s.queue) {
+		return
+	}
+	oldLen := len(s.queue)
+	remaining := oldLen - s.head
+	copy(s.queue[:remaining], s.queue[s.head:])
+	clear(s.queue[remaining:oldLen])
+	s.queue = s.queue[:remaining]
+	s.head = 0
+}
+
+func (s *writerAdvanceScheduler) notifyStateChange() {
+	if s != nil && s.onStateChange != nil {
+		s.onStateChange()
+	}
+}
+
+func (s *writerAdvanceScheduler) stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if !s.started {
+		s.stopping = true
+		s.mu.Unlock()
+		return
+	}
+	if !s.stopping {
+		s.stopping = true
+		s.cond.Broadcast()
+	}
+	done := s.done
+	s.mu.Unlock()
+	<-done
+}

--- a/internal/runtime/channelappend/advance_scheduler_test.go
+++ b/internal/runtime/channelappend/advance_scheduler_test.go
@@ -1,0 +1,34 @@
+package channelappend
+
+import "testing"
+
+func TestWriterAdvanceSchedulerCompactionClearsDequeuedTail(t *testing.T) {
+	const writerCount = 2048
+	scheduler := &writerAdvanceScheduler{
+		queue: make([]*channelWriter, writerCount),
+		head:  writerCount / 2,
+	}
+	for i := range scheduler.queue {
+		scheduler.queue[i] = &channelWriter{}
+	}
+	firstRemaining := scheduler.queue[scheduler.head]
+	oldLen := len(scheduler.queue)
+
+	scheduler.compactQueueLocked()
+
+	if scheduler.head != 0 {
+		t.Fatalf("compacted head = %d, want 0", scheduler.head)
+	}
+	if got, want := len(scheduler.queue), writerCount/2; got != want {
+		t.Fatalf("compacted queue len = %d, want %d", got, want)
+	}
+	if scheduler.queue[0] != firstRemaining {
+		t.Fatal("compacted queue lost the first live writer")
+	}
+	backing := scheduler.queue[:oldLen]
+	for i := len(scheduler.queue); i < oldLen; i++ {
+		if backing[i] != nil {
+			t.Fatalf("compacted queue retained dequeued writer at backing index %d", i)
+		}
+	}
+}

--- a/internal/runtime/channelappend/delivery.go
+++ b/internal/runtime/channelappend/delivery.go
@@ -114,6 +114,24 @@ func (p *RecipientProcessor) ProcessRecipientDeliveryPlan(ctx context.Context, p
 	}
 
 	resolved := targetResolver.EndpointsByTargets(ctx, plan.Targets)
+	observePlanOffline := shouldObserveOfflineRecipients(
+		plan.Event,
+		p.ports.offlineRecipientsObserver,
+		p.ports.offlineRecipientObserver,
+	)
+	deliveryPorts := p.ports
+	if observePlanOffline {
+		// Exact-target lookups are one physical routing concern, while plugin
+		// and webhook observers consume one committed-message recipient set.
+		// Aggregate successful target results before one observer admission.
+		deliveryPorts.offlineRecipientsObserver = nil
+		deliveryPorts.offlineRecipientObserver = nil
+	}
+	var planOfflineUIDs []string
+	var seenPlanOffline map[string]struct{}
+	if observePlanOffline {
+		seenPlanOffline = make(map[string]struct{}, plan.RecipientCount())
+	}
 	grouped := make(map[uint64]*recipientPlanOwnerRoutes)
 	ownerOrder := make([]uint64, 0)
 	for i, target := range plan.Targets {
@@ -128,7 +146,15 @@ func (p *RecipientProcessor) ProcessRecipientDeliveryPlan(ctx context.Context, p
 			results[i] = withPostCommitFailureDetail(resolved[i].Err, detail)
 			continue
 		}
-		routes, err := prepareRecipientBatchRoutesSafely(ctx, batch, resolved[i].Routes, p.ports)
+		if observePlanOffline {
+			planOfflineUIDs = appendOfflineRecipientUIDs(
+				planOfflineUIDs,
+				seenPlanOffline,
+				batch.Recipients,
+				resolved[i].Routes,
+			)
+		}
+		routes, err := prepareRecipientBatchRoutesSafely(ctx, batch, resolved[i].Routes, deliveryPorts)
 		if err != nil {
 			results[i] = err
 			continue
@@ -144,7 +170,18 @@ func (p *RecipientProcessor) ProcessRecipientDeliveryPlan(ctx context.Context, p
 			ownerRoutes.targetIndexes = append(ownerRoutes.targetIndexes, i)
 		}
 	}
+	var offlineObserverErr error
+	if len(planOfflineUIDs) > 0 {
+		offlineObserverErr = notifyOfflineRecipientsSafely(
+			ctx,
+			plan.Event,
+			planOfflineUIDs,
+			p.ports.offlineRecipientsObserver,
+			p.ports.offlineRecipientObserver,
+		)
+	}
 	if p.ports.pusher == nil {
+		recordRecipientPlanSideEffectFailure(results, offlineObserverErr)
 		return results
 	}
 	batchSize := boundedPositive(p.ports.ownerPushBatchSize, defaultRecipientBatchSize)
@@ -183,7 +220,23 @@ func (p *RecipientProcessor) ProcessRecipientDeliveryPlan(ctx context.Context, p
 			}
 		}
 	}
+	recordRecipientPlanSideEffectFailure(results, offlineObserverErr)
 	return results
+}
+
+func recordRecipientPlanSideEffectFailure(results []error, err error) {
+	if err == nil {
+		return
+	}
+	// The plan-level observer is one independent best-effort side effect.
+	// Preserve one bounded diagnostic failure without blocking owner delivery
+	// or multiplying the same failure across every exact target.
+	for i := range results {
+		if results[i] == nil {
+			results[i] = err
+			return
+		}
+	}
 }
 
 func runBoundedRecipientOwnerPushes(count, concurrency int, run func(int)) {
@@ -409,6 +462,11 @@ func observeOfflineRecipients(
 	if (batchObserver == nil && singleObserver == nil) || !offlineRecipientObserverEligible(batch.Event) {
 		return
 	}
+	offlineUIDs := offlineRecipientUIDs(uids, routes)
+	notifyOfflineRecipients(ctx, batch.Event, offlineUIDs, batchObserver, singleObserver)
+}
+
+func offlineRecipientUIDs(uids []string, routes []Route) []string {
 	online := make(map[string]struct{}, len(routes))
 	for _, route := range routes {
 		if route.UID != "" {
@@ -430,6 +488,45 @@ func observeOfflineRecipients(
 		seenOffline[uid] = struct{}{}
 		offlineUIDs = append(offlineUIDs, uid)
 	}
+	return offlineUIDs
+}
+
+func appendOfflineRecipientUIDs(
+	out []string,
+	seen map[string]struct{},
+	recipients []Recipient,
+	routes []Route,
+) []string {
+	online := make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		if route.UID != "" {
+			online[route.UID] = struct{}{}
+		}
+	}
+	for _, recipient := range recipients {
+		uid := recipient.UID
+		if uid == "" {
+			continue
+		}
+		if _, ok := online[uid]; ok {
+			continue
+		}
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+		out = append(out, uid)
+	}
+	return out
+}
+
+func notifyOfflineRecipients(
+	ctx context.Context,
+	event CommittedEnvelope,
+	offlineUIDs []string,
+	batchObserver OfflineRecipientsObserver,
+	singleObserver OfflineRecipientObserver,
+) {
 	if len(offlineUIDs) == 0 {
 		return
 	}
@@ -438,7 +535,7 @@ func observeOfflineRecipients(
 	}
 	if batchObserver != nil {
 		batchObserver.ObserveOfflineRecipients(ctx, OfflineRecipientsEvent{
-			Event: batch.Event,
+			Event: event,
 			UIDs:  append([]string(nil), offlineUIDs...),
 		})
 		return
@@ -447,8 +544,32 @@ func observeOfflineRecipients(
 		return
 	}
 	for _, uid := range offlineUIDs {
-		singleObserver.ObserveOfflineRecipient(ctx, OfflineRecipientEvent{Event: batch.Event, UID: uid})
+		singleObserver.ObserveOfflineRecipient(ctx, OfflineRecipientEvent{Event: event, UID: uid})
 	}
+}
+
+func notifyOfflineRecipientsSafely(
+	ctx context.Context,
+	event CommittedEnvelope,
+	offlineUIDs []string,
+	batchObserver OfflineRecipientsObserver,
+	singleObserver OfflineRecipientObserver,
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = withPostCommitFailureDetail(
+				effectPanicError(effectStagePostCommit, recovered),
+				PostCommitFailureDetail{
+					Phase:          "offline_recipient_observer",
+					UID:            firstString(offlineUIDs),
+					UIDCount:       len(offlineUIDs),
+					RecipientCount: len(offlineUIDs),
+				},
+			)
+		}
+	}()
+	notifyOfflineRecipients(ctx, event, offlineUIDs, batchObserver, singleObserver)
+	return nil
 }
 
 func offlineRecipientObserverEligible(event CommittedEnvelope) bool {

--- a/internal/runtime/channelappend/delivery_test.go
+++ b/internal/runtime/channelappend/delivery_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -538,6 +539,108 @@ func TestRecipientProcessorPrefersBatchOfflineObserver(t *testing.T) {
 	}
 }
 
+func TestRecipientProcessorBatchesOfflineObservationAcrossExactTargets(t *testing.T) {
+	observer := &recordingBatchOfflineRecipientObserverForDeliveryTest{}
+	resolver := &recordingTargetPresenceResolverForDeliveryWorkerTest{
+		results: []RecipientTargetPresenceResult{
+			{Routes: []Route{{UID: "u1", OwnerNodeID: 1, SessionID: 11}}},
+			{},
+		},
+	}
+	processor := NewRecipientProcessor(RecipientProcessorOptions{
+		PresenceResolver:          resolver,
+		OfflineRecipientsObserver: observer,
+	})
+
+	errs := processor.ProcessRecipientDeliveryPlan(context.Background(), RecipientDeliveryPlan{
+		Event: CommittedEnvelope{
+			MessageID:   10,
+			MessageSeq:  4,
+			ChannelID:   "g1",
+			ChannelType: 2,
+			FromUID:     "sender",
+		},
+		Targets: []RecipientTargetBatch{
+			{
+				Target:     recipientAuthorityTargetForTest(1, 10, 100),
+				Recipients: []Recipient{{UID: "u1"}, {UID: "u2"}},
+			},
+			{
+				Target:     recipientAuthorityTargetForTest(2, 20, 200),
+				Recipients: []Recipient{{UID: "u3"}},
+			},
+		},
+	})
+
+	if got, want := errs, make([]error, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ProcessRecipientDeliveryPlan() errors = %#v, want %#v", got, want)
+	}
+	if got := observer.batchCallCount(); got != 1 {
+		t.Fatalf("batch offline observer calls = %d, want one plan-level batch", got)
+	}
+	if got, want := observer.batchUIDs(), []string{"u2", "u3"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch offline uids = %#v, want %#v", got, want)
+	}
+}
+
+func TestRecipientProcessorPlanOfflineObserverPanicDoesNotBlockOwnerPush(t *testing.T) {
+	observer := &panicBatchOfflineRecipientObserverForDeliveryTest{}
+	resolver := &recordingTargetPresenceResolverForDeliveryWorkerTest{
+		results: []RecipientTargetPresenceResult{
+			{Routes: []Route{{UID: "u1", OwnerNodeID: 1, SessionID: 11}}},
+			{Routes: []Route{{UID: "u3", OwnerNodeID: 2, SessionID: 33}}},
+		},
+	}
+	pusher := &recordingOwnerPusherForDeliveryTest{}
+	processor := NewRecipientProcessor(RecipientProcessorOptions{
+		PresenceResolver:          resolver,
+		OwnerPusher:               pusher,
+		OfflineRecipientsObserver: observer,
+	})
+
+	errs := processor.ProcessRecipientDeliveryPlan(context.Background(), RecipientDeliveryPlan{
+		Event: CommittedEnvelope{
+			MessageID:   10,
+			MessageSeq:  4,
+			ChannelID:   "g1",
+			ChannelType: 2,
+			FromUID:     "sender",
+		},
+		Targets: []RecipientTargetBatch{
+			{
+				Target:     recipientAuthorityTargetForTest(1, 10, 100),
+				Recipients: []Recipient{{UID: "u1"}, {UID: "u2"}},
+			},
+			{
+				Target:     recipientAuthorityTargetForTest(2, 20, 200),
+				Recipients: []Recipient{{UID: "u3"}, {UID: "u4"}},
+			},
+		},
+	})
+
+	if got := observer.callCount(); got != 1 {
+		t.Fatalf("batch offline observer calls = %d, want 1", got)
+	}
+	if got := pusher.callCount(); got != 2 {
+		t.Fatalf("owner push calls = %d, want both owners despite observer panic", got)
+	}
+	panicErrors := 0
+	successes := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrEffectPanic):
+			panicErrors++
+		default:
+			t.Fatalf("ProcessRecipientDeliveryPlan() unexpected error = %v", err)
+		}
+	}
+	if panicErrors != 1 || successes != 1 {
+		t.Fatalf("ProcessRecipientDeliveryPlan() errors = %#v, want one isolated observer panic and one success", errs)
+	}
+}
+
 func TestRecipientProcessorOptionsAcceptsBatchOnlyOfflineObserver(t *testing.T) {
 	observer := &recordingBatchOnlyOfflineRecipientObserverForDeliveryTest{}
 	processor := NewRecipientProcessor(RecipientProcessorOptions{
@@ -906,6 +1009,22 @@ func (o *recordingBatchOfflineRecipientObserverForDeliveryTest) sawUIDAlias() bo
 type recordingBatchOnlyOfflineRecipientObserverForDeliveryTest struct {
 	mu     sync.Mutex
 	events []OfflineRecipientsEvent
+}
+
+type panicBatchOfflineRecipientObserverForDeliveryTest struct {
+	calls atomic.Int64
+}
+
+func (o *panicBatchOfflineRecipientObserverForDeliveryTest) ObserveOfflineRecipients(
+	context.Context,
+	OfflineRecipientsEvent,
+) {
+	o.calls.Add(1)
+	panic("offline recipient observer panic")
+}
+
+func (o *panicBatchOfflineRecipientObserverForDeliveryTest) callCount() int {
+	return int(o.calls.Load())
 }
 
 func (o *recordingBatchOnlyOfflineRecipientObserverForDeliveryTest) ObserveOfflineRecipients(_ context.Context, event OfflineRecipientsEvent) {

--- a/internal/runtime/channelappend/group.go
+++ b/internal/runtime/channelappend/group.go
@@ -13,6 +13,9 @@ type Group struct {
 	shards []*shard
 	// advancePool runs non-blocking writer state-machine activation.
 	advancePool *workerPool
+	// advanceScheduler is the only blocking submitter to advancePool. It keeps
+	// callers and effect completions out of cross-pool dependency cycles.
+	advanceScheduler *writerAdvanceScheduler
 	// appendPool runs foreground blocking durable append effects.
 	appendPool *workerPool
 	// postCommitPool runs best-effort post-commit and realtime recipient effects.
@@ -39,6 +42,7 @@ func New(opts Options) *Group {
 	opts = applyDefaults(opts)
 	limits := stateLimitsFromOptions(opts)
 	advancePool := newWorkerPool(opts.AdvancePoolSize)
+	advanceScheduler := newWriterAdvanceScheduler(advancePool)
 	appendPool := newWorkerPool(opts.EffectPoolSize)
 	postCommitPool := newNonblockingWorkerPool(opts.EffectPoolSize)
 	handoff := newPostCommitHandoff(opts.PostCommitHandoffCapacity)
@@ -50,6 +54,7 @@ func New(opts Options) *Group {
 	group := &Group{
 		opts:              opts,
 		advancePool:       advancePool,
+		advanceScheduler:  advanceScheduler,
 		appendPool:        appendPool,
 		postCommitPool:    postCommitPool,
 		handoff:           handoff,
@@ -71,11 +76,13 @@ func New(opts Options) *Group {
 			appendPool:        appendPool,
 			postCommitPool:    postCommitPool,
 			advancePool:       advancePool,
+			advanceScheduler:  advanceScheduler,
 			handoff:           handoff,
 			postCommitRetries: postCommitRetries,
 		}
 		metrics = &group.metrics
 	}
+	advanceScheduler.onStateChange = group.metrics.observePressure
 	ports := writerPorts{
 		prepare:        preparePortsFromOptions(opts),
 		append:         appendPortsFromOptions(opts),
@@ -98,7 +105,7 @@ func New(opts Options) *Group {
 }
 
 func (g *Group) schedule(w *channelWriter) {
-	_ = g.advancePool.submit(func() { w.advance() })
+	g.advanceScheduler.schedule(w)
 }
 
 func (g *Group) shardForTarget(target AuthorityTarget) *shard {
@@ -120,6 +127,7 @@ func (g *Group) Start(ctx context.Context) error {
 		g.mu.Unlock()
 		return nil
 	}
+	g.advanceScheduler.start()
 	g.metrics.startPressurePublisher()
 	g.postCommitRetries.start()
 	g.started = true
@@ -157,6 +165,7 @@ func (g *Group) finishStop() {
 	background := context.Background()
 	_ = g.drainWriters(background)
 	_ = g.postCommitRetries.stopAndWait(background)
+	g.advanceScheduler.stop()
 	_ = g.metrics.stopPressurePublisher(background)
 	_ = g.advancePool.stop(background)
 	_ = g.appendPool.stop(background)

--- a/internal/runtime/channelappend/group_test.go
+++ b/internal/runtime/channelappend/group_test.go
@@ -77,6 +77,72 @@ func TestAdvancePoolSizeIsIndependentFromAuthorityShards(t *testing.T) {
 	}
 }
 
+func TestGroupBurstDoesNotDeadlockAdvanceAndAppendPools(t *testing.T) {
+	const messageCount = 64
+	group := New(Options{
+		LocalNodeID:                 1,
+		AuthorityShardCount:         4,
+		AdvancePoolSize:             1,
+		EffectPoolSize:              1,
+		AdmissionCapacityPerShard:   messageCount,
+		ChannelBacklogHighWatermark: messageCount,
+		MessageID:                   newSequenceIDsForPrepare(1),
+		Appender:                    newRecordingAppenderForAppendTest(),
+		InboxCoalesceWindow:         -time.Nanosecond,
+	})
+	if err := group.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	type submitResult struct {
+		futures []*Future
+		err     error
+	}
+	submittedC := make(chan submitResult, 1)
+	go func() {
+		futures := make([]*Future, 0, messageCount)
+		for i := 0; i < messageCount; i++ {
+			channelID := "burst-" + strconv.Itoa(i)
+			target := AuthorityTarget{
+				ChannelID:    ChannelID{ID: channelID, Type: 2},
+				ChannelKey:   "2:" + channelID,
+				LeaderNodeID: 1,
+				Epoch:        1,
+				LeaderEpoch:  1,
+			}
+			future, err := group.SubmitLocal(
+				context.Background(),
+				target,
+				[]SendBatchItem{testSendItem("u"+strconv.Itoa(i), channelID)},
+			)
+			if err != nil {
+				submittedC <- submitResult{err: err}
+				return
+			}
+			futures = append(futures, future)
+		}
+		submittedC <- submitResult{futures: futures}
+	}()
+
+	var submitted submitResult
+	select {
+	case submitted = <-submittedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("burst SubmitLocal deadlocked between advance and append pools")
+	}
+	if submitted.err != nil {
+		t.Fatalf("burst SubmitLocal() error = %v", submitted.err)
+	}
+	for _, future := range submitted.futures {
+		requireAppendSuccessAnyID(t, waitFutureForTest(t, future), 0)
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := group.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}
+
 func TestSubmitLocalRejectsRemoteAuthorityWithoutState(t *testing.T) {
 	group := newStartedTestGroup(t, Options{LocalNodeID: 1})
 	target := AuthorityTarget{ChannelID: ChannelID{ID: "room", Type: 2}, LeaderNodeID: 2}

--- a/internal/runtime/channelappend/metrics.go
+++ b/internal/runtime/channelappend/metrics.go
@@ -15,6 +15,7 @@ type groupMetrics struct {
 	appendPool        *workerPool
 	postCommitPool    *workerPool
 	advancePool       *workerPool
+	advanceScheduler  *writerAdvanceScheduler
 	handoff           *postCommitHandoff
 	postCommitRetries *postCommitRetryScheduler
 
@@ -149,7 +150,7 @@ func (m *groupMetrics) publishPressureSnapshot() {
 	if !ok || antsObserver == nil {
 		return
 	}
-	observeWorkerPool(antsObserver, "advance", m.advancePool)
+	observeWorkerPoolWithWaiting(antsObserver, "advance", m.advancePool, m.advanceScheduler.waiting())
 	observeWorkerPool(antsObserver, "append_effect", m.appendPool)
 	observeWorkerPool(antsObserver, "post_commit", m.postCommitPool)
 }
@@ -169,6 +170,13 @@ func (m *groupMetrics) admissionDepth() int {
 }
 
 func observeWorkerPool(observer AntsPoolObserver, name string, pool *workerPool) {
+	if pool == nil {
+		return
+	}
+	observeWorkerPoolWithWaiting(observer, name, pool, pool.waiting())
+}
+
+func observeWorkerPoolWithWaiting(observer AntsPoolObserver, name string, pool *workerPool, waiting int) {
 	if observer == nil || pool == nil {
 		return
 	}
@@ -176,6 +184,6 @@ func observeWorkerPool(observer AntsPoolObserver, name string, pool *workerPool)
 		Pool:     name,
 		Running:  pool.running(),
 		Capacity: pool.capacity(),
-		Waiting:  pool.waiting(),
+		Waiting:  waiting,
 	})
 }

--- a/internal/runtime/channelappend/options.go
+++ b/internal/runtime/channelappend/options.go
@@ -429,7 +429,7 @@ type Options struct {
 	SenderFence SenderFenceValidator
 	// AuthorityShardCount is the number of channel-key lookup shards. Values <= 0 use one shard.
 	AuthorityShardCount int
-	// AdvancePoolSize is the direct ants pool size used to activate writer state machines. Values <= 0 use a conservative default; larger values are capped at the ants/v2 int32 capacity limit.
+	// AdvancePoolSize bounds writer state-machine concurrency behind the dedicated non-blocking activation dispatcher. Values <= 0 use a conservative default; larger values are capped at the ants/v2 int32 capacity limit.
 	AdvancePoolSize int
 	// AdmissionCapacityPerShard bounds admitted-but-incomplete items per shard. Values <= 0 use a conservative bounded default.
 	AdmissionCapacityPerShard int

--- a/internal/runtime/channelappend/pressure_test.go
+++ b/internal/runtime/channelappend/pressure_test.go
@@ -3,6 +3,7 @@ package channelappend
 import (
 	"context"
 	"reflect"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,8 @@ type capturePressureObserver struct {
 	maxPostCommitHandoffDepth   int
 	maxPostCommitRetryQueue     int
 	sawPostCommitRetryContended bool
+	maxAdvanceWaiting           int
+	lastAdvance                 AntsPoolObservation
 	antsSeen                    map[string]AntsPoolObservation
 	antsReady                   chan struct{}
 	ready                       chan struct{}
@@ -99,6 +102,12 @@ func (c *capturePressureObserver) postCommitSnapshot() (WriterPressureObservatio
 func (c *capturePressureObserver) ObserveChannelAppendAntsPool(event AntsPoolObservation) {
 	c.mu.Lock()
 	c.antsSeen[event.Pool] = event
+	if event.Pool == "advance" {
+		c.lastAdvance = event
+		if event.Waiting > c.maxAdvanceWaiting {
+			c.maxAdvanceWaiting = event.Waiting
+		}
+	}
 	if len(c.antsSeen) >= 3 {
 		select {
 		case <-c.antsReady:
@@ -107,6 +116,12 @@ func (c *capturePressureObserver) ObserveChannelAppendAntsPool(event AntsPoolObs
 		}
 	}
 	c.mu.Unlock()
+}
+
+func (c *capturePressureObserver) advanceSnapshot() (AntsPoolObservation, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastAdvance, c.maxAdvanceWaiting
 }
 
 func TestGroupEmitsAggregatePressure(t *testing.T) {
@@ -192,6 +207,114 @@ func TestGroupEmitsAggregatePressure(t *testing.T) {
 	observer.mu.Unlock()
 	if advance.Capacity == 0 || appendEffect.Capacity != 5 || postCommit.Capacity != 5 {
 		t.Fatalf("ants pool observations = advance %#v append_effect %#v post_commit %#v, want advance, append_effect, and post_commit pools", advance, appendEffect, postCommit)
+	}
+}
+
+type blockingAdvanceAuthorizerForPressureTest struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingAdvanceAuthorizerForPressureTest() *blockingAdvanceAuthorizerForPressureTest {
+	return &blockingAdvanceAuthorizerForPressureTest{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (a *blockingAdvanceAuthorizerForPressureTest) AuthorizeSend(ctx context.Context, _ SendCommand) (Decision, error) {
+	a.once.Do(func() { close(a.started) })
+	select {
+	case <-a.release:
+		return Decision{Allowed: true, Reason: ReasonSuccess}, nil
+	case <-ctx.Done():
+		return Decision{}, ctx.Err()
+	}
+}
+
+func TestAdvanceDispatcherPublishesQueuedAndDrainedPressure(t *testing.T) {
+	observer := newCapturePressureObserver()
+	authorizer := newBlockingAdvanceAuthorizerForPressureTest()
+	group := New(Options{
+		LocalNodeID:                 1,
+		AuthorityShardCount:         1,
+		AdvancePoolSize:             1,
+		EffectPoolSize:              1,
+		AdmissionCapacityPerShard:   8,
+		ChannelBacklogHighWatermark: 8,
+		MessageID:                   newSequenceIDsForPrepare(1),
+		Authorizer:                  authorizer,
+		Appender:                    newRecordingAppenderForAppendTest(),
+		Observer:                    observer,
+		InboxCoalesceWindow:         -time.Nanosecond,
+	})
+	if err := group.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(authorizer.release) })
+	}
+	t.Cleanup(func() {
+		release()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := group.Stop(ctx); err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	})
+
+	futures := make([]*Future, 0, 3)
+	submit := func(index int) {
+		channelID := "advance-pressure-" + strconv.Itoa(index)
+		future, err := group.SubmitLocal(context.Background(), AuthorityTarget{
+			ChannelID:    ChannelID{ID: channelID, Type: 2},
+			ChannelKey:   "2:" + channelID,
+			LeaderNodeID: 1,
+			Epoch:        1,
+			LeaderEpoch:  1,
+		}, []SendBatchItem{testSendItem("u"+strconv.Itoa(index), channelID)})
+		if err != nil {
+			t.Fatalf("SubmitLocal(%d) error = %v", index, err)
+		}
+		futures = append(futures, future)
+	}
+	submit(0)
+	select {
+	case <-authorizer.started:
+	case <-time.After(time.Second):
+		t.Fatal("first advance worker did not enter blocking authorizer")
+	}
+	submit(1)
+	submit(2)
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, maxWaiting := observer.advanceSnapshot()
+		if maxWaiting >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			last, maxWaiting := observer.advanceSnapshot()
+			t.Fatalf("advance waiting max = %d, want at least 2 queued/dispatching writers; last = %#v", maxWaiting, last)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	release()
+	for _, future := range futures {
+		requireAppendSuccessAnyID(t, waitFutureForTest(t, future), 0)
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	if err := group.Stop(stopCtx); err != nil {
+		cancel()
+		t.Fatalf("Stop() error = %v", err)
+	}
+	cancel()
+	last, _ := observer.advanceSnapshot()
+	if last.Waiting != 0 {
+		t.Fatalf("terminal advance waiting = %d, want 0", last.Waiting)
 	}
 }
 

--- a/internal/runtime/channelappend/recipient.go
+++ b/internal/runtime/channelappend/recipient.go
@@ -14,6 +14,37 @@ import (
 
 const subscriberSnapshotLoadLimit = 1 << 30
 
+const (
+	inlineRecipientAuthorityUIDLimit = 512
+	inlineRecipientAuthorityUIDSlots = 1024
+)
+
+type inlineRecipientAuthorityUIDTable struct {
+	// hashes stores the allocation-free FNV-1a hash for each occupied probe slot.
+	hashes [inlineRecipientAuthorityUIDSlots]uint64
+	// positions stores the authority UID index plus one; zero marks an empty probe slot.
+	positions [inlineRecipientAuthorityUIDSlots]uint16
+}
+
+// lookupOrInsert resolves one UID against the inline table and records nextIndex when absent.
+func (t *inlineRecipientAuthorityUIDTable) lookupOrInsert(uid string, authorityUIDs []string, nextIndex int) (int, bool) {
+	hash := hashString64(uid)
+	position := int(hash & (inlineRecipientAuthorityUIDSlots - 1))
+	for {
+		indexPlusOne := t.positions[position]
+		if indexPlusOne == 0 {
+			t.hashes[position] = hash
+			t.positions[position] = uint16(nextIndex + 1)
+			return nextIndex, false
+		}
+		index := int(indexPlusOne - 1)
+		if t.hashes[position] == hash && authorityUIDs[index] == uid {
+			return index, true
+		}
+		position = (position + 1) & (inlineRecipientAuthorityUIDSlots - 1)
+	}
+}
+
 type recipientDispatchResult struct {
 	// subscriberCache carries a successfully loaded non-large recipient snapshot.
 	subscriberCache subscriberCache
@@ -300,8 +331,11 @@ func dispatchRecipientPlans(
 				n = len(recipients)
 			}
 			plan.Targets = append(plan.Targets, RecipientTargetBatch{
-				Target:     target,
-				Recipients: append([]Recipient(nil), recipients[:n]...),
+				Target: target,
+				// Grouping already owns this normalized recipient storage. A
+				// capacity-limited view can transfer to the async plan without
+				// another copy and cannot overwrite a sibling target window.
+				Recipients: recipients[:n:n],
 			})
 			recipients = recipients[n:]
 			remaining -= n
@@ -356,46 +390,73 @@ func conversationKindForCommittedEnvelope(event CommittedEnvelope) metadb.Conver
 }
 
 func normalizeRecipientsForAuthorityResolution(senderUID string, recipients []Recipient, includeSender bool) normalizedRecipientAuthoritySet {
-	type uidState struct {
-		index     int
-		recipient bool
-	}
 	set := normalizedRecipientAuthoritySet{
-		recipients:                make([]Recipient, 0, len(recipients)),
 		authorityUIDs:             make([]string, 0, len(recipients)+1),
 		authorityRecipient:        make([]bool, 0, len(recipients)+1),
 		recipientAuthorityIndexes: make([]int, 0, len(recipients)),
 		senderAuthorityIndex:      -1,
 	}
-	seen := make(map[string]uidState, len(recipients)+1)
+	copyRecipients := false
+	var inlineUIDs inlineRecipientAuthorityUIDTable
+	var seen map[string]int
+	if len(recipients) > inlineRecipientAuthorityUIDLimit {
+		seen = make(map[string]int, len(recipients)+1)
+	}
 	if includeSender && senderUID != "" {
 		set.senderAuthorityIndex = 0
 		set.authorityUIDs = append(set.authorityUIDs, senderUID)
 		set.authorityRecipient = append(set.authorityRecipient, false)
-		seen[senderUID] = uidState{index: 0}
+		if seen != nil {
+			seen[senderUID] = 0
+		} else {
+			inlineUIDs.lookupOrInsert(senderUID, set.authorityUIDs, 0)
+		}
 	}
-	for _, recipient := range recipients {
+	for recipientIndex, recipient := range recipients {
 		uid := strings.TrimSpace(recipient.UID)
 		if uid == "" {
+			if !copyRecipients {
+				set.recipients = make([]Recipient, 0, len(recipients))
+				set.recipients = append(set.recipients, recipients[:recipientIndex]...)
+				copyRecipients = true
+			}
 			continue
 		}
-		recipient.UID = uid
-		set.recipients = append(set.recipients, recipient)
-		state, ok := seen[uid]
+		if uid != recipient.UID && !copyRecipients {
+			set.recipients = make([]Recipient, 0, len(recipients))
+			set.recipients = append(set.recipients, recipients[:recipientIndex]...)
+			copyRecipients = true
+		}
+		if copyRecipients {
+			recipient.UID = uid
+			set.recipients = append(set.recipients, recipient)
+		}
+		var (
+			authorityIndex int
+			ok             bool
+		)
+		if seen != nil {
+			authorityIndex, ok = seen[uid]
+		} else {
+			authorityIndex, ok = inlineUIDs.lookupOrInsert(uid, set.authorityUIDs, len(set.authorityUIDs))
+		}
 		if !ok {
-			state.index = len(set.authorityUIDs)
+			authorityIndex = len(set.authorityUIDs)
 			set.authorityUIDs = append(set.authorityUIDs, uid)
 			set.authorityRecipient = append(set.authorityRecipient, true)
-			state.recipient = true
 			set.uniqueRecipientCount++
-			seen[uid] = state
-		} else if !state.recipient {
-			state.recipient = true
-			set.authorityRecipient[state.index] = true
+			if seen != nil {
+				seen[uid] = authorityIndex
+			}
+		} else if !set.authorityRecipient[authorityIndex] {
+			set.authorityRecipient[authorityIndex] = true
 			set.uniqueRecipientCount++
-			seen[uid] = state
 		}
-		set.recipientAuthorityIndexes = append(set.recipientAuthorityIndexes, state.index)
+		set.recipientAuthorityIndexes = append(set.recipientAuthorityIndexes, authorityIndex)
+	}
+	if !copyRecipients {
+		// The caller retains ownership; downstream grouping only reads this normalized view.
+		set.recipients = recipients
 	}
 	return set
 }
@@ -424,22 +485,50 @@ func resolveRecipientAuthorityTargets(ctx context.Context, resolver RecipientAut
 }
 
 func groupRecipientAuthorities(set normalizedRecipientAuthoritySet, results []RecipientAuthorityResult, senderUID string) (recipientAuthorityGrouping, error) {
-	grouping := recipientAuthorityGrouping{activeReady: len(results) == len(set.authorityUIDs)}
+	groupCapacity := recipientAuthorityGroupCapacity(results)
+	grouping := recipientAuthorityGrouping{
+		groups:        make([]recipientAuthorityGroup, 0, groupCapacity),
+		deliveryOrder: make([]int, 0, groupCapacity),
+		activeOrder:   make([]int, 0, groupCapacity),
+		activeReady:   len(results) == len(set.authorityUIDs),
+	}
 	if len(results) != len(set.authorityUIDs) {
 		return grouping, fmt.Errorf("channelappend: aligned recipient authority result count %d does not match UID count %d: %w", len(results), len(set.authorityUIDs), ErrRouteNotReady)
 	}
-	groupIndex := make(map[RecipientAuthorityTarget]int, min(len(results), 256))
+	// The default physical hash-slot table is 256 entries. The fixed first-group
+	// index removes a target-keyed map from the hot path while the exact-target
+	// scan preserves semantics for custom slot counts and transition collisions.
+	var firstGroupByHashSlot [256]uint32
 	authorityGroupIndexes := make([]int, len(results))
 	for index := range authorityGroupIndexes {
 		authorityGroupIndexes[index] = -1
 	}
 	ensureGroup := func(target RecipientAuthorityTarget) int {
-		if index, ok := groupIndex[target]; ok {
-			return index
+		hashSlot := int(target.HashSlot)
+		if hashSlot < len(firstGroupByHashSlot) {
+			if position := firstGroupByHashSlot[hashSlot]; position != 0 {
+				index := int(position - 1)
+				if grouping.groups[index].target == target {
+					return index
+				}
+				for index := range grouping.groups {
+					if grouping.groups[index].target == target {
+						return index
+					}
+				}
+			}
+		} else {
+			for index := range grouping.groups {
+				if grouping.groups[index].target == target {
+					return index
+				}
+			}
 		}
 		index := len(grouping.groups)
-		groupIndex[target] = index
 		grouping.groups = append(grouping.groups, recipientAuthorityGroup{target: target})
+		if hashSlot < len(firstGroupByHashSlot) && firstGroupByHashSlot[hashSlot] == 0 {
+			firstGroupByHashSlot[hashSlot] = uint32(index + 1)
+		}
 		return index
 	}
 	for index, result := range results {
@@ -528,6 +617,29 @@ func groupRecipientAuthorities(set normalizedRecipientAuthoritySet, results []Re
 		}
 	}
 	return grouping, nil
+}
+
+func recipientAuthorityGroupCapacity(results []RecipientAuthorityResult) int {
+	var occupiedPhysicalSlots [256]bool
+	capacity := 0
+	for _, result := range results {
+		if result.Err != nil || result.Target.Validate() != nil {
+			continue
+		}
+		hashSlot := int(result.Target.HashSlot)
+		if hashSlot >= len(occupiedPhysicalSlots) {
+			// Custom physical slot tables are uncommon and may contain exact
+			// duplicates. A slight overestimate is preferable to a map here.
+			capacity++
+			continue
+		}
+		if occupiedPhysicalSlots[hashSlot] {
+			continue
+		}
+		occupiedPhysicalSlots[hashSlot] = true
+		capacity++
+	}
+	return capacity
 }
 
 func withRecipientRouteResolveDetail(err error, set normalizedRecipientAuthoritySet) error {

--- a/internal/runtime/pluginhook/benchmark_test.go
+++ b/internal/runtime/pluginhook/benchmark_test.go
@@ -3,6 +3,7 @@ package pluginhook
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -49,6 +50,49 @@ func BenchmarkPluginHookReceiveEnqueue(b *testing.B) {
 	})
 }
 
+func BenchmarkPluginHookReceiveBatchAdmission(b *testing.B) {
+	for _, recipients := range []int{512, 10000} {
+		b.Run(fmt.Sprintf("recipients_%d", recipients), func(b *testing.B) {
+			uids := make([]string, recipients)
+			for i := range uids {
+				uids[i] = fmt.Sprintf("u-%05d", i)
+			}
+			payload := bytes.Repeat([]byte("a"), 1024)
+			worker := NewWorker(Options{
+				Usecase:        noopPersistAfterUsecase{},
+				ReceiveUsecase: noopReceiveUsecase{},
+			})
+			b.Run("scalar", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					for _, uid := range uids {
+						worker.EnqueueReceive(context.Background(), pluginevents.ReceiveOffline{
+							MessageID:  1,
+							MessageSeq: 1,
+							UID:        uid,
+							Payload:    payload,
+						})
+					}
+				}
+			})
+			b.Run("batch", func(b *testing.B) {
+				event := pluginevents.ReceiveOfflineBatch{
+					MessageID:  1,
+					MessageSeq: 1,
+					UIDs:       uids,
+					Payload:    payload,
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					worker.EnqueueReceiveBatch(context.Background(), event)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkPluginHookQueueFull(b *testing.B) {
 	worker := NewWorker(Options{Usecase: newBlockingPersistAfterUsecase(), QueueSize: 1, Workers: 1, Timeout: time.Second})
 	require.NoError(b, worker.Start(context.Background()))
@@ -88,6 +132,10 @@ func (noopPersistAfterUsecase) PersistAfterCommitted(context.Context, plugineven
 type noopReceiveUsecase struct{}
 
 func (noopReceiveUsecase) ReceiveOffline(context.Context, pluginevents.ReceiveOffline) error {
+	return nil
+}
+
+func (noopReceiveUsecase) ReceiveOfflineBatch(context.Context, pluginevents.ReceiveOfflineBatch) error {
 	return nil
 }
 

--- a/internal/runtime/pluginhook/worker.go
+++ b/internal/runtime/pluginhook/worker.go
@@ -48,6 +48,11 @@ type ReceiveUsecase interface {
 	ReceiveOffline(context.Context, pluginevents.ReceiveOffline) error
 }
 
+// ReceiveBatchUsecase runs one batch while applying timeout independently to each recipient.
+type ReceiveBatchUsecase interface {
+	ReceiveOfflineBatchWithTimeout(context.Context, pluginevents.ReceiveOfflineBatch, time.Duration) error
+}
+
 // Observer records enqueue and invoke outcomes for plugin hook runtime metrics.
 type Observer interface {
 	ObservePersistAfterEnqueue(result string, wait time.Duration)
@@ -89,18 +94,21 @@ type hookEventKind uint8
 const (
 	hookEventPersistAfter hookEventKind = iota + 1
 	hookEventReceive
+	hookEventReceiveBatch
 )
 
 type hookEvent struct {
 	kind         hookEventKind
 	persistAfter pluginevents.PersistAfterCommitted
 	receive      pluginevents.ReceiveOffline
+	receiveBatch pluginevents.ReceiveOfflineBatch
 }
 
 // Worker provides fail-open bounded admission for async plugin hook side effects.
 type Worker struct {
 	usecase        PersistAfterUsecase
 	receiveUsecase ReceiveUsecase
+	receiveBatch   ReceiveBatchUsecase
 	queueSize      int
 	workers        int
 	timeout        time.Duration
@@ -136,9 +144,16 @@ func NewWorker(opts Options) *Worker {
 			receiveUsecase = candidate
 		}
 	}
+	var receiveBatch ReceiveBatchUsecase
+	if candidate, ok := receiveUsecase.(ReceiveBatchUsecase); ok {
+		receiveBatch = candidate
+	} else if candidate, ok := opts.Usecase.(ReceiveBatchUsecase); ok {
+		receiveBatch = candidate
+	}
 	return &Worker{
 		usecase:        opts.Usecase,
 		receiveUsecase: receiveUsecase,
+		receiveBatch:   receiveBatch,
 		queueSize:      queueSize,
 		workers:        workers,
 		timeout:        timeout,
@@ -226,6 +241,11 @@ func (w *Worker) EnqueuePersistAfter(_ context.Context, event pluginevents.Persi
 // EnqueueReceive clones the event and attempts bounded admission without failing the caller.
 func (w *Worker) EnqueueReceive(_ context.Context, event pluginevents.ReceiveOffline) {
 	w.enqueue(hookEvent{kind: hookEventReceive, receive: event.Clone()}, w.observeReceiveEnqueue)
+}
+
+// EnqueueReceiveBatch clones shared mutable fields once and admits the whole recipient batch.
+func (w *Worker) EnqueueReceiveBatch(_ context.Context, event pluginevents.ReceiveOfflineBatch) {
+	w.enqueue(hookEvent{kind: hookEventReceiveBatch, receiveBatch: event.Clone()}, w.observeReceiveEnqueue)
 }
 
 func (w *Worker) enqueue(event hookEvent, observe func(string, time.Duration)) {
@@ -363,7 +383,11 @@ func (w *Worker) invoke(runCtx context.Context, event hookEvent) {
 		w.observeInvoke(event.kind, result, time.Since(startedAt))
 	}()
 
-	invokeCtx, cancel := context.WithTimeout(runCtx, w.timeout)
+	invokeCtx := runCtx
+	cancel := func() {}
+	if event.kind != hookEventReceiveBatch {
+		invokeCtx, cancel = context.WithTimeout(runCtx, w.timeout)
+	}
 	defer cancel()
 
 	if err := w.invokeEvent(invokeCtx, event); err != nil {
@@ -390,6 +414,26 @@ func (w *Worker) invokeEvent(ctx context.Context, event hookEvent) error {
 			return errNilReceiveUsecase
 		}
 		return w.receiveUsecase.ReceiveOffline(ctx, event.receive)
+	case hookEventReceiveBatch:
+		if w.receiveBatch != nil {
+			return w.receiveBatch.ReceiveOfflineBatchWithTimeout(ctx, event.receiveBatch, w.timeout)
+		}
+		if w.receiveUsecase == nil {
+			return errNilReceiveUsecase
+		}
+		var joined error
+		for _, uid := range event.receiveBatch.UIDs {
+			itemCtx, cancel := context.WithTimeout(ctx, w.timeout)
+			err := w.receiveUsecase.ReceiveOffline(itemCtx, event.receiveBatch.ForUID(uid))
+			cancel()
+			if err != nil {
+				joined = errors.Join(joined, err)
+				if ctx.Err() != nil {
+					break
+				}
+			}
+		}
+		return joined
 	default:
 		return nil
 	}
@@ -424,7 +468,7 @@ func (w *Worker) observeInvoke(kind hookEventKind, result string, d time.Duratio
 		return
 	}
 	switch kind {
-	case hookEventReceive:
+	case hookEventReceive, hookEventReceiveBatch:
 		w.observer.ObserveReceiveInvoke(result, d)
 	default:
 		w.observer.ObservePersistAfterInvoke(result, d)

--- a/internal/runtime/pluginhook/worker_test.go
+++ b/internal/runtime/pluginhook/worker_test.go
@@ -112,6 +112,44 @@ func TestWorkerEnqueueReceiveInvokesReceiveUsecaseAndClonesPayload(t *testing.T)
 	require.Eventually(t, func() bool { return observer.receiveInvokeCount(invokeResultOK) == 1 }, time.Second, time.Millisecond)
 }
 
+func TestWorkerEnqueueReceiveBatchInvokesBatchUsecaseAndClonesMutableFieldsOnce(t *testing.T) {
+	usecase := &recordingHookUsecase{receiveBatchDone: make(chan struct{})}
+	observer := &recordingObserver{}
+	worker := NewWorker(Options{Usecase: usecase, QueueSize: 1, Workers: 1, Timeout: time.Second, Observer: observer})
+	require.NoError(t, worker.Start(context.Background()))
+	defer worker.Stop(context.Background())
+
+	uids := []string{"u2", "u3"}
+	payload := []byte("hello")
+	scopedUIDs := []string{"bot"}
+	worker.EnqueueReceiveBatch(context.Background(), pluginevents.ReceiveOfflineBatch{
+		MessageID:         1,
+		UIDs:              uids,
+		Payload:           payload,
+		MessageScopedUIDs: scopedUIDs,
+	})
+	uids[0] = "changed"
+	payload[0] = 'x'
+	scopedUIDs[0] = "changed"
+
+	select {
+	case <-usecase.receiveBatchDone:
+	case <-time.After(time.Second):
+		t.Fatal("ReceiveOfflineBatch was not invoked")
+	}
+
+	usecase.mu.Lock()
+	defer usecase.mu.Unlock()
+	require.Len(t, usecase.receiveBatchCalls, 1)
+	require.Equal(t, []string{"u2", "u3"}, usecase.receiveBatchCalls[0].UIDs)
+	require.Equal(t, []byte("hello"), usecase.receiveBatchCalls[0].Payload)
+	require.Equal(t, []string{"bot"}, usecase.receiveBatchCalls[0].MessageScopedUIDs)
+	require.Equal(t, []time.Duration{time.Second}, usecase.receiveBatchTimeouts)
+	require.Empty(t, usecase.receiveCalls)
+	require.Eventually(t, func() bool { return observer.receiveEnqueueCount(enqueueResultAccepted) == 1 }, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return observer.receiveInvokeCount(invokeResultOK) == 1 }, time.Second, time.Millisecond)
+}
+
 func TestWorkerQueueFullDropsWithoutBlockingCaller(t *testing.T) {
 	usecase := newBlockingPersistAfterUsecase()
 	observer := &recordingObserver{}
@@ -292,11 +330,14 @@ func (f persistAfterUsecaseFunc) PersistAfterCommitted(ctx context.Context, even
 }
 
 type recordingHookUsecase struct {
-	receiveDone chan struct{}
+	receiveDone      chan struct{}
+	receiveBatchDone chan struct{}
 
-	mu                sync.Mutex
-	persistAfterCalls []pluginevents.PersistAfterCommitted
-	receiveCalls      []pluginevents.ReceiveOffline
+	mu                   sync.Mutex
+	persistAfterCalls    []pluginevents.PersistAfterCommitted
+	receiveCalls         []pluginevents.ReceiveOffline
+	receiveBatchCalls    []pluginevents.ReceiveOfflineBatch
+	receiveBatchTimeouts []time.Duration
 }
 
 func (r *recordingHookUsecase) PersistAfterCommitted(_ context.Context, event pluginevents.PersistAfterCommitted) error {
@@ -315,6 +356,25 @@ func (r *recordingHookUsecase) ReceiveOffline(_ context.Context, event plugineve
 		case <-r.receiveDone:
 		default:
 			close(r.receiveDone)
+		}
+	}
+	return nil
+}
+
+func (r *recordingHookUsecase) ReceiveOfflineBatchWithTimeout(
+	_ context.Context,
+	event pluginevents.ReceiveOfflineBatch,
+	timeout time.Duration,
+) error {
+	r.mu.Lock()
+	r.receiveBatchCalls = append(r.receiveBatchCalls, event)
+	r.receiveBatchTimeouts = append(r.receiveBatchTimeouts, timeout)
+	r.mu.Unlock()
+	if r.receiveBatchDone != nil {
+		select {
+		case <-r.receiveBatchDone:
+		default:
+			close(r.receiveBatchDone)
 		}
 	}
 	return nil

--- a/internal/usecase/plugin/FLOW.md
+++ b/internal/usecase/plugin/FLOW.md
@@ -82,30 +82,39 @@ metrics when plugins are enabled.
 
 ```text
 channelappend recipient delivery after presence resolution
-  -> runtime/pluginhook bounded worker
-  -> App.ReceiveOffline
-  -> reject ineligible candidates:
+  -> pluginReceiveObserver maps one offline UID batch
+  -> runtime/pluginhook bounded worker owns one copy of the UID slice and payload
+  -> App.ReceiveOfflineBatch
+  -> reject an ineligible message batch:
        NoPersist, SyncOnce, request-scoped, temp-channel, missing durable ids,
-       missing sender, sender == recipient, or system sender
-  -> read UID-owned plugin bindings from the cluster-authoritative metadata port
-  -> intersect bindings with node-local plugins after cached desired enable state
-  -> select running plugins advertising MethodReceive
-  -> select the highest-priority plugin, then plugin number asc
-  -> suppress duplicate messageID+UID candidates for a bounded TTL
-  -> map the recipient view to pluginproto.RecvPacket
-       strip command-channel suffixes
-       for person channels, expose the recipient's counterpart channel id
-       clone payload before crossing the plugin boundary
-  -> invoke /plugin/receive synchronously when ReplySync=true,
-     otherwise send the legacy async Receive msgType
-  -> observe low-cardinality invoke result when Observer is configured
+       missing sender, or system sender
+  -> snapshot node-local plugins advertising MethodReceive once
+  -> apply cached desired enable state and order running candidates by
+       priority desc, plugin number asc
+  -> if no candidate remains, return without UID binding reads
+  -> for each distinct non-empty UID other than the sender, in order:
+       read UID-owned plugin bindings from cluster-authoritative metadata
+       select the highest-priority bound candidate
+       suppress duplicate messageID+UID candidates for a bounded TTL
+       project the shared batch into the recipient view
+       map to pluginproto.RecvPacket
+         strip command-channel suffixes
+         for person channels, expose the recipient's counterpart channel id
+         let synchronous wire marshal own the per-bound-recipient payload copy
+       invoke /plugin/receive synchronously when ReplySync=true,
+         otherwise send the legacy async Receive msgType
+       apply the plugin-worker timeout independently to this UID
+       continue after independent recipient failures or timeouts, unless the
+         batch parent context is canceled
+       observe low-cardinality invoke result when Observer is configured
 ```
 
 Receive hooks are post-commit side effects. Their failures are logged and
 reported through hook metrics but do not change SENDACK, durable append,
 conversation projection, or ordinary online delivery outcomes. The usecase does
-not scan subscribers; channelappend provides one already-expanded offline UID
-candidate at a time.
+not scan subscribers; channelappend provides already-expanded offline UID
+batches. Scalar `ReceiveOffline` and worker fallback remain compatibility paths
+and reuse the same candidate selection and batch-to-recipient projection rules.
 
 ## Host RPC Message Send Flow
 

--- a/internal/usecase/plugin/benchmark_test.go
+++ b/internal/usecase/plugin/benchmark_test.go
@@ -418,6 +418,123 @@ func BenchmarkReceiveOffline(b *testing.B) {
 	}
 }
 
+func BenchmarkReceiveOfflineBatchCloudMediumFanout(b *testing.B) {
+	const recipients = 512
+	uids := make([]string, recipients)
+	for i := range uids {
+		uids[i] = fmt.Sprintf("bench-bot-%04d", i)
+	}
+	plugins := benchmarkReceivePlugins(1)
+	bindings := benchmarkReceiveBindingReader{bindings: benchmarkReceiveBindings(1)}
+	newApp := func(b *testing.B) *App {
+		b.Helper()
+		app, err := NewApp(Options{
+			Runtime:          &recordingRuntime{plugins: plugins},
+			Invoker:          benchmarkReceiveInvoker{},
+			ReceiveBindings:  bindings,
+			DefaultSenderUID: "____system",
+			ReceiveDedupeTTL: time.Nanosecond,
+		})
+		require.NoError(b, err)
+		return app
+	}
+	payload := make([]byte, 1024)
+
+	b.Run("scalar", func(b *testing.B) {
+		app := newApp(b)
+		event := benchmarkReceiveOfflineEvent(len(payload))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for index, uid := range uids {
+				event.MessageID = uint64(i*recipients + index + 1)
+				event.MessageSeq = event.MessageID
+				event.UID = uid
+				if err := app.ReceiveOffline(context.Background(), event); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+	b.Run("batch", func(b *testing.B) {
+		app := newApp(b)
+		event := pluginevents.ReceiveOfflineBatch{
+			MessageID:   1,
+			MessageSeq:  1,
+			ChannelID:   "room",
+			ChannelType: 2,
+			FromUID:     "sender",
+			UIDs:        uids,
+			Payload:     payload,
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			event.MessageID = uint64(i + 1)
+			event.MessageSeq = event.MessageID
+			if err := app.ReceiveOfflineBatch(context.Background(), event); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkReceiveOfflineBatchNoPluginCloudMediumFanout(b *testing.B) {
+	const recipients = 512
+	uids := make([]string, recipients)
+	for i := range uids {
+		uids[i] = fmt.Sprintf("bench-offline-%04d", i)
+	}
+	newApp := func(b *testing.B) *App {
+		b.Helper()
+		app, err := NewApp(Options{
+			Runtime:         &recordingRuntime{},
+			Invoker:         benchmarkReceiveInvoker{},
+			ReceiveBindings: benchmarkReceiveBindingReader{bindings: benchmarkReceiveBindings(1)},
+		})
+		require.NoError(b, err)
+		return app
+	}
+
+	b.Run("scalar", func(b *testing.B) {
+		app := newApp(b)
+		event := benchmarkReceiveOfflineEvent(1024)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for index, uid := range uids {
+				event.MessageID = uint64(i*recipients + index + 1)
+				event.MessageSeq = event.MessageID
+				event.UID = uid
+				if err := app.ReceiveOffline(context.Background(), event); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+	b.Run("batch", func(b *testing.B) {
+		app := newApp(b)
+		event := pluginevents.ReceiveOfflineBatch{
+			MessageID:   1,
+			MessageSeq:  1,
+			ChannelID:   "room",
+			ChannelType: 2,
+			FromUID:     "sender",
+			UIDs:        uids,
+			Payload:     make([]byte, 1024),
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			event.MessageID = uint64(i + 1)
+			event.MessageSeq = event.MessageID
+			if err := app.ReceiveOfflineBatch(context.Background(), event); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 func messageResultForBenchmark() message.SendResult {
 	return message.SendResult{MessageID: 1, Reason: message.ReasonSuccess}
 }

--- a/internal/usecase/plugin/persist_after_test.go
+++ b/internal/usecase/plugin/persist_after_test.go
@@ -211,6 +211,7 @@ func TestPersistAfterCommittedJoinedErrorPreservesMultiplePluginFailures(t *test
 type recordingRuntime struct {
 	mu          sync.Mutex
 	plugins     []ObservedPlugin
+	listCalls   int
 	registered  []ObservedPlugin
 	closed      []string
 	restarted   []string
@@ -248,11 +249,18 @@ func (r *recordingRuntime) MarkClosed(_ context.Context, pluginNo string) error 
 func (r *recordingRuntime) List() []ObservedPlugin {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.listCalls++
 	out := make([]ObservedPlugin, 0, len(r.plugins))
 	for _, plugin := range r.plugins {
 		out = append(out, cloneObservedPlugin(plugin))
 	}
 	return out
+}
+
+func (r *recordingRuntime) listCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.listCalls
 }
 
 func (r *recordingRuntime) registeredPlugins() []ObservedPlugin {

--- a/internal/usecase/plugin/receive.go
+++ b/internal/usecase/plugin/receive.go
@@ -18,19 +18,104 @@ func (a *App) ReceiveOffline(ctx context.Context, event pluginevents.ReceiveOffl
 	if a == nil || !a.offlineReceiveEligible(event) {
 		return nil
 	}
-	plugin, ok, err := a.boundReceivePluginForUID(ctx, event.UID)
+	candidates, err := a.receivePluginCandidates(ctx)
+	if err != nil {
+		return err
+	}
+	plugin, ok, err := a.boundReceivePluginForUIDFromCandidates(ctx, event.UID, candidates)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return nil
 	}
+	return a.invokeReceiveOffline(ctx, event, plugin)
+}
+
+// ReceiveOfflineBatch invokes bound local Receive plugins for one committed message batch.
+func (a *App) ReceiveOfflineBatch(ctx context.Context, batch pluginevents.ReceiveOfflineBatch) error {
+	return a.receiveOfflineBatch(ctx, batch, 0)
+}
+
+// ReceiveOfflineBatchWithTimeout invokes a batch with an independent timeout for each recipient.
+func (a *App) ReceiveOfflineBatchWithTimeout(
+	ctx context.Context,
+	batch pluginevents.ReceiveOfflineBatch,
+	recipientTimeout time.Duration,
+) error {
+	return a.receiveOfflineBatch(ctx, batch, recipientTimeout)
+}
+
+func (a *App) receiveOfflineBatch(
+	ctx context.Context,
+	batch pluginevents.ReceiveOfflineBatch,
+	recipientTimeout time.Duration,
+) error {
+	if a == nil || !a.offlineReceiveBatchEligible(batch) || len(batch.UIDs) == 0 {
+		return nil
+	}
+	setupCtx, cancelSetup := receiveContextWithTimeout(ctx, recipientTimeout)
+	candidates, err := a.receivePluginCandidates(setupCtx)
+	cancelSetup()
+	if err != nil || len(candidates) == 0 {
+		return err
+	}
+	if a.receiveBindings == nil {
+		return ErrReceiveBindingReaderRequired
+	}
+
+	seen := make(map[string]struct{}, len(batch.UIDs))
+	var joined error
+	for _, uid := range batch.UIDs {
+		if uid == "" || uid == batch.FromUID {
+			continue
+		}
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+
+		recipientCtx, cancelRecipient := receiveContextWithTimeout(ctx, recipientTimeout)
+		plugin, ok, err := a.boundReceivePluginForUIDFromCandidates(recipientCtx, uid, candidates)
+		if err != nil {
+			cancelRecipient()
+			joined = errors.Join(joined, err)
+			if ctx.Err() != nil {
+				break
+			}
+			continue
+		}
+		if !ok {
+			cancelRecipient()
+			continue
+		}
+		event := batch.ForUID(uid)
+		err = a.invokeReceiveOffline(recipientCtx, event, plugin)
+		cancelRecipient()
+		if err != nil {
+			joined = errors.Join(joined, err)
+			if ctx.Err() != nil {
+				break
+			}
+		}
+	}
+	return joined
+}
+
+func receiveContextWithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func (a *App) invokeReceiveOffline(ctx context.Context, event pluginevents.ReceiveOffline, plugin ObservedPlugin) error {
 	if !a.markReceiveDedupe(event.MessageID, event.UID) {
 		return nil
 	}
 	packet := receivePacketFromOfflineEvent(event)
 	startedAt := time.Now()
-	err = a.InvokeReceive(ctx, plugin, packet)
+	err := a.InvokeReceive(ctx, plugin, packet)
 	result := "ok"
 	if err != nil {
 		result = "error"
@@ -39,6 +124,19 @@ func (a *App) ReceiveOffline(ctx context.Context, event pluginevents.ReceiveOffl
 	}
 	a.observeReceiveInvoke(result, time.Since(startedAt))
 	return err
+}
+
+func (a *App) offlineReceiveBatchEligible(event pluginevents.ReceiveOfflineBatch) bool {
+	if event.MessageID == 0 || event.MessageSeq == 0 {
+		return false
+	}
+	if len(event.MessageScopedUIDs) > 0 || protocolmeta.ChannelType(event.ChannelType) == protocolmeta.ChannelTypeTemp {
+		return false
+	}
+	if event.NoPersist || event.SyncOnce {
+		return false
+	}
+	return event.FromUID != "" && !a.isSystemSender(event.FromUID)
 }
 
 func (a *App) offlineReceiveEligible(event pluginevents.ReceiveOffline) bool {
@@ -68,38 +166,54 @@ func (a *App) isSystemSender(uid string) bool {
 }
 
 func (a *App) boundReceivePluginForUID(ctx context.Context, uid string) (ObservedPlugin, bool, error) {
+	candidates, err := a.receivePluginCandidates(ctx)
+	if err != nil {
+		return ObservedPlugin{}, false, err
+	}
+	return a.boundReceivePluginForUIDFromCandidates(ctx, uid, candidates)
+}
+
+func (a *App) receivePluginCandidates(ctx context.Context) ([]ObservedPlugin, error) {
+	if a == nil || a.runtime == nil {
+		return nil, ErrRuntimeRequired
+	}
+	plugins := a.runtime.List()
+	receivePlugins := plugins[:0]
+	for _, plugin := range plugins {
+		if hasMethod(plugin, MethodReceive) {
+			receivePlugins = append(receivePlugins, plugin)
+		}
+	}
+	plugins, err := a.applyDesiredToPlugins(ctx, receivePlugins)
+	if err != nil {
+		return nil, err
+	}
+	return runningPluginsByMethod(plugins, MethodReceive), nil
+}
+
+func (a *App) boundReceivePluginForUIDFromCandidates(
+	ctx context.Context,
+	uid string,
+	candidates []ObservedPlugin,
+) (ObservedPlugin, bool, error) {
 	if a == nil || a.receiveBindings == nil {
 		return ObservedPlugin{}, false, ErrReceiveBindingReaderRequired
+	}
+	if uid == "" || len(candidates) == 0 {
+		return ObservedPlugin{}, false, nil
 	}
 	bindings, err := a.receiveBindings.ListPluginBindingsByUID(ctx, uid)
 	if err != nil {
 		return ObservedPlugin{}, false, err
 	}
-	bound := make(map[string]struct{}, len(bindings))
-	for _, binding := range bindings {
-		if binding.PluginNo != "" {
-			bound[binding.PluginNo] = struct{}{}
+	for _, candidate := range candidates {
+		for _, binding := range bindings {
+			if binding.PluginNo == candidate.No {
+				return candidate, true, nil
+			}
 		}
 	}
-	if len(bound) == 0 {
-		return ObservedPlugin{}, false, nil
-	}
-	plugins := a.runtime.List()
-	candidates := make([]ObservedPlugin, 0, len(bound))
-	for _, plugin := range plugins {
-		if _, ok := bound[plugin.No]; ok {
-			candidates = append(candidates, plugin)
-		}
-	}
-	effective, err := a.applyDesiredToPlugins(ctx, candidates)
-	if err != nil {
-		return ObservedPlugin{}, false, err
-	}
-	ordered := runningPluginsByMethod(effective, MethodReceive)
-	if len(ordered) == 0 {
-		return ObservedPlugin{}, false, nil
-	}
-	return ordered[0], true, nil
+	return ObservedPlugin{}, false, nil
 }
 
 func receivePacketFromOfflineEvent(event pluginevents.ReceiveOffline) *pluginproto.RecvPacket {
@@ -108,7 +222,8 @@ func receivePacketFromOfflineEvent(event pluginevents.ReceiveOffline) *pluginpro
 		ToUid:       event.UID,
 		ChannelId:   receiveChannelIDForRecipient(event),
 		ChannelType: uint32(event.ChannelType),
-		Payload:     append([]byte(nil), event.Payload...),
+		// Marshal synchronously owns the wire copy; the batch payload is immutable here.
+		Payload: event.Payload,
 	}
 }
 

--- a/internal/usecase/plugin/receive_test.go
+++ b/internal/usecase/plugin/receive_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -116,6 +117,125 @@ func TestReceiveOfflineDedupeUsesMessageIDAndUIDWithinTTL(t *testing.T) {
 	now = now.Add(time.Minute + time.Second)
 	require.NoError(t, app.ReceiveOffline(context.Background(), event))
 	require.Len(t, invoker.sentMessages(), 3)
+}
+
+func TestReceiveOfflineBatchSnapshotsPluginsOnceAndPreservesRecipientOrder(t *testing.T) {
+	runtime := &recordingRuntime{plugins: []ObservedPlugin{
+		{No: "bot", Methods: []Method{MethodReceive}, Priority: 1, Status: StatusRunning, Enabled: true},
+		{No: "bot-2", Methods: []Method{MethodReceive}, Priority: 1, Status: StatusRunning, Enabled: true},
+	}}
+	bindings := &countingReceiveBindingReader{bindingsByUID: map[string][]PluginBinding{
+		"bot":   {{UID: "bot", PluginNo: "bot"}},
+		"bot-2": {{UID: "bot-2", PluginNo: "bot-2"}},
+	}}
+	invoker := &recordingInvoker{}
+	app, err := NewApp(Options{
+		Runtime:          runtime,
+		Invoker:          invoker,
+		ReceiveBindings:  bindings,
+		DefaultSenderUID: "____system",
+		ReceiveDedupeTTL: time.Minute,
+	})
+	require.NoError(t, err)
+
+	event := testReceiveOfflineBatchEvent("alice", "bot", "bot-2", "bot")
+	require.NoError(t, app.ReceiveOfflineBatch(context.Background(), event))
+
+	sends := invoker.sentMessages()
+	require.Len(t, sends, 2)
+	require.Equal(t, "bot", decodeReceivePacket(t, sends[0].body).GetToUid())
+	require.Equal(t, "bot-2", decodeReceivePacket(t, sends[1].body).GetToUid())
+	require.Equal(t, 1, runtime.listCallCount())
+	require.Equal(t, []string{"bot", "bot-2"}, bindings.calledUIDs())
+}
+
+func TestReceiveOfflineBatchSkipsBindingReadsWhenNoReceivePluginIsRunning(t *testing.T) {
+	runtime := &recordingRuntime{plugins: []ObservedPlugin{
+		{No: "send-only", Methods: []Method{MethodSend}, Priority: 1, Status: StatusRunning, Enabled: true},
+	}}
+	bindings := &countingReceiveBindingReader{bindingsByUID: map[string][]PluginBinding{
+		"bot": {{UID: "bot", PluginNo: "send-only"}},
+	}}
+	invoker := &recordingInvoker{}
+	app, err := NewApp(Options{
+		Runtime:         runtime,
+		Invoker:         invoker,
+		ReceiveBindings: bindings,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, app.ReceiveOfflineBatch(context.Background(), testReceiveOfflineBatchEvent("alice", "bot")))
+
+	require.Empty(t, invoker.sentMessages())
+	require.Equal(t, 1, runtime.listCallCount())
+	require.Empty(t, bindings.calledUIDs())
+}
+
+func TestReceiveOfflineBatchIgnoresDesiredStateFailuresForUnrelatedPlugins(t *testing.T) {
+	runtime := &recordingRuntime{plugins: []ObservedPlugin{
+		{No: "send-only", Methods: []Method{MethodSend}, Priority: 1, Status: StatusRunning, Enabled: true},
+	}}
+	store := newRecordingDesiredStore()
+	store.err = errors.New("unrelated desired-state failure")
+	app, err := NewApp(Options{
+		Runtime:      runtime,
+		Invoker:      &recordingInvoker{},
+		DesiredStore: store,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, app.ReceiveOfflineBatch(context.Background(), testReceiveOfflineBatchEvent("alice", "bot")))
+}
+
+func TestReceiveOfflineBatchContinuesAfterIndependentRecipientFailure(t *testing.T) {
+	sentinel := errors.New("first recipient failed")
+	runtime := &recordingRuntime{plugins: []ObservedPlugin{
+		{No: "bad-plugin", Methods: []Method{MethodReceive}, Priority: 1, Status: StatusRunning, Enabled: true},
+		{No: "good-plugin", Methods: []Method{MethodReceive}, Priority: 1, Status: StatusRunning, Enabled: true},
+	}}
+	invoker := &recordingInvoker{sendErrors: map[string]error{"bad-plugin": sentinel}}
+	app, err := NewApp(Options{
+		Runtime: runtime,
+		Invoker: invoker,
+		ReceiveBindings: receiveBindingReader{bindingsByUID: map[string][]PluginBinding{
+			"bot":   {{UID: "bot", PluginNo: "bad-plugin"}},
+			"bot-2": {{UID: "bot-2", PluginNo: "good-plugin"}},
+		}},
+	})
+	require.NoError(t, err)
+
+	err = app.ReceiveOfflineBatch(context.Background(), testReceiveOfflineBatchEvent("alice", "bot", "bot-2"))
+
+	require.ErrorIs(t, err, sentinel)
+	sends := invoker.sentMessages()
+	require.Len(t, sends, 2)
+	require.Equal(t, "bot", decodeReceivePacket(t, sends[0].body).GetToUid())
+	require.Equal(t, "bot-2", decodeReceivePacket(t, sends[1].body).GetToUid())
+}
+
+func TestReceiveOfflineBatchTimeoutIsIndependentPerRecipient(t *testing.T) {
+	invoker := &timeoutFirstReceiveInvoker{}
+	app, err := NewApp(Options{
+		Runtime: &recordingRuntime{plugins: []ObservedPlugin{
+			{No: "slow-plugin", Methods: []Method{MethodReceive}, Priority: 1, Status: StatusRunning, Enabled: true, ReplySync: true},
+			{No: "fast-plugin", Methods: []Method{MethodReceive}, Priority: 1, Status: StatusRunning, Enabled: true, ReplySync: true},
+		}},
+		Invoker: invoker,
+		ReceiveBindings: receiveBindingReader{bindingsByUID: map[string][]PluginBinding{
+			"slow": {{UID: "slow", PluginNo: "slow-plugin"}},
+			"fast": {{UID: "fast", PluginNo: "fast-plugin"}},
+		}},
+	})
+	require.NoError(t, err)
+
+	err = app.ReceiveOfflineBatchWithTimeout(
+		context.Background(),
+		testReceiveOfflineBatchEvent("alice", "slow", "fast"),
+		20*time.Millisecond,
+	)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, []string{"slow-plugin", "fast-plugin"}, invoker.calledPluginNos())
 }
 
 func TestReceiveOfflineRetriesAfterHookFailureBeforeDedupe(t *testing.T) {
@@ -233,6 +353,24 @@ func testReceiveOfflineEvent(fromUID string) pluginevents.ReceiveOffline {
 	}
 }
 
+func testReceiveOfflineBatchEvent(fromUID string, uids ...string) pluginevents.ReceiveOfflineBatch {
+	event := testReceiveOfflineEvent(fromUID)
+	return pluginevents.ReceiveOfflineBatch{
+		MessageID:         event.MessageID,
+		MessageSeq:        event.MessageSeq,
+		ChannelID:         event.ChannelID,
+		ChannelType:       event.ChannelType,
+		FromUID:           event.FromUID,
+		UIDs:              append([]string(nil), uids...),
+		ClientMsgNo:       event.ClientMsgNo,
+		ServerTimestampMS: event.ServerTimestampMS,
+		Payload:           append([]byte(nil), event.Payload...),
+		NoPersist:         event.NoPersist,
+		SyncOnce:          event.SyncOnce,
+		MessageScopedUIDs: append([]string(nil), event.MessageScopedUIDs...),
+	}
+}
+
 func receiveOfflineWith(mutator func(*pluginevents.ReceiveOffline)) pluginevents.ReceiveOffline {
 	event := testReceiveOfflineEvent("alice")
 	mutator(&event)
@@ -242,6 +380,46 @@ func receiveOfflineWith(mutator func(*pluginevents.ReceiveOffline)) pluginevents
 type receiveBindingReader struct {
 	bindingsByUID map[string][]PluginBinding
 	err           error
+}
+
+type countingReceiveBindingReader struct {
+	bindingsByUID map[string][]PluginBinding
+	calls         []string
+}
+
+type timeoutFirstReceiveInvoker struct {
+	mu      sync.Mutex
+	plugins []string
+}
+
+func (i *timeoutFirstReceiveInvoker) RequestPlugin(ctx context.Context, pluginNo, _ string, _ []byte) ([]byte, error) {
+	i.mu.Lock()
+	i.plugins = append(i.plugins, pluginNo)
+	i.mu.Unlock()
+	if pluginNo == "slow-plugin" {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, nil
+}
+
+func (i *timeoutFirstReceiveInvoker) SendPlugin(string, uint32, []byte) error {
+	return nil
+}
+
+func (i *timeoutFirstReceiveInvoker) calledPluginNos() []string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return append([]string(nil), i.plugins...)
+}
+
+func (r *countingReceiveBindingReader) ListPluginBindingsByUID(_ context.Context, uid string) ([]PluginBinding, error) {
+	r.calls = append(r.calls, uid)
+	return append([]PluginBinding(nil), r.bindingsByUID[uid]...), nil
+}
+
+func (r *countingReceiveBindingReader) calledUIDs() []string {
+	return append([]string(nil), r.calls...)
 }
 
 func (r receiveBindingReader) ListPluginBindingsByUID(_ context.Context, uid string) ([]PluginBinding, error) {

--- a/internal/usecase/presence/FLOW.md
+++ b/internal/usecase/presence/FLOW.md
@@ -90,8 +90,10 @@ Target-aware lookup returns one aligned `EndpointLookupResult` per input group.
 A group-scoped lookup error is recorded on that result and does not abort later
 groups. Production cluster adapters preserve the supplied complete target
 fence; the legacy fallback deliberately cannot do so and exists only for
-compatibility with older or limited authority implementations. Lookup stays
-authority-routed behind the `AuthorityClient` port.
+compatibility with older or limited authority implementations. When the
+production batch surface is present, the usecase returns its aligned result
+directly and does not allocate a discarded compatibility result slice. Lookup
+stays authority-routed behind the `AuthorityClient` port.
 
 ## Import Boundary
 

--- a/internal/usecase/presence/lookup.go
+++ b/internal/usecase/presence/lookup.go
@@ -54,8 +54,8 @@ func (a *App) EndpointsByTargets(ctx context.Context, groups []EndpointLookupGro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	results := make([]EndpointLookupResult, len(groups))
 	if a.authority == nil {
+		results := make([]EndpointLookupResult, len(groups))
 		for i := range results {
 			results[i].Err = ErrAuthorityUnavailable
 		}
@@ -64,6 +64,7 @@ func (a *App) EndpointsByTargets(ctx context.Context, groups []EndpointLookupGro
 	if batch, ok := a.authority.(TargetBatchAuthorityClient); ok {
 		return batch.EndpointsByTargets(ctx, groups)
 	}
+	results := make([]EndpointLookupResult, len(groups))
 	for i, group := range groups {
 		for _, uid := range group.UIDs {
 			if uid == "" {

--- a/scripts/wkcli_sim_smoke_script_test.go
+++ b/scripts/wkcli_sim_smoke_script_test.go
@@ -895,7 +895,10 @@ func TestWkcliSimThreeNodeSmokeScriptReportsSimFailureBeforeDelayedAutoJoin(t *t
 		"--members", "4",
 		"--rate", "6/s",
 		"--duration", "4s",
-		"--ready-timeout", "2",
+		// The fake start process publishes readiness asynchronously; keep this
+		// tolerant of repository-wide parallel test scheduling while the
+		// delayed auto-join assertion remains two seconds.
+		"--ready-timeout", "10",
 		"--poll", "0",
 	)
 	cmd.Dir = root


### PR DESCRIPTION
## Summary

- batch offline recipient plugin observation and avoid per-UID payload cloning
- reduce Presence and conversation-authority grouping allocations while preserving 256 physical hash-slot fences and 10 logical Slot semantics
- break the channelappend advance/append bounded-pool circular wait with a dedicated writer activation dispatcher
- expose low-cardinality runtime queue pressure by pool and add Cloud Medium-shaped regression benchmarks

## Evidence

- pre-fix full-slice burst timed out after 20s with a goroutine dump proving the cross-pool circular wait
- fixed full-slice burst completes around 5.72ms locally with exactly 130 plugin batches
- single-leader Presence path: 16.51µs / 58,448 B / 24 allocs to 9.26µs / 10,944 B / 2 allocs
- plugin admission for 512 UIDs: 76.0µs / 524,291 B / 512 allocs to 0.833µs / 10,496 B / 2 allocs

## Verification

- focused functional tests passed
- focused race tests passed
- burst deadlock regression passed 20 repetitions
- Cloud Medium-shaped burst integration passed five repetitions
- git diff --check passed
- explicit-root repository Go gate passed: GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1
- independent Standards review passed with no remaining findings
- independent Spec review found no semantic issue

## Cloud cost gate

This PR intentionally does **not** dispatch Alibaba Cloud resources. Paid Cloud Medium validation remains NO-GO because local evidence does not include real network, Raft, Pebble, and socket tail latency. The release-candidate report records the evidence and remaining gate.