### PR TITLE
fix(backup): use runner clock for job deadlines

### DIFF
--- a/internal/usecase/backup/job_runner.go
+++ b/internal/usecase/backup/job_runner.go
@@ -390,8 +390,9 @@ func (r *JobRunner) runBatch(
 	job backupcontract.BackupJob,
 	claims []claimedSlot,
 ) error {
-	runContext, cancel := context.WithDeadline(
-		ctx, time.UnixMilli(job.DeadlineUnixMillis),
+	remaining := time.UnixMilli(job.DeadlineUnixMillis).Sub(r.now().UTC())
+	runContext, cancel := context.WithTimeout(
+		ctx, remaining,
 	)
 	defer cancel()
 	outcomes := make([]slotOutcome, len(claims))


### PR DESCRIPTION
## Summary

- derive the Slot batch timeout from the JobRunner injected clock
- keep fake-clock unit jobs independent of the host wall clock
- unblock the required `go-fast` unit shard without mixing backup code into Issue Agent PR #670

This is the minimal extraction of the final deadline fix already present in Draft PR #671. That branch can drop the duplicate patch when it rebases.

## Verification

- before fix: both affected tests fail with `context deadline exceeded`
- `GOWORK=off go test ./internal/usecase/backup -run 'TestJobRunner(ExportsEveryHashSlotThenPublishesAndFinishes|HonorsWorkersPerNodeAcrossDataNodes)$' -count=20`\n- `GOWORK=off go test ./internal/usecase/backup -count=1`\n- `gofmt -d internal/usecase/backup/job_runner.go`\n- `git diff --check`