### PR TITLE
fix(issue-agent): preserve Codex Action runtime path

### DIFF
--- a/internal/infra/issueagentmodel/FLOW.md
+++ b/internal/infra/issueagentmodel/FLOW.md
@@ -28,8 +28,10 @@ The Codex Adapter accepts only the Action's exact
 `http://127.0.0.1:<port>/v1` Responses provider from a regular bootstrap config
 that is not group- or world-writable. It rejects every extra setting, then
 passes canonical provider overrides to one ephemeral, user-config-free
-`codex exec` per round. Each round receives a fresh empty home and workspace,
-retains read-only/never-approval policy with native tools disabled, and uses
+`codex exec` per round. Each round receives a fresh empty home and workspace
+while retaining the trusted Action-established executable path so the
+npm-installed Codex launcher can reach its pinned Node runtime. It retains
+read-only/never-approval policy with native tools disabled and uses
 only the authoritative `turn.completed` usage record. DeepSeek uses the
 OpenAI-compatible tool-call protocol with strict bounded JSON or SSE decoding.
 Neither Adapter permits the model to supply a repository `ChangeSet`, command

--- a/internal/infra/issueagentmodel/codex.go
+++ b/internal/infra/issueagentmodel/codex.go
@@ -183,6 +183,9 @@ type CodexCLIConfig struct {
 type CodexCLIRunner struct {
 	config CodexCLIConfig
 	proxy  codexActionProxyConfig
+	// executableSearchPath freezes the trusted Action-established PATH without
+	// inheriting any other environment variable into Codex subprocesses.
+	executableSearchPath string
 }
 
 var codexVersionPattern = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
@@ -199,15 +202,21 @@ func NewCodexCLIRunner(config CodexCLIConfig) (*CodexCLIRunner, error) {
 	if err != nil {
 		return nil, err
 	}
+	runtimePath := os.Getenv("PATH")
+	if strings.TrimSpace(runtimePath) == "" {
+		return nil, errors.New("Codex CLI version is unavailable or too old")
+	}
 	command := exec.Command(config.Binary, "--version")
-	command.Env = []string{"PATH=/usr/local/bin:/usr/bin:/bin"}
+	command.Env = []string{"PATH=" + runtimePath}
 	output, err := command.Output()
 	if err != nil || !versionAtLeast(
 		codexVersionPattern.FindString(string(output)), config.MinVersion,
 	) {
 		return nil, errors.New("Codex CLI version is unavailable or too old")
 	}
-	return &CodexCLIRunner{config: config, proxy: proxy}, nil
+	return &CodexCLIRunner{
+		config: config, proxy: proxy, executableSearchPath: runtimePath,
+	}, nil
 }
 
 // RunRound invokes Codex without user config, project rules, native tools, or persistence.
@@ -258,7 +267,7 @@ func (runner *CodexCLIRunner) RunRound(
 	}
 	command := exec.CommandContext(ctx, runner.config.Binary, args...)
 	command.Env = []string{
-		"PATH=/usr/local/bin:/usr/bin:/bin",
+		"PATH=" + runner.executableSearchPath,
 		"HOME=" + tempRoot,
 		"CODEX_HOME=" + tempRoot,
 	}

--- a/internal/infra/issueagentmodel/codex_cli_test.go
+++ b/internal/infra/issueagentmodel/codex_cli_test.go
@@ -115,6 +115,55 @@ func TestCodexCLIRunnerRejectsOldBinary(t *testing.T) {
 	require.EqualError(t, err, "Codex CLI version is unavailable or too old")
 }
 
+func TestCodexCLIRunnerPreservesActionRuntimePath(t *testing.T) {
+	toolDirectory := t.TempDir()
+	node := filepath.Join(toolDirectory, "node")
+	require.NoError(t, os.WriteFile(
+		node,
+		[]byte(`#!/bin/sh
+set -eu
+if [ "${2:-}" = "--version" ]; then
+  printf 'codex-cli 0.145.0\n'
+  exit 0
+fi
+shift
+output=
+previous=
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then
+    output=$argument
+  fi
+  previous=$argument
+done
+test -n "$output"
+cat >/dev/null
+printf '%s' '{"schema_version":1,"kind":"final","tool_calls":[],"result":null}' >"$output"
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":25,"output_tokens":7}}'
+`),
+		0o700,
+	))
+	codex := filepath.Join(toolDirectory, "codex")
+	require.NoError(t, os.WriteFile(
+		codex,
+		[]byte("#!/usr/bin/env node\n"),
+		0o700,
+	))
+	t.Setenv("PATH", toolDirectory+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	runner, err := NewCodexCLIRunner(CodexCLIConfig{
+		Binary: codex,
+		BootstrapHome: writeCodexBootstrapHome(
+			t, validCodexActionProxyConfig, 0o644,
+		),
+		MinVersion: "0.145.0",
+	})
+	require.NoError(t, err)
+	_, err = runner.RunRound(context.Background(), CodexRoundRequest{
+		Model: "gpt-5.6-sol", Prompt: "strict prompt", MaxBytes: 1 << 20,
+	})
+	require.NoError(t, err)
+}
+
 func TestCodexCLIRunnerDoesNotLeakProcessFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- preserve the trusted executable search path established by `openai/codex-action`
- keep the Codex child environment limited to `PATH`, fresh `HOME`, and fresh `CODEX_HOME`
- add a regression that models the Action-installed `#!/usr/bin/env node` launcher for both version probing and a bounded round
- document the runtime-path contract in the model adapter FLOW

## Root cause

The #685 canary Worker bootstrapped `@openai/codex@0.145.0` and Node 24 successfully, then failed before reaching OpenRouter. `NewCodexCLIRunner` replaced the child `PATH` with `/usr/local/bin:/usr/bin:/bin`; the npm-installed Codex launcher uses `/usr/bin/env node`, while GitHub-hosted Node lives in the Action toolcache. The version probe therefore failed immediately.

Failed canary: https://github.com/WuKongIM/WuKongIM/actions/runs/30492077250

## Security boundary

This does not forward the parent environment. Codex subprocesses still receive only the Action-established executable search path plus a fresh ephemeral `HOME` and `CODEX_HOME`; provider and GitHub credentials remain absent.

## Validation

- `GOWORK=off go test ./internal/infra/issueagentmodel ./internal/runtime/issueagentworker ./internal/access/issueagentcli ./cmd/wkissueagent -count=1`
- `GOWORK=off go test ./internal/app -count=1`
- two-axis standards/spec review; the one initial field-comment finding was addressed

The exact commit-bound Agent validation plan is recorded as a separate protocol comment.
