### PR TITLE
test(e2e): gate Medium load on stable Slot leaders

### DIFF
--- a/test/e2e/message/medium_recipient_hotpath/AGENTS.md
+++ b/test/e2e/message/medium_recipient_hotpath/AGENTS.md
@@ -35,6 +35,10 @@ that allowance and hide a product-path allocation regression.
 - Preserve 256 physical hash slots, 10 logical Slot groups, and three replicas.
 - Keep the 250-message / 19,650-recipient-row / 2,545-online-route slice exact.
 - Keep setup outside the measured SEND window.
+- Before setup and again immediately before cold prime, require all three nodes
+  to agree on every actual Raft leader for the 10 non-empty logical Slots for a
+  bounded stability window. A healthy `readyz` or a PreferredLeader assignment
+  alone is not workload readiness.
 - Emit one machine-readable `WKRC-HIFI-EVIDENCE` line for revision-neutral
   runners.
 - Do not treat absolute local throughput as cloud capacity. Compare exact

--- a/test/e2e/message/medium_recipient_hotpath/acceptance_test.go
+++ b/test/e2e/message/medium_recipient_hotpath/acceptance_test.go
@@ -18,6 +18,9 @@ func TestHotPathAcceptanceError(t *testing.T) {
 		OnlineRoutes:            expectedMeasuredOnlineRoutes(),
 		Connections:             expectedConnectionCount(),
 		OfferedQPS:              mediumOfferedQPS,
+		ClusterConvergenceMS:    2_500,
+		ClusterStableWindowMS:   milliseconds(mediumConvergenceStableWindow),
+		SlotLeaders:             []uint64{1, 2, 3, 1, 2, 3, 1, 2, 3, 1},
 		MeasuredDurationMS:      float64(mediumMessageCount*mediumMeasuredRounds) / mediumOfferedQPS * 1000,
 		IngressPerSecond:        mediumOfferedQPS,
 		SendackP99MS:            1_000,
@@ -52,6 +55,10 @@ func TestHotPathAcceptanceError(t *testing.T) {
 		{name: "online routes", edit: func(e *hotPathEvidence) { e.OnlineRoutes-- }, want: "online routes"},
 		{name: "connections", edit: func(e *hotPathEvidence) { e.Connections-- }, want: "acceptance connections"},
 		{name: "offered load", edit: func(e *hotPathEvidence) { e.OfferedQPS++ }, want: "offered QPS"},
+		{name: "cluster convergence missing", edit: func(e *hotPathEvidence) { e.ClusterConvergenceMS = 0 }, want: "cluster convergence"},
+		{name: "cluster stability short", edit: func(e *hotPathEvidence) { e.ClusterStableWindowMS-- }, want: "cluster stable window"},
+		{name: "actual slot leader missing", edit: func(e *hotPathEvidence) { e.SlotLeaders[0] = 0 }, want: "actual Slot leaders"},
+		{name: "actual slot leader count", edit: func(e *hotPathEvidence) { e.SlotLeaders = e.SlotLeaders[:9] }, want: "actual Slot leaders"},
 		{name: "ingress", edit: func(e *hotPathEvidence) {
 			e.IngressPerSecond = float64(mediumOfferedQPS)*mediumMinIngressFraction - 0.001
 		}, want: "acceptance ingress"},
@@ -80,6 +87,7 @@ func TestHotPathAcceptanceError(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			evidence := passing
+			evidence.SlotLeaders = append([]uint64(nil), passing.SlotLeaders...)
 			test.edit(&evidence)
 			err := hotPathAcceptanceError(evidence, mediumOfferedQPS)
 			if err == nil || !strings.Contains(err.Error(), test.want) {

--- a/test/e2e/message/medium_recipient_hotpath/cluster_convergence.go
+++ b/test/e2e/message/medium_recipient_hotpath/cluster_convergence.go
@@ -1,0 +1,351 @@
+//go:build e2e
+
+package medium_recipient_hotpath
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/test/e2e/suite"
+)
+
+const (
+	mediumConvergencePollInterval = 100 * time.Millisecond
+	mediumConvergenceStableWindow = 2 * time.Second
+)
+
+// mediumSlotsResponse is the manager Slot inventory used to prove that every
+// node observes the same actual Raft leaders before the workload starts.
+type mediumSlotsResponse struct {
+	Total int             `json:"total"`
+	Items []suite.SlotDTO `json:"items"`
+}
+
+// mediumSlotConvergence captures the stable actual Raft leader inventory and
+// the bounded setup time required to observe it.
+type mediumSlotConvergence struct {
+	Leaders        []uint64
+	Fingerprint    string
+	WaitDuration   time.Duration
+	StableDuration time.Duration
+}
+
+// mediumConvergenceSnapshot is one fully validated cross-node Slot
+// observation. Leaders are ordered by logical Slot ID.
+type mediumConvergenceSnapshot struct {
+	Leaders     []uint64
+	Fingerprint string
+}
+
+// mediumConvergenceTracker rejects a changing Raft leader inventory until the
+// same validated fingerprint survives the required stability window.
+type mediumConvergenceTracker struct {
+	stableWindow time.Duration
+	fingerprint  string
+	stableSince  time.Time
+}
+
+func newMediumConvergenceTracker(stableWindow time.Duration) *mediumConvergenceTracker {
+	return &mediumConvergenceTracker{stableWindow: stableWindow}
+}
+
+func (t *mediumConvergenceTracker) Observe(now time.Time, fingerprint string) (time.Duration, bool) {
+	if strings.TrimSpace(fingerprint) == "" {
+		t.Reset()
+		return 0, false
+	}
+	if t.fingerprint != fingerprint || t.stableSince.IsZero() {
+		t.fingerprint = fingerprint
+		t.stableSince = now
+		return 0, t.stableWindow <= 0
+	}
+	stableFor := now.Sub(t.stableSince)
+	if stableFor < 0 {
+		t.stableSince = now
+		return 0, false
+	}
+	return stableFor, stableFor >= t.stableWindow
+}
+
+func (t *mediumConvergenceTracker) Reset() {
+	t.fingerprint = ""
+	t.stableSince = time.Time{}
+}
+
+func waitForMediumSlotConvergence(ctx context.Context, cluster *suite.StartedCluster) (mediumSlotConvergence, error) {
+	if cluster == nil {
+		return mediumSlotConvergence{}, fmt.Errorf("started cluster is nil")
+	}
+	startedAt := time.Now()
+	tracker := newMediumConvergenceTracker(mediumConvergenceStableWindow)
+	ticker := time.NewTicker(mediumConvergencePollInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		inventories, err := readMediumSlotInventories(ctx, cluster)
+		if err == nil {
+			var snapshot mediumConvergenceSnapshot
+			snapshot, err = validateMediumSlotConvergence(inventories)
+			if err == nil {
+				stableFor, ready := tracker.Observe(time.Now(), snapshot.Fingerprint)
+				if ready {
+					return mediumSlotConvergence{
+						Leaders:        append([]uint64(nil), snapshot.Leaders...),
+						Fingerprint:    snapshot.Fingerprint,
+						WaitDuration:   time.Since(startedAt),
+						StableDuration: stableFor,
+					}, nil
+				}
+				lastErr = fmt.Errorf(
+					"actual Raft leader inventory is valid but stable for only %s of %s",
+					stableFor,
+					mediumConvergenceStableWindow,
+				)
+			}
+		}
+		if err != nil {
+			lastErr = err
+			tracker.Reset()
+		}
+
+		select {
+		case <-ctx.Done():
+			return mediumSlotConvergence{}, fmt.Errorf("actual Raft leaders did not stabilize: %w (last observation: %v)", ctx.Err(), lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func readMediumSlotInventories(ctx context.Context, cluster *suite.StartedCluster) (map[uint64]mediumSlotsResponse, error) {
+	inventories := make(map[uint64]mediumSlotsResponse, len(cluster.Nodes))
+	for _, node := range cluster.Nodes {
+		if strings.TrimSpace(node.ManagerAddr()) == "" {
+			return nil, fmt.Errorf("node %d manager HTTP is disabled", node.Spec.ID)
+		}
+		var response mediumSlotsResponse
+		url := fmt.Sprintf("http://%s/manager/slots?node_id=%d", node.ManagerAddr(), node.Spec.ID)
+		if _, err := suite.GetJSON(ctx, url, &response); err != nil {
+			return nil, fmt.Errorf("read node %d Slot inventory: %w", node.Spec.ID, err)
+		}
+		inventories[node.Spec.ID] = response
+	}
+	return inventories, nil
+}
+
+func validateMediumSlotConvergence(inventories map[uint64]mediumSlotsResponse) (mediumConvergenceSnapshot, error) {
+	expectedPeers := []uint64{1, 2, 3}
+	if len(inventories) != mediumReplicaCount {
+		return mediumConvergenceSnapshot{}, fmt.Errorf("node inventories = %d, want %d", len(inventories), mediumReplicaCount)
+	}
+
+	var reference []suite.SlotDTO
+	for nodeID := uint64(1); nodeID <= mediumReplicaCount; nodeID++ {
+		inventory, ok := inventories[nodeID]
+		if !ok {
+			return mediumConvergenceSnapshot{}, fmt.Errorf("node %d Slot inventory is missing", nodeID)
+		}
+		if inventory.Total != mediumLogicalSlots || len(inventory.Items) != mediumLogicalSlots {
+			return mediumConvergenceSnapshot{}, fmt.Errorf(
+				"node %d logical slots total/items = %d/%d, want %d/%d",
+				nodeID,
+				inventory.Total,
+				len(inventory.Items),
+				mediumLogicalSlots,
+				mediumLogicalSlots,
+			)
+		}
+
+		items := append([]suite.SlotDTO(nil), inventory.Items...)
+		sort.Slice(items, func(i, j int) bool { return items[i].SlotID < items[j].SlotID })
+		if err := validateMediumNodeSlots(nodeID, items, expectedPeers); err != nil {
+			return mediumConvergenceSnapshot{}, err
+		}
+		if nodeID == 1 {
+			if err := validateMediumHashSlotCoverage(items); err != nil {
+				return mediumConvergenceSnapshot{}, err
+			}
+			reference = items
+			continue
+		}
+		if err := validateMediumSlotControlAgreement(reference, items, nodeID); err != nil {
+			return mediumConvergenceSnapshot{}, err
+		}
+	}
+
+	leaders := make([]uint64, len(reference))
+	var fingerprint strings.Builder
+	for slotIndex, item := range reference {
+		leaderID := item.NodeLog.LeaderID
+		for nodeID := uint64(2); nodeID <= mediumReplicaCount; nodeID++ {
+			observed := sortedMediumSlots(inventories[nodeID].Items)[slotIndex]
+			if observed.NodeLog.LeaderID != leaderID {
+				return mediumConvergenceSnapshot{}, fmt.Errorf(
+					"slot %d actual leader disagreement: node 1 reports %d, node %d reports %d",
+					item.SlotID,
+					leaderID,
+					nodeID,
+					observed.NodeLog.LeaderID,
+				)
+			}
+		}
+		leaders[slotIndex] = leaderID
+		fmt.Fprintf(
+			&fingerprint,
+			"%d:%d:%d:%d;",
+			item.SlotID,
+			leaderID,
+			item.Assignment.ConfigEpoch,
+			item.Assignment.BalanceVersion,
+		)
+	}
+	return mediumConvergenceSnapshot{
+		Leaders:     leaders,
+		Fingerprint: fingerprint.String(),
+	}, nil
+}
+
+func validateMediumNodeSlots(nodeID uint64, items []suite.SlotDTO, expectedPeers []uint64) error {
+	var previousSlotID uint32
+	for index, item := range items {
+		if index > 0 && item.SlotID == previousSlotID {
+			return fmt.Errorf("node %d has duplicate logical slot %d", nodeID, item.SlotID)
+		}
+		previousSlotID = item.SlotID
+		if item.Task != nil {
+			return fmt.Errorf("node %d slot %d still has active task %#v", nodeID, item.SlotID, item.Task)
+		}
+		if !sameUint64Values(item.Assignment.DesiredPeers, expectedPeers) {
+			return fmt.Errorf("node %d slot %d desired peers = %v, want %v", nodeID, item.SlotID, item.Assignment.DesiredPeers, expectedPeers)
+		}
+		if item.NodeLog == nil {
+			return fmt.Errorf("node %d slot %d local Raft observation is missing", nodeID, item.SlotID)
+		}
+		if item.NodeLog.NodeID != nodeID {
+			return fmt.Errorf("node %d slot %d Raft observation belongs to node %d", nodeID, item.SlotID, item.NodeLog.NodeID)
+		}
+		if item.NodeLog.LeaderID == 0 || !containsUint64(item.Assignment.DesiredPeers, item.NodeLog.LeaderID) {
+			return fmt.Errorf("node %d slot %d actual leader = %d, desired peers %v", nodeID, item.SlotID, item.NodeLog.LeaderID, item.Assignment.DesiredPeers)
+		}
+		if !sameUint64Values(item.NodeLog.CurrentVoters, expectedPeers) {
+			return fmt.Errorf("node %d slot %d current voters = %v, want %v", nodeID, item.SlotID, item.NodeLog.CurrentVoters, expectedPeers)
+		}
+		if !sameUint64Values(item.Runtime.CurrentVoters, expectedPeers) || !item.Runtime.HasQuorum {
+			return fmt.Errorf(
+				"node %d slot %d runtime voters/quorum = %v/%v, want %v/true",
+				nodeID,
+				item.SlotID,
+				item.Runtime.CurrentVoters,
+				item.Runtime.HasQuorum,
+				expectedPeers,
+			)
+		}
+		if nodeID == item.NodeLog.LeaderID && item.NodeLog.Role != "leader" {
+			return fmt.Errorf("node %d slot %d reports itself as actual leader with role %q", nodeID, item.SlotID, item.NodeLog.Role)
+		}
+		if nodeID != item.NodeLog.LeaderID && item.NodeLog.Role != "follower" {
+			return fmt.Errorf("node %d slot %d reports leader %d with role %q", nodeID, item.SlotID, item.NodeLog.LeaderID, item.NodeLog.Role)
+		}
+		if item.NodeLog.AppliedIndex > item.NodeLog.CommitIndex {
+			return fmt.Errorf(
+				"node %d slot %d applied index %d exceeds commit index %d",
+				nodeID,
+				item.SlotID,
+				item.NodeLog.AppliedIndex,
+				item.NodeLog.CommitIndex,
+			)
+		}
+	}
+	return nil
+}
+
+func validateMediumHashSlotCoverage(items []suite.SlotDTO) error {
+	covered := make([]bool, mediumPhysicalHashSlots)
+	for _, item := range items {
+		if item.HashSlots == nil || item.HashSlots.Count != len(item.HashSlots.Items) {
+			return fmt.Errorf("slot %d physical hash-slot inventory is incomplete", item.SlotID)
+		}
+		if len(item.HashSlots.Items) == 0 {
+			return fmt.Errorf("logical slot %d physical hash-slot inventory is empty", item.SlotID)
+		}
+		for _, hashSlot := range item.HashSlots.Items {
+			if int(hashSlot) >= len(covered) || covered[hashSlot] {
+				return fmt.Errorf("slot %d physical hash-slot %d is out of range or duplicated", item.SlotID, hashSlot)
+			}
+			covered[hashSlot] = true
+		}
+	}
+	for hashSlot, present := range covered {
+		if !present {
+			return fmt.Errorf("physical hash-slot coverage is missing hash slot %d", hashSlot)
+		}
+	}
+	return nil
+}
+
+func validateMediumSlotControlAgreement(reference, observed []suite.SlotDTO, nodeID uint64) error {
+	for index, expected := range reference {
+		actual := observed[index]
+		if actual.SlotID != expected.SlotID ||
+			actual.Assignment.PreferredLeaderID != expected.Assignment.PreferredLeaderID ||
+			actual.Assignment.ConfigEpoch != expected.Assignment.ConfigEpoch ||
+			actual.Assignment.BalanceVersion != expected.Assignment.BalanceVersion ||
+			!sameUint64Values(actual.Assignment.DesiredPeers, expected.Assignment.DesiredPeers) ||
+			!sameHashSlots(actual.HashSlots, expected.HashSlots) {
+			return fmt.Errorf(
+				"node %d slot control state disagrees at index %d: got %#v, node 1 %#v",
+				nodeID,
+				index,
+				actual,
+				expected,
+			)
+		}
+	}
+	return nil
+}
+
+func sortedMediumSlots(items []suite.SlotDTO) []suite.SlotDTO {
+	sorted := append([]suite.SlotDTO(nil), items...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].SlotID < sorted[j].SlotID })
+	return sorted
+}
+
+func sameUint64Values(left, right []uint64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]uint64(nil), left...)
+	rightCopy := append([]uint64(nil), right...)
+	sort.Slice(leftCopy, func(i, j int) bool { return leftCopy[i] < leftCopy[j] })
+	sort.Slice(rightCopy, func(i, j int) bool { return rightCopy[i] < rightCopy[j] })
+	for index := range leftCopy {
+		if leftCopy[index] != rightCopy[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameHashSlots(left, right *suite.SlotHashSlotsDTO) bool {
+	if left == nil || right == nil || left.Count != right.Count || len(left.Items) != len(right.Items) {
+		return false
+	}
+	for index := range left.Items {
+		if left.Items[index] != right.Items[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsUint64(items []uint64, want uint64) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/message/medium_recipient_hotpath/cluster_convergence_test.go
+++ b/test/e2e/message/medium_recipient_hotpath/cluster_convergence_test.go
@@ -1,0 +1,231 @@
+//go:build e2e
+
+package medium_recipient_hotpath
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/test/e2e/suite"
+)
+
+func TestValidateMediumSlotConvergence(t *testing.T) {
+	inventories := stableMediumSlotInventories()
+
+	t.Run("accepts actual leaders that differ from preferred leaders", func(t *testing.T) {
+		inventories := cloneMediumSlotInventories(inventories)
+		for nodeID, inventory := range inventories {
+			inventory.Items[0].Assignment.PreferredLeaderID = 2
+			inventory.Items[0].NodeLog.LeaderID = 1
+			inventories[nodeID] = inventory
+		}
+
+		snapshot, err := validateMediumSlotConvergence(inventories)
+		if err != nil {
+			t.Fatalf("validate convergence: %v", err)
+		}
+		if len(snapshot.Leaders) != mediumLogicalSlots || snapshot.Leaders[0] != 1 {
+			t.Fatalf("leaders = %v, want %d leaders beginning with actual leader 1", snapshot.Leaders, mediumLogicalSlots)
+		}
+		if snapshot.Fingerprint == "" {
+			t.Fatal("convergence fingerprint is empty")
+		}
+	})
+
+	tests := []struct {
+		name string
+		edit func(map[uint64]mediumSlotsResponse)
+		want string
+	}{
+		{
+			name: "missing logical slot",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				inventory := items[1]
+				inventory.Items = inventory.Items[:len(inventory.Items)-1]
+				inventory.Total = len(inventory.Items)
+				items[1] = inventory
+			},
+			want: "logical slots",
+		},
+		{
+			name: "missing local raft observation",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				items[2].Items[3].NodeLog = nil
+			},
+			want: "Raft observation",
+		},
+		{
+			name: "leader disagreement",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				items[3].Items[4].NodeLog.LeaderID = 1
+			},
+			want: "leader disagreement",
+		},
+		{
+			name: "incomplete voter set",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				items[1].Items[5].NodeLog.CurrentVoters = []uint64{1, 2}
+			},
+			want: "current voters",
+		},
+		{
+			name: "lost hash slot",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				hashSlots := items[1].Items[0].HashSlots
+				hashSlots.Items = hashSlots.Items[1:]
+				hashSlots.Count = len(hashSlots.Items)
+			},
+			want: "physical hash-slot coverage",
+		},
+		{
+			name: "empty logical slot",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				first := items[1].Items[0].HashSlots
+				second := items[1].Items[1].HashSlots
+				second.Items = append(append([]uint16(nil), first.Items...), second.Items...)
+				second.Count = len(second.Items)
+				first.Items = nil
+				first.Count = 0
+			},
+			want: "physical hash-slot inventory is empty",
+		},
+		{
+			name: "active controller task",
+			edit: func(items map[uint64]mediumSlotsResponse) {
+				items[1].Items[6].Task = &suite.SlotTaskDTO{TaskID: "task-1"}
+			},
+			want: "active task",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := cloneMediumSlotInventories(inventories)
+			test.edit(candidate)
+			_, err := validateMediumSlotConvergence(candidate)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestMediumConvergenceTrackerRequiresUnchangedStabilityWindow(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	tracker := newMediumConvergenceTracker(2 * time.Second)
+
+	if stableFor, ready := tracker.Observe(start, "leaders-a"); ready || stableFor != 0 {
+		t.Fatalf("first observation = (%s, %v), want (0, false)", stableFor, ready)
+	}
+	if stableFor, ready := tracker.Observe(start.Add(1999*time.Millisecond), "leaders-a"); ready || stableFor != 1999*time.Millisecond {
+		t.Fatalf("pre-window observation = (%s, %v), want (1.999s, false)", stableFor, ready)
+	}
+	if stableFor, ready := tracker.Observe(start.Add(2*time.Second), "leaders-a"); !ready || stableFor != 2*time.Second {
+		t.Fatalf("stable observation = (%s, %v), want (2s, true)", stableFor, ready)
+	}
+
+	if stableFor, ready := tracker.Observe(start.Add(3*time.Second), "leaders-b"); ready || stableFor != 0 {
+		t.Fatalf("changed leaders = (%s, %v), want reset (0, false)", stableFor, ready)
+	}
+	if stableFor, ready := tracker.Observe(start.Add(5*time.Second), "leaders-b"); !ready || stableFor != 2*time.Second {
+		t.Fatalf("restabilized leaders = (%s, %v), want (2s, true)", stableFor, ready)
+	}
+
+	tracker.Reset()
+	if stableFor, ready := tracker.Observe(start.Add(6*time.Second), "leaders-b"); ready || stableFor != 0 {
+		t.Fatalf("observation after reset = (%s, %v), want (0, false)", stableFor, ready)
+	}
+}
+
+func stableMediumSlotInventories() map[uint64]mediumSlotsResponse {
+	items := make([]suite.SlotDTO, mediumLogicalSlots)
+	nextHashSlot := 0
+	for slotIndex := range items {
+		hashSlotCount := mediumPhysicalHashSlots / mediumLogicalSlots
+		if slotIndex < mediumPhysicalHashSlots%mediumLogicalSlots {
+			hashSlotCount++
+		}
+		hashSlots := make([]uint16, hashSlotCount)
+		for i := range hashSlots {
+			hashSlots[i] = uint16(nextHashSlot)
+			nextHashSlot++
+		}
+		leaderID := uint64(slotIndex%mediumReplicaCount + 1)
+		items[slotIndex] = suite.SlotDTO{
+			SlotID: uint32(slotIndex + 1),
+			HashSlots: &suite.SlotHashSlotsDTO{
+				Count: len(hashSlots),
+				Items: hashSlots,
+			},
+			Assignment: suite.SlotAssignmentDTO{
+				DesiredPeers:      []uint64{1, 2, 3},
+				PreferredLeaderID: uint64((slotIndex+1)%mediumReplicaCount + 1),
+				ConfigEpoch:       7,
+				BalanceVersion:    9,
+			},
+			Runtime: suite.SlotRuntimeDTO{
+				CurrentPeers:      []uint64{1, 2, 3},
+				CurrentVoters:     []uint64{1, 2, 3},
+				HealthyVoters:     3,
+				HasQuorum:         true,
+				PreferredLeaderID: uint64((slotIndex+1)%mediumReplicaCount + 1),
+			},
+			NodeLog: &suite.SlotNodeLogDTO{
+				LeaderID:      leaderID,
+				Role:          "follower",
+				CurrentVoters: []uint64{1, 2, 3},
+				CommitIndex:   10,
+				AppliedIndex:  10,
+			},
+		}
+	}
+
+	inventories := make(map[uint64]mediumSlotsResponse, mediumReplicaCount)
+	for nodeID := uint64(1); nodeID <= mediumReplicaCount; nodeID++ {
+		nodeItems := cloneMediumSlots(items)
+		for index := range nodeItems {
+			nodeItems[index].NodeLog.NodeID = nodeID
+			if nodeItems[index].NodeLog.LeaderID == nodeID {
+				nodeItems[index].NodeLog.Role = "leader"
+			}
+		}
+		inventories[nodeID] = mediumSlotsResponse{Total: len(nodeItems), Items: nodeItems}
+	}
+	return inventories
+}
+
+func cloneMediumSlotInventories(source map[uint64]mediumSlotsResponse) map[uint64]mediumSlotsResponse {
+	cloned := make(map[uint64]mediumSlotsResponse, len(source))
+	for nodeID, inventory := range source {
+		cloned[nodeID] = mediumSlotsResponse{
+			Total: inventory.Total,
+			Items: cloneMediumSlots(inventory.Items),
+		}
+	}
+	return cloned
+}
+
+func cloneMediumSlots(source []suite.SlotDTO) []suite.SlotDTO {
+	cloned := make([]suite.SlotDTO, len(source))
+	for index, item := range source {
+		cloned[index] = item
+		cloned[index].Assignment.DesiredPeers = append([]uint64(nil), item.Assignment.DesiredPeers...)
+		cloned[index].Runtime.CurrentPeers = append([]uint64(nil), item.Runtime.CurrentPeers...)
+		cloned[index].Runtime.CurrentVoters = append([]uint64(nil), item.Runtime.CurrentVoters...)
+		if item.HashSlots != nil {
+			hashSlots := *item.HashSlots
+			hashSlots.Items = append([]uint16(nil), item.HashSlots.Items...)
+			cloned[index].HashSlots = &hashSlots
+		}
+		if item.NodeLog != nil {
+			nodeLog := *item.NodeLog
+			nodeLog.CurrentVoters = append([]uint64(nil), item.NodeLog.CurrentVoters...)
+			cloned[index].NodeLog = &nodeLog
+		}
+		if item.Task != nil {
+			task := *item.Task
+			cloned[index].Task = &task
+		}
+	}
+	return cloned
+}

--- a/test/e2e/message/medium_recipient_hotpath/medium_recipient_hotpath_test.go
+++ b/test/e2e/message/medium_recipient_hotpath/medium_recipient_hotpath_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	mediumEvidenceSchema    = "wukongim/local-medium-rc-hifi-evidence/v1"
+	mediumEvidenceSchema    = "wukongim/local-medium-rc-hifi-evidence/v2"
 	mediumPhysicalHashSlots = 256
 	mediumLogicalSlots      = 10
 	mediumReplicaCount      = 3
@@ -89,47 +89,50 @@ type senderResult struct {
 // hotPathEvidence is the machine-readable, revision-neutral result emitted by
 // the opt-in process-level gate.
 type hotPathEvidence struct {
-	Schema                   string  `json:"schema"`
-	PhysicalHashSlots        int     `json:"physical_hash_slots"`
-	LogicalSlots             int     `json:"logical_slots"`
-	Replicas                 int     `json:"replicas"`
-	Messages                 int     `json:"messages"`
-	RecipientRows            int     `json:"recipient_rows"`
-	OnlineRoutes             int     `json:"online_routes"`
-	Connections              int     `json:"connections"`
-	OfferedQPS               int     `json:"offered_qps"`
-	ColdPrimeDurationMS      float64 `json:"cold_prime_duration_ms"`
-	SendLoopDurationMS       float64 `json:"send_loop_duration_ms"`
-	MeasuredDurationMS       float64 `json:"measured_duration_ms"`
-	CompletionDrainMS        float64 `json:"completion_drain_ms"`
-	IngressPerSecond         float64 `json:"ingress_per_second"`
-	CompletionPerSecond      float64 `json:"completion_per_second"`
-	SendackP50MS             float64 `json:"sendack_p50_ms"`
-	SendackP99MS             float64 `json:"sendack_p99_ms"`
-	SendackMaxMS             float64 `json:"sendack_max_ms"`
-	RecvP99MS                float64 `json:"recv_p99_ms"`
-	RecvMaxMS                float64 `json:"recv_max_ms"`
-	MaxGatewayQueueRatio     float64 `json:"max_gateway_queue_ratio"`
-	MaxRecipientQueueRatio   float64 `json:"max_recipient_queue_ratio"`
-	MaxRecipientWorkerRatio  float64 `json:"max_recipient_worker_ratio"`
-	MaxAdvancePoolUtil       float64 `json:"max_advance_pool_utilization"`
-	MaxAdvancePoolWaiting    float64 `json:"max_advance_pool_waiting"`
-	MaxAppendPoolUtil        float64 `json:"max_append_pool_utilization"`
-	MaxPostCommitPoolUtil    float64 `json:"max_post_commit_pool_utilization"`
-	MaxPostCommitBacklog     float64 `json:"max_post_commit_backlog"`
-	MaxPostCommitHandoffRate float64 `json:"max_post_commit_handoff_ratio"`
-	MaxHeapBytes             float64 `json:"max_heap_bytes"`
-	AllocatedBytes           float64 `json:"allocated_bytes"`
-	GCCountDelta             float64 `json:"gc_count_delta"`
-	PluginReceiveAccepted    float64 `json:"plugin_receive_enqueue_accepted"`
-	PluginReceiveFull        float64 `json:"plugin_receive_enqueue_full"`
-	PluginReceiveClosed      float64 `json:"plugin_receive_enqueue_closed"`
-	PluginReceiveInvokeOK    float64 `json:"plugin_receive_invoke_ok"`
-	PluginReceiveInvokeError float64 `json:"plugin_receive_invoke_error"`
-	MetricSamples            int     `json:"metric_samples"`
-	MetricSampleErrors       int     `json:"metric_sample_errors"`
-	Drained                  bool    `json:"drained"`
-	ProcessContinuous        bool    `json:"process_continuous"`
+	Schema                   string   `json:"schema"`
+	PhysicalHashSlots        int      `json:"physical_hash_slots"`
+	LogicalSlots             int      `json:"logical_slots"`
+	Replicas                 int      `json:"replicas"`
+	Messages                 int      `json:"messages"`
+	RecipientRows            int      `json:"recipient_rows"`
+	OnlineRoutes             int      `json:"online_routes"`
+	Connections              int      `json:"connections"`
+	OfferedQPS               int      `json:"offered_qps"`
+	ClusterConvergenceMS     float64  `json:"cluster_convergence_ms"`
+	ClusterStableWindowMS    float64  `json:"cluster_stable_window_ms"`
+	SlotLeaders              []uint64 `json:"slot_leaders"`
+	ColdPrimeDurationMS      float64  `json:"cold_prime_duration_ms"`
+	SendLoopDurationMS       float64  `json:"send_loop_duration_ms"`
+	MeasuredDurationMS       float64  `json:"measured_duration_ms"`
+	CompletionDrainMS        float64  `json:"completion_drain_ms"`
+	IngressPerSecond         float64  `json:"ingress_per_second"`
+	CompletionPerSecond      float64  `json:"completion_per_second"`
+	SendackP50MS             float64  `json:"sendack_p50_ms"`
+	SendackP99MS             float64  `json:"sendack_p99_ms"`
+	SendackMaxMS             float64  `json:"sendack_max_ms"`
+	RecvP99MS                float64  `json:"recv_p99_ms"`
+	RecvMaxMS                float64  `json:"recv_max_ms"`
+	MaxGatewayQueueRatio     float64  `json:"max_gateway_queue_ratio"`
+	MaxRecipientQueueRatio   float64  `json:"max_recipient_queue_ratio"`
+	MaxRecipientWorkerRatio  float64  `json:"max_recipient_worker_ratio"`
+	MaxAdvancePoolUtil       float64  `json:"max_advance_pool_utilization"`
+	MaxAdvancePoolWaiting    float64  `json:"max_advance_pool_waiting"`
+	MaxAppendPoolUtil        float64  `json:"max_append_pool_utilization"`
+	MaxPostCommitPoolUtil    float64  `json:"max_post_commit_pool_utilization"`
+	MaxPostCommitBacklog     float64  `json:"max_post_commit_backlog"`
+	MaxPostCommitHandoffRate float64  `json:"max_post_commit_handoff_ratio"`
+	MaxHeapBytes             float64  `json:"max_heap_bytes"`
+	AllocatedBytes           float64  `json:"allocated_bytes"`
+	GCCountDelta             float64  `json:"gc_count_delta"`
+	PluginReceiveAccepted    float64  `json:"plugin_receive_enqueue_accepted"`
+	PluginReceiveFull        float64  `json:"plugin_receive_enqueue_full"`
+	PluginReceiveClosed      float64  `json:"plugin_receive_enqueue_closed"`
+	PluginReceiveInvokeOK    float64  `json:"plugin_receive_invoke_ok"`
+	PluginReceiveInvokeError float64  `json:"plugin_receive_invoke_error"`
+	MetricSamples            int      `json:"metric_samples"`
+	MetricSampleErrors       int      `json:"metric_sample_errors"`
+	Drained                  bool     `json:"drained"`
+	ProcessContinuous        bool     `json:"process_continuous"`
 }
 
 func TestCloudMediumScaledRecipientHotPath(t *testing.T) {
@@ -154,6 +157,16 @@ func TestCloudMediumScaledRecipientHotPath(t *testing.T) {
 	if err := cluster.WaitClusterReady(setupCtx); err != nil {
 		t.Fatalf("wait for Cloud Medium-shaped cluster: %v\n%s", err, cluster.DumpDiagnostics())
 	}
+	setupConvergence, err := waitForMediumSlotConvergence(setupCtx, cluster)
+	if err != nil {
+		t.Fatalf("wait for stable actual Slot leaders before setup: %v\n%s", err, cluster.DumpDiagnostics())
+	}
+	t.Logf(
+		"WKRC-HIFI-SLOT-CONVERGENCE phase=setup wait=%s stable=%s leaders=%v",
+		setupConvergence.WaitDuration,
+		setupConvergence.StableDuration,
+		setupConvergence.Leaders,
+	)
 	groupChannels, groupRecipients, groupOnline := prepareGroupChannels(t, setupCtx, cluster.MustNode(1))
 	personRecipients := make([]string, 125)
 	for i := range personRecipients {
@@ -177,6 +190,16 @@ func TestCloudMediumScaledRecipientHotPath(t *testing.T) {
 
 	payload := bytes.Repeat([]byte("w"), mediumPayloadBytes)
 	primeSender := mustConnect(t, cluster.MustNode(1), mediumSenderUID(0))
+	convergence, err := waitForMediumSlotConvergence(setupCtx, cluster)
+	if err != nil {
+		t.Fatalf("wait for stable actual Slot leaders before cold prime: %v\n%s", err, cluster.DumpDiagnostics())
+	}
+	t.Logf(
+		"WKRC-HIFI-SLOT-CONVERGENCE phase=cold-prime wait=%s stable=%s leaders=%v",
+		convergence.WaitDuration,
+		convergence.StableDuration,
+		convergence.Leaders,
+	)
 	proveWarmupSend(t, cluster, primeSender)
 	coldPrimeDuration := primeHotPathChannels(t, cluster, primeSender, recipients, primeMessages, payload)
 	_ = primeSender.Close()
@@ -296,6 +319,9 @@ func TestCloudMediumScaledRecipientHotPath(t *testing.T) {
 		OnlineRoutes:             measuredOnlineRoutes,
 		Connections:              len(recipients) + len(senders),
 		OfferedQPS:               offeredQPS,
+		ClusterConvergenceMS:     milliseconds(convergence.WaitDuration),
+		ClusterStableWindowMS:    milliseconds(convergence.StableDuration),
+		SlotLeaders:              append([]uint64(nil), convergence.Leaders...),
 		ColdPrimeDurationMS:      milliseconds(coldPrimeDuration),
 		SendLoopDurationMS:       milliseconds(sendLoopDuration),
 		MeasuredDurationMS:       milliseconds(measuredDuration),
@@ -366,6 +392,21 @@ func hotPathAcceptanceError(evidence hotPathEvidence, expectedOfferedQPS int) er
 		return fmt.Errorf("acceptance connections = %d, want %d", evidence.Connections, expectedConnectionCount())
 	case evidence.OfferedQPS != expectedOfferedQPS:
 		return fmt.Errorf("acceptance offered QPS = %d, want %d", evidence.OfferedQPS, expectedOfferedQPS)
+	case evidence.ClusterConvergenceMS <= 0:
+		return fmt.Errorf("acceptance cluster convergence = %.3fms, want a positive duration", evidence.ClusterConvergenceMS)
+	case evidence.ClusterStableWindowMS < milliseconds(mediumConvergenceStableWindow):
+		return fmt.Errorf(
+			"acceptance cluster stable window = %.3fms, want at least %.3fms",
+			evidence.ClusterStableWindowMS,
+			milliseconds(mediumConvergenceStableWindow),
+		)
+	case !validMediumSlotLeaders(evidence.SlotLeaders):
+		return fmt.Errorf(
+			"acceptance actual Slot leaders = %v, want %d leaders in nodes [1,%d]",
+			evidence.SlotLeaders,
+			mediumLogicalSlots,
+			mediumReplicaCount,
+		)
 	case evidence.IngressPerSecond < float64(expectedOfferedQPS)*mediumMinIngressFraction:
 		return fmt.Errorf(
 			"acceptance ingress = %.3f/s, want at least %.3f/s (%.1f%% of offered load)",
@@ -647,10 +688,23 @@ func startMediumCluster(t *testing.T) *suite.StartedCluster {
 	}
 	s := suite.New(t)
 	return s.StartThreeNodeCluster(
+		suite.WithManagerHTTP(),
 		suite.WithNodeConfigOverrides(1, overrides),
 		suite.WithNodeConfigOverrides(2, overrides),
 		suite.WithNodeConfigOverrides(3, overrides),
 	)
+}
+
+func validMediumSlotLeaders(leaders []uint64) bool {
+	if len(leaders) != mediumLogicalSlots {
+		return false
+	}
+	for _, leaderID := range leaders {
+		if leaderID == 0 || leaderID > uint64(mediumReplicaCount) {
+			return false
+		}
+	}
+	return true
 }
 
 func prepareGroupChannels(t *testing.T, ctx context.Context, node *suite.StartedNode) ([]string, int, []string) {


### PR DESCRIPTION
## Summary

- prove 256 physical hash slots map into 10 non-empty logical Slots with three voters
- require all three nodes to agree on actual Raft leaders for two seconds before setup and again immediately before cold prime
- record final convergence duration and actual Slot leaders in v2 machine evidence

## Root cause

Exact-main Nightly run 30020534908 passed HTTP/WKProto readiness while Slot leader elections were still completing. The Medium cold prime then started against a changing routing topology and one online personal recipient timed out after five seconds. This change tightens the test precondition; it does not increase the client timeout and does not equate PreferredLeader with the actual Raft leader.

## Evidence

- focused functional tests: PASS (`-count=10`)
- focused race tests: PASS (`-count=3`; existing macOS LC_DYSYMTAB linker warning only)
- final three-process CI-scale E2E: PASS
  - setup convergence: 2.10s
  - pre-prime convergence: 2.00s
  - cold prime: 1.88s
  - ingress: 500.02/s
  - SENDACK P99: 388ms
  - RECV P99: 300ms
  - plugin batches: 10,400/10,400; queues drained; processes continuous
- earlier repeated three-process runs: 3/3 PASS, SENDACK P99 339-468ms, RECV P99 238-368ms
- explicit-root repository Go gate: PASS
- `git diff --check`: PASS
- independent Spec review: PASS after addressing final-gate placement and non-empty logical Slot coverage
- independent Standards review: PASS

## Cost gate

No Alibaba Cloud Provision is dispatched by this PR. Paid validation remains blocked until PR CI, exact-SHA Nightly, merge, exact-main CI/Nightly, and a fresh no-live-resource check all pass.
