### PR TITLE
fix(issue-agent): recover dynamic worker run names

### DIFF
--- a/internal/app/issue_agent.go
+++ b/internal/app/issue_agent.go
@@ -830,7 +830,11 @@ func readCurrentLeaseArtifacts(
 	result := make([]issueagentusecase.WorkerArtifact, 0, 1)
 	for _, run := range runs {
 		workflowPath := ".github/workflows/" + lease.Workflow
-		if run.Name != "Agent Tool - Issue Worker" ||
+		// GitHub exposes a workflow's dynamic run-name through both Name and
+		// DisplayTitle. Bind identity to the protected workflow path and dispatch
+		// context, then use the lease-specific title to select the exact run.
+		if run.Event != "workflow_dispatch" ||
+			run.Status != "completed" ||
 			run.HeadBranch != "main" ||
 			run.Path != workflowPath &&
 				run.Path != workflowPath+"@main" &&

--- a/internal/app/issue_agent_github_test.go
+++ b/internal/app/issue_agent_github_test.go
@@ -682,13 +682,14 @@ func TestMovingMainDecisionReadsProtectedDefaultBranchHead(t *testing.T) {
 	require.Len(t, facts.MainRuns, 3)
 }
 
-func TestSweeperFindsExactCompletedWorkerArtifactForCurrentLease(t *testing.T) {
+func TestSweeperFindsExactCompletedWorkerArtifactWithDynamicRunName(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 28, 18, 0, 0, 0, time.UTC)
 	operationID := "sha256:" + strings.Repeat("a", 64)
 	taskDigest := "sha256:" + strings.Repeat("b", 64)
 	artifactName := "issue-agent-result-" + strings.Repeat("a", 16)
+	runTitle := "Issue Agent worker Issue 42 operation " + operationID
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
@@ -702,14 +703,13 @@ func TestSweeperFindsExactCompletedWorkerArtifactForCurrentLease(t *testing.T) {
 				"workflow_runs": []map[string]any{{
 					"id": 77, "event": "workflow_dispatch",
 					"status": "completed", "conclusion": "failure",
-					"head_branch": "main",
-					"head_sha":    "0123456789abcdef0123456789abcdef01234567",
-					"name":        "Agent Tool - Issue Worker",
-					"path":        ".github/workflows/issue-agent-run.yml@main",
-					"display_title": "Issue Agent worker Issue 42 operation " +
-						operationID,
-					"run_attempt": 1,
-					"created_at":  now.Add(-30 * time.Minute).Format(time.RFC3339),
+					"head_branch":   "main",
+					"head_sha":      "0123456789abcdef0123456789abcdef01234567",
+					"name":          runTitle,
+					"path":          ".github/workflows/issue-agent-run.yml@main",
+					"display_title": runTitle,
+					"run_attempt":   1,
+					"created_at":    now.Add(-30 * time.Minute).Format(time.RFC3339),
 				}},
 			})
 		case "/repos/WuKongIM/WuKongIM/actions/runs/77/artifacts":

--- a/internal/infra/issueagentgithub/FLOW.md
+++ b/internal/infra/issueagentgithub/FLOW.md
@@ -68,7 +68,9 @@ Completed Worker-run inventory is filtered to the signed lease time window and
 bounded to GitHub's documented 1,000-result search ceiling. Reconciliation
 accepts only a unique exact display-title and Artifact-name match, then the
 ordinary Publisher revalidates the downloaded task and result against the
-current signed lease.
+current signed lease. Workflow identity is bound to the protected workflow
+path, dispatch event, and `main` head; GitHub's `name` is presentation metadata
+because a configured `run-name` replaces it with the dynamic run title.
 
 An admin recovery is the only exception to ordinary contiguous history
 verification. A later valid signed recovery checkpoint must identify the exact

--- a/internal/infra/issueagentgithub/reader_test.go
+++ b/internal/infra/issueagentgithub/reader_test.go
@@ -161,6 +161,8 @@ func TestReaderFindsCompleteBoundedWorkerRunInventorySinceLease(t *testing.T) {
 
 	since := time.Date(2026, 7, 28, 12, 0, 0, 500_000_000, time.UTC)
 	lowerBound := since.Truncate(time.Second)
+	runTitle := "Issue Agent worker Issue 42 operation sha256:" +
+		strings.Repeat("a", 64)
 	server := httptest.NewServer(http.HandlerFunc(func(
 		writer http.ResponseWriter,
 		request *http.Request,
@@ -181,12 +183,11 @@ func TestReaderFindsCompleteBoundedWorkerRunInventorySinceLease(t *testing.T) {
 			"workflow_runs": []map[string]any{{
 				"id": 11, "event": "workflow_dispatch", "status": "completed",
 				"conclusion": "failure", "head_branch": "main",
-				"head_sha": fortyHex("b"),
-				"name":     "Agent Tool - Issue Worker",
-				"path":     ".github/workflows/issue-agent-run.yml@main",
-				"display_title": "Issue Agent worker Issue 42 operation sha256:" +
-					strings.Repeat("a", 64),
-				"run_attempt": 1, "created_at": lowerBound,
+				"head_sha":      fortyHex("b"),
+				"name":          runTitle,
+				"path":          ".github/workflows/issue-agent-run.yml@main",
+				"display_title": runTitle,
+				"run_attempt":   1, "created_at": lowerBound,
 			}},
 		})
 	}))
@@ -199,6 +200,7 @@ func TestReaderFindsCompleteBoundedWorkerRunInventorySinceLease(t *testing.T) {
 	require.Len(t, runs, 1)
 	require.Equal(t, int64(11), runs[0].ID)
 	require.Equal(t, lowerBound, runs[0].CreatedAt)
+	require.Equal(t, runTitle, runs[0].Name)
 }
 
 func TestReaderRejectsRecoverableWorkerRunOutsideProtectedMainIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary

- accept GitHub Actions dynamic `run-name` metadata during current-lease recovery
- keep recovery bound to the protected workflow path, completed workflow dispatches on `main`, the exact lease title, and the exact Artifact name
- document the GitHub API behavior and cover it with regression tests

## Validation

- `GOWORK=off go test ./internal/infra/issueagentgithub ./internal/app -count=1`
- `GOWORK=off go test ./internal/runtime/issueagentworker ./internal/access/issueagentcli ./cmd/wkissueagent -count=1`

The exact trusted validation plan is published as a separate top-level PR comment.