### PR TITLE
fix(agent): route native GitHub events

### DIFF
--- a/.github/workflows/issue-agent-control.yml
+++ b/.github/workflows/issue-agent-control.yml
@@ -91,7 +91,7 @@ jobs:
           set -euo pipefail
           rollout="$(jq -er '.rollout_mode' control/.github/issue-agent/policy.json)"
           enabled="$(jq -er '.enabled' control/.github/issue-agent/policy.json)"
-          event_name="$(jq -r '.event_name' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+          event_name="$(jq -r '.event_name // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
           if [[ -z "$event_name" ]]; then
             event_name="$GITHUB_EVENT_NAME"
           fi

--- a/.github/workflows/issue-agent-control.yml
+++ b/.github/workflows/issue-agent-control.yml
@@ -91,10 +91,7 @@ jobs:
           set -euo pipefail
           rollout="$(jq -er '.rollout_mode' control/.github/issue-agent/policy.json)"
           enabled="$(jq -er '.enabled' control/.github/issue-agent/policy.json)"
-          event_name="$(jq -r '.event_name // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
-          if [[ -z "$event_name" ]]; then
-            event_name="$GITHUB_EVENT_NAME"
-          fi
+          event_name="$GITHUB_EVENT_NAME"
           action="$(jq -r '.action // ""' "$GITHUB_EVENT_PATH")"
           issue_number=""
           comment_id=""

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -205,21 +205,15 @@ func TestIssueAgentControlIntakeRolloutAdmitsOnlyIntakeAndAuthorization(
        needs.planner.outputs.operation == 'authorize'`)
 }
 
-func TestIssueAgentControlFallsBackToGitHubEventNameWhenPayloadHasNoOverride(
+func TestIssueAgentControlUsesTrustedGitHubEventName(
 	t *testing.T,
 ) {
 	t.Parallel()
 
 	raw := string(readWorkflow(t, "issue-agent-control.yml"))
-	require.Contains(t, raw,
-		`event_name="$(jq -r '.event_name // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"`,
-	)
-	require.Contains(t, raw, `if [[ -z "$event_name" ]]; then
-            event_name="$GITHUB_EVENT_NAME"
-          fi`)
-	require.NotContains(t, raw,
-		`event_name="$(jq -r '.event_name' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"`,
-	)
+	require.Contains(t, raw, `event_name="$GITHUB_EVENT_NAME"`)
+	require.NotContains(t, raw, `jq -r '.event_name`)
+	require.NotContains(t, raw, `if [[ -z "$event_name" ]]`)
 }
 
 func TestIssueAgentControlRoutesTypedLifecycleFailuresAndMaintainerCommands(t *testing.T) {

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -205,6 +205,23 @@ func TestIssueAgentControlIntakeRolloutAdmitsOnlyIntakeAndAuthorization(
        needs.planner.outputs.operation == 'authorize'`)
 }
 
+func TestIssueAgentControlFallsBackToGitHubEventNameWhenPayloadHasNoOverride(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	raw := string(readWorkflow(t, "issue-agent-control.yml"))
+	require.Contains(t, raw,
+		`event_name="$(jq -r '.event_name // ""' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"`,
+	)
+	require.Contains(t, raw, `if [[ -z "$event_name" ]]; then
+            event_name="$GITHUB_EVENT_NAME"
+          fi`)
+	require.NotContains(t, raw,
+		`event_name="$(jq -r '.event_name' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"`,
+	)
+}
+
 func TestIssueAgentControlRoutesTypedLifecycleFailuresAndMaintainerCommands(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- route native events from the trusted Actions `$GITHUB_EVENT_NAME` environment value
- remove the ineffective payload override/fallback path that converted a missing field into the literal string `null`
- lock the trusted source and reject future payload-based event-name parsing with a static Workflow contract test

## Canary evidence

Intake canary Issue #674 produced native `issues` runs `30459571044` and `30459572822`. Both planners succeeded but skipped both Publishers. A normal GitHub webhook has no top-level `event_name`; `jq -r '.event_name'` returns `null`, so the planner case statement never matched and retained `report_only`.\n\nThe canary remains open and has not been authorized. After this fix passes and merges, a non-authorization label event will rerun deterministic Intake, followed by a maintainer `ready-for-agent` event to verify the signed checkpoint.\n\n## Verification\n\n- regression contract failed before the Workflow fix and passed after it\n- `GOWORK=off go test ./scripts -count=1`\n- control Workflow parses as YAML\n- `git diff --check`\n\n## Safety\n\nNo permissions, Secrets, environments, checked-in rollout mode, or write-capability allowlist changes. Intake remains capped to `intake|authorize` by the independent planner and publisher gates from #670.