### PR TITLE
fix(issue-agent): freeze safe workspace symlinks

### DIFF
--- a/internal/runtime/issueagentworker/FLOW.md
+++ b/internal/runtime/issueagentworker/FLOW.md
@@ -22,6 +22,11 @@ evidence, Artifact digest, diagnosis evidence digest, and token counts empty.
 The trusted Worker derives those values from the workspace, broker transcript,
 and Adapter response and validates the completed Artifact again. The Publisher
 replays the same validations before any GitHub write.
+Pre-existing relative symlinks may point in one hop only to regular files
+inside the workspace, outside `.git` and Worker scratch state. The Worker
+freezes each link path-to-target mapping across its before/after snapshots and
+rejects any added, removed, file-type-replaced, retargeted, escaping, chained,
+or otherwise unsafe symlink.
 
 On Linux CI the workspace is placed in a digest-pinned, no-network container
 with a read-only root, PID/memory/CPU constraints, temporary build caches, and

--- a/internal/runtime/issueagentworker/broker.go
+++ b/internal/runtime/issueagentworker/broker.go
@@ -307,7 +307,13 @@ func safeRelativePath(value string) bool {
 
 func withinRoot(root string, candidate string) bool {
 	relative, err := filepath.Rel(root, candidate)
-	return err == nil && relative != ".." && !strings.HasPrefix(relative, "../") &&
+	return err == nil && relativeWithinRoot(relative)
+}
+
+func relativeWithinRoot(relative string) bool {
+	return relative != ".." &&
+		!strings.HasPrefix(relative, "../") &&
+		!strings.HasPrefix(relative, `..\`) &&
 		!filepath.IsAbs(relative)
 }
 

--- a/internal/runtime/issueagentworker/worker.go
+++ b/internal/runtime/issueagentworker/worker.go
@@ -478,8 +478,9 @@ func requireAssertionFailures(expected string, groups ...[]ToolEvidence) error {
 }
 
 type workspaceFile struct {
-	mode    issueagent.FileMode
-	content []byte
+	mode          issueagent.FileMode
+	content       []byte
+	symlinkTarget string
 }
 
 func snapshotWorkspace(root string) (map[string]workspaceFile, error) {
@@ -500,7 +501,37 @@ func snapshotWorkspace(root string) (map[string]workspaceFile, error) {
 			return nil
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			return errors.New("Worker workspace contains a symlink")
+			target, err := os.Readlink(current)
+			if err != nil || target == "" || filepath.IsAbs(target) ||
+				strings.ContainsRune(target, 0) {
+				return errors.New("Worker workspace contains an unsafe symlink")
+			}
+			directTarget := filepath.Clean(
+				filepath.Join(filepath.Dir(current), target),
+			)
+			if !withinRoot(root, directTarget) {
+				return errors.New("Worker workspace symlink escapes root")
+			}
+			targetRelative, err := filepath.Rel(root, directTarget)
+			targetRelative = filepath.ToSlash(targetRelative)
+			if err != nil || targetRelative == ".git" ||
+				strings.HasPrefix(targetRelative, ".git/") ||
+				targetRelative == ".issue-agent-tmp" ||
+				strings.HasPrefix(targetRelative, ".issue-agent-tmp/") {
+				return errors.New("Worker workspace symlink target is unsafe")
+			}
+			info, err := os.Lstat(directTarget)
+			if err != nil || info.Mode()&os.ModeSymlink != 0 ||
+				!info.Mode().IsRegular() ||
+				len(result) >= 200000 ||
+				totalBytes+int64(len(target)) > 2<<30 {
+				return errors.New("Worker workspace symlink target is invalid")
+			}
+			result[filepath.ToSlash(relative)] = workspaceFile{
+				symlinkTarget: target,
+			}
+			totalBytes += int64(len(target))
+			return nil
 		}
 		info, err := entry.Info()
 		if err != nil || !info.Mode().IsRegular() {
@@ -547,6 +578,15 @@ func deriveChangeSet(
 	for _, filePath := range paths {
 		oldFile, existed := before[filePath]
 		newFile, exists := after[filePath]
+		if oldFile.symlinkTarget != "" || newFile.symlinkTarget != "" {
+			if existed && exists &&
+				oldFile.symlinkTarget != "" &&
+				oldFile.symlinkTarget == newFile.symlinkTarget {
+				continue
+			}
+			return issueagent.ChangeSet{},
+				errors.New("Worker workspace symlink changed")
+		}
 		switch {
 		case existed && !exists:
 			changes = append(changes, issueagent.FileChange{

--- a/internal/runtime/issueagentworker/worker_test.go
+++ b/internal/runtime/issueagentworker/worker_test.go
@@ -391,6 +391,97 @@ func TestWorkerTurnsAdapterFailureIntoSanitizedPublishableArtifact(t *testing.T)
 	require.NotContains(t, artifact.Result.Failure.Summary, "secret")
 }
 
+func TestWorkerFreezesSafeInternalSymlinks(t *testing.T) {
+	t.Parallel()
+
+	newWorker := func(
+		t *testing.T,
+		initialTarget func(string) string,
+		mutate func(string) error,
+	) *issueagentworker.Worker {
+		t.Helper()
+		task := validWorkerTask()
+		prompt := []byte("fixed worker prompt")
+		policy := []byte(`{"enabled":true}`)
+		task.PromptDigest = digestForTest(prompt)
+		task.PolicyDigest = digestForTest(policy)
+		workspace := filepath.Join(t.TempDir(), "workspace")
+		require.NoError(t, os.Mkdir(workspace, 0o755))
+		instruction := []byte("# Worker instructions\n")
+		require.NoError(t, os.WriteFile(
+			filepath.Join(workspace, "AGENTS.md"), instruction, 0o644,
+		))
+		task.InstructionDigests = []issueagent.FileDigest{{
+			Path: "AGENTS.md", SHA256: digestForTest(instruction),
+		}}
+		require.NoError(t, os.WriteFile(
+			filepath.Join(workspace, "channel-metrics-summary.awk"),
+			[]byte("BEGIN { print \"ok\" }\n"), 0o644,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(workspace, "other.awk"),
+			[]byte("BEGIN { print \"other\" }\n"), 0o644,
+		))
+		link := filepath.Join(workspace, "channelv2-metrics-summary.awk")
+		target := "channel-metrics-summary.awk"
+		if initialTarget != nil {
+			target = initialTarget(workspace)
+		}
+		require.NoError(t, os.Symlink(target, link))
+		worker, err := issueagentworker.NewWorker(issueagentworker.WorkerConfig{
+			Task: task, Prompt: prompt, Policy: policy, Workspace: workspace,
+			Runner: &fakeRunner{},
+			Model: func(
+				context.Context,
+				issueagent.TaskEnvelope,
+				[]byte,
+				*issueagentworker.Broker,
+			) (issueagentworker.ModelOutput, error) {
+				if mutate != nil {
+					require.NoError(t, mutate(link))
+				}
+				return issueagentworker.ModelOutput{},
+					errors.New("secret provider detail")
+			},
+			MaxArtifactBytes: 1 << 20,
+		})
+		require.NoError(t, err)
+		return worker
+	}
+
+	t.Run("unchanged internal link", func(t *testing.T) {
+		worker := newWorker(t, nil, nil)
+		artifact, err := worker.Run(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, issueagentworker.ValidateArtifact(artifact))
+		require.Equal(t, issueagent.ResultStatusFailed, artifact.Result.Status)
+	})
+
+	t.Run("changed internal link", func(t *testing.T) {
+		worker := newWorker(t, nil, func(link string) error {
+			if err := os.Remove(link); err != nil {
+				return err
+			}
+			return os.Symlink("other.awk", link)
+		})
+		_, err := worker.Run(context.Background())
+		require.EqualError(t, err, "Worker workspace symlink changed")
+	})
+
+	t.Run("escaping relative link", func(t *testing.T) {
+		worker := newWorker(t, func(workspace string) string {
+			outsideName := filepath.Base(workspace) + "-outside.awk"
+			require.NoError(t, os.WriteFile(
+				filepath.Join(filepath.Dir(workspace), outsideName),
+				[]byte("outside\n"), 0o644,
+			))
+			return filepath.Join("..", outsideName)
+		}, nil)
+		_, err := worker.Run(context.Background())
+		require.EqualError(t, err, "Worker workspace symlink escapes root")
+	})
+}
+
 func digestForTest(value []byte) string {
 	sum := sha256.Sum256(value)
 	return "sha256:" + hex.EncodeToString(sum[:])

--- a/internal/runtime/issueagentworker/workspace_snapshot_test.go
+++ b/internal/runtime/issueagentworker/workspace_snapshot_test.go
@@ -1,0 +1,112 @@
+package issueagentworker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/issueagent"
+)
+
+func TestSnapshotWorkspaceRejectsSymlinkChains(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspace, "target.awk"), []byte("target\n"), 0o644,
+	))
+	scratch := filepath.Join(workspace, ".issue-agent-tmp")
+	require.NoError(t, os.Mkdir(scratch, 0o755))
+	require.NoError(t, os.Symlink(
+		filepath.Join("..", "target.awk"),
+		filepath.Join(scratch, "hop"),
+	))
+	require.NoError(t, os.Symlink(
+		filepath.Join(".issue-agent-tmp", "hop"),
+		filepath.Join(workspace, "alias.awk"),
+	))
+
+	_, err := snapshotWorkspace(workspace)
+	require.EqualError(t, err, "Worker workspace symlink target is unsafe")
+}
+
+func TestRelativeWithinRootRejectsPlatformParentSeparators(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, relativeWithinRoot(".."))
+	require.False(t, relativeWithinRoot("../outside"))
+	require.False(t, relativeWithinRoot(`..\outside`))
+	require.True(t, relativeWithinRoot("."))
+	require.True(t, relativeWithinRoot(filepath.Join("inside", "file")))
+}
+
+func TestDeriveChangeSetRejectsSymlinkStructuralChanges(t *testing.T) {
+	t.Parallel()
+
+	link := workspaceFile{symlinkTarget: "target.awk"}
+	regular := workspaceFile{
+		mode: issueagent.FileModeRegular, content: []byte("regular\n"),
+	}
+	tests := []struct {
+		name   string
+		before map[string]workspaceFile
+		after  map[string]workspaceFile
+	}{
+		{
+			name:   "added",
+			before: map[string]workspaceFile{},
+			after:  map[string]workspaceFile{"alias.awk": link},
+		},
+		{
+			name:   "deleted",
+			before: map[string]workspaceFile{"alias.awk": link},
+			after:  map[string]workspaceFile{},
+		},
+		{
+			name:   "symlink replaced by regular file",
+			before: map[string]workspaceFile{"alias.awk": link},
+			after:  map[string]workspaceFile{"alias.awk": regular},
+		},
+		{
+			name:   "regular file replaced by symlink",
+			before: map[string]workspaceFile{"alias.awk": regular},
+			after:  map[string]workspaceFile{"alias.awk": link},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := deriveChangeSet(test.before, test.after)
+			require.EqualError(t, err, "Worker workspace symlink changed")
+		})
+	}
+}
+
+func TestDeriveChangeSetCapturesChangesThroughUnchangedSymlink(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "target.awk")
+	require.NoError(t, os.WriteFile(target, []byte("before\n"), 0o644))
+	require.NoError(t, os.Symlink(
+		"target.awk", filepath.Join(workspace, "alias.awk"),
+	))
+	before, err := snapshotWorkspace(workspace)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(target, []byte("after\n"), 0o644))
+	after, err := snapshotWorkspace(workspace)
+	require.NoError(t, err)
+	changeSet, err := deriveChangeSet(before, after)
+	require.NoError(t, err)
+	require.Equal(t, issueagent.ChangeSet{Files: []issueagent.FileChange{{
+		Path:          "target.awk",
+		Operation:     issueagent.FileOperationUpsert,
+		Mode:          issueagent.FileModeRegular,
+		ContentBase64: issueagent.EncodeFileContent([]byte("after\n")),
+	}}}, changeSet)
+}


### PR DESCRIPTION
## Summary

- allow pre-existing one-hop relative symlinks to regular files inside the Worker workspace
- reject symlink chains, escapes, unsafe targets, and path-to-target mapping changes
- harden root-containment checks for both slash separator forms

## Why

The repository tracks `scripts/channelv2-metrics-summary.awk` as a relative symlink. The Worker previously rejected every symlink before invoking the model, so Issue Agent generation 3 failed during workspace snapshotting.

## Validation

- `GOWORK=off go test ./internal/runtime/issueagentworker -count=1`
- `GOWORK=off go test ./internal/app ./internal/access/issueagentcli ./cmd/wkissueagent -count=1`
- `GOWORK=off go test -race ./internal/runtime/issueagentworker -count=1`
- `GOWORK=off go vet ./internal/runtime/issueagentworker ./internal/app ./internal/access/issueagentcli ./cmd/wkissueagent`
- dual-axis code review: 0 findings