### PR TITLE
fix(agent): stabilize intake result contract

### DIFF
--- a/internal/app/issue_agent.go
+++ b/internal/app/issue_agent.go
@@ -122,6 +122,10 @@ type publishIntakePayload struct {
 	PossibleDuplicates []string `json:"possible_duplicates"`
 }
 
+type publishIntakeResult struct {
+	Complete bool `json:"complete"`
+}
+
 type publishAuthorizationPayload struct {
 	BaseURL      string                  `json:"base_url"`
 	Repository   string                  `json:"repository"`
@@ -3996,7 +4000,7 @@ func publishIntake(
 	if err := client.SetIssueLabels(ctx, payload.IssueNumber, labels); err != nil {
 		return nil, err
 	}
-	return plan, nil
+	return publishIntakeResult{Complete: plan.Complete}, nil
 }
 
 func publishAuthorization(

--- a/internal/app/issue_agent_github_test.go
+++ b/internal/app/issue_agent_github_test.go
@@ -62,6 +62,9 @@ func TestPublisherPerformsDeterministicIntakeWithoutModelOrExecution(t *testing.
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"complete":true}`, string(encoded))
 }
 
 func TestPublisherCreatesFirstSignedCheckpointOnlyForFreshMaintainerLabel(t *testing.T) {


### PR DESCRIPTION
## Summary

- return a narrow, stable `{"complete": boolean}` projection from deterministic Intake publication
- stop exposing the untagged internal `IntakePlan` as an accidental CLI JSON contract
- assert the exact serialized result in the App integration test

## Production evidence

After #677 fixed App token minting, canary #674 successfully minted its repository-scoped token and completed the Intake API reads/write. The Workflow then failed only on `jq -e .complete` because Go serialized the internal plan as `Complete`.

## Validation

- the new JSON contract assertion failed before the fix and showed the uppercase internal fields
- `GOWORK=off go test ./internal/app ./cmd/wkissueagent -count=1`
- real installed-App `publish-intake` succeeded against #674 and returned exactly `{"complete":true}`
- `git diff --check`

No App permissions, Secrets, Workflow permissions, labels, comments, signed state, or Worker capability change.