### PR TITLE
ci: qualify Agent E2E binary

### DIFF
--- a/.github/workflows/agent-pr-validation.yml
+++ b/.github/workflows/agent-pr-validation.yml
@@ -470,7 +470,12 @@ jobs:
         run: test "$(go env GOVERSION)" = "go1.25.11"
       - name: Build e2e binary once
         shell: bash
-        run: go build -tags=e2e -o "$RUNNER_TEMP/wukongim-e2e" ./cmd/wukongim
+        env:
+          MERGE_SHA: ${{ github.event.client_payload.merge_sha }}
+        run: |
+          go build -tags=e2e \
+            -ldflags="-X github.com/WuKongIM/WuKongIM/internal/app.backupQualifiedRevision=${MERGE_SHA}" \
+            -o "$RUNNER_TEMP/wukongim-e2e" ./cmd/wukongim
       - name: Run e2e packages
         shell: bash
         env:

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -1413,6 +1413,33 @@ func validateAgentPRValidationWorkflow(raw []byte) error {
 			}
 		}
 	}
+	goE2EBuild := workflow.Jobs["go-e2e"]
+	var buildE2EBinary *ciStep
+	for index := range goE2EBuild.Steps {
+		if goE2EBuild.Steps[index].Name == "Build e2e binary once" {
+			buildE2EBinary = &goE2EBuild.Steps[index]
+			break
+		}
+	}
+	if buildE2EBinary == nil {
+		return fmt.Errorf("Agent validation Go e2e job has no shared binary build step")
+	}
+	wantBuildEnv := map[string]string{
+		"MERGE_SHA": "${{ github.event.client_payload.merge_sha }}",
+	}
+	if !reflect.DeepEqual(buildE2EBinary.Env, wantBuildEnv) {
+		return fmt.Errorf(
+			"Agent validation Go e2e binary build env = %#v, want %#v",
+			buildE2EBinary.Env,
+			wantBuildEnv,
+		)
+	}
+	if !strings.Contains(
+		buildE2EBinary.Run,
+		`-ldflags="-X github.com/WuKongIM/WuKongIM/internal/app.backupQualifiedRevision=${MERGE_SHA}"`,
+	) {
+		return fmt.Errorf("Agent validation Go e2e binary is not qualified for the frozen test-merge revision")
+	}
 	gate, ok := workflow.Jobs["gate"]
 	if !ok {
 		return fmt.Errorf("Agent validation workflow gate job is missing")


### PR DESCRIPTION
## Summary

- bind the shared Agent E2E binary to the exact frozen test-merge revision
- add a workflow contract that verifies the revision source and linker binding

## Why

The trusted repository-dispatch worker currently builds the shared E2E binary without the backup qualification revision. Backup E2E therefore fails before startup even when the tested merge commit is clean.

## Validation

- YAML parse for every workflow
- focused Agent workflow contract tests
- git diff --check