### PR TITLE
Stabilize distributed E2E readiness and cleanup

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -175,6 +175,7 @@
 - Controller Raft shares the cluster transport server, so its wire message type must stay distinct from slot Raft and observation-hint message types.
 - Inbound Controller Raft frames must be addressed to the local node and originate from a different node; drop looped or misrouted frames before calling `RawNode.Step`.
 - Controller read RPCs can see `not leader` while Raft elects or fails over; keep those retryable read failures out of ERROR logs.
+- Controller-backed writes crossing the `pkg/cluster.Node` facade must expose cluster lifecycle errors while preserving Controller causes; manager routes map transient leadership/lifecycle failures to stable HTTP 503, and bounded idempotent e2e callers may retry only that status.
 
 ### Controller Raft compaction
 - Controller Raft snapshot restore starts from the snapshot index and replays post-snapshot entries; never skip replay by using a later persisted applied index after importing snapshot data.
@@ -184,6 +185,7 @@
 - Slot Raft snapshot restore follows the same boundary as Controller Raft: restore snapshot data first, then replay committed entries after the snapshot index.
 - After Slot Raft log compaction exists, membership changes must refresh the snapshot ConfState so newly added learners can install a snapshot and catch up.
 - Large Slot Raft snapshots are chunked only in `pkg/cluster` raft transport; receivers reassemble chunks into the original `MsgSnap` before calling `multiraft.Runtime.Step`.
+- A Multi-Raft Slot apply queue must stay pinned while an accepted apply crosses from the Slot lock to the apply-pipeline lock; idle retirement cannot invalidate that in-flight enqueue.
 
 ### Local storage
 - `pkg/db` is the single local storage library: `message` owns channel logs and `meta` owns hash-slot metadata.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -238,6 +238,7 @@
 - Cloud Simulation cleanup reconstructs temporary ingress deadlines from provider security rules; sweeps preserve unexpired local Analysis Windows and close expired, malformed, or duplicate windows.
 - Cloud Simulation normal completion uses a non-diagnostic Finalization Schedule plus local `finalize.sh`: arm cleanup before bounded GitHub preflight, retry an explicit in-progress workload while the lease permits, survive terminal signals through exact cleanup, then require structured provider-confirmed empty inventory.
 - Cloud Simulation stability topology uses 256 physical hash slots mapped to 10 logical Slot Raft Groups; bootstrap gates both values separately.
+- E2E `readyz` and WKProto probes prove process liveness only; scenarios that register distributed authority must also require a bounded stable window of voter-agreed actual Slot Raft leaders before creating clients.
 - Cloud Simulation bundles carry a versioned effective-node runtime contract; Bootstrap Gate must match every node's normalized TOML-sourced critical values before starting a paid workload.
 - Bootstrap Gate must parse the rendered YAML shape rather than source-file indentation, retry only convergence failures, and destroy the exact Run on terminal contract failure or workflow cancellation.
 - Omitted Channel store/RPC worker settings stay zero in the loader so the owning Channel runtime derives them; deployment profiles that require a fixed shape must set them explicitly.

--- a/internal/access/manager/FLOW.md
+++ b/internal/access/manager/FLOW.md
@@ -200,6 +200,10 @@ The downstream flow is `SlotReplicaMoveWriter -> Controller slot_replica_move
 task -> cluster task executor -> Slot Raft learner/config-change flow -> final
 Controller assignment commit`; HTTP never treats target learners as
 `DesiredPeers` before that final commit.
+Transient cluster lifecycle and Controller leadership failures use the stable
+`503 service_unavailable` envelope rather than leaking Controller internals as
+`500 internal_error`; callers may retry these idempotent fenced writes within
+their own bounded operation deadline.
 
 `/manager/nodes/:node_id/slot-move-out/*` exposes bounded Slot replica
 migration away from an active Data-role node without entering the scale-in

--- a/internal/access/manager/slot_onboarding.go
+++ b/internal/access/manager/slot_onboarding.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	managementusecase "github.com/WuKongIM/WuKongIM/internal/usecase/management"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 	"github.com/gin-gonic/gin"
 )
