### PR TITLE
ci(agent): route Codex through OpenRouter

### DIFF
--- a/.github/issue-agent/policy.json
+++ b/.github/issue-agent/policy.json
@@ -51,7 +51,7 @@
       "provider": "codex",
       "endpoint": "",
       "model_variable": "ISSUE_AGENT_CODEX_MODEL",
-      "credential_variable": "CODEX_API_KEY"
+      "credential_variable": "OPENROUTER_API_KEY"
     },
     {
       "provider": "deepseek",

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,22 +58,24 @@ blocks admission rather than assuming capacity.
 
 Write-capable modes retain three credential boundaries:
 
-- `issue-agent-codex` exposes `CODEX_API_KEY` only to the pinned official
-  Codex Action bootstrap;
+- `issue-agent-codex` exposes `OPENROUTER_API_KEY` only to the pinned official
+  Codex Action bootstrap, which sends Responses requests only to the fixed
+  OpenRouter endpoint;
 - `issue-agent-deepseek` exposes only `DEEPSEEK_API_KEY` to the selected
   DeepSeek Supervisor;
 - `issue-agent-publisher` exposes repository-scoped App and checkpoint signing
   material only to Publisher/dispatcher jobs that never execute target code.
 
 The Codex Action is pinned by full commit SHA and runs without a prompt. It
-installs the pinned CLI and matching Responses proxy, writes one otherwise
-empty bootstrap home, accepts only the exact `wukongim-issue-agent` App bot in
-addition to normal write-authorized actors, and irreversibly drops `sudo`
-before the repository-owned Worker starts. The immediately preceding step
-fails if that bootstrap-home path already exists or is a dangling symlink.
-Checkout, build, dependency prefetch, reproduction binaries, and digest-pinned
-Docker image pull must therefore complete before the Action. `wkissueagent`
-receives only
+installs the pinned CLI and matching Responses proxy, sends upstream requests
+only to the fixed `https://openrouter.ai/api/v1/responses` endpoint, writes one
+otherwise empty bootstrap home, accepts only the exact
+`wukongim-issue-agent` App bot in addition to normal write-authorized actors,
+and irreversibly drops `sudo` before the repository-owned Worker starts. The
+immediately preceding step fails if that bootstrap-home path already exists or
+is a dangling symlink. Checkout, build, dependency prefetch, reproduction
+binaries, and digest-pinned Docker image pull must therefore complete before
+the Action. `wkissueagent` receives only
 `ISSUE_AGENT_CODEX_BOOTSTRAP_HOME`; it strictly accepts the Action's
 `127.0.0.1` Responses provider and creates a new empty Codex home for every
 round. The API key must not appear in Worker arguments, environment dumps,

--- a/.github/workflows/issue-agent-run.yml
+++ b/.github/workflows/issue-agent-run.yml
@@ -198,7 +198,8 @@ jobs:
       - name: Bootstrap the pinned Codex CLI and Responses proxy
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
-          openai-api-key: ${{ secrets.CODEX_API_KEY }}
+          openai-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          responses-api-endpoint: https://openrouter.ai/api/v1/responses
           codex-version: 0.145.0
           codex-home: ${{ runner.temp }}/issue-agent-codex-bootstrap
           safety-strategy: drop-sudo

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -101,16 +101,18 @@ removed when the Worker exits.
 For Codex, the pinned official `openai/codex-action` runs after checkout,
 build, dependency prefetch, reproduction-binary build, and Docker image pull.
 It receives no prompt: it installs Codex and the matching Responses proxy,
-allows only normally write-authorized actors or the exact
-`wukongim-issue-agent` App bot, writes an otherwise empty bootstrap home, and
-then drops `sudo` for the remainder of the job. The Workflow first rejects an
-existing bootstrap-home path or dangling symlink, so the Action cannot merge
-stale runner configuration. `wkissueagent` receives only
+sends upstream requests only to the fixed
+`https://openrouter.ai/api/v1/responses` endpoint, allows only normally
+write-authorized actors or the exact `wukongim-issue-agent` App bot, writes an
+otherwise empty bootstrap home, and then drops `sudo` for the remainder of the
+job. The Workflow first rejects an existing bootstrap-home path or dangling
+symlink, so the Action cannot merge stale runner configuration. `wkissueagent`
+receives only
 `ISSUE_AGENT_CODEX_BOOTSTRAP_HOME`; it rejects anything except the exact
 Action-generated `http://127.0.0.1:<port>/v1` Responses provider and converts
 that endpoint to canonical overrides in a fresh empty Codex home for each
-round. Codex subprocesses never receive `CODEX_API_KEY`, user/project config,
-native tools, or GitHub credentials.
+round. Codex subprocesses never receive `OPENROUTER_API_KEY`, user/project
+config, native tools, or GitHub credentials.
 
 The model may return only a semantic proposal. The trusted Worker derives the
 complete file set, command transcript digests, diagnosis evidence digest, and
@@ -287,14 +289,16 @@ branch.
 4. Store `ISSUE_AGENT_APP_PRIVATE_KEY` and
    `ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY` only in
    `issue-agent-publisher`.
-5. Store `CODEX_API_KEY` only in `issue-agent-codex`; the official Action is
-   its only consumer and the bounded Worker receives only the generated
+5. Store `OPENROUTER_API_KEY` only in `issue-agent-codex`; the official Action
+   is its only consumer and the bounded Worker receives only the generated
    bootstrap-home path. Store `DEEPSEEK_API_KEY` only in
    `issue-agent-deepseek`. Configure independent provider spend limits.
 6. Add repository variables:
    `ISSUE_AGENT_APP_ID`, `ISSUE_AGENT_INSTALLATION_ID`,
    `ISSUE_AGENT_APP_LOGIN`, `ISSUE_AGENT_CHECKPOINT_KEY_ID`,
-   `ISSUE_AGENT_CODEX_MODEL`, and `ISSUE_AGENT_DEEPSEEK_MODEL`.
+   `ISSUE_AGENT_CODEX_MODEL`, and `ISSUE_AGENT_DEEPSEEK_MODEL`. Set
+   `ISSUE_AGENT_CODEX_MODEL` to an exact OpenRouter model slug such as
+   `openai/gpt-5.6-sol`.
 7. Create or verify `needs-triage`, `needs-info`, `ready-for-agent`,
    `agent-priority/high`, and the Agent PR validation labels documented in
    `.github/workflows/README.md`.

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -1,6 +1,7 @@
 package scripts_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -91,12 +92,14 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 					require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
 				}
 				require.NotContains(t, jobText, "CODEX_API_KEY")
