### PR TITLE
chore(agent): promote rollout to intake

### DIFF
--- a/.github/issue-agent/policy.json
+++ b/.github/issue-agent/policy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "enabled": true,
-  "rollout_mode": "shadow",
+  "rollout_mode": "intake",
   "default_provider": "codex",
   "sandbox_image": "golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58",
   "issue_budget": {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,8 +31,8 @@ for discovery and may become more specific over time.
 
 ## GitHub Issue Agent rollout
 
-The checked-in Issue Agent policy currently runs in `shadow` mode.
-When policy is promoted to `intake`, the trusted control planner admits only
+The checked-in Issue Agent policy currently runs in `intake` mode.
+In `intake`, the trusted control planner admits only
 deterministic `intake` and fresh `authorize` operations; every command,
 reconciliation, PR, Review, validation-result, merge, and recovery hint becomes
 `report_only` before any signed-state Publisher is selected.
@@ -50,10 +50,11 @@ Every job builds `cmd/wkissueagent` from protected `main` control source or
 checks its embedded revision. Target source uses a distinct exact-SHA checkout
 with persisted Git credentials disabled.
 
-In `shadow`, no Publisher or model job is eligible, so no App, checkpoint, or
-provider secret is consumed and no GitHub object is mutated. The scheduled scan
-reads at most one page below 100 records; saturation or any invalid signed
-chain blocks admission rather than assuming capacity.
+In `intake`, no model job is eligible, so no provider secret or model quota is
+consumed. Publisher access to the App and checkpoint key is limited to
+deterministic intake and fresh authorization writes. The scheduled scan reads
+at most one page below 100 records; saturation or any invalid signed chain
+blocks admission rather than assuming capacity.
 
 Write-capable modes retain three credential boundaries:
 

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -6,10 +6,10 @@ there is no control-plane server, self-hosted runner, external workflow
 database, or persistent Worker disk.
 
 The checked-in policy is intentionally `intake`. It permits only deterministic
-classification, a bounded request for missing information, and maintainer-
-triggered signed authorization; it does not run a model or create a branch or
-pull request. An administrator must promote each higher rollout stage in a
-separate protected-path change.
+classification, a bounded request for missing information, and
+maintainer-triggered signed authorization; it does not run a model or create a
+branch or pull request. An administrator must promote each higher rollout stage
+in a separate protected-path change.
 
 ## User intake
 

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -5,9 +5,11 @@ human-reviewed pull request. It runs entirely on GitHub-hosted Actions runners:
 there is no control-plane server, self-hosted runner, external workflow
 database, or persistent Worker disk.
 
-The checked-in policy is intentionally `shadow`. Merging the implementation
-does not enable writes or spend model quota; an administrator must complete the
-setup and promote each rollout stage in a separate protected-path change.
+The checked-in policy is intentionally `intake`. It permits only deterministic
+classification, a bounded request for missing information, and maintainer-
+triggered signed authorization; it does not run a model or create a branch or
+pull request. An administrator must promote each higher rollout stage in a
+separate protected-path change.
 
 ## User intake
 
@@ -319,8 +321,8 @@ Issue, PR, Workflow-run, commit, Artifact, and Gate links for: low-risk success,
 recovery, expired result rejection, broken-chain fail-closed behavior, and one
 no-publish smoke for each enabled provider. This repository has its first
 checkpoint public-key epoch configured while the remediation allowlist remains
-empty and rollout remains in `shadow` mode; those pilot references do not yet
-exist.
+empty and rollout remains in `intake` mode; higher-stage pilot references do
+not yet exist.
 
 Worker Artifacts retain bounded sanitized evidence for 90 days. The permanent
 audit record is the signed Issue chain, frozen regression, verified Git commit,

--- a/internal/usecase/issueagent/policy_test.go
+++ b/internal/usecase/issueagent/policy_test.go
@@ -23,7 +23,7 @@ func TestDecodePolicyLocksApprovedSafetyDefaults(t *testing.T) {
 
 	policy, err := issueagentusecase.DecodePolicy(file, 64<<10)
 	require.NoError(t, err)
-	require.Equal(t, issueagentusecase.RolloutShadow, policy.RolloutMode)
+	require.Equal(t, issueagentusecase.RolloutIntake, policy.RolloutMode)
 	require.True(t, policy.Enabled)
 	require.Contains(t, policy.SandboxImage, "@sha256:")
 	require.Equal(t, 3, policy.IssueBudget.MaxReproductionAttempts)


### PR DESCRIPTION
## Summary

- promote the reviewed Issue Agent capability ceiling from `shadow` to `intake`
- lock the checked-in policy test to `RolloutIntake`
- update rollout documentation to describe the exact live boundary

This is intentionally separate from capability code in PR #670. In `intake`, the trusted controller may only publish deterministic missing-chain intake or a fresh maintainer authorization checkpoint. It cannot run a model Worker, pin a version, create a branch, or open a PR.

## Verification

- `GOWORK=off go test ./internal/usecase/issueagent ./internal/app ./scripts -count=1`
- policy asserts `enabled=true` and `rollout_mode=intake`
- Issue Agent control Workflow parses as YAML
- `git diff --check origin/main...HEAD`

## Rollback

A protected-path policy-only PR can return `rollout_mode` to `shadow`; signed checkpoints remain append-only and verifiable.