### PR TITLE
chore(issue-agent): expose safe worker stage diagnostics

### DIFF
--- a/internal/access/issueagentcli/FLOW.md
+++ b/internal/access/issueagentcli/FLOW.md
@@ -18,7 +18,9 @@ generate-checkpoint-key --private-key-file <new path>
 ```
 
 Diagnostics go only to stderr and must not include JSON input, credentials, or
-private-key bytes. The command is independent of the WuKongIM server lifecycle.
+private-key bytes. `run-worker` may append only one fixed, allowlisted stage
+code to its generic failure diagnostic; unknown codes and every other command
+remain generic. The command is independent of the WuKongIM server lifecycle.
 
 Read commands re-fetch and verify the complete signed Issue history before
 returning a current checkpoint or unexpired task. Publish commands mint no

--- a/internal/access/issueagentcli/command.go
+++ b/internal/access/issueagentcli/command.go
@@ -24,6 +24,16 @@ import (
 const (
 	maxCommandInput  = 20 << 20
 	maxCommandOutput = 20 << 20
+
+	// WorkerDiagnostic* values are the complete public-safe stage vocabulary
+	// accepted from the credential-separated Worker composition boundary.
+	WorkerDiagnosticCredentialBoundary = "worker-credential-boundary"
+	WorkerDiagnosticInputValidation    = "worker-input-validation"
+	WorkerDiagnosticSandboxSetup       = "worker-sandbox-setup"
+	WorkerDiagnosticBinaryEvidence     = "worker-binary-evidence"
+	WorkerDiagnosticModelSetup         = "worker-model-setup"
+	WorkerDiagnosticTaskSetup          = "worker-task-setup"
+	WorkerDiagnosticExecution          = "worker-execution"
 )
 
 // PlanEventRequest is the flattened strict CLI input for reconciliation.
@@ -192,7 +202,7 @@ func Run(
 		return 2
 	}
 	if err != nil {
-		writeDiagnostic(stderr, "command failed")
+		writeDiagnostic(stderr, commandFailureDiagnostic(args[0], err))
 		return 1
 	}
 	if err := writeResult(stdout, result); err != nil {
@@ -200,6 +210,31 @@ func Run(
 		return 1
 	}
 	return 0
+}
+
+func commandFailureDiagnostic(command string, err error) string {
+	if command != "run-worker" {
+		return "command failed"
+	}
+	var diagnostic interface {
+		SafeDiagnosticCode() string
+	}
+	if !errors.As(err, &diagnostic) {
+		return "command failed"
+	}
+	code := diagnostic.SafeDiagnosticCode()
+	switch code {
+	case WorkerDiagnosticCredentialBoundary,
+		WorkerDiagnosticInputValidation,
+		WorkerDiagnosticSandboxSetup,
+		WorkerDiagnosticBinaryEvidence,
+		WorkerDiagnosticModelSetup,
+		WorkerDiagnosticTaskSetup,
+		WorkerDiagnosticExecution:
+		return "command failed: " + code
+	default:
+		return "command failed"
+	}
 }
 
 func runDocument(

--- a/internal/access/issueagentcli/command_test.go
+++ b/internal/access/issueagentcli/command_test.go
@@ -117,3 +117,117 @@ func TestCommandRejectsUnknownCommandCancellationAndSecretDiagnostics(t *testing
 	))
 	require.NotContains(t, stderr.String(), secret)
 }
+
+func TestCommandReportsOnlyAllowlistedWorkerStageDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	secret := "provider-secret-detail"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := issueagentcli.Run(
+		context.Background(), []string{"run-worker", "--input", "-"},
+		bytes.NewBufferString(`{"schema_version":1,"payload":{}}`),
+		&stdout, &stderr,
+		issueagentcli.Operations{
+			RunWorker: func(
+				context.Context,
+				issueagentcli.DocumentRequest,
+			) (any, error) {
+				return nil, testSafeDiagnosticError{
+					code: "worker-model-setup", detail: secret,
+				}
+			},
+		},
+	)
+	require.Equal(t, 1, exitCode)
+	require.Empty(t, stdout.String())
+	require.Equal(t, "command failed: worker-model-setup\n", stderr.String())
+	require.NotContains(t, stderr.String(), secret)
+
+	stderr.Reset()
+	exitCode = issueagentcli.Run(
+		context.Background(), []string{"run-worker", "--input", "-"},
+		bytes.NewBufferString(`{"schema_version":1,"payload":{}}`),
+		&stdout, &stderr,
+		issueagentcli.Operations{
+			RunWorker: func(
+				context.Context,
+				issueagentcli.DocumentRequest,
+			) (any, error) {
+				return nil, testSafeDiagnosticError{
+					code: "untrusted-value", detail: secret,
+				}
+			},
+		},
+	)
+	require.Equal(t, 1, exitCode)
+	require.Equal(t, "command failed\n", stderr.String())
+	require.NotContains(t, stderr.String(), secret)
+
+	stderr.Reset()
+	exitCode = issueagentcli.Run(
+		context.Background(), []string{"run-worker", "--input", "-"},
+		bytes.NewBufferString(`{"schema_version":1,"payload":{}}`),
+		&stdout, &stderr,
+		issueagentcli.Operations{
+			RunWorker: func(
+				context.Context,
+				issueagentcli.DocumentRequest,
+			) (any, error) {
+				return nil, &testChangingSafeDiagnosticError{secret: secret}
+			},
+		},
+	)
+	require.Equal(t, 1, exitCode)
+	require.Equal(t, "command failed: worker-model-setup\n", stderr.String())
+	require.NotContains(t, stderr.String(), secret)
+
+	stderr.Reset()
+	exitCode = issueagentcli.Run(
+		context.Background(), []string{"plan-event", "--input", "-"},
+		bytes.NewBufferString(`{}`), &stdout, &stderr,
+		issueagentcli.Operations{
+			PlanEvent: func(
+				context.Context,
+				issueagentcli.PlanEventRequest,
+			) (any, error) {
+				return nil, testSafeDiagnosticError{
+					code: "worker-model-setup", detail: secret,
+				}
+			},
+		},
+	)
+	require.Equal(t, 1, exitCode)
+	require.Equal(t, "command failed\n", stderr.String())
+	require.NotContains(t, stderr.String(), secret)
+}
+
+type testSafeDiagnosticError struct {
+	code   string
+	detail string
+}
+
+func (failure testSafeDiagnosticError) Error() string {
+	return failure.detail
+}
+
+func (failure testSafeDiagnosticError) SafeDiagnosticCode() string {
+	return failure.code
+}
+
+type testChangingSafeDiagnosticError struct {
+	calls  int
+	secret string
+}
+
+func (failure *testChangingSafeDiagnosticError) Error() string {
+	return failure.secret
+}
+
+func (failure *testChangingSafeDiagnosticError) SafeDiagnosticCode() string {
+	failure.calls++
+	if failure.calls == 1 {
+		return "worker-model-setup"
+	}
+	return failure.secret
+}

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -1139,7 +1139,9 @@ verification, and App authentication are supplied as explicit standalone
 dependencies so Publisher credentials cannot enter the product process.
 The composition root also re-reads and publishes exact maintainer controls,
 bounded CI-repair leases, sanitized provider failures, and admin chain
-recovery. Authorization converts an omitted affected version into the exact
+recovery. The credential-separated Worker maps setup and execution failures to
+the CLI's fixed public-safe stage vocabulary while preserving the underlying
+error only inside the process. Authorization converts an omitted affected version into the exact
 `main` SHA from the same trusted read used for the diagnosis baseline.
 Reproduction lease publication derives topology from the frozen Bug facts,
 defaulting an omission to `single-node-cluster` and rejecting conflicting

--- a/internal/app/issue_agent.go
+++ b/internal/app/issue_agent.go
@@ -81,6 +81,27 @@ type runWorkerPayload struct {
 	DiagnosisBinary  string                          `json:"diagnosis_binary,omitempty"`
 }
 
+type issueAgentWorkerStageError struct {
+	code  string
+	cause error
+}
+
+func (failure issueAgentWorkerStageError) Error() string {
+	return "Issue Agent Worker stage failed"
+}
+
+func (failure issueAgentWorkerStageError) Unwrap() error {
+	return failure.cause
+}
+
+func (failure issueAgentWorkerStageError) SafeDiagnosticCode() string {
+	return failure.code
+}
+
+func workerStageFailure(code string, cause error) error {
+	return issueAgentWorkerStageError{code: code, cause: cause}
+}
+
 // IssueAgentGitHubConfig contains Publisher-only process dependencies.
 type IssueAgentGitHubConfig struct {
 	HTTPClient                 *http.Client
@@ -4193,19 +4214,30 @@ func NewIssueAgentWorkerDependency(
 		document issueagentcli.DocumentRequest,
 	) (any, error) {
 		if config.ForbiddenPublisherData {
-			return nil, errors.New("Worker process contains Publisher credentials")
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticCredentialBoundary,
+				errors.New("Worker process contains Publisher credentials"),
+			)
 		}
 		var payload runWorkerPayload
 		if err := decodeIssueAgentDocument(document.Payload, &payload); err != nil {
-			return nil, err
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticInputValidation, err,
+			)
 		}
 		prompt, err := base64.StdEncoding.Strict().DecodeString(payload.PromptBase64)
 		if err != nil || base64.StdEncoding.EncodeToString(prompt) != payload.PromptBase64 {
-			return nil, errors.New("Worker prompt encoding is invalid")
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticInputValidation,
+				errors.New("Worker prompt encoding is invalid"),
+			)
 		}
 		policy, err := base64.StdEncoding.Strict().DecodeString(payload.PolicyBase64)
 		if err != nil || base64.StdEncoding.EncodeToString(policy) != payload.PolicyBase64 {
-			return nil, errors.New("Worker policy encoding is invalid")
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticInputValidation,
+				errors.New("Worker policy encoding is invalid"),
+			)
 		}
 		sandbox, err := issueagentworker.NewDockerSandboxRunner(
 			issueagentworker.DockerSandboxConfig{
@@ -4218,18 +4250,24 @@ func NewIssueAgentWorkerDependency(
 			},
 		)
 		if err != nil {
-			return nil, err
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticSandboxSetup, err,
+			)
 		}
 		defer sandbox.Close()
 		binaries, err := reproductionBinaryEvidence(
 			payload.Task, payload.AffectedBinary, payload.DiagnosisBinary,
 		)
 		if err != nil {
-			return nil, err
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticBinaryEvidence, err,
+			)
 		}
 		modelRunner, err := composeModelRunner(config, payload.Task)
 		if err != nil {
-			return nil, err
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticModelSetup, err,
+			)
 		}
 		worker, err := issueagentworker.NewWorker(issueagentworker.WorkerConfig{
 			Task: payload.Task, Prompt: prompt, Policy: policy,
@@ -4238,9 +4276,17 @@ func NewIssueAgentWorkerDependency(
 			Binaries: binaries,
 		})
 		if err != nil {
-			return nil, err
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticTaskSetup, err,
+			)
 		}
-		return worker.Run(ctx)
+		artifact, err := worker.Run(ctx)
+		if err != nil {
+			return nil, workerStageFailure(
+				issueagentcli.WorkerDiagnosticExecution, err,
+			)
+		}
+		return artifact, nil
 	}
 }
 

--- a/internal/app/issue_agent_worker_test.go
+++ b/internal/app/issue_agent_worker_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -44,7 +46,45 @@ func TestIssueAgentWorkerRejectsPublisherCredentialsBeforePayload(t *testing.T) 
 		ForbiddenPublisherData: true,
 	})
 	_, err := run(context.Background(), issueagentcli.DocumentRequest{})
-	require.EqualError(t, err, "Worker process contains Publisher credentials")
+	require.EqualError(t, err, "Issue Agent Worker stage failed")
+	var diagnostic interface {
+		SafeDiagnosticCode() string
+	}
+	require.ErrorAs(t, err, &diagnostic)
+	require.Equal(
+		t, issueagentcli.WorkerDiagnosticCredentialBoundary,
+		diagnostic.SafeDiagnosticCode(),
+	)
+	require.NotContains(t, err.Error(), "Publisher credentials")
+}
+
+func TestIssueAgentWorkerClassifiesSandboxSetupWithoutLeakingCause(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(runWorkerPayload{
+		PromptBase64: base64.StdEncoding.EncodeToString([]byte("prompt")),
+		PolicyBase64: base64.StdEncoding.EncodeToString([]byte("policy")),
+		Workspace:    t.TempDir(),
+		ModuleCache:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	run := NewIssueAgentWorkerDependency(IssueAgentWorkerConfig{
+		SandboxImage: "not-digest-pinned",
+	})
+	_, err = run(context.Background(), issueagentcli.DocumentRequest{
+		SchemaVersion: 1,
+		Payload:       payload,
+	})
+	require.EqualError(t, err, "Issue Agent Worker stage failed")
+	var diagnostic interface {
+		SafeDiagnosticCode() string
+	}
+	require.ErrorAs(t, err, &diagnostic)
+	require.Equal(
+		t, issueagentcli.WorkerDiagnosticSandboxSetup,
+		diagnostic.SafeDiagnosticCode(),
+	)
+	require.NotContains(t, err.Error(), "Docker sandbox configuration")
 }
 
 func writeAppTestCodexBootstrap(t *testing.T) (string, string) {


### PR DESCRIPTION
## Summary

- classify Worker composition failures into seven fixed public-safe stages
- keep underlying provider, path, prompt, policy, credential, and error details out of CLI diagnostics
- preserve generic diagnostics for unknown codes and all non-Worker commands
- document the boundary and add a stateful-code regression test for the allowlist

## Why

The #685 canary Worker reached the official Codex Action bootstrap but failed with only a generic command failure. This bounded vocabulary adds enough evidence to identify the failing stage without weakening the credential or secret boundary.

## Validation

- GOWORK=off go test ./internal/access/issueagentcli ./internal/app -count=1
- GOWORK=off go test ./cmd/wkissueagent ./internal/runtime/issueagentworker ./internal/infra/issueagentmodel -count=1
- GOWORK=off go vet ./internal/access/issueagentcli ./internal/app ./cmd/wkissueagent
- dual-axis review: 0 findings after fixing the diagnostic-code TOCTOU