### PR TITLE
test(backup): stabilize three-node recovery drill

### DIFF
--- a/test/e2e/backup/three_node_restore/three_node_restore_test.go
+++ b/test/e2e/backup/three_node_restore/three_node_restore_test.go
@@ -293,12 +293,10 @@ func runThreeNodeRecoveryDrill(t *testing.T, qualification storageQualification)
 		t, cluster, "source-admin", "source-secret",
 	)
 
-	baselineTimeout := 20 * time.Second
-	if qualification.FileRoot == "" {
-		// Cross-region object storage must finish all initial Slot uploads
-		// before the first immutable checkpoint can be published.
-		baselineTimeout = 120 * time.Second
-	}
+	// Cluster readiness does not imply that every logical backup partition has
+	// completed its first capture. Keep one bounded convergence budget for both
+	// local file repositories and cross-region object storage.
+	baselineTimeout := 120 * time.Second
 	baseline := publishCheckpointEventually(
 		t, cluster, sourceToken, baselineTimeout,
 	)
@@ -420,7 +418,15 @@ func runThreeNodeRecoveryDrill(t *testing.T, qualification storageQualification)
 	exerciseRestoreLeaderFailure(
 		t, target, token, restoreControllerLeader,
 	)
-	plan = waitForRestoreStatus(t, target, token, "installed", 45*time.Second)
+	restoreInstallTimeout := 3 * time.Minute
+	if qualification.FileRoot == "" {
+		// Cross-region restore installs every logical partition on all target
+		// replicas and must also absorb the injected Controller failover.
+		restoreInstallTimeout = 5 * time.Minute
+	}
+	plan = waitForRestoreStatus(
+		t, target, token, "installed", restoreInstallTimeout,
+	)
 	require.Len(t, plan.Partitions, 16)
 	var restoredMessages uint64
 	for hashSlot, partition := range plan.Partitions {
@@ -1312,8 +1318,11 @@ func appendMessageDuringFailure(
 	}
 	var attemptErrors []error
 	for _, nodeID := range nodeIDs {
+		// Default node-health expiry is 30 seconds. Give the surviving Channel
+		// path enough time to migrate authority without changing production
+		// timing semantics.
 		ctx, cancel := context.WithTimeout(
-			context.Background(), 15*time.Second,
+			context.Background(), 60*time.Second,
 		)
 		message, err := suite.PostMessageSendEventually(
 			ctx, cluster.MustNode(nodeID).APIAddr(), body,
@@ -1371,7 +1380,10 @@ func advanceMessageRetentionEventually(
 	throughSeq uint64,
 ) retentionResponse {
 	t.Helper()
-	deadline := time.Now().Add(15 * time.Second)
+	// The request is idempotent by the durable channel/through-sequence
+	// boundary. Allow Controller forwarding and revision conflicts from the
+	// preceding fault drill to converge before declaring erasure unavailable.
+	deadline := time.Now().Add(2 * time.Minute)
 	var last retentionResponse
 	var lastErr error
 	for time.Now().Before(deadline) {
@@ -1519,6 +1531,12 @@ func localBackupNodeEnvironment(nodeID uint64, root string) suite.Option {
 }
 
 func sourceBackupConfig(qualification storageQualification, nodeID uint64) map[string]string {
+	auditInterval := "500ms"
+	if qualification.FileRoot != "" {
+		// Local file I/O can advance the one-artifact audit state machine much
+		// faster without applying that request rate to production object stores.
+		auditInterval = "10ms"
+	}
 	return map[string]string{
 		"WK_BACKUP_ENABLED":                             "true",
 		"WK_BACKUP_PROVIDER":                            qualification.Provider,
@@ -1533,7 +1551,7 @@ func sourceBackupConfig(qualification storageQualification, nodeID uint64) map[s
 		"WK_BACKUP_MAX_SEGMENT_OPEN_DURATION":           "500ms",
 		"WK_BACKUP_STAGING_MAX_BYTES":                   "67108864",
 		"WK_BACKUP_WORKER_COUNT":                        "2",
-		"WK_BACKUP_AUDIT_INTERVAL":                      "500ms",
+		"WK_BACKUP_AUDIT_INTERVAL":                      auditInterval,
 		"WK_BACKUP_AUDIT_SCRUB_INTERVAL":                "24h",
 		"WK_BACKUP_GARBAGE_COLLECTION_INTERVAL":         "1h",
 		"WK_BACKUP_GARBAGE_SAFETY_WINDOW":               "168h",

--- a/test/e2e/backup/three_node_restore/three_node_restore_test.go
+++ b/test/e2e/backup/three_node_restore/three_node_restore_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	backupusecase "github.com/WuKongIM/WuKongIM/internal/usecase/backup"
 	backupartifact "github.com/WuKongIM/WuKongIM/pkg/backup"
 	"github.com/WuKongIM/WuKongIM/pkg/hashslot"
 	"github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
@@ -733,15 +734,21 @@ func exerciseRepositoryIntegrityRepair(
 		t, cluster, token, root, "primary",
 		"backup-e2e-primary-repository-repair", repairTimeout,
 	)
-	exerciseSingleRepositoryIntegrityRepair(
+	barrierPublication := exerciseSingleRepositoryIntegrityRepair(
 		t, cluster, token, root, "secondary",
 		"backup-e2e-secondary-repository-repair", repairTimeout,
 	)
+	barrierHead, err := backupusecase.DecodeCatalogHeadToken(
+		barrierPublication.CatalogHeadToken,
+	)
+	require.NoError(t, err)
 	// Integrity audit cycles are bound to one immutable catalog window. Let the
-	// cycle containing both single-copy repairs finish before publishing the
-	// dual-copy fault, so the next cycle must include that exact new segment.
-	waitForIntegrityAuditCycleComplete(
-		t, cluster, token, 3*time.Second, repairTimeout,
+	// cycle containing both single-copy repairs cover the final published
+	// catalog page before publishing the dual-copy fault. This durable cursor
+	// barrier is independent of process-local metric projection and Leader
+	// changes.
+	waitForIntegrityAuditCatalogBarrier(
+		t, cluster, token, barrierHead.Sequence, repairTimeout,
 	)
 
 	frontiers := backupDurableFrontiers(t, cluster, token)
@@ -815,7 +822,7 @@ func exerciseSingleRepositoryIntegrityRepair(
 	repository string,
 	channelID string,
 	timeout time.Duration,
-) {
+) checkpointPublication {
 	t.Helper()
 	beforeCorruptions := backupMetricTotal(
 		t, cluster, "wukongim_backup_audit_corruptions_total",
@@ -861,7 +868,7 @@ func exerciseSingleRepositoryIntegrityRepair(
 		nil, beforeRepairBytes, timeout,
 	)
 	waitForBackupHealthy(t, cluster, token, timeout)
-	_ = publishCheckpointEventually(t, cluster, token, timeout)
+	return publishCheckpointEventually(t, cluster, token, timeout)
 }
 
 func setRepositoryCorruption(
@@ -1031,54 +1038,94 @@ func waitForBackupMetricIncrease(
 	)
 }
 
-func waitForIntegrityAuditCycleComplete(
+func waitForIntegrityAuditCatalogBarrier(
 	t *testing.T,
 	cluster *suite.StartedCluster,
 	token string,
-	stableFor time.Duration,
+	catalogSequence uint64,
 	timeout time.Duration,
 ) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
-	stableSince := time.Time{}
-	var stableLeader uint64
-	var lastLeader uint64
-	var lastDebt float64
+	var last backupStatus
 	var lastErr error
 	for time.Now().Before(deadline) {
-		var nodes managerNodesResponse
+		last = backupStatus{}
 		lastErr = managerRequestError(
-			cluster, token, http.MethodGet, "/manager/nodes", nil, &nodes,
+			cluster, token, http.MethodGet, "/manager/backups/status", nil, &last,
 		)
-		lastLeader = nodes.ControllerLeaderID
-		if lastErr != nil || lastLeader == 0 {
-			stableSince = time.Time{}
-			time.Sleep(100 * time.Millisecond)
-			continue
+		if lastErr == nil &&
+			integrityAuditReachedCatalogBarrier(
+				last.IntegrityAudit, catalogSequence,
+			) {
+			return
 		}
-		node := cluster.MustNode(lastLeader)
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		lastDebt, lastErr = suite.FetchMetricValue(
-			ctx, node.APIAddr(), "wukongim_backup_audit_debt_objects", nil,
-		)
-		cancel()
-		if lastErr == nil && lastDebt == 0 {
-			if stableSince.IsZero() || stableLeader != lastLeader {
-				stableSince = time.Now()
-				stableLeader = lastLeader
-			} else if time.Since(stableSince) >= stableFor {
-				return
-			}
-		} else {
-			stableSince = time.Time{}
-			stableLeader = 0
-		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf(
-		"integrity audit cycle did not become complete: leader=%d debt=%v err=%v\n%s",
-		lastLeader, lastDebt, lastErr, cluster.DumpDiagnostics(),
+		"integrity audit did not cover catalog sequence %d: audit=%+v err=%v\n%s",
+		catalogSequence, last.IntegrityAudit, lastErr,
+		cluster.DumpDiagnostics(),
 	)
+}
+
+func integrityAuditReachedCatalogBarrier(
+	audit backupIntegrityAudit,
+	catalogSequence uint64,
+) bool {
+	return audit.Cursor != nil &&
+		audit.Cursor.Phase == "complete" &&
+		audit.Cursor.CatalogSequence >= catalogSequence
+}
+
+func TestIntegrityAuditReachedCatalogBarrier(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name     string
+		cursor   *backupIntegrityAuditCursor
+		sequence uint64
+		want     bool
+	}{
+		{name: "missing cursor", sequence: 4},
+		{
+			name: "active covering cycle",
+			cursor: &backupIntegrityAuditCursor{
+				Phase: "inspect", CatalogSequence: 4,
+			},
+			sequence: 4,
+		},
+		{
+			name: "completed older cycle",
+			cursor: &backupIntegrityAuditCursor{
+				Phase: "complete", CatalogSequence: 3,
+			},
+			sequence: 4,
+		},
+		{
+			name: "completed exact cycle",
+			cursor: &backupIntegrityAuditCursor{
+				Phase: "complete", CatalogSequence: 4,
+			},
+			sequence: 4, want: true,
+		},
+		{
+			name: "completed newer cycle",
+			cursor: &backupIntegrityAuditCursor{
+				Phase: "complete", CatalogSequence: 5,
+			},
+			sequence: 4, want: true,
+		},
+	} {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got := integrityAuditReachedCatalogBarrier(
+				backupIntegrityAudit{Cursor: testCase.cursor},
+				testCase.sequence,
+			)
+			require.Equal(t, testCase.want, got)
+		})
+	}
 }
 
 func backupMetricTotal(
@@ -1531,11 +1578,15 @@ func localBackupNodeEnvironment(nodeID uint64, root string) suite.Option {
 }
 
 func sourceBackupConfig(qualification storageQualification, nodeID uint64) map[string]string {
+	captureReconcileInterval := "200ms"
 	auditInterval := "500ms"
 	if qualification.FileRoot != "" {
-		// Local file I/O can advance the one-artifact audit state machine much
-		// faster without applying that request rate to production object stores.
-		auditInterval = "10ms"
+		// The coordinator wakes maintenance only on capture reconciliation
+		// ticks. Keep both local intervals aligned so the one-artifact audit
+		// state machine advances quickly without applying that request rate to
+		// production object stores.
+		captureReconcileInterval = "25ms"
+		auditInterval = captureReconcileInterval
 	}
 	return map[string]string{
 		"WK_BACKUP_ENABLED":                             "true",
@@ -1543,7 +1594,7 @@ func sourceBackupConfig(qualification storageQualification, nodeID uint64) map[s
 		"WK_BACKUP_REPOSITORY_ID":                       qualification.RepositoryID,
 		"WK_BACKUP_SOURCE_GENERATION":                   qualification.SourceGeneration,
 		"WK_BACKUP_STAGING_DIR":                         qualificationStagingDir(qualification, "source", nodeID),
-		"WK_BACKUP_CAPTURE_RECONCILE_INTERVAL":          "200ms",
+		"WK_BACKUP_CAPTURE_RECONCILE_INTERVAL":          captureReconcileInterval,
 		"WK_BACKUP_CHECKPOINT_INTERVAL":                 "1h",
 		"WK_BACKUP_BASELINE_CHUNK_BYTES":                "1048576",
 		"WK_BACKUP_TARGET_SEGMENT_BYTES":                "1048576",


### PR DESCRIPTION
## What changed

- give initial capture, post-failover retention, and restore installation bounded convergence budgets that match the real three-node state machines
- allow foreground SEND to outlive the default 30-second node-health expiry during Slot authority migration
- align the local capture tick and audit cadence so the one-artifact integrity state machine can finish in test time without changing production OSS cadence
- replace the process-local audit-debt stability check with a durable catalog-sequence barrier
- add focused coverage for the catalog barrier predicate

## Why

The backup recovery drill used several wall-clock assumptions that were shorter than the production health and Controller convergence semantics. Its integrity barrier also watched a process metric without proving that the audit cycle covered the final checkpoint published after single-copy repair.

This produced repeatable false failures on a clean revision even though the backup state machines were continuing to make valid progress.

## Impact

The real three-node backup/restore qualification now waits on durable semantic evidence and remains bounded. Production runtime behavior and production object-store request cadence are unchanged.

## Validation

- `GOWORK=off go test -tags=e2e ./test/e2e/backup/three_node_restore -run '^TestIntegrityAuditReachedCatalogBarrier$' -count=1`
- `GOWORK=off go test -tags=e2e ./test/e2e/backup/three_node_restore -run '^TestThreeNodeBackupContinuousRestoresAndContinuesTraffic$' -count=1 -timeout 18m -p=1 -v` (passed in 140.232s)
- `GOWORK=off go test -tags=e2e ./test/e2e/backup/three_node_restore -count=1 -timeout 18m -p=1` (passed independently in 157.721s)
