### PR TITLE
fix: make local backup smoke build-qualified

### DIFF
--- a/docs/development/BACKUP_AND_RESTORE.md
+++ b/docs/development/BACKUP_AND_RESTORE.md
@@ -68,6 +68,25 @@ arm64 binaries. Retain them with the production evidence artifact as the
 recorded recovery drill. A missing, failed, skipped, different-commit, modified,
 or ordinary source build leaves automatic backup disabled.
 
+## Local E2E backup smoke
+
+The local three-node simulator can exercise automatic backup against isolated
+file-backed repositories:
+
+```sh
+./scripts/smoke-wkcli-sim-wukongim-three-nodes.sh --backup
+```
+
+When it builds the cluster binary, the helper resolves the current Git `HEAD`
+and injects that exact revision into its `e2e`-tagged test binary. The runtime
+still rejects tracked source modifications through Go's VCS build metadata.
+`--no-build` never stamps a binary; it requires the caller to place an already
+qualified executable at the smoke output path.
+
+This local test stamp is not a release qualification. Do not deploy the
+generated binary. Production deployments must use the commit-bound binaries
+and matching verdict emitted by the complete workflow above.
+
 ## Runtime model
 
 Each logical Hash Slot continuously captures two ordered streams:

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -1080,10 +1080,11 @@ key authority, worker, or timer. Automatic mode requires the qualified Alibaba
 OSS adapter and one protected deployment key package, then wires two
 cross-region repositories, local AES-256-GCM envelope encryption, Ed25519
 signing with the package's retained verification keyring, and an immutable
-Package ID/activated-revision pin chain in both repositories. Repository
-startup first requires the running binary's clean Go VCS revision to equal the
-commit revision embedded only in artifacts emitted by the successful backup
-qualification workflow; no TOML or environment bypass token exists. RAM
+Package ID/activated-revision pin chain in both repositories. Production
+repository startup first requires the running binary's clean Go VCS revision
+to equal the commit revision embedded only in artifacts emitted by the
+successful backup qualification workflow; no TOML or environment bypass token
+exists. RAM
 qualification uses positive provider operations plus negative probes: ordinary
 and repair roles must be denied version deletion, while garbage roles must be
 denied object-body reads.
@@ -1156,6 +1157,11 @@ deployment-key, and clock loaders remain authoritative. The file-backed substitu
 repository and key calls in one bounded artificial latency. A sentinel path
 activates that delay only after startup, allowing the black-box scale gate to
 prove foreground SEND does not synchronously cross either remote boundary. A
+file-backed local smoke build may carry a separately linked local E2E revision
+stamp. That stamp is accepted only when both the `e2e` build tag and the
+file-root substitute are active, must exactly match the clean Go VCS revision,
+and is never accepted by non-E2E or production-loader startup. A production
+qualification stamp remains valid for file-backed qualification jobs. A
 separate e2e-only fault directory can make segment-payload reads from one or
 both named copies return corrupt bytes; catalog objects and production loaders
 are never affected. Sticky single- or dual-copy faults select one exact logical

--- a/internal/app/backup_e2e.go
+++ b/internal/app/backup_e2e.go
@@ -33,6 +33,55 @@ const (
 	backupE2EPinTriggerEnv     = "WUKONGIM_BACKUP_E2E_PIN_PRESSURE_TRIGGER"
 )
 
