### PR TITLE
fix(agent): accept scoped app token response

### DIFF
--- a/internal/infra/issueagentgithub/FLOW.md
+++ b/internal/infra/issueagentgithub/FLOW.md
@@ -23,6 +23,12 @@ Publisher Environment Secret
   -> signed append-only checkpoint and deterministic Issue/PR projections
 ```
 
+Installation-token responses remain strict at the top level. GitHub returns a
+complete repository object for each selected repository, so the adapter treats
+that bounded metadata as opaque except for `id` and `full_name`. It still
+requires `repository_selection=selected`, one exact repository, the reviewed
+permission set, and a bounded future expiry before accepting the token.
+
 The adapter never executes target code, Worker files, Artifact executables, or
 model-authored shell. Every write names one exact repository, Issue, generation,
 sequence, predecessor, Agent branch, and expected old ref. Default branches,
@@ -56,8 +62,8 @@ tracking Issues are projections of already-validated state. No method can
 merge a PR, close a Bug Issue, or write a default branch or tag. No method can
 force-update a ref except the typed mechanical-rebase transaction above, which
 must atomically match both managed refs by exact `beforeOid`. A saturated
-inventory, paginated history, unknown response shape, corrupt checkpoint,
-stale lease, or object mismatch fails closed.
+inventory, paginated history, unknown security-relevant response shape, corrupt
+checkpoint, stale lease, or object mismatch fails closed.
 Completed Worker-run inventory is filtered to the signed lease time window and
 bounded to GitHub's documented 1,000-result search ceiling. Reconciliation
 accepts only a unique exact display-title and Artifact-name match, then the

--- a/internal/infra/issueagentgithub/app_token.go
+++ b/internal/infra/issueagentgithub/app_token.go
@@ -163,27 +163,33 @@ func (minter *AppTokenMinter) Mint(ctx context.Context) (InstallationToken, erro
 		return InstallationToken{}, errors.New("GitHub App token response has unexpected content type")
 	}
 	var payload struct {
-		Token        string            `json:"token"`
-		ExpiresAt    time.Time         `json:"expires_at"`
-		Permissions  map[string]string `json:"permissions"`
-		Repositories []struct {
-			ID       int64  `json:"id"`
-			FullName string `json:"full_name"`
-		} `json:"repositories"`
+		Token               string            `json:"token"`
+		ExpiresAt           time.Time         `json:"expires_at"`
+		Permissions         map[string]string `json:"permissions"`
+		RepositorySelection string            `json:"repository_selection"`
+		Repositories        []json.RawMessage `json:"repositories"`
 	}
 	decoder := json.NewDecoder(io.LimitReader(response.Body, 64<<10))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&payload); err != nil {
 		return InstallationToken{}, errors.New("decode GitHub App token response")
 	}
+	var repository struct {
+		ID       int64  `json:"id"`
+		FullName string `json:"full_name"`
+	}
+	if len(payload.Repositories) != 1 ||
+		json.Unmarshal(payload.Repositories[0], &repository) != nil {
+		return InstallationToken{}, errors.New("GitHub App token response scope is invalid")
+	}
 	if payload.Token == "" ||
 		len(payload.Token) > 4096 ||
 		!payload.ExpiresAt.After(now) ||
 		payload.ExpiresAt.After(now.Add(65*time.Minute)) ||
 		!samePermissions(payload.Permissions, issueAgentAppPermissions) ||
-		len(payload.Repositories) != 1 ||
-		payload.Repositories[0].ID != minter.config.RepositoryID ||
-		payload.Repositories[0].FullName != minter.config.Repository {
+		payload.RepositorySelection != "selected" ||
+		repository.ID != minter.config.RepositoryID ||
+		repository.FullName != minter.config.Repository {
 		return InstallationToken{}, errors.New("GitHub App token response scope is invalid")
 	}
 	return InstallationToken{

--- a/internal/infra/issueagentgithub/app_token_test.go
+++ b/internal/infra/issueagentgithub/app_token_test.go
@@ -27,6 +27,7 @@ func TestAppTokenMinterRequestsExactRepositoryAndPermissions(t *testing.T) {
 	const appID int64 = 1234
 	const installationID int64 = 5678
 	const repositoryID int64 = 9012
+	repositorySelection := "selected"
 
 	server := httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
@@ -70,11 +71,13 @@ func TestAppTokenMinterRequestsExactRepositoryAndPermissions(t *testing.T) {
 
 		writer.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
-			"token":       "installation-secret-token",
-			"expires_at":  now.Add(55 * time.Minute).Format(time.RFC3339),
-			"permissions": body.Permissions,
+			"token":                "installation-secret-token",
+			"expires_at":           now.Add(55 * time.Minute).Format(time.RFC3339),
+			"permissions":          body.Permissions,
+			"repository_selection": repositorySelection,
 			"repositories": []map[string]any{{
 				"id": repositoryID, "full_name": "WuKongIM/WuKongIM",
+				"private": false,
 			}},
 		}))
 	}))
@@ -102,6 +105,10 @@ func TestAppTokenMinterRequestsExactRepositoryAndPermissions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "installation-secret-token", token.Token)
 	require.Equal(t, now.Add(55*time.Minute), token.ExpiresAt)
+
+	repositorySelection = "all"
+	_, err = minter.Mint(context.Background())
+	require.Error(t, err)
 }
 
 func TestAppTokenMinterRedactsSecretsFromErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

- accept GitHub installation-token responses that include the documented `repository_selection` field
- keep the top-level response strict while treating full repository metadata as opaque except for exact `id` and `full_name`
- require `repository_selection=selected`, one exact repository, the reviewed permission set, and bounded expiry

## Production evidence

The Intake canary in #674 reached the deterministic publisher but failed while minting its App token. The same App key and exact App/Installation/repository scope succeeded against GitHub directly. GitHub returned `repository_selection` and a full repository object, which the previous strict nested DTO rejected.

## Validation

- regression fixture failed before the fix with `decode GitHub App token response`
- `GOWORK=off go test ./internal/infra/issueagentgithub ./cmd/wkissueagent -count=1`
- real `wkissueagent mint-app-token` succeeded against the installed App; only the expiry was printed
- `git diff --check`

After merge, #674 will rerun the same Intake path before authorization.