### PR TITLE
fix delivery recovery during slot leader handoff

### DIFF
--- a/internal/infra/cluster/FLOW.md
+++ b/internal/infra/cluster/FLOW.md
@@ -630,20 +630,20 @@ stale-route, not-leader, and background Slot proposal backpressure within a
 small bounded fresh-route window. Only aligned failed groups or failed UID
 route items are resolved again; successful siblings are never issued twice.
 Continued failure is returned to the caller so the post-commit path remains
-bounded.
+bounded. Retry delay grows exponentially from 5ms to a 100ms cap, and the
+50-attempt admission window remains inside the recipient plan's outer context.
 The routed active-batch surface is the normal channelappend fast path. Its first
 attempt consumes caller-supplied exact target groups without another route
 snapshot. If stale-route, not-leader, route-not-ready, proposal backpressure, or
 a retryable transport failure affects a group, only that group's sender and
-recipient rows are resolved again, and only once. Successfully admitted sibling
-groups are never replayed. A terminal sibling failure is retained as the
-overall result but does not suppress that one bounded retry for independent
-retryable siblings. If backoff, fresh routing, or the retry attempt also
-fails, the adapter joins that error with the retained terminal failure so
-callers can classify both causes with `errors.Is`. The legacy
-`AdmitActiveBatch` surface retains its
-three-attempt compatibility window for callers that do not already own an
-aligned route snapshot.
+recipient rows are resolved again inside the same bounded handoff window.
+Successfully admitted sibling groups are never replayed. A terminal sibling
+failure is retained as the overall result but does not suppress bounded retries
+for independent retryable siblings. If backoff, fresh routing, or the final
+retry attempt also fails, the adapter joins that error with the retained
+terminal failure so callers can classify both causes with `errors.Is`. The
+legacy `AdmitActiveBatch` surface uses the same bounded handoff window for
+callers that do not already own an aligned route snapshot.
 The normal one-batch path coalesces UIDs and recipient roles once, counts each
 exact target group before allocation, and fills disjoint capacity-limited
 slices from one shared recipient backing store. This avoids per-target growth
@@ -689,7 +689,8 @@ ConversationAuthorityClient
   -> AdmitRoutedActiveBatches([]ConversationActiveTargetBatch)
        -> admit caller-supplied exact targets without an initial route lookup
        -> preserve every physical hash-slot and logical Slot fence
-       -> fresh-route only failed groups once; never replay successful siblings
+       -> fresh-route only failed groups during a bounded handoff window
+       -> never replay successful siblings
   -> ListConversationActiveView(kind, uid)
        -> RouteKey(uid)
        -> local conversation authority active view for kind when local
@@ -708,10 +709,10 @@ ConversationAuthorityClient
 List route-not-ready, stale-route, and not-leader results are retried with a
 short bounded backoff so authority movement can settle without changing
 conversation list semantics. Legacy patch admission returns those errors
-directly, while active-batch admission makes a small bounded fresh-route retry
-window. A route snapshot outer failure retries the pending set, while an
-aligned UID failure retries only that UID subset after already-routed siblings
-have completed. Raw
+directly, while active-batch admission makes an election-sized bounded
+fresh-route retry window. A route snapshot outer failure retries the pending
+set, while an aligned UID failure retries only that UID subset after
+already-routed siblings have completed. Raw
 cluster route errors returned by remote RPC calls are mapped to the same
 conversation route sentinels before retry decisions.
 
@@ -886,9 +887,10 @@ to that leader; per-group stale/not-leader errors remain aligned and do not
 discard successful results from other groups.
 If one group returns not-leader, stale-route, or route-not-ready after waiting
 in the asynchronous delivery queue, the adapter batch-resolves current targets
-for only that group's UIDs and retries it once. Successful sibling groups are
-not issued again. The retry remains aligned to the original group and rejects
-an inconsistent refresh whose UIDs no longer share one exact target.
+for only that group's UIDs inside a bounded exponential-backoff handoff window.
+Successful sibling groups are not issued again. Every retry remains aligned to
+the original group and rejects an inconsistent refresh whose UIDs no longer
+share one exact target.
 An optional observer emits exactly once for each leader execution stage, after
 the aligned results are final. It uses only the fixed paths `local_bulk`,
 `remote_bulk`, and `legacy_fallback`, bounded outcomes, and a boolean stale