+				require.NotContains(t, jobText, "OPENROUTER_API_KEY")
 				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
 			case name == "issue-agent-reconcile.yml" && jobName == "dispatcher":
 				require.Equal(t, "issue-agent-publisher", job.Environment)
 				require.Contains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
 				require.NotContains(t, jobText, "CODEX_API_KEY")
+				require.NotContains(t, jobText, "OPENROUTER_API_KEY")
 				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
 			case name == "issue-agent-run.yml" && jobName == "publisher":
 				require.Equal(t, "issue-agent-publisher", job.Environment)
@@ -111,10 +114,12 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 				require.Contains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
 				require.Contains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
 				require.NotContains(t, jobText, "CODEX_API_KEY")
+				require.NotContains(t, jobText, "OPENROUTER_API_KEY")
 				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
 			case name == "issue-agent-run.yml" && jobName == "codex-worker":
 				require.Equal(t, "issue-agent-codex", job.Environment)
-				require.Contains(t, jobText, "CODEX_API_KEY")
+				require.Contains(t, jobText, "OPENROUTER_API_KEY")
+				require.NotContains(t, jobText, "CODEX_API_KEY")
 				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
@@ -122,6 +127,7 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 				require.Equal(t, "issue-agent-deepseek", job.Environment)
 				require.Contains(t, jobText, "DEEPSEEK_API_KEY")
 				require.NotContains(t, jobText, "CODEX_API_KEY")
