### PR TITLE
chore(agent): publish checkpoint signing key

### DIFF
--- a/.github/issue-agent/checkpoint-public-keys.json
+++ b/.github/issue-agent/checkpoint-public-keys.json
@@ -1,4 +1,11 @@
 {
   "schema_version": 1,
-  "keys": []
+  "keys": [
+    {
+      "id": "checkpoint-d0b5aa688ddc48bb",
+      "public_key": "ywLBynJmfEz03D0Ngx6rIipIeMnkNDEyY2J3DQP8/ek=",
+      "not_before": "2026-07-29T12:36:24Z",
+      "not_after": "2027-07-29T12:36:24Z"
+    }
+  ]
 }

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -317,9 +317,10 @@ Promote one mode per separate PR. Before `general`, record real immutable
 Issue, PR, Workflow-run, commit, Artifact, and Gate links for: low-risk success,
 `already_fixed`, `needs_info`, budget exhaustion, duplicate/missed event
 recovery, expired result rejection, broken-chain fail-closed behavior, and one
-no-publish smoke for each enabled provider. This repository intentionally ships
-with an empty public-key set, empty remediation allowlist, and `shadow` mode;
-those pilot references do not yet exist.
+no-publish smoke for each enabled provider. This repository has its first
+checkpoint public-key epoch configured while the remediation allowlist remains
+empty and rollout remains in `shadow` mode; those pilot references do not yet
+exist.
 
 Worker Artifacts retain bounded sanitized evidence for 90 days. The permanent
 audit record is the signed Issue chain, frozen regression, verified Git commit,

--- a/internal/infra/issueagentgithub/checkpoint_store_test.go
+++ b/internal/infra/issueagentgithub/checkpoint_store_test.go
@@ -24,9 +24,15 @@ func TestCheckpointPublicKeyFileIsStrictAndContainsConfiguredEpoch(t *testing.T)
 	keySet, err := issueagentgithub.DecodeKeySet(file, 64<<10)
 	require.NoError(t, err)
 	require.Equal(t, 1, keySet.SchemaVersion)
-	require.Len(t, keySet.Keys, 1)
-	key := keySet.Keys[0]
-	require.Equal(t, "checkpoint-d0b5aa688ddc48bb", key.ID)
+	require.NotEmpty(t, keySet.Keys)
+	var key *issueagentgithub.PublicKey
+	for index := range keySet.Keys {
+		if keySet.Keys[index].ID == "checkpoint-d0b5aa688ddc48bb" {
+			key = &keySet.Keys[index]
+			break
+		}
+	}
+	require.NotNil(t, key)
 	require.Equal(
 		t,
 		"ywLBynJmfEz03D0Ngx6rIipIeMnkNDEyY2J3DQP8/ek=",

--- a/internal/infra/issueagentgithub/checkpoint_store_test.go
+++ b/internal/infra/issueagentgithub/checkpoint_store_test.go
@@ -3,6 +3,7 @@ package issueagentgithub_test
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"os"
 	"strings"
 	"testing"
@@ -13,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckpointPublicKeyFileIsStrictAndSafeWhileDisabled(t *testing.T) {
+func TestCheckpointPublicKeyFileIsStrictAndContainsConfiguredEpoch(t *testing.T) {
 	t.Parallel()
 
 	file, err := os.Open("../../../.github/issue-agent/checkpoint-public-keys.json")
@@ -23,7 +24,16 @@ func TestCheckpointPublicKeyFileIsStrictAndSafeWhileDisabled(t *testing.T) {
 	keySet, err := issueagentgithub.DecodeKeySet(file, 64<<10)
 	require.NoError(t, err)
 	require.Equal(t, 1, keySet.SchemaVersion)
-	require.Empty(t, keySet.Keys)
+	require.Len(t, keySet.Keys, 1)
+	key := keySet.Keys[0]
+	require.Equal(t, "checkpoint-d0b5aa688ddc48bb", key.ID)
+	require.Equal(
+		t,
+		"ywLBynJmfEz03D0Ngx6rIipIeMnkNDEyY2J3DQP8/ek=",
+		base64.StdEncoding.EncodeToString(key.PublicKey),
+	)
+	require.Equal(t, time.Date(2026, 7, 29, 12, 36, 24, 0, time.UTC), key.NotBefore)
+	require.Equal(t, time.Date(2027, 7, 29, 12, 36, 24, 0, time.UTC), key.NotAfter)
 }
 
 func TestCheckpointStoreVerifiesAppendOnlySignedChain(t *testing.T) {


### PR DESCRIPTION
## Summary

- publish the first Issue Agent checkpoint verification key
- assert the configured key ID, public key, and validity window while allowing overlapping rotation epochs
- update the Issue Agent runbook from the pre-deployment empty-key state
- keep the corresponding private key only in the protected `issue-agent-publisher` environment

## Why

The Issue Agent cannot persist verifiable, append-only state until the public verification key is merged into the default branch. This is the prerequisite for promoting rollout from `shadow` to `intake`.

## Validation

- `GOWORK=off go test ./internal/usecase/issueagent ./internal/infra/issueagentgithub ./scripts -count=1`
- `GOWORK=off go test ./internal/access/issueagentcli ./cmd/wkissueagent -count=1`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' .github/ISSUE_TEMPLATE/bug.yml`
- `git diff --check`
- local cryptographic check that the protected private key derives the configured public key and key ID

## Review

- Standards: no hard violations; the rotation-maintenance smell found during review was removed
- Spec: corrected the stale runbook state; no scope creep

## Security

No private key material is committed. The signing key remains in the protected Publisher environment.