--- a/internal/infra/cluster/authority_handoff_retry.go
+++ b/internal/infra/cluster/authority_handoff_retry.go
@@ -1,0 +1,25 @@
+package cluster
+
+import "time"
+
+// boundedAuthorityHandoffBackoff returns exponential retry delay capped at max.
+// Attempt numbers start at one so the first retry uses base unchanged.
+func boundedAuthorityHandoffBackoff(base, max time.Duration, attempt int) time.Duration {
+	if base <= 0 || attempt <= 0 {
+		return 0
+	}
+	if max <= 0 || base >= max {
+		return base
+	}
+	delay := base
+	for i := 1; i < attempt && delay < max; i++ {
+		if delay > max/2 {
+			return max
+		}
+		delay *= 2
+	}
+	if delay > max {
+		return max
+	}
+	return delay
+}

--- a/internal/infra/cluster/authority_handoff_retry_test.go
+++ b/internal/infra/cluster/authority_handoff_retry_test.go
@@ -1,0 +1,28 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBoundedAuthorityHandoffBackoff(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    time.Duration
+		max     time.Duration
+		attempt int
+		want    time.Duration
+	}{
+		{name: "first", base: 5 * time.Millisecond, max: 100 * time.Millisecond, attempt: 1, want: 5 * time.Millisecond},
+		{name: "growth", base: 5 * time.Millisecond, max: 100 * time.Millisecond, attempt: 4, want: 40 * time.Millisecond},
+		{name: "cap", base: 5 * time.Millisecond, max: 100 * time.Millisecond, attempt: 8, want: 100 * time.Millisecond},
+		{name: "disabled", base: 0, max: 100 * time.Millisecond, attempt: 1, want: 0},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := boundedAuthorityHandoffBackoff(testCase.base, testCase.max, testCase.attempt); got != testCase.want {
+				t.Fatalf("boundedAuthorityHandoffBackoff() = %s, want %s", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/infra/cluster/conversation_authority.go
+++ b/internal/infra/cluster/conversation_authority.go
@@ -49,8 +49,9 @@ var _ channelappend.RoutedConversationActiveAdmitter = (*ConversationAuthorityCl
 
 const (
 	defaultConversationRouteRetryAttempts = 100
-	conversationAdmissionRetryAttempts    = 3
+	conversationAdmissionRetryAttempts    = 50
 	defaultConversationRouteRetryBackoff  = 5 * time.Millisecond
+	conversationAdmissionRetryMaxBackoff  = 100 * time.Millisecond
 	// maxConversationActiveBatchEnvelopeRows matches the bounded WKVC2 wire contract.
 	maxConversationActiveBatchEnvelopeRows = 4096
 	// maxConversationAuthorityDeleteGroup matches the bounded node RPC collection contract.
@@ -112,7 +113,7 @@ func (c *ConversationAuthorityClient) AdmitActiveBatch(ctx context.Context, batc
 		groups, routeFailures, err := c.groupActiveBatchesByTargetPartial(pending)
 		if err != nil {
 			if attempt+1 < conversationAdmissionRetryAttempts && shouldRetryConversationRouteLookup(err) {
-				if sleepErr := c.sleepBeforeRouteRetry(ctx); sleepErr != nil {
+				if sleepErr := c.sleepBeforeConversationAdmissionRetry(ctx, attempt+1); sleepErr != nil {
 					return sleepErr
 				}
 				continue
@@ -152,7 +153,7 @@ func (c *ConversationAuthorityClient) AdmitActiveBatch(ctx context.Context, batc
 			return nil
 		}
 		if attempt+1 < conversationAdmissionRetryAttempts {
-			if sleepErr := c.sleepBeforeRouteRetry(ctx); sleepErr != nil {
+			if sleepErr := c.sleepBeforeConversationAdmissionRetry(ctx, attempt+1); sleepErr != nil {
 				return sleepErr
 			}
 			pending = failed
@@ -163,8 +164,8 @@ func (c *ConversationAuthorityClient) AdmitActiveBatch(ctx context.Context, batc
 }
 
 // AdmitRoutedActiveBatches admits exact target groups already resolved by the
-// channelappend snapshot. A retryable failure gets one fresh route lookup for
-// only the failed group; successful siblings are never replayed.
+// channelappend snapshot. Retryable failures get bounded fresh-route attempts
+// for only failed groups; successful siblings are never replayed.
 func (c *ConversationAuthorityClient) AdmitRoutedActiveBatches(ctx context.Context, batches []channelappend.ConversationActiveTargetBatch) error {
 	if len(batches) == 0 {
 		return nil
@@ -215,22 +216,43 @@ func (c *ConversationAuthorityClient) AdmitRoutedActiveBatches(ctx context.Conte
 	if len(failed) == 0 {
 		return terminalErr
 	}
-	if err := c.sleepBeforeRouteRetry(ctx); err != nil {
-		return joinConversationActiveBatchError(terminalErr, err)
-	}
 
-	freshGroups, routeFailures, err := c.groupActiveBatchesByTargetPartial(failed)
-	if err != nil {
-		return joinConversationActiveBatchError(terminalErr, err)
-	}
-	for _, failure := range routeFailures {
-		terminalErr = joinConversationActiveBatchError(terminalErr, failure.err)
-	}
-	freshGroups = splitConversationActiveBatchGroups(freshGroups, maxConversationActiveBatchEnvelopeRows)
-	for _, result := range c.admitActiveBatchGroups(ctx, freshGroups) {
-		if result.Err != nil {
+	for attempt := 1; attempt < conversationAdmissionRetryAttempts; attempt++ {
+		if err := c.sleepBeforeConversationAdmissionRetry(ctx, attempt); err != nil {
+			return joinConversationActiveBatchError(terminalErr, err)
+		}
+
+		freshGroups, routeFailures, err := c.groupActiveBatchesByTargetPartial(failed)
+		if err != nil {
+			if attempt+1 < conversationAdmissionRetryAttempts && shouldRetryConversationRouteLookup(err) {
+				continue
+			}
+			return joinConversationActiveBatchError(terminalErr, err)
+		}
+
+		nextFailed := make([]conversationactive.ActiveBatch, 0, len(routeFailures)+len(freshGroups))
+		for _, failure := range routeFailures {
+			if attempt+1 < conversationAdmissionRetryAttempts && shouldRetryConversationRouteLookup(failure.err) {
+				nextFailed = append(nextFailed, failure.batch)
+				continue
+			}
+			terminalErr = joinConversationActiveBatchError(terminalErr, failure.err)
+		}
+		freshGroups = splitConversationActiveBatchGroups(freshGroups, maxConversationActiveBatchEnvelopeRows)
+		for index, result := range c.admitActiveBatchGroups(ctx, freshGroups) {
+			if result.Err == nil {
+				continue
+			}
+			if attempt+1 < conversationAdmissionRetryAttempts && shouldRetryConversationAdmission(result.Err) {
+				nextFailed = append(nextFailed, cloneConversationActiveBatchForRetry(freshGroups[index].batch))
+				continue
+			}
 			terminalErr = joinConversationActiveBatchError(terminalErr, result.Err)
 		}
+		if len(nextFailed) == 0 {
+			return terminalErr
+		}
+		failed = nextFailed
 	}
 	return terminalErr
 }
@@ -906,13 +928,32 @@ func (c *ConversationAuthorityClient) authorityForTarget(target conversationusec
 }
 
 func (c *ConversationAuthorityClient) sleepBeforeRouteRetry(ctx context.Context) error {
-	if c == nil || c.routeRetryBackoff <= 0 {
+	if c == nil {
+		return nil
+	}
+	return c.sleepBeforeRouteRetryFor(ctx, c.routeRetryBackoff)
+}
+
+func (c *ConversationAuthorityClient) sleepBeforeConversationAdmissionRetry(ctx context.Context, attempt int) error {
+	if c == nil {
+		return nil
+	}
+	backoff := boundedAuthorityHandoffBackoff(
+		c.routeRetryBackoff,
+		conversationAdmissionRetryMaxBackoff,
+		attempt,
+	)
+	return c.sleepBeforeRouteRetryFor(ctx, backoff)
+}
+
+func (c *ConversationAuthorityClient) sleepBeforeRouteRetryFor(ctx context.Context, backoff time.Duration) error {
+	if c == nil || backoff <= 0 {
 		return nil
 	}
 	if c.routeRetrySleep != nil {
-		return c.routeRetrySleep(ctx, c.routeRetryBackoff)
+		return c.routeRetrySleep(ctx, backoff)
 	}
-	timer := time.NewTimer(c.routeRetryBackoff)
+	timer := time.NewTimer(backoff)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/internal/infra/cluster/conversation_authority_test.go
+++ b/internal/infra/cluster/conversation_authority_test.go
@@ -572,7 +572,7 @@ func TestConversationAuthorityClientAdmitRoutedActiveBatchesPreservesTerminalAnd
 	}
 }
 
-func TestConversationAuthorityClientAdmitRoutedActiveBatchesBoundsFreshRouteToOneRetry(t *testing.T) {
+func TestConversationAuthorityClientAdmitRoutedActiveBatchesRidesOutLeaderHandoff(t *testing.T) {
 	local := &fakeConversationAuthorityLocal{
 		activeBatchErrsByHashSlot: map[uint16][]error{
 			2: {conversationusecase.ErrStaleRoute, conversationusecase.ErrStaleRoute, nil},
@@ -599,14 +599,54 @@ func TestConversationAuthorityClientAdmitRoutedActiveBatchesBoundsFreshRouteToOn
 			Recipients: []conversationactive.ActiveEntry{{UID: "receiver"}},
 		},
 	}})
-	if !errors.Is(err, conversationusecase.ErrStaleRoute) {
-		t.Fatalf("AdmitRoutedActiveBatches() error = %v, want ErrStaleRoute after one fresh retry", err)
+	if err != nil {
+		t.Fatalf("AdmitRoutedActiveBatches() error = %v", err)
 	}
-	if got := activeBatchAttemptCountsByHashSlot(local.activeBatches)[2]; got != 2 {
-		t.Fatalf("receiver attempts = %d, want supplied attempt plus one fresh-route retry", got)
+	if got := activeBatchAttemptCountsByHashSlot(local.activeBatches)[2]; got != 3 {
+		t.Fatalf("receiver attempts = %d, want supplied attempt plus two fresh-route retries", got)
 	}
-	if got := node.routeKeyCallsForUID("receiver"); got != 1 {
-		t.Fatalf("RouteKey(receiver) calls = %d, want exactly one fresh route", got)
+	if got := node.routeKeyCallsForUID("receiver"); got != 2 {
+		t.Fatalf("RouteKey(receiver) calls = %d, want one fresh route per failed attempt", got)
+	}
+}
+
+func TestConversationAuthorityClientAdmitRoutedActiveBatchesBoundsPersistentLeaderHandoff(t *testing.T) {
+	local := &fakeConversationAuthorityLocal{activeBatchAlwaysErr: conversationusecase.ErrNotLeader}
+	node := &fakeConversationAuthorityNode{
+		nodeID: 1,
+		routesByUID: map[string]cluster.Route{
+			"receiver": {HashSlot: 2, SlotID: 7, Leader: 1, LeaderTerm: 12, ConfigEpoch: 22},
+		},
+	}
+	client := NewConversationAuthorityClient(node, local)
+	sleepCalls := 0
+	client.routeRetrySleep = func(_ context.Context, delay time.Duration) error {
+		sleepCalls++
+		if sleepCalls == conversationAdmissionRetryAttempts-1 && delay != conversationAdmissionRetryMaxBackoff {
+			t.Fatalf("final retry delay = %s, want capped %s", delay, conversationAdmissionRetryMaxBackoff)
+		}
+		return nil
+	}
+
+	err := client.AdmitRoutedActiveBatches(context.Background(), []channelappend.ConversationActiveTargetBatch{{
+		Target: channelappend.RecipientAuthorityTarget{
+			HashSlot: 2, SlotID: 7, LeaderNodeID: 1, LeaderTerm: 11, ConfigEpoch: 21,
+		},
+		Batch: conversationactive.ActiveBatch{
+			Kind: metadb.ConversationKindNormal, ChannelID: "g1", ChannelType: 2,
+			MessageSeq: 9, ActiveAtMS: 100,
+			Recipients: []conversationactive.ActiveEntry{{UID: "receiver"}},
+		},
+	}})
+
+	if !errors.Is(err, conversationusecase.ErrNotLeader) {
+		t.Fatalf("AdmitRoutedActiveBatches() error = %v, want ErrNotLeader", err)
+	}
+	if got := activeBatchAttemptCountsByHashSlot(local.activeBatches)[2]; got != conversationAdmissionRetryAttempts {
+		t.Fatalf("receiver attempts = %d, want %d", got, conversationAdmissionRetryAttempts)
+	}
+	if sleepCalls != conversationAdmissionRetryAttempts-1 {
+		t.Fatalf("retry sleeps = %d, want %d", sleepCalls, conversationAdmissionRetryAttempts-1)
 	}
 }
 
@@ -737,14 +777,14 @@ func TestConversationAuthorityClientAdmitActiveBatchRetriesStaleRouteWithBounded
 		ActiveAtMS:  100,
 		Recipients:  []conversationactive.ActiveEntry{{UID: "receiver"}},
 	})
-	if !errors.Is(err, conversationusecase.ErrStaleRoute) {
-		t.Fatalf("AdmitActiveBatch() error = %v, want ErrStaleRoute after 3 attempts", err)
+	if err != nil {
+		t.Fatalf("AdmitActiveBatch() error = %v", err)
 	}
-	if got := node.routeKeyCallsForUID("receiver"); got != 3 {
+	if got := node.routeKeyCallsForUID("receiver"); got != 4 {
 		t.Fatalf("RouteKey(receiver) calls = %d, want fresh route per retry", got)
 	}
-	if len(local.activeBatches) != 3 {
-		t.Fatalf("active batch attempts = %d, want 3 attempts", len(local.activeBatches))
+	if len(local.activeBatches) != 4 {
+		t.Fatalf("active batch attempts = %d, want 4 attempts", len(local.activeBatches))
 	}
 	for i, attempt := range local.activeBatches {
 		wantRevision := uint64(10 + i)

--- a/internal/infra/cluster/presence.go
+++ b/internal/infra/cluster/presence.go
@@ -48,6 +48,8 @@ const (
 	defaultPresenceUnregisterTimeout         = 3 * time.Second
 	defaultPresenceRouteRetryAttempts        = 100
 	defaultPresenceRouteRetryBackoff         = 5 * time.Millisecond
+	defaultPresenceEndpointRetryAttempts     = 50
+	defaultPresenceEndpointRetryMaxBackoff   = 100 * time.Millisecond
 	defaultPresenceEndpointLeaderConcurrency = 4
 )
 
@@ -309,8 +311,17 @@ func (c *PresenceAuthorityClient) EndpointsByUIDs(ctx context.Context, uids []st
 
 // EndpointsByTargets reads aligned endpoint groups through their exact observed targets.
 func (c *PresenceAuthorityClient) EndpointsByTargets(ctx context.Context, groups []presence.EndpointLookupGroup) []presence.EndpointLookupResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	results := c.endpointsByTargetsOnce(ctx, groups, false)
-	return c.retryStaleEndpointLookupGroups(ctx, groups, results)
+	for attempt := 1; attempt < defaultPresenceEndpointRetryAttempts && hasRetryablePresenceEndpointLookup(results); attempt++ {
+		if err := c.sleepBeforeEndpointRetry(ctx, attempt); err != nil {
+			return replaceRetryablePresenceEndpointErrors(results, err)
+		}
+		results = c.retryStaleEndpointLookupGroups(ctx, groups, results)
+	}
+	return results
 }
 
 func (c *PresenceAuthorityClient) endpointsByTargetsOnce(ctx context.Context, groups []presence.EndpointLookupGroup, staleRetry bool) []presence.EndpointLookupResult {
@@ -578,6 +589,33 @@ func (c *PresenceAuthorityClient) retryStaleEndpointLookupGroups(
 	return results
 }
 
+func hasRetryablePresenceEndpointLookup(results []presence.EndpointLookupResult) bool {
+	for _, result := range results {
+		if shouldRetryPresenceRouteLookup(result.Err) {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceRetryablePresenceEndpointErrors(results []presence.EndpointLookupResult, err error) []presence.EndpointLookupResult {
+	for i, result := range results {
+		if shouldRetryPresenceRouteLookup(result.Err) {
+			results[i] = presence.EndpointLookupResult{Err: err}
+		}
+	}
+	return results
+}
+
+func (c *PresenceAuthorityClient) sleepBeforeEndpointRetry(ctx context.Context, attempt int) error {
+	backoff := boundedAuthorityHandoffBackoff(
+		c.routeRetryBackoff,
+		defaultPresenceEndpointRetryMaxBackoff,
+		attempt,
+	)
+	return c.sleepBeforeRouteRetryFor(ctx, backoff)
+}
+
 func nonEmptyPresenceUIDs(uids []string) []string {
 	out := make([]string, 0, len(uids))
 	for _, uid := range uids {
@@ -765,13 +803,20 @@ func (c *PresenceAuthorityClient) withFreshTargetSource(ctx context.Context, uid
 }
 
 func (c *PresenceAuthorityClient) sleepBeforeRouteRetry(ctx context.Context) error {
-	if c == nil || c.routeRetryBackoff <= 0 {
+	if c == nil {
+		return nil
+	}
+	return c.sleepBeforeRouteRetryFor(ctx, c.routeRetryBackoff)
+}
+
+func (c *PresenceAuthorityClient) sleepBeforeRouteRetryFor(ctx context.Context, backoff time.Duration) error {
+	if c == nil || backoff <= 0 {
 		return nil
 	}
 	if c.routeRetrySleep != nil {
-		return c.routeRetrySleep(ctx, c.routeRetryBackoff)
+		return c.routeRetrySleep(ctx, backoff)
 	}
-	timer := time.NewTimer(c.routeRetryBackoff)
+	timer := time.NewTimer(backoff)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/internal/infra/cluster/presence_test.go
+++ b/internal/infra/cluster/presence_test.go
@@ -817,6 +817,88 @@ func TestPresenceAuthorityClientEndpointsByTargetsReroutesOnlyStaleGroupOnce(t *
 	})
 }
 
+func TestPresenceAuthorityClientEndpointsByTargetsRidesOutLeaderHandoffWithoutReplayingSuccessfulGroups(t *testing.T) {
+	local := &fakePresenceAuthority{}
+	remote := &fakePresenceAuthority{
+		endpointBatchErrs: map[uint16]error{22: authoritypresence.ErrNotLeader},
+	}
+	fresh := cluster.Route{
+		HashSlot: 22, SlotID: 3, Leader: 2, LeaderTerm: 303,
+		ConfigEpoch: 403, Revision: 503, AuthorityEpoch: 603,
+	}
+	node := &fakePresenceCluster{
+		nodeID:          1,
+		routeKeyResults: []cluster.RouteKeyResult{{Route: fresh}},
+		rpcByNode: map[uint64]cluster.NodeRPCHandler{
+			2: presenceRPCHandler{adapter: accessnode.New(accessnode.Options{Authority: remote})},
+		},
+	}
+	client := NewPresenceAuthorityClient(node, local)
+	var retryDelays []time.Duration
+	client.routeRetrySleep = func(_ context.Context, delay time.Duration) error {
+		retryDelays = append(retryDelays, delay)
+		if len(retryDelays) == 3 {
+			delete(remote.endpointBatchErrs, 22)
+		}
+		return nil
+	}
+	groups := []presence.EndpointLookupGroup{
+		{Target: testEndpointLookupTarget(11, 1), UIDs: []string{"local"}},
+		{Target: testEndpointLookupTarget(22, 2), UIDs: []string{"handoff"}},
+		{Target: testEndpointLookupTarget(23, 2), UIDs: []string{"stable"}},
+	}
+
+	results := client.EndpointsByTargets(context.Background(), groups)
+
+	require.Len(t, results, len(groups))
+	for index, result := range results {
+		require.NoError(t, result.Err, "result index %d", index)
+		require.Len(t, result.Routes, 1, "result index %d", index)
+	}
+	require.Equal(t, []time.Duration{
+		5 * time.Millisecond,
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+	}, retryDelays)
+	require.Equal(t, [][]string{{"handoff"}, {"handoff"}, {"handoff"}}, node.routeKeysCalls)
+	require.Len(t, remote.endpointBatchCalls, 5)
+	require.Equal(t, []string{"handoff"}, remote.endpointBatchCalls[0].uids)
+	require.Equal(t, []string{"stable"}, remote.endpointBatchCalls[1].uids)
+	for _, call := range remote.endpointBatchCalls[2:] {
+		require.Equal(t, []string{"handoff"}, call.uids, "successful sibling must not be replayed")
+	}
+}
+
+func TestPresenceAuthorityClientEndpointsByTargetsBoundsPersistentLeaderHandoff(t *testing.T) {
+	local := &fakePresenceAuthority{
+		endpointBatchErrs: map[uint16]error{22: authoritypresence.ErrNotLeader},
+	}
+	fresh := cluster.Route{HashSlot: 22, SlotID: 3, Leader: 1, LeaderTerm: 303, ConfigEpoch: 403}
+	node := &fakePresenceCluster{
+		nodeID:          1,
+		routeKeyResults: []cluster.RouteKeyResult{{Route: fresh}},
+	}
+	client := NewPresenceAuthorityClient(node, local)
+	sleepCalls := 0
+	client.routeRetrySleep = func(_ context.Context, delay time.Duration) error {
+		sleepCalls++
+		if sleepCalls == defaultPresenceEndpointRetryAttempts-1 && delay != defaultPresenceEndpointRetryMaxBackoff {
+			t.Fatalf("final retry delay = %s, want capped %s", delay, defaultPresenceEndpointRetryMaxBackoff)
+		}
+		return nil
+	}
+
+	results := client.EndpointsByTargets(context.Background(), []presence.EndpointLookupGroup{{
+		Target: testEndpointLookupTarget(22, 1),
+		UIDs:   []string{"handoff"},
+	}})
+
+	require.Len(t, results, 1)
+	require.ErrorIs(t, results[0].Err, authoritypresence.ErrNotLeader)
+	require.Equal(t, defaultPresenceEndpointRetryAttempts-1, sleepCalls)
+	require.Len(t, local.endpointBatchCalls, defaultPresenceEndpointRetryAttempts)
+}
+
 func assertPresenceLookupObservation(t *testing.T, observations []PresenceEndpointLookupObservation, want PresenceEndpointLookupObservation) {
 	t.Helper()
 	for _, got := range observations {

--- a/test/e2e/message/medium_recipient_hotpath/acceptance_test.go
+++ b/test/e2e/message/medium_recipient_hotpath/acceptance_test.go
@@ -89,6 +89,7 @@ func TestHotPathAcceptanceError(t *testing.T) {
 		{name: "plugin accepted", edit: func(e *hotPathEvidence) { e.PluginReceiveAccepted-- }, want: "plugin receive accepted"},
 		{name: "plugin full", edit: func(e *hotPathEvidence) { e.PluginReceiveFull = 1 }, want: "enqueue non-accepted"},
 		{name: "plugin invoke", edit: func(e *hotPathEvidence) { e.PluginReceiveInvokeOK-- }, want: "plugin receive invoke"},
+		{name: "recipient process", edit: func(e *hotPathEvidence) { e.RecipientProcessError = 1 }, want: "recipient worker process errors"},
 		{name: "measured duration missing", edit: func(e *hotPathEvidence) { e.MeasuredDurationMS = 0 }, want: "measured duration"},
 		{name: "allocated missing", edit: func(e *hotPathEvidence) { e.AllocatedBytes = 0 }, want: "allocated bytes"},
 		{name: "allocated regression", edit: func(e *hotPathEvidence) {

--- a/test/e2e/message/medium_recipient_hotpath/medium_recipient_hotpath_test.go
+++ b/test/e2e/message/medium_recipient_hotpath/medium_recipient_hotpath_test.go
@@ -129,6 +129,7 @@ type hotPathEvidence struct {
 	PluginReceiveClosed      float64  `json:"plugin_receive_enqueue_closed"`
 	PluginReceiveInvokeOK    float64  `json:"plugin_receive_invoke_ok"`
 	PluginReceiveInvokeError float64  `json:"plugin_receive_invoke_error"`
+	RecipientProcessError    float64  `json:"recipient_worker_process_error"`
 	MetricSamples            int      `json:"metric_samples"`
 	MetricSampleErrors       int      `json:"metric_sample_errors"`
 	Drained                  bool     `json:"drained"`
@@ -350,6 +351,7 @@ func TestCloudMediumScaledRecipientHotPath(t *testing.T) {
 		PluginReceiveClosed:      counterDelta.pluginReceiveClosed,
 		PluginReceiveInvokeOK:    counterDelta.pluginReceiveInvokeOK,
 		PluginReceiveInvokeError: counterDelta.pluginReceiveInvokeError,
+		RecipientProcessError:    counterDelta.recipientProcessError,
 		MetricSamples:            pressure.samples,
 		MetricSampleErrors:       pressure.sampleErrors,
 		Drained:                  true,
@@ -446,6 +448,8 @@ func hotPathAcceptanceError(evidence hotPathEvidence, expectedOfferedQPS int, ex
 			evidence.PluginReceiveInvokeError,
 			evidence.PluginReceiveAccepted,
 		)
+	case evidence.RecipientProcessError != 0:
+		return fmt.Errorf("acceptance recipient worker process errors = %.0f, want 0", evidence.RecipientProcessError)
 	case evidence.MeasuredDurationMS <= 0:
 		return fmt.Errorf("acceptance measured duration = %.3fms, want a positive duration", evidence.MeasuredDurationMS)
 	case evidence.AllocatedBytes <= 0:
@@ -1176,6 +1180,7 @@ type hotPathCounters struct {
 	pluginReceiveClosed      float64
 	pluginReceiveInvokeOK    float64
 	pluginReceiveInvokeError float64
+	recipientProcessError    float64
 }
 
 func (c hotPathCounters) subtract(start hotPathCounters) hotPathCounters {
@@ -1187,6 +1192,7 @@ func (c hotPathCounters) subtract(start hotPathCounters) hotPathCounters {
 		pluginReceiveClosed:      c.pluginReceiveClosed - start.pluginReceiveClosed,
 		pluginReceiveInvokeOK:    c.pluginReceiveInvokeOK - start.pluginReceiveInvokeOK,
 		pluginReceiveInvokeError: c.pluginReceiveInvokeError - start.pluginReceiveInvokeError,
+		recipientProcessError:    c.recipientProcessError - start.recipientProcessError,
 	}
 }
 
@@ -1235,6 +1241,10 @@ func captureHotPathCounters(ctx context.Context, cluster *suite.StartedCluster) 
 					counters.pluginReceiveInvokeOK += sample.Value
 				case "error", "timeout", "panic":
 					counters.pluginReceiveInvokeError += sample.Value
+				}
+			case "wukongim_delivery_recipient_worker_process_total":
+				if sample.Labels["result"] != "ok" {
+					counters.recipientProcessError += sample.Value
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- retry only failed Presence endpoint groups across bounded Slot leader handoff windows
- retry only failed conversation-active admission batches with fresh exact targets while preserving successful siblings and terminal errors
- reject Medium recipient hot-path acceptance when any recipient worker processing error occurs

## Root cause
Nightly run 30044399003 observed a 1.7-3.7s logical Slot election. The post-commit Presence and conversation-active paths previously performed only one 5ms fresh-route retry, turning transient not-leader/stale-route results into terminal recipient-worker failures and lost RECV verification.

## Evidence
- focused functional tests: pass
- focused race tests: pass
- Slot leader transfer e2e: pass
- Cloud Medium-shaped three-process gate: 20,000 messages, 500.02/s actual, SENDACK P99 494.6ms, RECV P99 381.5ms, recipient process errors 0, continuous=true
- repository explicit-root Go gate: pass
- independent Standards review: PASS
- independent Spec review: PASS
- git diff --check: pass

## Cost gate
No Alibaba Cloud Provision is dispatched by this PR. Latest read-only Monitor 30046109566 produced an empty monitor-results.jsonl.