@@ -290,6 +291,10 @@ func writeNodeOnboardingError(c *gin.Context, err error) {
 	case errors.Is(err, managementusecase.ErrNodeOnboardingConflict):
 		jsonError(c, http.StatusConflict, "conflict", "conflict")
 	case errors.Is(err, managementusecase.ErrNodeOnboardingUnavailable):
+		jsonError(c, http.StatusServiceUnavailable, "service_unavailable", "service_unavailable")
+	case errors.Is(err, cluster.ErrNotStarted),
+		errors.Is(err, cluster.ErrNotLeader),
+		errors.Is(err, cluster.ErrStopping):
 		jsonError(c, http.StatusServiceUnavailable, "service_unavailable", "service_unavailable")
 	default:
 		jsonError(c, http.StatusInternalServerError, "internal_error", err.Error())

--- a/internal/access/manager/slot_onboarding_test.go
+++ b/internal/access/manager/slot_onboarding_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	managementusecase "github.com/WuKongIM/WuKongIM/internal/usecase/management"
+	"github.com/WuKongIM/WuKongIM/pkg/cluster"
 )
 
 func TestManagerNodeOnboardingPlanReturnsPreview(t *testing.T) {
@@ -156,6 +157,42 @@ func TestManagerNodeOnboardingStartMapsConflict(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"error":"conflict"`) {
 		t.Fatalf("body = %s, want conflict error", rec.Body.String())
+	}
+}
+
+func TestManagerNodeOnboardingStartMapsClusterUnavailable(t *testing.T) {
+	for _, err := range []error{
+		cluster.ErrNotStarted,
+		cluster.ErrNotLeader,
+		cluster.ErrStopping,
+	} {
+		t.Run(err.Error(), func(t *testing.T) {
+			srv := New(Options{
+				Auth: testAuthConfig([]UserConfig{{
+					Username: "admin",
+					Password: "secret",
+					Permissions: []PermissionConfig{{
+						Resource: "cluster.node",
+						Actions:  []string{"w"},
+					}},
+				}}),
+				Management: managerNodesStub{nodeOnboardingStartErr: err},
+			})
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/manager/nodes/4/onboarding/start", strings.NewReader(`{"max_slot_moves":1}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+mustIssueTestToken(t, srv, "admin"))
+
+			srv.Engine().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+			}
+			if !jsonEqual(rec.Body.String(), `{"error":"service_unavailable","message":"service_unavailable"}`) {
+				t.Fatalf("body = %s, want stable service_unavailable", rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/pkg/cluster/FLOW.md
+++ b/pkg/cluster/FLOW.md
@@ -97,6 +97,10 @@ already-planned intent to the control runtime. It uses the same generic
 control-write path: the cluster control runtime forwards `slot_replica_move`
 creation to the Controller leader and keeps the durable assignment unchanged
 until the later Controller commit command. The
+root Node facade normalizes Controller `not leader`, `not started`, and
+`stopped` lifecycle failures into the stable cluster error vocabulary while
+preserving the original Controller cause for lower-level diagnosis.
+The
 default transport-backed
 typed RPC client uses a larger per-priority write queue than the generic
 transport default so short foreground RPC fanout bursts are absorbed before

--- a/pkg/cluster/node_management.go
+++ b/pkg/cluster/node_management.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/WuKongIM/WuKongIM/pkg/cluster/control"
 	controller "github.com/WuKongIM/WuKongIM/pkg/controller"
@@ -44,7 +46,8 @@ func (n *Node) RequestSlotLeaderTransfer(ctx context.Context, req control.SlotLe
 	if !ok {
 		return control.SlotLeaderTransferResult{}, ErrNotStarted
 	}
-	return writer.RequestSlotLeaderTransfer(ctx, req)
+	result, err := writer.RequestSlotLeaderTransfer(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // RequestSlotReplicaMove submits a Controller-backed staged Slot replica move intent.
@@ -64,7 +67,8 @@ func (n *Node) RequestSlotReplicaMove(ctx context.Context, req control.SlotRepli
 	if !ok {
 		return control.SlotReplicaMoveResult{}, ErrNotStarted
 	}
-	return writer.RequestSlotReplicaMove(ctx, req)
+	result, err := writer.RequestSlotReplicaMove(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // JoinNode submits a Controller-backed data-node join intent.
@@ -84,7 +88,8 @@ func (n *Node) JoinNode(ctx context.Context, req control.JoinNodeRequest) (contr
 	if !ok {
 		return control.JoinNodeResult{}, ErrNotStarted
 	}
-	return writer.JoinNode(ctx, req)
+	result, err := writer.JoinNode(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // ActivateNode submits a Controller-backed node activation intent.
@@ -104,7 +109,8 @@ func (n *Node) ActivateNode(ctx context.Context, req control.ActivateNodeRequest
 	if !ok {
 		return control.ActivateNodeResult{}, ErrNotStarted
 	}
-	return writer.ActivateNode(ctx, req)
+	result, err := writer.ActivateNode(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // MarkNodeLeaving submits a Controller-backed node leaving intent.
@@ -124,7 +130,8 @@ func (n *Node) MarkNodeLeaving(ctx context.Context, req control.MarkNodeLeavingR
 	if !ok {
 		return control.MarkNodeLeavingResult{}, ErrNotStarted
 	}
-	return writer.MarkNodeLeaving(ctx, req)
+	result, err := writer.MarkNodeLeaving(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // MarkNodeRemoved submits a Controller-backed node removed intent.
@@ -144,7 +151,8 @@ func (n *Node) MarkNodeRemoved(ctx context.Context, req control.MarkNodeRemovedR
 	if !ok {
 		return control.MarkNodeRemovedResult{}, ErrNotStarted
 	}
-	return writer.MarkNodeRemoved(ctx, req)
+	result, err := writer.MarkNodeRemoved(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // PromoteControllerVoter promotes one active non-Controller node into Controller Raft voting membership.
@@ -164,7 +172,8 @@ func (n *Node) PromoteControllerVoter(ctx context.Context, req control.PromoteCo
 	if !ok {
 		return control.PromoteControllerVoterResult{}, ErrNotStarted
 	}
-	return writer.PromoteControllerVoter(ctx, req)
+	result, err := writer.PromoteControllerVoter(ctx, req)
+	return result, normalizeControlWriteError(err)
 }
 
 // PrepareControllerVoter prepares this node's local Controller runtime for voter promotion.
@@ -186,10 +195,27 @@ func (n *Node) PrepareControllerVoter(ctx context.Context, req controller.Prepar
 	}
 	result, err := writer.PrepareControllerVoter(ctx, req)
 	if err != nil {
-		return controller.PrepareControllerVoterResult{}, err
+		return controller.PrepareControllerVoterResult{}, normalizeControlWriteError(err)
 	}
 	if runtime, ok := n.control.(*control.Runtime); ok {
 		n.registerControlRuntimeRPCHandlers(runtime)
 	}
 	return result, nil
+}
+
+// normalizeControlWriteError keeps Controller lifecycle details while exposing
+// the stable cluster facade errors expected by upper access layers.
+func normalizeControlWriteError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, controller.ErrNotLeader):
+		return fmt.Errorf("%w: %w", ErrNotLeader, err)
+	case errors.Is(err, controller.ErrNotStarted):
+		return fmt.Errorf("%w: %w", ErrNotStarted, err)
+	case errors.Is(err, controller.ErrStopped):
+		return fmt.Errorf("%w: %w", ErrStopping, err)
+	default:
+		return err
+	}
 }

--- a/pkg/cluster/node_management_test.go
+++ b/pkg/cluster/node_management_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -144,6 +145,53 @@ func TestNodeRequestSlotReplicaMoveDelegatesToControl(t *testing.T) {
 	}
 	if len(controller.SlotReplicaMoves) != 1 || controller.SlotReplicaMoves[0].TargetNode != 4 {
 		t.Fatalf("controller moves = %#v, want one target node 4 request", controller.SlotReplicaMoves)
+	}
+}
+
+func TestNodeRequestSlotReplicaMoveNormalizesControllerLeadershipError(t *testing.T) {
+	controlSource := &recordingSlotReplicaMoveController{
+		StaticController: control.NewStaticController(control.Snapshot{}),
+		err:              controller.ErrNotLeader,
+	}
+	node := &Node{control: controlSource}
+	node.started.Store(true)
+
+	_, err := node.RequestSlotReplicaMove(context.Background(), control.SlotReplicaMoveRequest{SlotID: 1, TargetNode: 4})
+	if !errors.Is(err, ErrNotLeader) {
+		t.Fatalf("RequestSlotReplicaMove() error = %v, want cluster ErrNotLeader", err)
+	}
+	if !errors.Is(err, controller.ErrNotLeader) {
+		t.Fatalf("RequestSlotReplicaMove() error = %v, want preserved controller ErrNotLeader", err)
+	}
+}
+
+func TestNormalizeControlWriteError(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		input  error
+		facade error
+	}{
+		{name: "not leader", input: controller.ErrNotLeader, facade: ErrNotLeader},
+		{name: "not started", input: controller.ErrNotStarted, facade: ErrNotStarted},
+		{name: "stopped", input: controller.ErrStopped, facade: ErrStopping},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := normalizeControlWriteError(tc.input)
+			if !errors.Is(err, tc.facade) {
+				t.Fatalf("normalizeControlWriteError() = %v, want facade %v", err, tc.facade)
+			}
+			if !errors.Is(err, tc.input) {
+				t.Fatalf("normalizeControlWriteError() = %v, want preserved cause %v", err, tc.input)
+			}
+		})
+	}
+
+	other := errors.New("other")
+	if got := normalizeControlWriteError(other); got != other {
+		t.Fatalf("normalizeControlWriteError(other) = %v, want original error", got)
+	}
+	if got := normalizeControlWriteError(nil); got != nil {
+		t.Fatalf("normalizeControlWriteError(nil) = %v, want nil", got)
 	}
 }
 
@@ -345,6 +393,21 @@ type recordingMarkNodeLeavingController struct {
 	requests []control.MarkNodeLeavingRequest
 	result   control.MarkNodeLeavingResult
 	err      error
+}
+
+type recordingSlotReplicaMoveController struct {
+	*control.StaticController
+	requests []control.SlotReplicaMoveRequest
+	result   control.SlotReplicaMoveResult
+	err      error
+}
+
+func (c *recordingSlotReplicaMoveController) RequestSlotReplicaMove(_ context.Context, req control.SlotReplicaMoveRequest) (control.SlotReplicaMoveResult, error) {
+	c.requests = append(c.requests, req)
+	if c.err != nil {
+		return control.SlotReplicaMoveResult{}, c.err
+	}
+	return c.result, nil
 }
 
 func (c *recordingMarkNodeLeavingController) MarkNodeLeaving(_ context.Context, req control.MarkNodeLeavingRequest) (control.MarkNodeLeavingResult, error) {

--- a/pkg/slot/multiraft/apply_pipeline.go
+++ b/pkg/slot/multiraft/apply_pipeline.go
@@ -27,6 +27,9 @@ type applyQueue struct {
 	taskHead int
 	running  bool
 	closed   bool
+	// enqueueReservations pins this queue while an accepted Slot apply is
+	// crossing the Slot-lock to pipeline-lock handoff.
+	enqueueReservations int
 }
 
 type applyPipeline struct {
@@ -125,10 +128,12 @@ func (p *applyPipeline) enqueue(task applyTask) error {
 		p.mu.Unlock()
 		return ErrSlotClosed
 	}
+	q.enqueueReservations++
 	p.mu.Unlock()
 
 	if err := task.slot.beginApply(); err != nil {
 		p.mu.Lock()
+		q.enqueueReservations--
 		p.deleteQueueIfIdleLocked(slotID, q)
 		p.mu.Unlock()
 		return err
@@ -136,16 +141,17 @@ func (p *applyPipeline) enqueue(task applyTask) error {
 	runApplyPipelineAfterBeginApplyHook(slotID)
 
 	p.mu.Lock()
+	q.enqueueReservations--
 	if p.closed {
 		p.deleteQueueIfIdleLocked(slotID, q)
-		task.slot.finishApply()
 		p.mu.Unlock()
+		task.slot.finishApply()
 		return ErrRuntimeClosed
 	}
 	if p.queues[slotID] != q || q.closed {
 		p.deleteQueueIfIdleLocked(slotID, q)
-		task.slot.finishApply()
 		p.mu.Unlock()
+		task.slot.finishApply()
 		return ErrSlotClosed
 	}
 	task.queueDepth = q.taskLenLocked() + 1
@@ -262,7 +268,11 @@ func (q *applyQueue) taskLenLocked() int {
 }
 
 func (p *applyPipeline) deleteQueueIfIdleLocked(slotID SlotID, q *applyQueue) {
-	if q == nil || p.queues[slotID] != q || q.running || q.taskLenLocked() > 0 {
+	if q == nil ||
+		p.queues[slotID] != q ||
+		q.running ||
+		q.taskLenLocked() > 0 ||
+		q.enqueueReservations > 0 {
 		return
 	}
 	delete(p.queues, slotID)
@@ -314,7 +324,7 @@ func (p *applyPipeline) closeSlot(slotID SlotID) *applyQueue {
 		return nil
 	}
 	q.closed = true
-	if !q.running && q.taskLenLocked() == 0 {
+	if !q.running && q.taskLenLocked() == 0 && q.enqueueReservations == 0 {
 		delete(p.queues, slotID)
 		p.cond.Broadcast()
 	}

--- a/pkg/slot/multiraft/apply_pipeline_test.go
+++ b/pkg/slot/multiraft/apply_pipeline_test.go
@@ -1,6 +1,10 @@
 package multiraft
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
+)
 
 func TestApplyPipelineReadyQueuePopsFIFOWithoutShifting(t *testing.T) {
 	p := &applyPipeline{}
@@ -65,4 +69,96 @@ func TestApplyQueuePopsTasksFIFOWithoutShifting(t *testing.T) {
 	if _, ok := q.popTaskLocked(); ok {
 		t.Fatal("pop from empty task queue succeeded")
 	}
+}
+
+func TestApplyQueueRetirementPreservesInFlightEnqueue(t *testing.T) {
+	const slotID SlotID = 3
+	g := newTestSlotForDrain()
+	g.id = slotID
+
+	q := &applyQueue{
+		slotID:  slotID,
+		running: true,
+	}
+	p := &applyPipeline{
+		queues: map[SlotID]*applyQueue{slotID: q},
+	}
+	p.cond = sync.NewCond(&p.mu)
+
+	retireStarted := make(chan struct{})
+	releaseRetire := make(chan struct{})
+	enqueueStarted := make(chan struct{})
+	releaseEnqueue := make(chan struct{})
+	var retireOnce sync.Once
+	var enqueueOnce sync.Once
+	var releaseRetireOnce sync.Once
+	var releaseEnqueueOnce sync.Once
+	restoreRetireHook := setApplyPipelineBeforeRetireQueueHook(func(id SlotID) {
+		if id != slotID {
+			return
+		}
+		retireOnce.Do(func() { close(retireStarted) })
+		<-releaseRetire
+	})
+	defer restoreRetireHook()
+	restoreEnqueueHook := setApplyPipelineAfterBeginApplyHook(func(id SlotID) {
+		if id != slotID {
+			return
+		}
+		enqueueOnce.Do(func() { close(enqueueStarted) })
+		<-releaseEnqueue
+	})
+	defer restoreEnqueueHook()
+	defer releaseRetireOnce.Do(func() { close(releaseRetire) })
+	defer releaseEnqueueOnce.Do(func() { close(releaseEnqueue) })
+
+	retireDone := make(chan struct{})
+	go func() {
+		p.runQueue(q)
+		close(retireDone)
+	}()
+	select {
+	case <-retireStarted:
+	case <-time.After(time.Second):
+		t.Fatal("apply queue retirement did not start")
+	}
+
+	enqueueDone := make(chan error, 1)
+	go func() {
+		enqueueDone <- p.enqueue(applyTask{slot: g})
+	}()
+	select {
+	case <-enqueueStarted:
+	case <-time.After(time.Second):
+		t.Fatal("apply queue enqueue handoff did not start")
+	}
+
+	releaseRetireOnce.Do(func() { close(releaseRetire) })
+	select {
+	case <-retireDone:
+	case <-time.After(time.Second):
+		t.Fatal("apply queue retirement did not finish")
+	}
+	releaseEnqueueOnce.Do(func() { close(releaseEnqueue) })
+
+	select {
+	case err := <-enqueueDone:
+		if err != nil {
+			t.Fatalf("enqueue() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("apply queue enqueue did not finish")
+	}
+
+	p.mu.Lock()
+	gotQueue := p.queues[slotID]
+	taskCount := q.taskLenLocked()
+	p.mu.Unlock()
+	if gotQueue != q {
+		t.Fatalf("queues[%d] = %p, want original queue %p", slotID, gotQueue, q)
+	}
+	if taskCount != 1 {
+		t.Fatalf("queued tasks = %d, want 1", taskCount)
+	}
+	g.finishApply()
 }

--- a/scripts/cloud_sim_analyze_test.go
+++ b/scripts/cloud_sim_analyze_test.go
@@ -142,6 +142,7 @@ exit 89
 		"WK_ANALYZE_CALL_LOG="+callLog,
 		"WK_ANALYZE_STATE_DIR="+stateDir,
 		"WK_ANALYZE_SESSION_STATE=live",
+		"WK_CODEX_BIN=",
 		"WK_CODEX_BUNDLED_BIN="+bundledCodex,
 	)
 	output, err := command.CombinedOutput()
@@ -244,10 +245,17 @@ func TestCloudSimulationAnalyzeBoundsCodexEnvironmentProbes(t *testing.T) {
 			bin := filepath.Join(temp, "bin")
 			stateDir := filepath.Join(temp, "state")
 			callLog := filepath.Join(temp, "calls.log")
+			bundledMarker := filepath.Join(temp, "bundled-codex-called")
 			if err := os.MkdirAll(bin, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			writeAnalyzeFakes(t, bin)
+			bundledCodex := filepath.Join(bin, "codex-bundled")
+			writeSetupExecutable(t, bundledCodex, `#!/usr/bin/env bash
+set -euo pipefail
+: > `+strconv.Quote(bundledMarker)+`
+printf '%s\n' 'codex-cli 999.0.0'
+`)
 
 			command := exec.Command("bash", filepath.Join(root, "scripts", "cloud-sim", "analyze.sh"),
 				"run-live", "--repository", "example/project")
@@ -257,6 +265,7 @@ func TestCloudSimulationAnalyzeBoundsCodexEnvironmentProbes(t *testing.T) {
 				"WK_ANALYZE_CALL_LOG="+callLog,
 				"WK_ANALYZE_STATE_DIR="+stateDir,
 				"WK_ANALYZE_SESSION_STATE=live",
+				"WK_CODEX_BUNDLED_BIN="+bundledCodex,
 				"WK_ANALYZE_CODEX_HANG="+testCase.hangMode,
 				// Keep ordinary fake tool startup tolerant of concurrent package
 				// load while preserving the one-second Codex probe under test.
@@ -281,6 +290,9 @@ func TestCloudSimulationAnalyzeBoundsCodexEnvironmentProbes(t *testing.T) {
 			if !strings.Contains(string(calls), "-f operation=close") ||
 				strings.Contains(string(calls), "codex exec") {
 				t.Fatalf("bounded Codex probe did not close before exit:\n%s", calls)
+			}
+			if _, statErr := os.Stat(bundledMarker); !os.IsNotExist(statErr) {
+				t.Fatalf("explicit fake Codex failure escaped to bundled installation: %v", statErr)
 			}
 		})
 	}
@@ -323,6 +335,7 @@ func TestCloudSimulationAnalyzeBoundsDiagnosisAndValidationProcessGroups(t *test
 				// Keep ordinary fake tool startup separate from the one-second
 				// diagnosis deadline under concurrent repository test load.
 				"WK_LOCAL_TOOL_COMMAND_TIMEOUT_SECONDS=3",
+				"WK_ANALYSIS_CODEX_PROBE_TIMEOUT_SECONDS=8",
 				"WK_ANALYSIS_DIAGNOSIS_TIMEOUT_SECONDS=1",
 			)
 			if testCase.hangTarget == "validation" {
@@ -483,6 +496,7 @@ func TestCloudSimulationAnalyzeBoundsCryptoAndWorktreeProcessGroups(t *testing.T
 				"WK_ANALYZE_SESSION_STATE=live",
 				"WK_ANALYZE_HANG_PID_FILE="+descendantPIDFile,
 				"WK_LOCAL_TOOL_COMMAND_TIMEOUT_SECONDS=2",
+				"WK_ANALYSIS_CODEX_PROBE_TIMEOUT_SECONDS=8",
 			)
 			command.Env = append(command.Env, extraEnvironment...)
 			started := time.Now()
@@ -1159,6 +1173,7 @@ func TestCloudSimulationAnalyzeDiscoversGoFromGOROOTOutsidePATH(t *testing.T) {
 		"GOROOT="+goRoot,
 		"WK_GH_BIN="+filepath.Join(bin, "gh"),
 		"WK_GO_BIN="+filepath.Join(goRoot, "bin", "go"),
+		"WK_CODEX_BIN="+filepath.Join(bin, "codex"),
 		"WK_ANALYZE_CALL_LOG="+callLog,
 		"WK_ANALYZE_STATE_DIR="+stateDir,
 		"WK_ANALYZE_SESSION_STATE=live",
@@ -1230,6 +1245,7 @@ exit 98
 		"PATH="+bin,
 		"WK_GH_BIN="+filepath.Join(toolBin, "selected-gh"),
 		"WK_GO_BIN="+filepath.Join(toolBin, "selected-go"),
+		"WK_CODEX_BIN="+filepath.Join(bin, "codex"),
 		"WK_ANALYZE_CALL_LOG="+callLog,
 		"WK_ANALYZE_STATE_DIR="+stateDir,
 		"WK_ANALYZE_SESSION_STATE=live",
@@ -2061,5 +2077,8 @@ func analyzeFakeEnvironment(bin string) []string {
 	return append(os.Environ(),
 		"WK_GH_BIN="+filepath.Join(bin, "gh"),
 		"WK_GO_BIN="+filepath.Join(bin, "go"),
+		// Test commands must never fall through to a developer- or runner-owned
+		// Codex installation when a deliberately bounded fake exits or times out.
+		"WK_CODEX_BIN="+filepath.Join(bin, "codex"),
 	)
 }

--- a/test/e2e/cluster/dynamic_node_join/slot_onboarding_concurrency_test.go
+++ b/test/e2e/cluster/dynamic_node_join/slot_onboarding_concurrency_test.go
@@ -154,7 +154,7 @@ func runConcurrentOnboardingStarts(t testing.TB, manager *suite.ManagerClient, n
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			response, status, body, err := manager.StartOnboarding(ctx, nodeID, maxSlotMoves)
+			response, status, body, err := retryConcurrentOnboardingStart(ctx, manager, nodeID, maxSlotMoves)
 			results <- onboardingStartResult{response: response, status: status, body: body, err: err}
 		}()
 	}
@@ -169,11 +169,46 @@ func runConcurrentScaleInAdvances(t testing.TB, manager *suite.ManagerClient, no
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			response, status, body, err := manager.AdvanceScaleIn(ctx, nodeID, maxSlotMoves)
+			response, status, body, err := retryConcurrentScaleInAdvance(ctx, manager, nodeID, maxSlotMoves)
 			results <- scaleInAdvanceResult{response: response, status: status, body: body, err: err}
 		}()
 	}
 	return collectScaleInAdvanceResults(results, count)
+}
+
+func retryConcurrentOnboardingStart(ctx context.Context, manager *suite.ManagerClient, nodeID uint64, maxSlotMoves uint32) (suite.NodeOnboardingStartDTO, int, []byte, error) {
+	for {
+		response, status, body, err := manager.StartOnboarding(ctx, nodeID, maxSlotMoves)
+		if err != nil || status != http.StatusServiceUnavailable {
+			return response, status, body, err
+		}
+		if err := waitForConcurrentControlWriteRetry(ctx); err != nil {
+			return response, status, body, nil
+		}
+	}
+}
+
+func retryConcurrentScaleInAdvance(ctx context.Context, manager *suite.ManagerClient, nodeID uint64, maxSlotMoves uint32) (suite.NodeScaleInAdvanceDTO, int, []byte, error) {
+	for {
+		response, status, body, err := manager.AdvanceScaleIn(ctx, nodeID, maxSlotMoves)
+		if err != nil || status != http.StatusServiceUnavailable {
+			return response, status, body, err
+		}
+		if err := waitForConcurrentControlWriteRetry(ctx); err != nil {
+			return response, status, body, nil
+		}
+	}
+}
+
+func waitForConcurrentControlWriteRetry(ctx context.Context) error {
+	timer := time.NewTimer(50 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func collectOnboardingStartResults(results <-chan onboardingStartResult, count int) []onboardingStartResult {

--- a/test/e2e/message/cross_node_delivery/AGENTS.md
+++ b/test/e2e/message/cross_node_delivery/AGENTS.md
@@ -15,6 +15,10 @@ GOWORK=off go test -tags=e2e ./test/e2e/message/cross_node_delivery -count=1 -ti
 - Keep assertions black-box through public WKProto entrypoints.
 - Start all three nodes with `WK_DELIVERY_ENABLE=true`; delivery-off scenarios
   belong in separate coverage.
+- Enable read-only Manager HTTP and require every node to agree on the actual
+  Raft-elected logical Slot leaders for a bounded stability window before
+  connecting users. `/readyz` and WKProto availability alone do not prove that
+  initial Slot elections have converged.
 - Validate both directions: node1 user to node2 user, and node2 user back to
   node1 user.
 - After each `RECV`, assert the recipient owner node reports a pending

--- a/test/e2e/message/cross_node_delivery/cross_node_delivery_test.go
+++ b/test/e2e/message/cross_node_delivery/cross_node_delivery_test.go
@@ -17,6 +17,7 @@ func TestThreeNodeClusterCrossNodeUsersExchangeMessages(t *testing.T) {
 	s := suite.New(t)
 	overrides := deliveryTopOverrides()
 	cluster := s.StartThreeNodeCluster(
+		suite.WithManagerHTTP(),
 		suite.WithNodeConfigOverrides(1, overrides),
 		suite.WithNodeConfigOverrides(2, overrides),
 		suite.WithNodeConfigOverrides(3, overrides),
@@ -25,6 +26,14 @@ func TestThreeNodeClusterCrossNodeUsersExchangeMessages(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	require.NoError(t, cluster.WaitClusterReady(ctx), cluster.DumpDiagnostics())
+	convergence, err := cluster.WaitSlotLeadersStable(ctx, 2*time.Second)
+	require.NoError(t, err, cluster.DumpDiagnostics())
+	t.Logf(
+		"actual Slot leaders stable for %s after %s: %v",
+		convergence.StableDuration,
+		convergence.WaitDuration,
+		convergence.Leaders,
+	)
 
 	userA := newConnectedClient(t, cluster.MustNode(1), "e2e-cross-a")
 	defer func() { _ = userA.Close() }()

--- a/test/e2e/message/medium_recipient_hotpath/cluster_convergence.go
+++ b/test/e2e/message/medium_recipient_hotpath/cluster_convergence.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	mediumConvergencePollInterval = 100 * time.Millisecond
 	mediumConvergenceStableWindow = 2 * time.Second
 )
 
@@ -40,84 +39,43 @@ type mediumConvergenceSnapshot struct {
 	Fingerprint string
 }
 
-// mediumConvergenceTracker rejects a changing Raft leader inventory until the
-// same validated fingerprint survives the required stability window.
-type mediumConvergenceTracker struct {
-	stableWindow time.Duration
-	fingerprint  string
-	stableSince  time.Time
-}
-
-func newMediumConvergenceTracker(stableWindow time.Duration) *mediumConvergenceTracker {
-	return &mediumConvergenceTracker{stableWindow: stableWindow}
-}
-
-func (t *mediumConvergenceTracker) Observe(now time.Time, fingerprint string) (time.Duration, bool) {
-	if strings.TrimSpace(fingerprint) == "" {
-		t.Reset()
-		return 0, false
-	}
-	if t.fingerprint != fingerprint || t.stableSince.IsZero() {
-		t.fingerprint = fingerprint
-		t.stableSince = now
-		return 0, t.stableWindow <= 0
-	}
-	stableFor := now.Sub(t.stableSince)
-	if stableFor < 0 {
-		t.stableSince = now
-		return 0, false
-	}
-	return stableFor, stableFor >= t.stableWindow
-}
-
-func (t *mediumConvergenceTracker) Reset() {
-	t.fingerprint = ""
-	t.stableSince = time.Time{}
-}
-
 func waitForMediumSlotConvergence(ctx context.Context, cluster *suite.StartedCluster) (mediumSlotConvergence, error) {
-	if cluster == nil {
-		return mediumSlotConvergence{}, fmt.Errorf("started cluster is nil")
-	}
 	startedAt := time.Now()
-	tracker := newMediumConvergenceTracker(mediumConvergenceStableWindow)
-	ticker := time.NewTicker(mediumConvergencePollInterval)
-	defer ticker.Stop()
-
-	var lastErr error
-	for {
-		inventories, err := readMediumSlotInventories(ctx, cluster)
-		if err == nil {
-			var snapshot mediumConvergenceSnapshot
-			snapshot, err = validateMediumSlotConvergence(inventories)
-			if err == nil {
-				stableFor, ready := tracker.Observe(time.Now(), snapshot.Fingerprint)
-				if ready {
-					return mediumSlotConvergence{
-						Leaders:        append([]uint64(nil), snapshot.Leaders...),
-						Fingerprint:    snapshot.Fingerprint,
-						WaitDuration:   time.Since(startedAt),
-						StableDuration: stableFor,
-					}, nil
-				}
-				lastErr = fmt.Errorf(
-					"actual Raft leader inventory is valid but stable for only %s of %s",
-					stableFor,
-					mediumConvergenceStableWindow,
-				)
-			}
-		}
-		if err != nil {
-			lastErr = err
-			tracker.Reset()
-		}
-
-		select {
-		case <-ctx.Done():
-			return mediumSlotConvergence{}, fmt.Errorf("actual Raft leaders did not stabilize: %w (last observation: %v)", ctx.Err(), lastErr)
-		case <-ticker.C:
-		}
+	convergence, err := cluster.WaitSlotLeadersStable(ctx, mediumConvergenceStableWindow)
+	if err != nil {
+		return mediumSlotConvergence{}, err
 	}
+	inventories, err := readMediumSlotInventories(ctx, cluster)
+	if err != nil {
+		return mediumSlotConvergence{}, err
+	}
+	snapshot, err := validateMediumSlotConvergence(inventories)
+	if err != nil {
+		return mediumSlotConvergence{}, err
+	}
+	if err := validateMediumSlotStateMatchesStableProof(convergence, snapshot); err != nil {
+		return mediumSlotConvergence{}, err
+	}
+	return mediumSlotConvergence{
+		Leaders:        append([]uint64(nil), snapshot.Leaders...),
+		Fingerprint:    snapshot.Fingerprint,
+		WaitDuration:   time.Since(startedAt),
+		StableDuration: convergence.StableDuration,
+	}, nil
+}
+
+func validateMediumSlotStateMatchesStableProof(
+	convergence suite.SlotLeaderConvergence,
+	snapshot mediumConvergenceSnapshot,
+) error {
+	if snapshot.Fingerprint != convergence.Fingerprint {
+		return fmt.Errorf(
+			"strict Medium Slot state changed after the stability proof: stable=%q current=%q",
+			convergence.Fingerprint,
+			snapshot.Fingerprint,
+		)
+	}
+	return nil
 }
 
 func readMediumSlotInventories(ctx context.Context, cluster *suite.StartedCluster) (map[uint64]mediumSlotsResponse, error) {
@@ -195,11 +153,13 @@ func validateMediumSlotConvergence(inventories map[uint64]mediumSlotsResponse) (
 		leaders[slotIndex] = leaderID
 		fmt.Fprintf(
 			&fingerprint,
-			"%d:%d:%d:%d;",
+			"%d:%d:%d:%d:%d:%v;",
 			item.SlotID,
 			leaderID,
+			item.Assignment.PreferredLeaderID,
 			item.Assignment.ConfigEpoch,
 			item.Assignment.BalanceVersion,
+			expectedPeers,
 		)
 	}
 	return mediumConvergenceSnapshot{

--- a/test/e2e/message/medium_recipient_hotpath/cluster_convergence_test.go
+++ b/test/e2e/message/medium_recipient_hotpath/cluster_convergence_test.go
@@ -5,7 +5,6 @@ package medium_recipient_hotpath
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/WuKongIM/WuKongIM/test/e2e/suite"
 )
@@ -110,30 +109,66 @@ func TestValidateMediumSlotConvergence(t *testing.T) {
 	}
 }
 
-func TestMediumConvergenceTrackerRequiresUnchangedStabilityWindow(t *testing.T) {
-	start := time.Unix(1_700_000_000, 0)
-	tracker := newMediumConvergenceTracker(2 * time.Second)
-
-	if stableFor, ready := tracker.Observe(start, "leaders-a"); ready || stableFor != 0 {
-		t.Fatalf("first observation = (%s, %v), want (0, false)", stableFor, ready)
+func TestValidateMediumSlotStateMatchesStableProofRejectsTOCTOU(t *testing.T) {
+	baseline, err := validateMediumSlotConvergence(stableMediumSlotInventories())
+	if err != nil {
+		t.Fatalf("validate baseline convergence: %v", err)
 	}
-	if stableFor, ready := tracker.Observe(start.Add(1999*time.Millisecond), "leaders-a"); ready || stableFor != 1999*time.Millisecond {
-		t.Fatalf("pre-window observation = (%s, %v), want (1.999s, false)", stableFor, ready)
-	}
-	if stableFor, ready := tracker.Observe(start.Add(2*time.Second), "leaders-a"); !ready || stableFor != 2*time.Second {
-		t.Fatalf("stable observation = (%s, %v), want (2s, true)", stableFor, ready)
+	proof := suite.SlotLeaderConvergence{Fingerprint: baseline.Fingerprint}
+	if err := validateMediumSlotStateMatchesStableProof(proof, baseline); err != nil {
+		t.Fatalf("unchanged state rejected: %v", err)
 	}
 
-	if stableFor, ready := tracker.Observe(start.Add(3*time.Second), "leaders-b"); ready || stableFor != 0 {
-		t.Fatalf("changed leaders = (%s, %v), want reset (0, false)", stableFor, ready)
+	tests := map[string]func(map[uint64]mediumSlotsResponse){
+		"actual leader": func(inventories map[uint64]mediumSlotsResponse) {
+			for nodeID, inventory := range inventories {
+				inventory.Items[0].NodeLog.LeaderID = 3
+				inventory.Items[0].NodeLog.Role = "follower"
+				if nodeID == 3 {
+					inventory.Items[0].NodeLog.Role = "leader"
+				}
+				inventories[nodeID] = inventory
+			}
+		},
+		"preferred leader": func(inventories map[uint64]mediumSlotsResponse) {
+			for nodeID, inventory := range inventories {
+				inventory.Items[0].Assignment.PreferredLeaderID = 3
+				inventories[nodeID] = inventory
+			}
+		},
+		"config epoch": func(inventories map[uint64]mediumSlotsResponse) {
+			for nodeID, inventory := range inventories {
+				inventory.Items[0].Assignment.ConfigEpoch++
+				inventories[nodeID] = inventory
+			}
+		},
+		"balance version": func(inventories map[uint64]mediumSlotsResponse) {
+			for nodeID, inventory := range inventories {
+				inventory.Items[0].Assignment.BalanceVersion++
+				inventories[nodeID] = inventory
+			}
+		},
+		"slot IDs": func(inventories map[uint64]mediumSlotsResponse) {
+			for nodeID, inventory := range inventories {
+				for index := range inventory.Items {
+					inventory.Items[index].SlotID += 100
+				}
+				inventories[nodeID] = inventory
+			}
+		},
 	}
-	if stableFor, ready := tracker.Observe(start.Add(5*time.Second), "leaders-b"); !ready || stableFor != 2*time.Second {
-		t.Fatalf("restabilized leaders = (%s, %v), want (2s, true)", stableFor, ready)
-	}
-
-	tracker.Reset()
-	if stableFor, ready := tracker.Observe(start.Add(6*time.Second), "leaders-b"); ready || stableFor != 0 {
-		t.Fatalf("observation after reset = (%s, %v), want (0, false)", stableFor, ready)
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			inventories := stableMediumSlotInventories()
+			mutate(inventories)
+			current, err := validateMediumSlotConvergence(inventories)
+			if err != nil {
+				t.Fatalf("validate current convergence: %v", err)
+			}
+			if err := validateMediumSlotStateMatchesStableProof(proof, current); err == nil {
+				t.Fatal("changed state matched the stable proof")
+			}
+		})
 	}
 }
 

--- a/test/e2e/suite/FLOW.md
+++ b/test/e2e/suite/FLOW.md
@@ -20,6 +20,9 @@ HTTP helpers for real `cmd/wukongim` tests.
    `Wait` call for the group leader.
 4. Test cleanup stops the current process for every registered node, including
    nodes appended after cluster startup and processes replaced by restart.
+   Static cluster nodes receive graceful termination concurrently so one node
+   does not lose Raft quorum while later nodes are still waiting to begin
+   shutdown, and so per-node stop budgets do not accumulate serially.
    Concurrent or repeated stops join the same exit result, and readiness waits
    fail immediately when their child exits instead of consuming the full poll
    timeout. Leader exit also starts group cleanup: the harness sends `TERM`,
@@ -59,3 +62,14 @@ redacted using case-insensitive, separator-independent key matching.
 HTTP helpers preserve typed non-2xx response details. Message-send recovery
 retries only the exact public `503 {"error":"retry required"}` signal while
 reusing one serialized request body and idempotency key.
+
+## Cluster convergence
+
+`WaitClusterReady` proves only public HTTP and WKProto availability. Scenarios
+whose correctness depends on stable Slot authority enable read-only Manager
+HTTP and call `WaitSlotLeadersStable`. That helper polls every node's full
+control inventory plus each node-scoped voter inventory, proves the two views
+are closed over the same Slots, validates desired/current voters and quorum,
+uses the actual Raft-elected `node_log.leader_id` rather than
+`preferred_leader_id`, requires cross-node agreement, and resets its bounded
+stability timer whenever the leader/config fingerprint changes.

--- a/test/e2e/suite/runtime.go
+++ b/test/e2e/suite/runtime.go
@@ -494,9 +494,21 @@ func registerStartedNodeCleanup(t startedNodeCleanupTB, node *StartedNode) {
 func registerStartedClusterCleanup(t startedNodeCleanupTB, cluster *StartedCluster) {
 	t.Helper()
 	t.Cleanup(func() {
+		type stopResult struct {
+			nodeID uint64
+			err    error
+		}
+		results := make(chan stopResult, len(cluster.Nodes))
 		for i := len(cluster.Nodes) - 1; i >= 0; i-- {
-			if err := cluster.Nodes[i].Stop(); err != nil {
-				t.Errorf("stop started cluster node %d: %v", cluster.Nodes[i].Spec.ID, err)
+			node := &cluster.Nodes[i]
+			go func() {
+				results <- stopResult{nodeID: node.Spec.ID, err: node.Stop()}
+			}()
+		}
+		for range cluster.Nodes {
+			result := <-results
+			if result.err != nil {
+				t.Errorf("stop started cluster node %d: %v", result.nodeID, result.err)
 			}
 		}
 	})

--- a/test/e2e/suite/runtime_test.go
+++ b/test/e2e/suite/runtime_test.go
@@ -8,9 +8,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -349,6 +352,95 @@ func TestStartedClusterCleanupStopsNodesAppendedAfterRegistration(t *testing.T) 
 	_, secondExited := second.ExitResult()
 	require.True(t, firstExited)
 	require.True(t, secondExited)
+}
+
+func TestStartedClusterCleanupStopsNodesConcurrently(t *testing.T) {
+	cleanupTB := &recordedCleanupTB{}
+	cluster := &StartedCluster{}
+	registerStartedClusterCleanup(cleanupTB, cluster)
+	releasePath := filepath.Join(t.TempDir(), "release")
+	termPaths := make([]string, 0, 3)
+
+	for nodeID := uint64(1); nodeID <= 3; nodeID++ {
+		readyPath := filepath.Join(t.TempDir(), "ready")
+		termPath := filepath.Join(t.TempDir(), "term")
+		termPaths = append(termPaths, termPath)
+		command := exec.Command(os.Args[0], "-test.run=TestStartedClusterCleanupSignalHelper")
+		command.Env = append(
+			os.Environ(),
+			"GO_WANT_CLUSTER_CLEANUP_SIGNAL_HELPER=1",
+			"READY_FILE="+readyPath,
+			"TERM_FILE="+termPath,
+			"RELEASE_FILE="+releasePath,
+		)
+		process := newCommandNodeProcess(t, command)
+		process.Spec.ID = nodeID
+		process.StopTimeout = 5 * time.Second
+		require.NoError(t, process.Start())
+		require.Eventually(t, func() bool {
+			_, err := os.Stat(readyPath)
+			return err == nil
+		}, time.Second, 10*time.Millisecond)
+		t.Cleanup(func() {
+			if process.Running() {
+				_ = process.Stop()
+			}
+		})
+		cluster.Nodes = append(cluster.Nodes, StartedNode{Spec: process.Spec, Process: process})
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		cleanupTB.cleanups[0]()
+		close(cleanupDone)
+	}()
+	allTerminated := waitForPaths(termPaths, 3*time.Second)
+	require.NoError(t, os.WriteFile(releasePath, []byte("release"), 0o600))
+	select {
+	case <-cleanupDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cluster cleanup did not finish after release")
+	}
+
+	require.Empty(t, cleanupTB.errors)
+	require.True(t, allTerminated, "cluster cleanup did not signal every node before release")
+}
+
+func TestStartedClusterCleanupSignalHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_CLUSTER_CLEANUP_SIGNAL_HELPER") != "1" {
+		return
+	}
+
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, syscall.SIGTERM)
+	defer signal.Stop(term)
+	require.NoError(t, os.WriteFile(os.Getenv("READY_FILE"), nil, 0o600))
+	<-term
+	require.NoError(t, os.WriteFile(os.Getenv("TERM_FILE"), nil, 0o600))
+	for {
+		if _, err := os.Stat(os.Getenv("RELEASE_FILE")); err == nil {
+			os.Exit(0)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForPaths(paths []string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		allExist := true
+		for _, path := range paths {
+			if _, err := os.Stat(path); err != nil {
+				allExist = false
+				break
+			}
+		}
+		if allExist {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
 }
 
 func TestStartedClusterStartStoppedNodeStartsDetachedProcess(t *testing.T) {

--- a/test/e2e/suite/slot_convergence.go
+++ b/test/e2e/suite/slot_convergence.go
@@ -1,0 +1,576 @@
+//go:build e2e
+
+package suite
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const slotLeaderConvergencePollInterval = 100 * time.Millisecond
+
+// ActualSlotLeader identifies the Raft-elected leader for one logical Slot.
+type ActualSlotLeader struct {
+	// SlotID is the stable logical Slot identifier.
+	SlotID uint32
+	// LeaderID is the non-zero node selected by the Slot Raft group.
+	LeaderID uint64
+}
+
+// SlotLeaderConvergence records the cross-node Slot leader state that remained
+// unchanged for the requested stability window.
+type SlotLeaderConvergence struct {
+	// Leaders contains the actual Raft leaders ordered by logical Slot ID.
+	Leaders []ActualSlotLeader
+	// Fingerprint identifies the stable leaders, voters, and control assignment.
+	Fingerprint string
+	// WaitDuration is the total time spent proving convergence.
+	WaitDuration time.Duration
+	// StableDuration is how long the final fingerprint remained unchanged.
+	StableDuration time.Duration
+}
+
+type slotLeaderConvergenceSnapshot struct {
+	Leaders     []ActualSlotLeader
+	Fingerprint string
+}
+
+type slotLeaderAggregate struct {
+	reference    SlotDTO
+	observations map[uint64]SlotDTO
+}
+
+type slotLeaderInventorySet struct {
+	full    map[uint64]managerSlotsResponse
+	byVoter map[uint64]managerSlotsResponse
+}
+
+type slotLeaderConvergenceTracker struct {
+	stableWindow time.Duration
+	fingerprint  string
+	stableSince  time.Time
+}
+
+func newSlotLeaderConvergenceTracker(stableWindow time.Duration) *slotLeaderConvergenceTracker {
+	return &slotLeaderConvergenceTracker{stableWindow: stableWindow}
+}
+
+func (t *slotLeaderConvergenceTracker) Observe(now time.Time, fingerprint string) (time.Duration, bool) {
+	if strings.TrimSpace(fingerprint) == "" {
+		t.Reset()
+		return 0, false
+	}
+	if t.fingerprint != fingerprint || t.stableSince.IsZero() {
+		t.fingerprint = fingerprint
+		t.stableSince = now
+		return 0, t.stableWindow <= 0
+	}
+	stableFor := now.Sub(t.stableSince)
+	if stableFor < 0 {
+		t.stableSince = now
+		return 0, false
+	}
+	return stableFor, stableFor >= t.stableWindow
+}
+
+func (t *slotLeaderConvergenceTracker) Reset() {
+	t.fingerprint = ""
+	t.stableSince = time.Time{}
+}
+
+// WaitSlotLeadersStable waits until every node reports the same valid
+// Raft-elected Slot leaders and that inventory remains unchanged for
+// stableWindow. The cluster must be started with WithManagerHTTP.
+func (c *StartedCluster) WaitSlotLeadersStable(ctx context.Context, stableWindow time.Duration) (SlotLeaderConvergence, error) {
+	if c == nil {
+		return SlotLeaderConvergence{}, fmt.Errorf("started cluster is nil")
+	}
+	if len(c.Nodes) == 0 {
+		return SlotLeaderConvergence{}, fmt.Errorf("started cluster has no nodes")
+	}
+	if stableWindow < 0 {
+		return SlotLeaderConvergence{}, fmt.Errorf("stable window must not be negative")
+	}
+
+	nodeIDs := make([]uint64, 0, len(c.Nodes))
+	seenNodeIDs := make(map[uint64]struct{}, len(c.Nodes))
+	for _, node := range c.Nodes {
+		if strings.TrimSpace(node.ManagerAddr()) == "" {
+			return SlotLeaderConvergence{}, fmt.Errorf("node %d manager HTTP is disabled", node.Spec.ID)
+		}
+		if _, exists := seenNodeIDs[node.Spec.ID]; exists {
+			return SlotLeaderConvergence{}, fmt.Errorf("duplicate node ID %d", node.Spec.ID)
+		}
+		seenNodeIDs[node.Spec.ID] = struct{}{}
+		nodeIDs = append(nodeIDs, node.Spec.ID)
+	}
+	sort.Slice(nodeIDs, func(i, j int) bool { return nodeIDs[i] < nodeIDs[j] })
+
+	startedAt := time.Now()
+	tracker := newSlotLeaderConvergenceTracker(stableWindow)
+	ticker := time.NewTicker(slotLeaderConvergencePollInterval)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		inventories, err := c.readSlotLeaderInventories(ctx)
+		if err == nil {
+			var snapshot slotLeaderConvergenceSnapshot
+			snapshot, err = validateSlotLeaderConvergence(inventories, nodeIDs)
+			if err == nil {
+				stableFor, ready := tracker.Observe(time.Now(), snapshot.Fingerprint)
+				if ready {
+					return SlotLeaderConvergence{
+						Leaders:        append([]ActualSlotLeader(nil), snapshot.Leaders...),
+						Fingerprint:    snapshot.Fingerprint,
+						WaitDuration:   time.Since(startedAt),
+						StableDuration: stableFor,
+					}, nil
+				}
+				lastErr = fmt.Errorf(
+					"actual Raft leader inventory is valid but stable for only %s of %s",
+					stableFor,
+					stableWindow,
+				)
+			}
+		}
+		if err != nil {
+			lastErr = err
+			tracker.Reset()
+		}
+
+		select {
+		case <-ctx.Done():
+			return SlotLeaderConvergence{}, fmt.Errorf(
+				"actual Raft leaders did not stabilize: %w (last observation: %v)",
+				ctx.Err(),
+				lastErr,
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *StartedCluster) readSlotLeaderInventories(ctx context.Context) (slotLeaderInventorySet, error) {
+	inventories := slotLeaderInventorySet{
+		full:    make(map[uint64]managerSlotsResponse, len(c.Nodes)),
+		byVoter: make(map[uint64]managerSlotsResponse, len(c.Nodes)),
+	}
+	for _, node := range c.Nodes {
+		var full managerSlotsResponse
+		fullURL := fmt.Sprintf("http://%s/manager/slots", node.ManagerAddr())
+		if _, err := GetJSON(ctx, fullURL, &full); err != nil {
+			return slotLeaderInventorySet{}, fmt.Errorf("read node %d full Slot inventory: %w", node.Spec.ID, err)
+		}
+		inventories.full[node.Spec.ID] = full
+
+		var byVoter managerSlotsResponse
+		voterURL := fmt.Sprintf("http://%s/manager/slots?node_id=%d", node.ManagerAddr(), node.Spec.ID)
+		if _, err := GetJSON(ctx, voterURL, &byVoter); err != nil {
+			return slotLeaderInventorySet{}, fmt.Errorf("read node %d voter Slot inventory: %w", node.Spec.ID, err)
+		}
+		inventories.byVoter[node.Spec.ID] = byVoter
+	}
+	return inventories, nil
+}
+
+func validateSlotLeaderConvergence(
+	inventories slotLeaderInventorySet,
+	nodeIDs []uint64,
+) (slotLeaderConvergenceSnapshot, error) {
+	if len(nodeIDs) == 0 {
+		return slotLeaderConvergenceSnapshot{}, fmt.Errorf("expected node IDs are empty")
+	}
+	knownNodeIDs := make(map[uint64]struct{}, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		if nodeID == 0 {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf("expected node IDs contain zero")
+		}
+		if _, duplicate := knownNodeIDs[nodeID]; duplicate {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf("expected node IDs contain duplicate %d", nodeID)
+		}
+		knownNodeIDs[nodeID] = struct{}{}
+	}
+	if len(inventories.full) != len(nodeIDs) {
+		return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+			"full node inventories = %d, want %d",
+			len(inventories.full),
+			len(nodeIDs),
+		)
+	}
+	if len(inventories.byVoter) != len(nodeIDs) {
+		return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+			"voter node inventories = %d, want %d",
+			len(inventories.byVoter),
+			len(nodeIDs),
+		)
+	}
+
+	fullSlots, err := validateFullSlotInventories(inventories.full, nodeIDs, knownNodeIDs)
+	if err != nil {
+		return slotLeaderConvergenceSnapshot{}, err
+	}
+
+	aggregates := make(map[uint32]*slotLeaderAggregate)
+	for _, nodeID := range nodeIDs {
+		inventory, ok := inventories.byVoter[nodeID]
+		if !ok {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf("node %d voter Slot inventory is missing", nodeID)
+		}
+		if inventory.Total != len(inventory.Items) {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+				"node %d logical slots total/items = %d/%d",
+				nodeID,
+				inventory.Total,
+				len(inventory.Items),
+			)
+		}
+
+		items := append([]SlotDTO(nil), inventory.Items...)
+		sort.Slice(items, func(i, j int) bool { return items[i].SlotID < items[j].SlotID })
+		var previousSlotID uint32
+		for index, item := range items {
+			if index > 0 && item.SlotID == previousSlotID {
+				return slotLeaderConvergenceSnapshot{}, fmt.Errorf("node %d has duplicate logical Slot %d", nodeID, item.SlotID)
+			}
+			previousSlotID = item.SlotID
+			if err := validateNodeSlotLeader(nodeID, item, knownNodeIDs); err != nil {
+				return slotLeaderConvergenceSnapshot{}, err
+			}
+
+			aggregate := aggregates[item.SlotID]
+			if aggregate == nil {
+				aggregate = &slotLeaderAggregate{
+					reference:    item,
+					observations: make(map[uint64]SlotDTO, len(item.Assignment.DesiredPeers)),
+				}
+				aggregates[item.SlotID] = aggregate
+			} else if err := validateSlotAssignmentAgreement(aggregate.reference, item, nodeID); err != nil {
+				return slotLeaderConvergenceSnapshot{}, err
+			}
+			aggregate.observations[nodeID] = item
+		}
+	}
+	if len(aggregates) != len(fullSlots) {
+		return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+			"voter-observed logical Slots = %d, full control inventory has %d",
+			len(aggregates),
+			len(fullSlots),
+		)
+	}
+	for slotID, fullSlot := range fullSlots {
+		aggregate := aggregates[slotID]
+		if aggregate == nil {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+				"full control Slot %d has no voter observation",
+				slotID,
+			)
+		}
+		if err := validateSlotAssignmentAgreement(fullSlot, aggregate.reference, aggregate.reference.NodeLog.NodeID); err != nil {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf("full/voter control state: %w", err)
+		}
+	}
+
+	slotIDs := make([]uint32, 0, len(aggregates))
+	for slotID := range aggregates {
+		slotIDs = append(slotIDs, slotID)
+	}
+	sort.Slice(slotIDs, func(i, j int) bool { return slotIDs[i] < slotIDs[j] })
+
+	leaders := make([]ActualSlotLeader, 0, len(slotIDs))
+	var fingerprint strings.Builder
+	for _, slotID := range slotIDs {
+		aggregate := aggregates[slotID]
+		voters, err := normalizedKnownNodeSet(
+			aggregate.reference.Assignment.DesiredPeers,
+			knownNodeIDs,
+			fmt.Sprintf("Slot %d desired peers", slotID),
+		)
+		if err != nil {
+			return slotLeaderConvergenceSnapshot{}, err
+		}
+		if len(aggregate.observations) != len(voters) {
+			return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+				"Slot %d voter observations = %d, want %d from %v",
+				slotID,
+				len(aggregate.observations),
+				len(voters),
+				voters,
+			)
+		}
+
+		leaderID := aggregate.reference.NodeLog.LeaderID
+		for _, voterID := range voters {
+			observation, ok := aggregate.observations[voterID]
+			if !ok {
+				return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+					"Slot %d is missing actual leader observation from voter %d",
+					slotID,
+					voterID,
+				)
+			}
+			if observation.NodeLog.LeaderID != leaderID {
+				return slotLeaderConvergenceSnapshot{}, fmt.Errorf(
+					"Slot %d actual leader disagreement: voter %d reports %d, voter %d reports %d",
+					slotID,
+					aggregate.reference.NodeLog.NodeID,
+					leaderID,
+					voterID,
+					observation.NodeLog.LeaderID,
+				)
+			}
+		}
+
+		leaders = append(leaders, ActualSlotLeader{SlotID: slotID, LeaderID: leaderID})
+		fmt.Fprintf(
+			&fingerprint,
+			"%d:%d:%d:%d:%d:%v;",
+			slotID,
+			leaderID,
+			aggregate.reference.Assignment.PreferredLeaderID,
+			aggregate.reference.Assignment.ConfigEpoch,
+			aggregate.reference.Assignment.BalanceVersion,
+			voters,
+		)
+	}
+	return slotLeaderConvergenceSnapshot{
+		Leaders:     leaders,
+		Fingerprint: fingerprint.String(),
+	}, nil
+}
+
+func validateFullSlotInventories(
+	inventories map[uint64]managerSlotsResponse,
+	nodeIDs []uint64,
+	knownNodeIDs map[uint64]struct{},
+) (map[uint32]SlotDTO, error) {
+	var reference []SlotDTO
+	for index, nodeID := range nodeIDs {
+		inventory, ok := inventories[nodeID]
+		if !ok {
+			return nil, fmt.Errorf("node %d full Slot inventory is missing", nodeID)
+		}
+		if inventory.Total != len(inventory.Items) {
+			return nil, fmt.Errorf(
+				"node %d full logical slots total/items = %d/%d",
+				nodeID,
+				inventory.Total,
+				len(inventory.Items),
+			)
+		}
+		if len(inventory.Items) == 0 {
+			return nil, fmt.Errorf("node %d full logical Slot inventory is empty", nodeID)
+		}
+
+		items := append([]SlotDTO(nil), inventory.Items...)
+		sort.Slice(items, func(i, j int) bool { return items[i].SlotID < items[j].SlotID })
+		var previousSlotID uint32
+		for itemIndex, item := range items {
+			if itemIndex > 0 && item.SlotID == previousSlotID {
+				return nil, fmt.Errorf("node %d full inventory has duplicate logical Slot %d", nodeID, item.SlotID)
+			}
+			previousSlotID = item.SlotID
+			if item.Task != nil {
+				return nil, fmt.Errorf("node %d full Slot %d still has active task %#v", nodeID, item.SlotID, item.Task)
+			}
+			desiredPeers, err := normalizedKnownNodeSet(
+				item.Assignment.DesiredPeers,
+				knownNodeIDs,
+				fmt.Sprintf("node %d full Slot %d desired peers", nodeID, item.SlotID),
+			)
+			if err != nil {
+				return nil, err
+			}
+			if item.Assignment.PreferredLeaderID != 0 &&
+				!containsUint64Value(desiredPeers, item.Assignment.PreferredLeaderID) {
+				return nil, fmt.Errorf(
+					"node %d full Slot %d preferred leader %d is outside desired peers %v",
+					nodeID,
+					item.SlotID,
+					item.Assignment.PreferredLeaderID,
+					desiredPeers,
+				)
+			}
+		}
+
+		if index == 0 {
+			reference = items
+			continue
+		}
+		if len(items) != len(reference) {
+			return nil, fmt.Errorf(
+				"node %d full logical Slots = %d, reference has %d",
+				nodeID,
+				len(items),
+				len(reference),
+			)
+		}
+		for itemIndex, item := range items {
+			if item.SlotID != reference[itemIndex].SlotID {
+				return nil, fmt.Errorf(
+					"node %d full Slot ID at index %d = %d, want %d",
+					nodeID,
+					itemIndex,
+					item.SlotID,
+					reference[itemIndex].SlotID,
+				)
+			}
+			if err := validateSlotAssignmentAgreement(reference[itemIndex], item, nodeID); err != nil {
+				return nil, fmt.Errorf("full control state: %w", err)
+			}
+		}
+	}
+
+	result := make(map[uint32]SlotDTO, len(reference))
+	for _, item := range reference {
+		result[item.SlotID] = item
+	}
+	return result, nil
+}
+
+func validateNodeSlotLeader(nodeID uint64, item SlotDTO, knownNodeIDs map[uint64]struct{}) error {
+	if item.Task != nil {
+		return fmt.Errorf("node %d Slot %d still has active task %#v", nodeID, item.SlotID, item.Task)
+	}
+	desiredPeers, err := normalizedKnownNodeSet(
+		item.Assignment.DesiredPeers,
+		knownNodeIDs,
+		fmt.Sprintf("node %d Slot %d desired peers", nodeID, item.SlotID),
+	)
+	if err != nil {
+		return err
+	}
+	if !containsUint64Value(desiredPeers, nodeID) {
+		return fmt.Errorf("node %d reported Slot %d without being a desired peer %v", nodeID, item.SlotID, desiredPeers)
+	}
+	if item.NodeLog == nil {
+		return fmt.Errorf("node %d Slot %d local Raft observation is missing", nodeID, item.SlotID)
+	}
+	if item.NodeLog.NodeID != nodeID {
+		return fmt.Errorf(
+			"node %d Slot %d Raft observation belongs to node %d",
+			nodeID,
+			item.SlotID,
+			item.NodeLog.NodeID,
+		)
+	}
+	if item.NodeLog.LeaderID == 0 || !containsUint64Value(desiredPeers, item.NodeLog.LeaderID) {
+		return fmt.Errorf(
+			"node %d Slot %d actual leader = %d, desired peers %v",
+			nodeID,
+			item.SlotID,
+			item.NodeLog.LeaderID,
+			desiredPeers,
+		)
+	}
+	raftVoters, err := normalizedKnownNodeSet(
+		item.NodeLog.CurrentVoters,
+		knownNodeIDs,
+		fmt.Sprintf("node %d Slot %d Raft voters", nodeID, item.SlotID),
+	)
+	if err != nil {
+		return err
+	}
+	if !sameUint64Set(raftVoters, desiredPeers) {
+		return fmt.Errorf(
+			"node %d Slot %d Raft voters = %v, want %v",
+			nodeID,
+			item.SlotID,
+			raftVoters,
+			desiredPeers,
+		)
+	}
+	runtimeVoters, err := normalizedKnownNodeSet(
+		item.Runtime.CurrentVoters,
+		knownNodeIDs,
+		fmt.Sprintf("node %d Slot %d runtime voters", nodeID, item.SlotID),
+	)
+	if err != nil {
+		return err
+	}
+	if !sameUint64Set(runtimeVoters, desiredPeers) || !item.Runtime.HasQuorum {
+		return fmt.Errorf(
+			"node %d Slot %d runtime voters/quorum = %v/%v, want %v/true",
+			nodeID,
+			item.SlotID,
+			runtimeVoters,
+			item.Runtime.HasQuorum,
+			desiredPeers,
+		)
+	}
+	if nodeID == item.NodeLog.LeaderID && item.NodeLog.Role != "leader" {
+		return fmt.Errorf(
+			"node %d Slot %d reports itself as actual leader with role %q",
+			nodeID,
+			item.SlotID,
+			item.NodeLog.Role,
+		)
+	}
+	if nodeID != item.NodeLog.LeaderID && item.NodeLog.Role != "follower" {
+		return fmt.Errorf(
+			"node %d Slot %d reports leader %d with role %q",
+			nodeID,
+			item.SlotID,
+			item.NodeLog.LeaderID,
+			item.NodeLog.Role,
+		)
+	}
+	if item.NodeLog.AppliedIndex > item.NodeLog.CommitIndex {
+		return fmt.Errorf(
+			"node %d Slot %d applied index %d exceeds commit index %d",
+			nodeID,
+			item.SlotID,
+			item.NodeLog.AppliedIndex,
+			item.NodeLog.CommitIndex,
+		)
+	}
+	return nil
+}
+
+func validateSlotAssignmentAgreement(reference, observed SlotDTO, nodeID uint64) error {
+	if !sameUint64Set(observed.Assignment.DesiredPeers, reference.Assignment.DesiredPeers) ||
+		observed.Assignment.PreferredLeaderID != reference.Assignment.PreferredLeaderID ||
+		observed.Assignment.ConfigEpoch != reference.Assignment.ConfigEpoch ||
+		observed.Assignment.BalanceVersion != reference.Assignment.BalanceVersion {
+		return fmt.Errorf(
+			"node %d Slot %d assignment disagrees with reference",
+			nodeID,
+			observed.SlotID,
+		)
+	}
+	return nil
+}
+
+func normalizedKnownNodeSet(values []uint64, knownNodeIDs map[uint64]struct{}, label string) ([]uint64, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%s are empty", label)
+	}
+	normalized := append([]uint64(nil), values...)
+	sort.Slice(normalized, func(i, j int) bool { return normalized[i] < normalized[j] })
+	var previous uint64
+	for index, nodeID := range normalized {
+		if nodeID == 0 {
+			return nil, fmt.Errorf("%s contain zero", label)
+		}
+		if _, known := knownNodeIDs[nodeID]; !known {
+			return nil, fmt.Errorf("%s contain unknown node %d", label, nodeID)
+		}
+		if index > 0 && nodeID == previous {
+			return nil, fmt.Errorf("%s contain duplicate node %d", label, nodeID)
+		}
+		previous = nodeID
+	}
+	return normalized, nil
+}
+
+func containsUint64Value(values []uint64, target uint64) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/suite/slot_convergence_test.go
+++ b/test/e2e/suite/slot_convergence_test.go
@@ -1,0 +1,191 @@
+//go:build e2e
+
+package suite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlotLeaderConvergenceTrackerRequiresUnchangedFingerprint(t *testing.T) {
+	tracker := newSlotLeaderConvergenceTracker(2 * time.Second)
+	start := time.Unix(100, 0)
+
+	stableFor, ready := tracker.Observe(start, "slot-1:leader-2")
+	require.Zero(t, stableFor)
+	require.False(t, ready)
+
+	stableFor, ready = tracker.Observe(start.Add(time.Second), "slot-1:leader-2")
+	require.Equal(t, time.Second, stableFor)
+	require.False(t, ready)
+
+	stableFor, ready = tracker.Observe(start.Add(1500*time.Millisecond), "slot-1:leader-3")
+	require.Zero(t, stableFor)
+	require.False(t, ready)
+
+	stableFor, ready = tracker.Observe(start.Add(3500*time.Millisecond), "slot-1:leader-3")
+	require.Equal(t, 2*time.Second, stableFor)
+	require.True(t, ready)
+}
+
+func TestValidateSlotLeaderConvergenceRejectsCrossNodeLeaderDisagreement(t *testing.T) {
+	inventories := validSlotLeaderInventories()
+	inventories.byVoter[3].Items[0].NodeLog.LeaderID = 3
+	inventories.byVoter[3].Items[0].NodeLog.Role = "leader"
+
+	_, err := validateSlotLeaderConvergence(inventories, []uint64{1, 2, 3})
+	require.ErrorContains(t, err, "actual leader disagreement")
+}
+
+func TestValidateSlotLeaderConvergenceAcceptsAgreedRaftState(t *testing.T) {
+	snapshot, err := validateSlotLeaderConvergence(validSlotLeaderInventories(), []uint64{1, 2, 3})
+	require.NoError(t, err)
+	require.Equal(t, []ActualSlotLeader{{SlotID: 1, LeaderID: 2}}, snapshot.Leaders)
+	require.NotEmpty(t, snapshot.Fingerprint)
+}
+
+func TestValidateSlotLeaderConvergenceAcceptsNonVoterNodeAndPreferredLeaderMismatch(t *testing.T) {
+	inventories := validSlotLeaderInventories()
+	for nodeID := uint64(1); nodeID <= 3; nodeID++ {
+		inventories.full[nodeID].Items[0].Assignment.PreferredLeaderID = 1
+		inventories.byVoter[nodeID].Items[0].Assignment.PreferredLeaderID = 1
+	}
+	inventories.full[4] = managerSlotsResponse{
+		Total: 1,
+		Items: []SlotDTO{inventories.full[1].Items[0]},
+	}
+	inventories.byVoter[4] = managerSlotsResponse{}
+
+	snapshot, err := validateSlotLeaderConvergence(inventories, []uint64{1, 2, 3, 4})
+	require.NoError(t, err)
+	require.Equal(t, []ActualSlotLeader{{SlotID: 1, LeaderID: 2}}, snapshot.Leaders)
+}
+
+func TestValidateSlotLeaderConvergenceRejectsLostQuorum(t *testing.T) {
+	inventories := validSlotLeaderInventories()
+	inventories.byVoter[1].Items[0].Runtime.HasQuorum = false
+
+	_, err := validateSlotLeaderConvergence(inventories, []uint64{1, 2, 3})
+	require.ErrorContains(t, err, "runtime voters/quorum")
+}
+
+func TestValidateSlotLeaderConvergenceRejectsInvalidDesiredPeers(t *testing.T) {
+	for name, peers := range map[string][]uint64{
+		"duplicate": {1, 2, 2},
+		"unknown":   {1, 2, 4},
+		"zero":      {0, 1, 2},
+	} {
+		t.Run(name, func(t *testing.T) {
+			inventories := validSlotLeaderInventories()
+			inventories.full[1].Items[0].Assignment.DesiredPeers = peers
+
+			_, err := validateSlotLeaderConvergence(inventories, []uint64{1, 2, 3})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateSlotLeaderConvergenceRejectsUnknownOnlyControlSlot(t *testing.T) {
+	inventories := validSlotLeaderInventories()
+	unknownSlot := inventories.full[1].Items[0]
+	unknownSlot.SlotID = 2
+	unknownSlot.Assignment.DesiredPeers = []uint64{4, 5, 6}
+	for nodeID := uint64(1); nodeID <= 3; nodeID++ {
+		inventory := inventories.full[nodeID]
+		inventory.Total = 2
+		inventory.Items = append(inventory.Items, unknownSlot)
+		inventories.full[nodeID] = inventory
+	}
+
+	_, err := validateSlotLeaderConvergence(inventories, []uint64{1, 2, 3})
+	require.ErrorContains(t, err, "unknown node")
+}
+
+func TestValidateSlotLeaderConvergenceRejectsRaftAndRuntimeVoterMismatch(t *testing.T) {
+	tests := map[string]func(*SlotDTO){
+		"Raft": func(item *SlotDTO) {
+			item.NodeLog.CurrentVoters = []uint64{1, 2}
+		},
+		"runtime": func(item *SlotDTO) {
+			item.Runtime.CurrentVoters = []uint64{1, 2}
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			inventories := validSlotLeaderInventories()
+			mutate(&inventories.byVoter[1].Items[0])
+
+			_, err := validateSlotLeaderConvergence(inventories, []uint64{1, 2, 3})
+			require.ErrorContains(t, err, "voters")
+		})
+	}
+}
+
+func TestValidateSlotLeaderConvergenceFingerprintIncludesVoters(t *testing.T) {
+	first, err := validateSlotLeaderConvergence(
+		slotLeaderInventoriesForPeers([]uint64{1, 2, 3}, 2, []uint64{1, 2, 3, 4}),
+		[]uint64{1, 2, 3, 4},
+	)
+	require.NoError(t, err)
+	second, err := validateSlotLeaderConvergence(
+		slotLeaderInventoriesForPeers([]uint64{1, 2, 4}, 2, []uint64{1, 2, 3, 4}),
+		[]uint64{1, 2, 3, 4},
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, first.Fingerprint, second.Fingerprint)
+}
+
+func validSlotLeaderInventories() slotLeaderInventorySet {
+	return slotLeaderInventoriesForPeers([]uint64{1, 2, 3}, 2, []uint64{1, 2, 3})
+}
+
+func slotLeaderInventoriesForPeers(peers []uint64, leaderID uint64, nodeIDs []uint64) slotLeaderInventorySet {
+	inventories := slotLeaderInventorySet{
+		full:    make(map[uint64]managerSlotsResponse, len(nodeIDs)),
+		byVoter: make(map[uint64]managerSlotsResponse, len(nodeIDs)),
+	}
+	reference := SlotDTO{
+		SlotID: 1,
+		Assignment: SlotAssignmentDTO{
+			DesiredPeers:   append([]uint64(nil), peers...),
+			ConfigEpoch:    4,
+			BalanceVersion: 7,
+		},
+	}
+	for _, nodeID := range nodeIDs {
+		inventories.full[nodeID] = managerSlotsResponse{
+			Total: 1,
+			Items: []SlotDTO{reference},
+		}
+		if !containsUint64Value(peers, nodeID) {
+			inventories.byVoter[nodeID] = managerSlotsResponse{}
+			continue
+		}
+		role := "follower"
+		if nodeID == leaderID {
+			role = "leader"
+		}
+		inventories.byVoter[nodeID] = managerSlotsResponse{
+			Total: 1,
+			Items: []SlotDTO{{
+				SlotID:     reference.SlotID,
+				Assignment: reference.Assignment,
+				Runtime: SlotRuntimeDTO{
+					CurrentVoters: append([]uint64(nil), peers...),
+					HasQuorum:     true,
+				},
+				NodeLog: &SlotNodeLogDTO{
+					NodeID:        nodeID,
+					LeaderID:      leaderID,
+					Role:          role,
+					CurrentVoters: append([]uint64(nil), peers...),
+					CommitIndex:   10,
+					AppliedIndex:  10,
+				},
+			}},
+		}
+	}
+	return inventories
+}


### PR DESCRIPTION
## What changed

- Added a reusable `WaitSlotLeadersStable` E2E gate that validates every node's full control-plane Slot inventory against node-scoped voter Raft observations.
- Requires closed Slot sets, valid desired/current voters, quorum, cross-voter agreement, no active task, and a stable fingerprint based on actual Raft leaders—not `PreferredLeader` intent.
- Reused the gate in cross-node delivery and Cloud Medium recipient scenarios; the Medium strict 256 physical hash slot / 10 logical Slot / 3 replica snapshot must exactly match the stable proof, preventing TOCTOU acceptance.
- Stops cluster node processes concurrently during cleanup so teardown does not serialize stop budgets or unnecessarily remove quorum before peers begin shutdown.
- Pins fake Codex binaries and separates probe deadlines in analysis script tests so hostile/local runner environments cannot escape into a real Codex installation.
- Updated E2E flow and project knowledge documentation.

## Root cause

The exact-main Nightly cross-node delivery failure began client authority registration after `/readyz` and WKProto succeeded, while actual Slot Raft leadership was still changing. The reverse delivery could therefore time out even though process liveness was healthy. A separate test-isolation defect allowed deliberately failed fake Codex probes to fall back to a developer/runner Codex binary under concurrent load.

## Validation

- Focused Slot/cleanup tests: repeated 20–50 times
- Focused race tests: repeated 5 times
- Real three-node cross-node delivery: 3 consecutive passes
- Bounded Cloud Medium high-fidelity gate: PASS with 20,000 sends at exact 500/s CI scale; process continuity and conservation checks passed
- Full E2E suite package and non-opt-in Medium package: PASS
- Hostile inherited `WK_CODEX_BIN` analysis tests: PASS
- `git diff --check`: PASS
- Explicit repository Go gate: `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`: PASS
- Independent spec review: PASS
- Independent standards review: PASS

## Cost guardrail

This PR does not dispatch Alibaba Cloud. Paid Cloud Medium validation remains NO-GO until this exact candidate passes required PR CI, exact-SHA Nightly, merges to `main`, exact-main CI/Nightly are green, and a fresh monitor proves no live cloud resources.

## Exact-SHA Nightly follow-up

The first exact-SHA Nightly (`30029554279`) exposed two additional product defects rather than environment failures:

- Multi-Raft could retire an idle Slot apply queue while an accepted apply crossed the Slot-lock to pipeline-lock handoff, returning a false `multiraft: slot closed`. The queue is now pinned by a symmetric enqueue reservation and covered by a deterministic race regression.
- A transient Controller election leaked `controller.ErrNotLeader` through the cluster facade and onboarding HTTP as 500. Controller lifecycle causes are now normalized to stable cluster errors, manager returns 503, and the idempotent concurrency e2e retries only 503 within its existing 5-second deadline.

Additional validation: affected packages full unit and race passed; new focused tests passed 20-100 repeated rounds; real four-node onboarding/scale-in concurrency e2e passed 3 rounds; explicit repository Go gate passed; both independent reviews passed. No Cloud Provision was dispatched.
