### PR TITLE
fix(agent): verify controller VCS revision

### DIFF
--- a/.github/workflows/issue-agent-control.yml
+++ b/.github/workflows/issue-agent-control.yml
@@ -78,7 +78,7 @@ jobs:
           [[ "$revision" =~ ^[0-9a-f]{40}$ ]]
           (cd control && GOWORK=off go build -trimpath -o "$RUNNER_TEMP/wkissueagent" ./cmd/wkissueagent)
           go version -m "$RUNNER_TEMP/wkissueagent" >"$RUNNER_TEMP/wkissueagent.buildinfo"
-          grep -F "vcs.revision	$revision" "$RUNNER_TEMP/wkissueagent.buildinfo"
+          grep -F "vcs.revision=$revision" "$RUNNER_TEMP/wkissueagent.buildinfo"
       - name: Plan bounded event
         id: plan
         shell: bash

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -181,6 +181,14 @@ func TestIssueAgentWorkflowRunUsesSeparateReadOnlyCheckouts(t *testing.T) {
 	require.Contains(t, raw, "pull-requests: read")
 }
 
+func TestIssueAgentControlVerifiesProtectedControllerRevision(t *testing.T) {
+	t.Parallel()
+
+	raw := string(readWorkflow(t, "issue-agent-control.yml"))
+	require.Contains(t, raw, `grep -F "vcs.revision=$revision"`)
+	require.NotContains(t, raw, `grep -F "vcs.revision\t$revision"`)
+}
+
 func TestIssueAgentControlRoutesTypedLifecycleFailuresAndMaintainerCommands(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- Match the `go version -m` VCS metadata using the actual `vcs.revision=<sha>` key/value format.
- Add a workflow contract test that rejects the previous tab-delimited matcher.

## Root cause

The Issue Agent control workflow built `wkissueagent` successfully, then searched its build metadata for `vcs.revision<TAB><sha>`. Go emits `build<TAB>vcs.revision=<sha>`, so the post-build verification always returned exit code 1 before the Shadow planner could run.

This reproduced twice in Canary Issue #667:

- https://github.com/WuKongIM/WuKongIM/actions/runs/30444859471
- https://github.com/WuKongIM/WuKongIM/actions/runs/30444859870

## Validation

- `GOWORK=off go test ./scripts -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/issue-agent-control.yml .github/workflows/issue-agent-reconcile.yml .github/workflows/issue-agent-run.yml`
- Real `GOWORK=off go build -trimpath ./cmd/wkissueagent` followed by `go version -m` and exact revision match