+// backupLocalE2ERevision is stamped only into local e2e backup smoke binaries.
+// Production qualification never reads or accepts this value.
+var backupLocalE2ERevision string
+
+// ValidateBackupLocalE2EBuildQualification binds the file-backed e2e substitute
+// to the exact clean source revision used to build the local smoke binary.
+func ValidateBackupLocalE2EBuildQualification(
+	qualification BackupBuildQualification,
+	localRevision string,
+) error {
+	buildRevision := strings.ToLower(
+		strings.TrimSpace(qualification.BuildRevision),
+	)
+	localRevision = strings.ToLower(strings.TrimSpace(localRevision))
+	if !validGitRevision(buildRevision) ||
+		!validGitRevision(localRevision) ||
+		buildRevision != localRevision ||
+		qualification.BuildModified {
+		return fmt.Errorf(
+			"%w: local e2e automatic backup requires an exact clean build revision",
+			ErrInvalidConfig,
+		)
+	}
+	return nil
+}
+
+func validateCurrentBackupBuildQualification() error {
+	return validateBackupBuildQualificationForE2EMode(
+		CurrentBackupBuildQualification(),
+		backupLocalE2ERevision,
+		strings.TrimSpace(os.Getenv(backupE2EFileRootEnv)) != "",
+	)
+}
+
+func validateBackupBuildQualificationForE2EMode(
+	qualification BackupBuildQualification,
+	localRevision string,
+	fileRepositoryEnabled bool,
+) error {
+	productionErr := ValidateBackupBuildQualification(qualification)
+	if productionErr == nil || !fileRepositoryEnabled {
+		return productionErr
+	}
+	return ValidateBackupLocalE2EBuildQualification(
+		qualification,
+		localRevision,
+	)
+}
+
 func init() {
 	productionRepositoryLoader := loadAppBackupRepository
 	productionRepairLoader := loadAppBackupRepairRepository

--- a/internal/app/backup_e2e_test.go
+++ b/internal/app/backup_e2e_test.go
@@ -21,6 +21,86 @@ import (
 	backupartifact "github.com/WuKongIM/WuKongIM/pkg/backup"
 )
 
+func TestBackupLocalE2EBuildQualificationRequiresExactCleanRevision(t *testing.T) {
+	const revision = "0123456789abcdef0123456789abcdef01234567"
+
+	if err := ValidateBackupLocalE2EBuildQualification(
+		BackupBuildQualification{BuildRevision: revision},
+		revision,
+	); err != nil {
+		t.Fatalf("exact clean local e2e revision rejected: %v", err)
+	}
+
+	for _, test := range []struct {
+		name          string
+		qualification BackupBuildQualification
+		localRevision string
+	}{
+		{
+			name:          "missing local revision",
+			qualification: BackupBuildQualification{BuildRevision: revision},
+		},
+		{
+			name:          "different local revision",
+			qualification: BackupBuildQualification{BuildRevision: revision},
+			localRevision: "1123456789abcdef0123456789abcdef01234567",
+		},
+		{
+			name: "modified source",
+			qualification: BackupBuildQualification{
+				BuildRevision: revision,
+				BuildModified: true,
+			},
+			localRevision: revision,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateBackupLocalE2EBuildQualification(
+				test.qualification,
+				test.localRevision,
+			)
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Fatalf("error = %v, want ErrInvalidConfig", err)
+			}
+			if !strings.Contains(err.Error(), "local e2e") {
+				t.Fatalf("error = %v, want local e2e qualification context", err)
+			}
+		})
+	}
+}
+
+func TestBackupE2EQualificationUsesLocalRevisionOnlyForFileSubstitute(t *testing.T) {
+	const revision = "0123456789abcdef0123456789abcdef01234567"
+
+	localQualification := BackupBuildQualification{BuildRevision: revision}
+	if err := validateBackupBuildQualificationForE2EMode(
+		localQualification,
+		revision,
+		true,
+	); err != nil {
+		t.Fatalf("file-backed local e2e qualification rejected: %v", err)
+	}
+	if err := validateBackupBuildQualificationForE2EMode(
+		localQualification,
+		revision,
+		false,
+	); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("production provider accepted local e2e revision: %v", err)
+	}
+
+	productionQualification := BackupBuildQualification{
+		BuildRevision:     revision,
+		QualifiedRevision: revision,
+	}
+	if err := validateBackupBuildQualificationForE2EMode(
+		productionQualification,
+		"",
+		true,
+	); err != nil {
+		t.Fatalf("file-backed qualification job rejected production stamp: %v", err)
+	}
+}
+
 func TestBackupE2ERemoteLatencyIsBounded(t *testing.T) {
 	t.Setenv(backupE2ERemoteLatencyEnv, "250ms")
 	got, err := backupE2ERemoteLatency()

--- a/internal/app/backup_qualification_current.go
+++ b/internal/app/backup_qualification_current.go
@@ -1,0 +1,9 @@
+//go:build !e2e
+
+package app
+
+func validateCurrentBackupBuildQualification() error {
+	return ValidateBackupBuildQualification(
+		CurrentBackupBuildQualification(),
+	)
+}

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -47,9 +47,7 @@ func (a *App) applyConfigDefaults() error {
 		return err
 	}
 	if a.cfg.Backup.Enabled {
-		if err := ValidateBackupBuildQualification(
-			CurrentBackupBuildQualification(),
-		); err != nil {
+		if err := validateCurrentBackupBuildQualification(); err != nil {
 			return err
 		}
 	}

--- a/scripts/smoke-wkcli-sim-wukongim-three-nodes.sh
+++ b/scripts/smoke-wkcli-sim-wukongim-three-nodes.sh
@@ -24,9 +24,11 @@ MAX_GOROUTINES="${WK_WKCLI_SIM_THREE_SMOKE_MAX_GOROUTINES:-2000}"
 MAX_HEAP_ALLOC_BYTES="${WK_WKCLI_SIM_THREE_SMOKE_MAX_HEAP_ALLOC_BYTES:-4294967296}"
 BACKUP_ENABLE="${WK_WKCLI_SIM_THREE_SMOKE_BACKUP_ENABLE:-false}"
 BACKUP_BUILD_TAGS="e2e"
+BACKUP_E2E_REVISION=""
 BACKUP_MANAGER_API="${WK_WKCLI_SIM_THREE_SMOKE_BACKUP_MANAGER_API:-http://127.0.0.1:5311}"
 BACKUP_CHECKPOINT_INTERVAL="${WK_WKCLI_SIM_THREE_SMOKE_BACKUP_CHECKPOINT_INTERVAL:-30s}"
-BACKUP_WAIT_TIMEOUT="${WK_WKCLI_SIM_THREE_SMOKE_BACKUP_WAIT_TIMEOUT:-120}"
+BACKUP_WAIT_TIMEOUT="${WK_WKCLI_SIM_THREE_SMOKE_BACKUP_WAIT_TIMEOUT:-300}"
+BACKUP_WORKER_COUNT="${WK_WKCLI_SIM_THREE_SMOKE_BACKUP_WORKER_COUNT:-16}"
 AUTO_JOIN_NODE="${WK_WKCLI_SIM_THREE_SMOKE_AUTO_JOIN_NODE:-false}"
 AUTO_JOIN_AFTER="${WK_WKCLI_SIM_THREE_SMOKE_AUTO_JOIN_AFTER:-2}"
 AUTO_JOIN_NODE_ID="${WK_WKCLI_SIM_THREE_SMOKE_AUTO_JOIN_NODE_ID:-4}"
@@ -87,6 +89,8 @@ BACKUP_PREVIOUS_CHECKPOINT_ID=""
 API_VALUES=()
 GATEWAY_VALUES=()
 AUTO_JOIN_SEED_VALUES=()
+CLUSTER_START_ENV=()
+CLUSTER_START_ARGS=()
 
 usage() {
   cat <<'USAGE'
@@ -120,10 +124,11 @@ Options:
   --ready-timeout SECS      Cluster ready wait timeout. Default: 90.
   --poll SECS               Ready polling interval. Default: 1.
   --backup                 Enable isolated local file-backed automatic backup validation.
-                           This builds the product with -tags=e2e, uses two repositories
-                           below OUT_DIR, requires jq, and does not use production object storage.
+                           This builds the product with -tags=e2e, binds it to the
+                           current Git revision, uses two repositories below OUT_DIR,
+                           requires jq, and does not use production object storage.
   --backup-manager-api URL Manager API used to verify local backup. Default: http://127.0.0.1:5311.
-  --backup-wait-timeout N  Seconds to wait for a new checkpoint. Default: 120.
+  --backup-wait-timeout N  Seconds to wait for a new checkpoint. Default: 300.
   --auto-join-node          Start one seed-join data node while wkcli sim is sending.
   --auto-join-after SECS    Seconds after the send phase starts before starting the new node. Default: 2.
   --auto-join-node-id N     Joining node ID. Default: 4.
@@ -293,6 +298,17 @@ backup_repository_root() {
 
 backup_staging_root() {
   printf '%s/backup-staging' "$OUT_DIR"
+}
+
+resolve_backup_e2e_revision() {
+  local revision
+  command -v git >/dev/null 2>&1 ||
+    die '--backup build requires git to resolve the exact source revision'
+  revision="$(git -C "$ROOT_DIR" rev-parse --verify HEAD 2>/dev/null)" ||
+    die '--backup build could not resolve the exact source revision'
+  [[ "$revision" =~ ^[0-9a-fA-F]{40}$ ]] ||
+    die "--backup build resolved an invalid Git revision: $revision"
+  printf '%s' "$revision"
 }
 
 backup_status_file() {
@@ -470,7 +486,7 @@ cluster_profile_env() {
       "WK_BACKUP_TARGET_SEGMENT_BYTES=8388608" \
       "WK_BACKUP_MAX_SEGMENT_OPEN_DURATION=5s" \
       "WK_BACKUP_STAGING_MAX_BYTES=1073741824" \
-      "WK_BACKUP_WORKER_COUNT=2" \
+      "WK_BACKUP_WORKER_COUNT=$BACKUP_WORKER_COUNT" \
       "WK_BACKUP_AUDIT_INTERVAL=500ms" \
       "WK_BACKUP_AUDIT_SCRUB_INTERVAL=24h" \
       "WK_BACKUP_GARBAGE_COLLECTION_INTERVAL=1h" \
@@ -496,22 +512,44 @@ cluster_profile_env() {
   fi
 }
 
-cluster_start_env_preview() {
+prepare_cluster_start_command() {
   local assignment
-  local envs=()
+  CLUSTER_START_ENV=()
+  CLUSTER_START_ARGS=()
+  if [[ "$START_CLUSTER" -eq 0 ]]; then
+    return
+  fi
   while IFS= read -r assignment; do
-    envs+=("$assignment")
+    CLUSTER_START_ENV+=("$assignment")
   done < <(cluster_profile_env)
   if [[ "$FAULT_KILL_NODE" == "true" ]]; then
-    [[ -n "$FAULT_HEALTH_REPORT_INTERVAL" ]] && envs+=("WK_CLUSTER_NODE_HEALTH_REPORT_INTERVAL=$FAULT_HEALTH_REPORT_INTERVAL")
-    [[ -n "$FAULT_HEALTH_REPORT_TTL" ]] && envs+=("WK_CLUSTER_NODE_HEALTH_REPORT_TTL=$FAULT_HEALTH_REPORT_TTL")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_SCAN_INTERVAL" ]] && envs+=("WK_CHANNEL_MIGRATION_SCAN_INTERVAL=$FAULT_CHANNEL_MIGRATION_SCAN_INTERVAL")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_SCAN_LIMIT" ]] && envs+=("WK_CHANNEL_MIGRATION_SCAN_LIMIT=$FAULT_CHANNEL_MIGRATION_SCAN_LIMIT")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK" ]] && envs+=("WK_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK=$FAULT_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK" ]] && envs+=("WK_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK=$FAULT_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_TASK_LIMIT" ]] && envs+=("WK_CHANNEL_MIGRATION_TASK_LIMIT=$FAULT_CHANNEL_MIGRATION_TASK_LIMIT")
+    [[ -n "$FAULT_HEALTH_REPORT_INTERVAL" ]] && CLUSTER_START_ENV+=("WK_CLUSTER_NODE_HEALTH_REPORT_INTERVAL=$FAULT_HEALTH_REPORT_INTERVAL")
+    [[ -n "$FAULT_HEALTH_REPORT_TTL" ]] && CLUSTER_START_ENV+=("WK_CLUSTER_NODE_HEALTH_REPORT_TTL=$FAULT_HEALTH_REPORT_TTL")
+    [[ -n "$FAULT_CHANNEL_MIGRATION_SCAN_INTERVAL" ]] && CLUSTER_START_ENV+=("WK_CHANNEL_MIGRATION_SCAN_INTERVAL=$FAULT_CHANNEL_MIGRATION_SCAN_INTERVAL")
+    [[ -n "$FAULT_CHANNEL_MIGRATION_SCAN_LIMIT" ]] && CLUSTER_START_ENV+=("WK_CHANNEL_MIGRATION_SCAN_LIMIT=$FAULT_CHANNEL_MIGRATION_SCAN_LIMIT")
+    [[ -n "$FAULT_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK" ]] && CLUSTER_START_ENV+=("WK_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK=$FAULT_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK")
+    [[ -n "$FAULT_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK" ]] && CLUSTER_START_ENV+=("WK_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK=$FAULT_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK")
+    [[ -n "$FAULT_CHANNEL_MIGRATION_TASK_LIMIT" ]] && CLUSTER_START_ENV+=("WK_CHANNEL_MIGRATION_TASK_LIMIT=$FAULT_CHANNEL_MIGRATION_TASK_LIMIT")
   fi
-  printf '%s' "${envs[*]}"
+
+  CLUSTER_START_ARGS=("$START_SCRIPT")
+  if [[ "$CLEAN_CLUSTER" -eq 1 ]]; then
+    CLUSTER_START_ARGS+=(--clean)
+  fi
+  CLUSTER_START_ARGS+=(--ready-timeout "$READY_TIMEOUT" --bin "$(cluster_bin)" --log-dir "$(node_log_dir)")
+  if [[ "$BACKUP_ENABLE" == "true" ]]; then
+    CLUSTER_START_ARGS+=(--build-tags "$BACKUP_BUILD_TAGS")
+    if [[ "$BUILD_CLUSTER" -eq 1 ]]; then
+      CLUSTER_START_ARGS+=(--backup-e2e-revision "$BACKUP_E2E_REVISION")
+    fi
+    CLUSTER_START_ARGS+=(--backup-staging-root "$(backup_staging_root)")
+  fi
+  if [[ "$BUILD_CLUSTER" -eq 0 ]]; then
+    CLUSTER_START_ARGS+=(--no-build)
+  fi
+  if [[ "$FAULT_KILL_NODE" == "true" ]]; then
+    CLUSTER_START_ARGS+=(--pid-dir "$FAULT_PID_DIR" --allow-node-exit "$FAULT_NODE_ID")
+  fi
 }
 
 print_start_cmd() {
@@ -519,20 +557,9 @@ print_start_cmd() {
     printf 'start_cmd=<disabled>\n'
     return
   fi
-  printf 'start_cmd=env %s %s' "$(cluster_start_env_preview)" "$START_SCRIPT"
-  if [[ "$CLEAN_CLUSTER" -eq 1 ]]; then
-    printf ' --clean'
-  fi
-  printf ' --ready-timeout %s --bin %s --log-dir %s' "$READY_TIMEOUT" "$(cluster_bin)" "$(node_log_dir)"
-  if [[ "$BACKUP_ENABLE" == "true" ]]; then
-    printf ' --build-tags %s --backup-staging-root %s' "$BACKUP_BUILD_TAGS" "$(backup_staging_root)"
-  fi
-  if [[ "$BUILD_CLUSTER" -eq 0 ]]; then
-    printf ' --no-build'
-  fi
-  if [[ "$FAULT_KILL_NODE" == "true" ]]; then
-    printf ' --pid-dir %s --allow-node-exit %s' "$FAULT_PID_DIR" "$FAULT_NODE_ID"
-  fi
+  printf 'start_cmd=env'
+  printf ' %s' "${CLUSTER_START_ENV[@]}"
+  printf ' %s' "${CLUSTER_START_ARGS[@]}"
   printf '\n'
 }
 
@@ -623,6 +650,13 @@ print_plan() {
   printf 'backup_repository_root=%s\n' "$(backup_repository_root)"
   printf 'backup_staging_root=%s\n' "$(backup_staging_root)"
   printf 'backup_build_tags=%s\n' "$BACKUP_BUILD_TAGS"
+  if [[ "$BACKUP_ENABLE" == "true" && "$BUILD_CLUSTER" -eq 1 ]]; then
+    printf 'backup_e2e_revision=%s\n' "$BACKUP_E2E_REVISION"
+  elif [[ "$BACKUP_ENABLE" == "true" ]]; then
+    printf 'backup_e2e_revision=<prebuilt>\n'
+  else
+    printf 'backup_e2e_revision=<disabled>\n'
+  fi
   printf 'backup_manager_api=%s\n' "$BACKUP_MANAGER_API"
   printf 'backup_checkpoint_interval=%s\n' "$BACKUP_CHECKPOINT_INTERVAL"
   printf 'backup_wait_timeout_secs=%s\n' "$BACKUP_WAIT_TIMEOUT"
@@ -1065,6 +1099,7 @@ require_nonempty 'WK_WKCLI_SIM_THREE_SMOKE_GATEWAY_SEND_TIMEOUT' "$GATEWAY_SEND_
 require_nonempty 'WK_WKCLI_SIM_THREE_SMOKE_ACK_TIMEOUT' "$SIM_ACK_TIMEOUT"
 require_bool 'WK_WKCLI_SIM_THREE_SMOKE_BACKUP_ENABLE' "$BACKUP_ENABLE"
 require_positive_uint '--backup-wait-timeout' "$BACKUP_WAIT_TIMEOUT"
+require_positive_uint 'WK_WKCLI_SIM_THREE_SMOKE_BACKUP_WORKER_COUNT' "$BACKUP_WORKER_COUNT"
 require_bool 'WK_WKCLI_SIM_THREE_SMOKE_AUTO_JOIN_NODE' "$AUTO_JOIN_NODE"
 require_bool 'WK_WKCLI_SIM_THREE_SMOKE_AUTO_PROMOTE_CONTROLLER_VOTER' "$AUTO_PROMOTE_CONTROLLER_VOTER"
 require_bool 'WK_WKCLI_SIM_THREE_SMOKE_AUTO_PROMOTE_MANAGER_AUTH' "$AUTO_PROMOTE_MANAGER_AUTH"
@@ -1097,6 +1132,9 @@ BACKUP_MANAGER_API="${BACKUP_MANAGER_API%/}"
 if [[ "$BACKUP_ENABLE" == "true" ]]; then
   require_nonempty '--backup-manager-api' "$BACKUP_MANAGER_API"
   [[ "$START_CLUSTER" -eq 1 ]] || die '--backup requires the script to start its isolated cluster'
+  if [[ "$BUILD_CLUSTER" -eq 1 ]]; then
+    BACKUP_E2E_REVISION="$(resolve_backup_e2e_revision)"
+  fi
 fi
 if [[ "$AUTO_JOIN_NODE" == "true" ]]; then
   require_nonempty '--auto-join-api' "$AUTO_JOIN_API_ADDR"
@@ -1128,6 +1166,7 @@ if [[ "$FAULT_KILL_NODE" == "true" ]]; then
   esac
   require_nonempty '--fault-pid-dir' "$FAULT_PID_DIR"
 fi
+prepare_cluster_start_command
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
   print_plan
@@ -1177,8 +1216,7 @@ start_cluster() {
     log 'using already-running cluster'
     return
   fi
-  local args=("$START_SCRIPT")
-  local assignment
+  local args=("${CLUSTER_START_ARGS[@]}")
   local exported_name
   local env_args=()
   while IFS= read -r exported_name; do
@@ -1186,29 +1224,7 @@ start_cluster() {
       WK_WKCLI_SIM_THREE_SMOKE_*) env_args+=("-u" "$exported_name") ;;
     esac
   done < <(compgen -e)
-  while IFS= read -r assignment; do
-    env_args+=("$assignment")
-  done < <(cluster_profile_env)
-  if [[ "$CLEAN_CLUSTER" -eq 1 ]]; then
-    args+=(--clean)
-  fi
-  args+=(--ready-timeout "$READY_TIMEOUT" --bin "$(cluster_bin)" --log-dir "$(node_log_dir)")
-  if [[ "$BACKUP_ENABLE" == "true" ]]; then
-    args+=(--build-tags "$BACKUP_BUILD_TAGS" --backup-staging-root "$(backup_staging_root)")
-  fi
-  if [[ "$BUILD_CLUSTER" -eq 0 ]]; then
-    args+=(--no-build)
-  fi
-  if [[ "$FAULT_KILL_NODE" == "true" ]]; then
-    args+=(--pid-dir "$FAULT_PID_DIR" --allow-node-exit "$FAULT_NODE_ID")
-    [[ -n "$FAULT_HEALTH_REPORT_INTERVAL" ]] && env_args+=("WK_CLUSTER_NODE_HEALTH_REPORT_INTERVAL=$FAULT_HEALTH_REPORT_INTERVAL")
-    [[ -n "$FAULT_HEALTH_REPORT_TTL" ]] && env_args+=("WK_CLUSTER_NODE_HEALTH_REPORT_TTL=$FAULT_HEALTH_REPORT_TTL")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_SCAN_INTERVAL" ]] && env_args+=("WK_CHANNEL_MIGRATION_SCAN_INTERVAL=$FAULT_CHANNEL_MIGRATION_SCAN_INTERVAL")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_SCAN_LIMIT" ]] && env_args+=("WK_CHANNEL_MIGRATION_SCAN_LIMIT=$FAULT_CHANNEL_MIGRATION_SCAN_LIMIT")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK" ]] && env_args+=("WK_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK=$FAULT_CHANNEL_MIGRATION_MAX_PAGES_PER_TICK")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK" ]] && env_args+=("WK_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK=$FAULT_CHANNEL_MIGRATION_MAX_TASKS_PER_TICK")
-    [[ -n "$FAULT_CHANNEL_MIGRATION_TASK_LIMIT" ]] && env_args+=("WK_CHANNEL_MIGRATION_TASK_LIMIT=$FAULT_CHANNEL_MIGRATION_TASK_LIMIT")
-  fi
+  env_args+=("${CLUSTER_START_ENV[@]}")
   log "starting three-node cluster: $START_SCRIPT"
   (
     cd "$ROOT_DIR"
@@ -1707,14 +1723,29 @@ backup_manager_get() {
     "$BACKUP_MANAGER_API$path" >"$output"
 }
 
-backup_checkpoint_healthy() {
+backup_checkpoint_available() {
   local input="$1"
   jq -e '
     (.enabled == true) and
-    (.health == "healthy") and
-    ((.checkpoint_age_seconds | type) == "number") and
+    (.running == true) and
+    (.capture_status_complete == true) and
+    (((.capture_status_missing_node_ids // []) | length) == 0) and
+    (((.capture_status_missing_slots // []) | length) == 0) and
     ((.latest_checkpoint.id | type) == "string") and
-    ((.latest_checkpoint.id | length) > 0)
+    ((.latest_checkpoint.id | length) > 0) and
+    (
+      (.health == "healthy") or
+      (
+        (.health == "degraded") and
+        (.failure_category == null) and
+        ((.checkpoint_age_seconds | type) == "number") and
+        ((.max_checkpoint_age_seconds | type) == "number") and
+        (.checkpoint_age_seconds > .max_checkpoint_age_seconds) and
+        ((.integrity_audit.debt_objects // 0) == 0) and
+        ((.compaction.debt_slots // 0) == 0) and
+        ((.garbage_collection.debt_repositories // 0) == 0)
+      )
+    )
   ' "$input" >/dev/null 2>&1
 }
 
@@ -1753,7 +1784,7 @@ capture_backup_baseline() {
   fi
 }
 
-wait_backup_checkpoint_health() {
+wait_backup_checkpoint_available() {
   if [[ "$BACKUP_ENABLE" != "true" ]]; then
     return
   fi
@@ -1767,15 +1798,15 @@ wait_backup_checkpoint_health() {
       if jq -e '.enabled == false' "$output" >/dev/null 2>&1; then
         die 'local backup remained disabled after backup-enabled startup'
       fi
-      if backup_checkpoint_healthy "$output"; then
+      if backup_checkpoint_available "$output"; then
         capture_backup_baseline
-        log 'local backup checkpoint healthy'
+        log 'local backup checkpoint available'
         return
       fi
     fi
     backup_poll_sleep
   done
-  die "local backup checkpoint did not become healthy within ${BACKUP_WAIT_TIMEOUT}s"
+  die "local backup checkpoint did not become available within ${BACKUP_WAIT_TIMEOUT}s"
 }
 
 wait_backup_checkpoint() {
@@ -2176,7 +2207,7 @@ write_summary() {
 
 start_cluster
 wait_ready
-wait_backup_checkpoint_health
+wait_backup_checkpoint_available
 capture_target_evidence
 capture_metrics before
 run_sim

--- a/scripts/start-wukongim-three-nodes.sh
+++ b/scripts/start-wukongim-three-nodes.sh
@@ -19,6 +19,8 @@ PROMETHEUS_SOURCE_REF="${WK_PROMETHEUS_SOURCE_REF:-${WK_PROMETHEUS_EMBED_VERSION
 PROMETHEUS_REPO="${WK_PROMETHEUS_REPO:-https://github.com/prometheus/prometheus.git}"
 PROMETHEUS_EMBED_DIR="${WK_PROMETHEUS_EMBED_DIR:-$ROOT_DIR/internal/app/prometheus_embedded}"
 BUILD_TAGS="${WK_WUKONGIM_THREE_NODES_BUILD_TAGS:-}"
+BACKUP_E2E_REVISION=""
+BACKUP_E2E_GIT_DIR=""
 BACKUP_STAGING_ROOT="${WK_WUKONGIM_THREE_NODES_BACKUP_STAGING_ROOT:-}"
 PID_DIR="${WK_WUKONGIM_THREE_NODES_PID_DIR:-}"
 ALLOW_NODE_EXIT="${WK_WUKONGIM_THREE_NODES_ALLOW_NODE_EXIT:-}"
@@ -39,6 +41,7 @@ METRICS_TARGETS=(
 )
 PIDS=()
 ALLOW_NODE_EXIT_VALUES=()
+BUILD_COMMAND=()
 
 usage() {
   cat <<'USAGE'
@@ -56,6 +59,8 @@ Options:
   --clean                Remove the node data directories and log dir before start.
   --no-build             Reuse --bin instead of running go build.
   --build-tags TAGS      Optional comma-separated Go build tags.
+  --backup-e2e-revision REVISION
+                         Bind a file-backed e2e backup build to one exact Git revision.
   --bin PATH             Binary path. Default: WK_WUKONGIM_THREE_NODES_BIN or data/wukongim-three-nodes/wukongim.
   --log-dir DIR          Per-node log directory. Default: WK_WUKONGIM_THREE_NODES_LOG_DIR or data/wukongim-three-node-logs.
   --data-root DIR        Parent for isolated node data directories. Default: WK_WUKONGIM_THREE_NODES_DATA_ROOT or data/.
@@ -194,6 +199,47 @@ backup_staging_path() {
   printf '%s/node-%s' "$BACKUP_STAGING_ROOT" "$node"
 }
 
+backup_e2e_ldflags() {
+  printf '%s' "-X=github.com/WuKongIM/WuKongIM/internal/app.backupLocalE2ERevision=${BACKUP_E2E_REVISION}"
+}
+
+prepare_build_command() {
+  BUILD_COMMAND=()
+  if [[ "$BUILD" -eq 0 ]]; then
+    return
+  fi
+  if [[ -n "$BACKUP_E2E_REVISION" ]]; then
+    BUILD_COMMAND=(
+      env
+      "GIT_DIR=$BACKUP_E2E_GIT_DIR"
+      "GIT_WORK_TREE=$ROOT_DIR"
+      go build
+      "-tags=$BUILD_TAGS"
+      "-ldflags=$(backup_e2e_ldflags)"
+      -o "$BIN_PATH"
+      ./cmd/wukongim
+    )
+  elif [[ -n "$BUILD_TAGS" ]]; then
+    BUILD_COMMAND=(go build "-tags=$BUILD_TAGS" -o "$BIN_PATH" ./cmd/wukongim)
+  else
+    BUILD_COMMAND=(go build -o "$BIN_PATH" ./cmd/wukongim)
+  fi
+}
+
+print_shell_command() {
+  local label="$1"
+  local separator=""
+  local arg
+  shift
+  printf '%s' "$label"
+  for arg in "$@"; do
+    printf '%s' "$separator"
+    printf '%q' "$arg"
+    separator=" "
+  done
+  printf '\n'
+}
+
 node_env_preview() {
   local node="$1"
   printf '%s' "$(prometheus_node_env_preview "$node")"
@@ -205,11 +251,7 @@ node_env_preview() {
 print_plan() {
   printf 'repo_root=%s\n' "$ROOT_DIR"
   if [[ "$BUILD" -eq 1 ]]; then
-    if [[ -n "$BUILD_TAGS" ]]; then
-      printf 'build_cmd=go build -tags=%s -o %s ./cmd/wukongim\n' "$BUILD_TAGS" "$BIN_PATH"
-    else
-      printf 'build_cmd=go build -o %s ./cmd/wukongim\n' "$BIN_PATH"
-    fi
+    print_shell_command 'build_cmd=' "${BUILD_COMMAND[@]}"
   else
     printf 'build_cmd=<disabled>\n'
   fi
@@ -300,6 +342,11 @@ while [[ $# -gt 0 ]]; do
       BUILD_TAGS="$2"
       shift 2
       ;;
+    --backup-e2e-revision)
+      [[ $# -ge 2 ]] || die '--backup-e2e-revision requires a value'
+      BACKUP_E2E_REVISION="$2"
+      shift 2
+      ;;
     --bin)
       [[ $# -ge 2 ]] || die '--bin requires a value'
       BIN_PATH="$2"
@@ -381,10 +428,23 @@ require_positive_uint '--ready-timeout' "$READY_TIMEOUT"
 require_uint '--poll' "$POLL_INTERVAL"
 require_bool 'prometheus enable' "$PROMETHEUS_ENABLE"
 [[ -n "$DATA_ROOT" ]] || die '--data-root must not be empty'
+if [[ -n "$BACKUP_E2E_REVISION" ]]; then
+  [[ "$BACKUP_E2E_REVISION" =~ ^[0-9a-fA-F]{40}$ ]] ||
+    die '--backup-e2e-revision must be a full 40-character Git revision'
+  [[ ",$BUILD_TAGS," == *,e2e,* ]] ||
+    die '--backup-e2e-revision requires the e2e build tag'
+  [[ "$BUILD" -eq 1 ]] ||
+    die '--backup-e2e-revision cannot be combined with --no-build'
+  command -v git >/dev/null 2>&1 ||
+    die '--backup-e2e-revision requires git'
+  BACKUP_E2E_GIT_DIR="$(git -C "$ROOT_DIR" rev-parse --absolute-git-dir 2>/dev/null)" ||
+    die '--backup-e2e-revision could not resolve the worktree Git directory'
+fi
 if [[ -n "$BACKUP_STAGING_ROOT" && "$BACKUP_STAGING_ROOT" != /* ]]; then
   die '--backup-staging-root must be an absolute path'
 fi
 parse_allow_node_exit
+prepare_build_command
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
   print_plan
@@ -447,11 +507,7 @@ if [[ "$BUILD" -eq 1 ]]; then
   log "building $BIN_PATH"
   (
     cd "$ROOT_DIR"
-    if [[ -n "$BUILD_TAGS" ]]; then
-      go build -tags="$BUILD_TAGS" -o "$BIN_PATH" ./cmd/wukongim
-    else
-      go build -o "$BIN_PATH" ./cmd/wukongim
-    fi
+    "${BUILD_COMMAND[@]}"
   )
 elif [[ ! -x "$BIN_PATH" ]]; then
   die "--no-build requested but binary is not executable: $BIN_PATH"

--- a/scripts/start-wukongim-three-nodes.sh
+++ b/scripts/start-wukongim-three-nodes.sh
@@ -211,6 +211,7 @@ prepare_build_command() {
   if [[ -n "$BACKUP_E2E_REVISION" ]]; then
     BUILD_COMMAND=(
       env
+      "GOWORK=off"
       "GIT_DIR=$BACKUP_E2E_GIT_DIR"
       "GIT_WORK_TREE=$ROOT_DIR"
       go build

--- a/scripts/wkcli_sim_smoke_script_test.go
+++ b/scripts/wkcli_sim_smoke_script_test.go
@@ -109,6 +109,7 @@ func TestWkcliSimThreeNodeSmokeScriptDryRunPrintsLocalBackupPlan(t *testing.T) {
 	root := repoRoot(t)
 	outDir := t.TempDir()
 	startScript := filepath.Join(t.TempDir(), "start-three.sh")
+	revision := scriptTestGitRevision(t, root)
 
 	cmd := exec.Command("bash", "scripts/smoke-wkcli-sim-wukongim-three-nodes.sh",
 		"--dry-run",
@@ -127,14 +128,17 @@ func TestWkcliSimThreeNodeSmokeScriptDryRunPrintsLocalBackupPlan(t *testing.T) {
 		"backup_repository_root=" + filepath.Join(outDir, "backup-repositories"),
 		"backup_staging_root=" + filepath.Join(outDir, "backup-staging"),
 		"backup_build_tags=e2e",
+		"backup_e2e_revision=" + revision,
 		"backup_checkpoint_interval=30s",
-		"backup_wait_timeout_secs=120",
+		"backup_wait_timeout_secs=300",
 		"WUKONGIM_BACKUP_E2E_FILE_ROOT=" + filepath.Join(outDir, "backup-repositories"),
 		"WK_BACKUP_ENABLED=true",
 		"WK_BACKUP_PROVIDER=aliyun",
 		"WK_BACKUP_REPOSITORY_ID=wkcli-sim-three-node-smoke",
 		"WK_BACKUP_SOURCE_GENERATION=local-smoke-generation",
+		"WK_BACKUP_WORKER_COUNT=16",
 		"--build-tags e2e",
+		"--backup-e2e-revision " + revision,
 		"--backup-staging-root " + filepath.Join(outDir, "backup-staging"),
 		"backup_status_cmd=curl -fsS -H Authorization: Bearer <token> http://127.0.0.1:5311/manager/backups/status",
 	} {
@@ -144,12 +148,46 @@ func TestWkcliSimThreeNodeSmokeScriptDryRunPrintsLocalBackupPlan(t *testing.T) {
 	}
 }
 
+func TestWkcliSimThreeNodeSmokeScriptDryRunReusesPrebuiltBackupBinaryWithoutRestamping(t *testing.T) {
+	root := repoRoot(t)
+	outDir := t.TempDir()
+	startScript := filepath.Join(t.TempDir(), "start-three.sh")
+
+	cmd := exec.Command("bash", "scripts/smoke-wkcli-sim-wukongim-three-nodes.sh",
+		"--dry-run",
+		"--backup",
+		"--no-build",
+		"--out-dir", outDir,
+		"--start-script", startScript,
+	)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dry-run failed: %v\n%s", err, output)
+	}
+	text := string(output)
+	for _, want := range []string{
+		"backup_e2e_revision=<prebuilt>",
+		"--build-tags e2e",
+		"--backup-staging-root " + filepath.Join(outDir, "backup-staging"),
+		"--no-build",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "--backup-e2e-revision") {
+		t.Fatalf("prebuilt backup binary must not be restamped:\n%s", text)
+	}
+}
+
 func TestWkcliSimThreeNodeSmokeScriptPublishesLocalBackupCheckpoint(t *testing.T) {
 	root := repoRoot(t)
 	binDir := t.TempDir()
 	callsDir := t.TempDir()
 	outDir := t.TempDir()
 	startScript := filepath.Join(binDir, "start-three.sh")
+	revision := scriptTestGitRevision(t, root)
 	writeFakeThreeNodeSimGo(t, filepath.Join(binDir, "go"), callsDir)
 	writeFakeThreeNodeSimCurl(t, filepath.Join(binDir, "curl"), callsDir)
 	writeFakeThreeNodeSimStartScript(t, startScript, callsDir)
@@ -178,7 +216,7 @@ func TestWkcliSimThreeNodeSmokeScriptPublishesLocalBackupCheckpoint(t *testing.T
 	}
 	text := string(output)
 	for _, want := range []string{
-		"local backup checkpoint healthy",
+		"local backup checkpoint available",
 		"local backup checkpoint published: checkpoint-local-1",
 		"smoke passed",
 	} {
@@ -195,6 +233,7 @@ func TestWkcliSimThreeNodeSmokeScriptPublishesLocalBackupCheckpoint(t *testing.T
 	startCalls := readFile(t, filepath.Join(callsDir, "start.calls"))
 	for _, want := range []string{
 		"--build-tags e2e",
+		"--backup-e2e-revision " + revision,
 		"--backup-staging-root " + filepath.Join(outDir, "backup-staging"),
 	} {
 		if !strings.Contains(startCalls, want) {
@@ -232,6 +271,17 @@ func TestWkcliSimThreeNodeSmokeScriptPublishesLocalBackupCheckpoint(t *testing.T
 	}
 }
 
+func scriptTestGitRevision(t *testing.T, root string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = root
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("resolve current Git revision: %v", err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
 func TestWkcliSimThreeNodeSmokeScriptRejectsMisleadingBackupEvidence(t *testing.T) {
 	for _, testCase := range []struct {
 		name      string
@@ -239,9 +289,9 @@ func TestWkcliSimThreeNodeSmokeScriptRejectsMisleadingBackupEvidence(t *testing.
 		wantError string
 	}{
 		{
-			name:      "aggregate health must be healthy",
+			name:      "failed status must not be masked by decoy health",
 			mode:      "health-decoy",
-			wantError: "local backup checkpoint did not become healthy",
+			wantError: "local backup checkpoint did not become available",
 		},
 		{
 			name:      "newest checkpoint must have an identity",
@@ -1347,9 +1397,9 @@ case "$url" in
     ;;
   http://127.0.0.1:5311/manager/backups/status)
     if [[ "${WK_TEST_BACKUP_EVIDENCE_MODE-}" == "health-decoy" ]]; then
-      echo '{"enabled":true,"health":"failed","checkpoint_age_seconds":1,"latest_checkpoint":{"id":"checkpoint-baseline"},"decoy":{"health":"healthy"}}'
+      echo '{"enabled":true,"running":true,"health":"failed","failure_category":"checkpoint","checkpoint_age_seconds":1,"latest_checkpoint":{"id":"checkpoint-baseline"},"capture_status_complete":true,"capture_status_missing_node_ids":[],"capture_status_missing_slots":[],"decoy":{"health":"healthy"}}'
     else
-      echo '{"enabled":true,"health":"healthy","checkpoint_age_seconds":1,"latest_checkpoint":{"id":"checkpoint-baseline"}}'
+      echo '{"enabled":true,"running":true,"health":"degraded","failure_category":null,"checkpoint_age_seconds":205,"max_checkpoint_age_seconds":30,"latest_checkpoint":{"id":"checkpoint-baseline"},"capture_status_complete":true,"capture_status_missing_node_ids":[],"capture_status_missing_slots":[],"integrity_audit":{"debt_objects":0},"compaction":{"debt_slots":0},"garbage_collection":{"debt_repositories":0}}'
     fi
     ;;
   "http://127.0.0.1:5311/manager/backups/checkpoints?limit=1")

--- a/scripts/wukongim_three_nodes_build_integration_test.go
+++ b/scripts/wukongim_three_nodes_build_integration_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package scripts_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWukongIMThreeNodeLocalE2EBuildUsesSelectedWorktreeRevision(t *testing.T) {
+	root := repoRoot(t)
+	revisionCommand := exec.Command("git", "rev-parse", "HEAD")
+	revisionCommand.Dir = root
+	revisionOutput, err := revisionCommand.Output()
+	if err != nil {
+		t.Fatalf("resolve worktree revision: %v", err)
+	}
+	revision := strings.TrimSpace(string(revisionOutput))
+	outputBin := filepath.Join(t.TempDir(), "wukongim")
+
+	dryRunCommand := exec.Command("bash", "scripts/start-wukongim-three-nodes.sh",
+		"--dry-run",
+		"--build-tags", "e2e",
+		"--backup-e2e-revision", revision,
+		"--bin", outputBin,
+	)
+	dryRunCommand.Dir = root
+	dryRunOutput, err := dryRunCommand.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve local e2e build command: %v\n%s", err, dryRunOutput)
+	}
+
+	var buildCommand string
+	for _, line := range strings.Split(string(dryRunOutput), "\n") {
+		if strings.HasPrefix(line, "build_cmd=") {
+			buildCommand = strings.TrimPrefix(line, "build_cmd=")
+			break
+		}
+	}
+	if buildCommand == "" {
+		t.Fatalf("dry-run output missing build command:\n%s", dryRunOutput)
+	}
+
+	build := exec.Command("bash", "-c", buildCommand)
+	build.Dir = root
+	build.Env = append(envWithout("GOWORK"), "GOWORK=off")
+	buildOutput, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build local e2e binary: %v\n%s", err, buildOutput)
+	}
+
+	versionCommand := exec.Command("go", "version", "-m", outputBin)
+	versionOutput, err := versionCommand.CombinedOutput()
+	if err != nil {
+		t.Fatalf("inspect local e2e binary: %v\n%s", err, versionOutput)
+	}
+	want := "vcs.revision=" + revision
+	if !strings.Contains(string(versionOutput), want) {
+		t.Fatalf("binary metadata missing %q:\n%s", want, versionOutput)
+	}
+}

--- a/scripts/wukongim_three_nodes_build_integration_test.go
+++ b/scripts/wukongim_three_nodes_build_integration_test.go
@@ -45,7 +45,10 @@ func TestWukongIMThreeNodeLocalE2EBuildUsesSelectedWorktreeRevision(t *testing.T
 
 	build := exec.Command("bash", "-c", buildCommand)
 	build.Dir = root
-	build.Env = append(envWithout("GOWORK"), "GOWORK=off")
+	build.Env = append(
+		envWithout("GOWORK"),
+		"GOWORK="+filepath.Join(t.TempDir(), "missing-go.work"),
+	)
 	buildOutput, err := build.CombinedOutput()
 	if err != nil {
 		t.Fatalf("build local e2e binary: %v\n%s", err, buildOutput)

--- a/scripts/wukongim_three_nodes_script_test.go
+++ b/scripts/wukongim_three_nodes_script_test.go
@@ -290,7 +290,7 @@ func TestWukongIMThreeNodeScriptDryRunPrintsLocalE2EBackupBuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run failed: %v\n%s", err, output)
 	}
-	want := "build_cmd=env GIT_DIR=" + gitDir + " GIT_WORK_TREE=" + root +
+	want := "build_cmd=env GOWORK=off GIT_DIR=" + gitDir + " GIT_WORK_TREE=" + root +
 		" go build -tags=e2e -ldflags=-X=github.com/WuKongIM/WuKongIM/internal/app.backupLocalE2ERevision=" +
 		revision + " -o " + outputBin + " ./cmd/wukongim"
 	if text := string(output); !strings.Contains(text, want) {

--- a/scripts/wukongim_three_nodes_script_test.go
+++ b/scripts/wukongim_three_nodes_script_test.go
@@ -267,6 +267,55 @@ func TestWukongIMThreeNodeScriptDryRunPrintsTaggedBuildAndIsolatedBackupStaging(
 	}
 }
 
+func TestWukongIMThreeNodeScriptDryRunPrintsLocalE2EBackupBuild(t *testing.T) {
+	root := repoRoot(t)
+	outputBin := filepath.Join(t.TempDir(), "wukongim")
+	const revision = "0123456789abcdef0123456789abcdef01234567"
+	gitDirCommand := exec.Command("git", "rev-parse", "--absolute-git-dir")
+	gitDirCommand.Dir = root
+	gitDirOutput, err := gitDirCommand.Output()
+	if err != nil {
+		t.Fatalf("resolve worktree Git directory: %v", err)
+	}
+	gitDir := strings.TrimSpace(string(gitDirOutput))
+
+	cmd := exec.Command("bash", "scripts/start-wukongim-three-nodes.sh",
+		"--dry-run",
+		"--build-tags", "e2e",
+		"--backup-e2e-revision", revision,
+		"--bin", outputBin,
+	)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dry-run failed: %v\n%s", err, output)
+	}
+	want := "build_cmd=env GIT_DIR=" + gitDir + " GIT_WORK_TREE=" + root +
+		" go build -tags=e2e -ldflags=-X=github.com/WuKongIM/WuKongIM/internal/app.backupLocalE2ERevision=" +
+		revision + " -o " + outputBin + " ./cmd/wukongim"
+	if text := string(output); !strings.Contains(text, want) {
+		t.Fatalf("dry-run output missing %q:\n%s", want, text)
+	}
+}
+
+func TestWukongIMThreeNodeScriptRejectsLocalBackupRevisionWithoutE2ETag(t *testing.T) {
+	root := repoRoot(t)
+	const revision = "0123456789abcdef0123456789abcdef01234567"
+
+	cmd := exec.Command("bash", "scripts/start-wukongim-three-nodes.sh",
+		"--dry-run",
+		"--backup-e2e-revision", revision,
+	)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("qualified backup build without e2e tag should fail:\n%s", output)
+	}
+	if text := string(output); !strings.Contains(text, "--backup-e2e-revision requires the e2e build tag") {
+		t.Fatalf("unexpected qualification error:\n%s", text)
+	}
+}
+
 func TestWukongIMThreeNodeScriptRejectsEmptyDataRoot(t *testing.T) {
 	root := repoRoot(t)
 	cmd := exec.Command("bash", "scripts/start-wukongim-three-nodes.sh", "--dry-run", "--data-root", "")


### PR DESCRIPTION
## Summary

- add a separate file-backed E2E backup build qualification without weakening production qualification
- bind local smoke builds to the selected worktree Git revision, force `GOWORK=off`, and reuse one argv definition for dry-run and execution
- size local backup startup for the 256-slot topology and accept an initial age-only degraded checkpoint only when capture is complete and there is no backup debt
- document the local qualification boundary and add runtime, script, and real-build regression coverage

## Root cause

The three-node backup smoke enabled automatic backup on an ordinary local build, while application startup correctly requires an exact clean qualified revision. The smoke build had no accepted qualification. In nested `.worktrees` checkouts, Go could also discover the enclosing main worktree and embed a different `vcs.revision` than the revision passed through `-ldflags`; inheriting the parent `go.work` could additionally resolve build packages from the main checkout.

After qualification was fixed, the smoke's initial checkpoint gate was still calibrated below the time required to initialize all 256 Hash Slots and treated an otherwise complete checkpoint as unavailable when its only degraded signal was age.

## Impact

The original local three-node `--backup` workflow can start all nodes, publish an initial file-backed checkpoint, and enter the simulation workload. Production automatic backup remains fail-closed and never accepts the local E2E qualification.

## Validation

- `GOWORK=off go test ./internal/app -count=1`
- `GOWORK=off go test -tags=e2e ./internal/app -count=1`
- `GOWORK=off go test ./scripts -count=1`
- `GOWORK=off go test -tags=integration ./scripts -run '^TestWukongIMThreeNodeLocalE2EBuildUsesSelectedWorktreeRevision$' -count=1`
- the real-build integration test supplies an invalid inherited `GOWORK` and proves the generated build command overrides it with `GOWORK=off`
- repository unit gate exercised across `./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/...`; unrelated intermittent cases passed on isolated rerun
- real smoke with `--backup --duration 1h --users 2000 --groups 2000 --members 10 --rate 4/s` reached all three nodes ready, reported the initial checkpoint available, and entered `wkcli sim` setup before the long run was intentionally stopped