+				require.NotContains(t, jobText, "OPENROUTER_API_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
 			default:
@@ -129,6 +135,7 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 				require.NotContains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
 				require.NotContains(t, jobText, "CODEX_API_KEY")
+				require.NotContains(t, jobText, "OPENROUTER_API_KEY")
 				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
 			}
 			for _, step := range job.Steps {
@@ -210,15 +217,19 @@ func TestIssueAgentCodexWorkerUsesOfficialBootstrap(t *testing.T) {
 	require.Equal(t, bootstrapIndex+1, workerIndex)
 	require.Contains(t, verify.Run,
 		`[[ -e "$bootstrap_home" || -L "$bootstrap_home" ]]`)
-	require.Equal(t, 1, strings.Count(string(raw), "secrets.CODEX_API_KEY"))
+	require.Equal(t, 1,
+		strings.Count(string(raw), "secrets.OPENROUTER_API_KEY"))
+	require.NotContains(t, string(raw), "secrets.CODEX_API_KEY")
 	require.NotContains(t, worker.Env, "ISSUE_AGENT_CODEX_API_KEY")
 	require.NotContains(t, worker.Env, "CODEX_API_KEY")
+	require.NotContains(t, worker.Env, "OPENROUTER_API_KEY")
 	require.Equal(t,
 		"${{ runner.temp }}/issue-agent-codex-bootstrap",
 		worker.Env["ISSUE_AGENT_CODEX_BOOTSTRAP_HOME"],
 	)
 	require.NotContains(t, worker.Run, "CODEX_API_KEY")
 	require.NotContains(t, worker.Run, "ISSUE_AGENT_CODEX_API_KEY")
+	require.NotContains(t, worker.Run, "OPENROUTER_API_KEY")
 }
 
 func TestIssueAgentCodexBootstrapContractRejectsMutations(t *testing.T) {
@@ -236,6 +247,16 @@ func TestIssueAgentCodexBootstrapContractRejectsMutations(t *testing.T) {
 		},
 		"prompt": func(step *ciStep) {
 			step.With["prompt"] = "inspect the repository"
+		},
+		"missing OpenRouter endpoint": func(step *ciStep) {
+			delete(step.With, "responses-api-endpoint")
+		},
+		"alternate Responses endpoint": func(step *ciStep) {
+			step.With["responses-api-endpoint"] =
+				"https://example.com/v1/responses"
+		},
+		"legacy API key": func(step *ciStep) {
+			step.With["openai-api-key"] = "${{ secrets.CODEX_API_KEY }}"
 		},
 		"extra bot": func(step *ciStep) {
 			step.With["allow-bot-users"] =
@@ -264,8 +285,37 @@ func TestIssueAgentCodexWorkerBoundaryRejectsOrderAndKeyMutations(t *testing.T) 
 	})
 	t.Run("forward API key", func(t *testing.T) {
 		job := canonicalCodexWorkerBoundary()
-		job.Steps[3].Env["CODEX_API_KEY"] = "${{ secrets.CODEX_API_KEY }}"
+		job.Steps[3].Env["OPENROUTER_API_KEY"] =
+			"${{ secrets.OPENROUTER_API_KEY }}"
 		require.Error(t, validateCodexWorkerBoundary(job))
+	})
+}
+
+func TestIssueAgentCodexProviderPolicyUsesOpenRouterCredential(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Join(
+		repoRoot(t), ".github", "issue-agent", "policy.json",
+	))
+	require.NoError(t, err)
+	var policy struct {
+		Providers []struct {
+			Provider           string `json:"provider"`
+			Endpoint           string `json:"endpoint"`
+			ModelVariable      string `json:"model_variable"`
+			CredentialVariable string `json:"credential_variable"`
+		} `json:"providers"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &policy))
+	require.Contains(t, policy.Providers, struct {
+		Provider           string `json:"provider"`
+		Endpoint           string `json:"endpoint"`
+		ModelVariable      string `json:"model_variable"`
+		CredentialVariable string `json:"credential_variable"`
+	}{
+		Provider:           "codex",
+		ModelVariable:      "ISSUE_AGENT_CODEX_MODEL",
+		CredentialVariable: "OPENROUTER_API_KEY",
 	})
 }
 
@@ -378,11 +428,12 @@ func canonicalCodexBootstrapStep() ciStep {
 		Uses: "openai/codex-action@" +
 			"52fe01ec70a42f454c9d2ebd47598f9fd6893d56",
 		With: map[string]any{
-			"openai-api-key":  "${{ secrets.CODEX_API_KEY }}",
-			"codex-version":   "0.145.0",
-			"codex-home":      "${{ runner.temp }}/issue-agent-codex-bootstrap",
-			"safety-strategy": "drop-sudo",
-			"allow-bot-users": "wukongim-issue-agent",
+			"openai-api-key":         "${{ secrets.OPENROUTER_API_KEY }}",
+			"responses-api-endpoint": "https://openrouter.ai/api/v1/responses",
+			"codex-version":          "0.145.0",
+			"codex-home":             "${{ runner.temp }}/issue-agent-codex-bootstrap",
+			"safety-strategy":        "drop-sudo",
+			"allow-bot-users":        "wukongim-issue-agent",
 		},
 	}
 }
@@ -440,8 +491,10 @@ func validateCodexWorkerBoundary(job ciJob) error {
 		worker.Env["ISSUE_AGENT_CODEX_BOOTSTRAP_HOME"] !=
 			"${{ runner.temp }}/issue-agent-codex-bootstrap" ||
 		worker.Env["CODEX_API_KEY"] != "" ||
+		worker.Env["OPENROUTER_API_KEY"] != "" ||
 		worker.Env["ISSUE_AGENT_CODEX_API_KEY"] != "" ||
-		strings.Contains(worker.Run, "CODEX_API_KEY") {
+		strings.Contains(worker.Run, "CODEX_API_KEY") ||
+		strings.Contains(worker.Run, "OPENROUTER_API_KEY") {
 		return fmt.Errorf("Codex Worker boundary is not exact")
 	}
 	return nil


### PR DESCRIPTION
## What changed

- routes the pinned official Codex Action's Responses proxy to the fixed OpenRouter endpoint
- replaces the Codex Environment credential contract with `OPENROUTER_API_KEY`
- keeps the key out of `wkissueagent`, Codex subprocesses, Docker, prompts, logs, and Artifacts
- documents the exact OpenRouter model slug requirement
- adds exact Workflow and policy contract tests for endpoint and secret-boundary regressions

## Why

The Issue Agent must use the user's OpenRouter account because no OpenAI API
key is available, while preserving the existing serverless and
credential-separated design.

Rollout remains `intake`; this PR does not start model work or widen Issue
Agent capability.

## Validation

- focused red/green Workflow contract tests
- full Issue Agent package suite
- YAML/JSON parsing
- actionlint v1.7.9
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`

## Review

Two-axis review found no hard standards violations, no scope creep, and no
incorrect implementation. The live `ISSUE_AGENT_CODEX_MODEL` repository
variable must be updated to `openai/gpt-5.6-sol` after merge and before the
canary.
