### PR TITLE
fix(issue-agent): classify Codex provider failures

### DIFF
--- a/internal/infra/issueagentmodel/FLOW.md
+++ b/internal/infra/issueagentmodel/FLOW.md
@@ -21,8 +21,9 @@ errors. DeepSeek keeps its key in Adapter memory. Codex uses the official
 Responses proxy, and drop `sudo`; neither `wkissueagent` nor a Codex subprocess
 receives `CODEX_API_KEY`. Unknown tools, malformed arguments, provider
 redirects, response overflows, excessive tool rounds, and silent
-model/provider changes fail closed. The state machine and Worker do not
-interpret provider-specific messages.
+model/provider changes fail closed. Raw provider messages remain process-local.
+Only Codex JSON error events may be reduced to a fixed response-free diagnostic
+vocabulary; the state machine and Worker never interpret provider text.
 
 The Codex Adapter accepts only the Action's exact
 `http://127.0.0.1:<port>/v1` Responses provider from a regular bootstrap config

--- a/internal/infra/issueagentmodel/codex.go
+++ b/internal/infra/issueagentmodel/codex.go
@@ -103,6 +103,10 @@ func (adapter *CodexAdapter) Run(
 			if ctx.Err() != nil {
 				return Outcome{}, ctx.Err()
 			}
+			var providerFailure *ProviderError
+			if errors.As(err, &providerFailure) {
+				return Outcome{}, providerFailure
+			}
 			return Outcome{}, &ProviderError{Class: "codex_process", Retryable: true}
 		}
 		inputTokens += response.InputTokens
@@ -188,7 +192,12 @@ type CodexCLIRunner struct {
 	executableSearchPath string
 }
 
-var codexVersionPattern = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
+var (
+	codexVersionPattern       = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)`)
+	codexFailureStatusPattern = regexp.MustCompile(
+		`(?i)status(?:[ _-]?code)?[^0-9]{0,8}([45][0-9]{2})`,
+	)
+)
 
 // NewCodexCLIRunner validates the binary and its minimum version.
 func NewCodexCLIRunner(config CodexCLIConfig) (*CodexCLIRunner, error) {
@@ -280,7 +289,7 @@ func (runner *CodexCLIRunner) RunRound(
 		if ctx.Err() != nil {
 			return CodexRoundResponse{}, ctx.Err()
 		}
-		return CodexRoundResponse{}, errors.New("Codex CLI process failed")
+		return CodexRoundResponse{}, classifyCodexProcessFailure(stdout.Bytes())
 	}
 	envelope, err := os.ReadFile(outputPath)
 	if err != nil || int64(len(envelope)) > request.MaxBytes {
@@ -290,6 +299,128 @@ func (runner *CodexCLIRunner) RunRound(
 	return CodexRoundResponse{
 		Envelope: envelope, InputTokens: inputTokens, OutputTokens: outputTokens,
 	}, nil
+}
+
+type codexFailureEvent struct {
+	Type    string          `json:"type"`
+	Status  json.RawMessage `json:"status"`
+	Message string          `json:"message"`
+	Error   json.RawMessage `json:"error"`
+}
+
+type codexFailureDetail struct {
+	Status  json.RawMessage `json:"status"`
+	Code    json.RawMessage `json:"code"`
+	Type    string          `json:"type"`
+	Message string          `json:"message"`
+}
+
+// classifyCodexProcessFailure inspects only structured CLI failure events and
+// returns a fixed class without retaining provider-authored text.
+func classifyCodexProcessFailure(output []byte) error {
+	for _, line := range bytes.Split(output, []byte{'\n'}) {
+		var event codexFailureEvent
+		if json.Unmarshal(line, &event) != nil ||
+			(event.Type != "error" && event.Type != "turn.failed") {
+			continue
+		}
+		status := decodeCodexFailureStatus(event.Status)
+		message := event.Message
+		var detail codexFailureDetail
+		if len(event.Error) != 0 && json.Unmarshal(event.Error, &detail) == nil {
+			if status == 0 {
+				status = decodeCodexFailureStatus(detail.Status)
+			}
+			message += " " + detail.Type + " " + detail.Message + " " +
+				string(detail.Code)
+		}
+		if status == 0 {
+			status = codexFailureStatusFromMessage(message)
+		}
+		if failure := classifiedCodexProviderError(status, message); failure != nil {
+			return failure
+		}
+	}
+	return &ProviderError{Class: "codex_process", Retryable: true}
+}
+
+func decodeCodexFailureStatus(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var numeric int
+	if json.Unmarshal(raw, &numeric) == nil {
+		return numeric
+	}
+	var text string
+	if json.Unmarshal(raw, &text) != nil {
+		return 0
+	}
+	numeric, _ = strconv.Atoi(text)
+	return numeric
+}
+
+func codexFailureStatusFromMessage(message string) int {
+	match := codexFailureStatusPattern.FindStringSubmatch(message)
+	if len(match) != 2 {
+		return 0
+	}
+	status, _ := strconv.Atoi(match[1])
+	return status
+}
+
+func classifiedCodexProviderError(status int, message string) *ProviderError {
+	normalized := strings.ToLower(message)
+	if strings.Contains(normalized, "model") &&
+		(strings.Contains(normalized, "not supported") ||
+			strings.Contains(normalized, "not found") ||
+			strings.Contains(normalized, "unavailable")) {
+		return &ProviderError{Class: "model_unavailable"}
+	}
+	if strings.Contains(normalized, "rate limit") ||
+		strings.Contains(normalized, "rate_limit") {
+		return &ProviderError{Class: "rate_limit", Retryable: true}
+	}
+	if strings.Contains(normalized, "insufficient credit") ||
+		strings.Contains(normalized, "insufficient quota") ||
+		strings.Contains(normalized, "payment required") {
+		return &ProviderError{Class: "quota"}
+	}
+	if strings.Contains(normalized, "unauthorized") ||
+		strings.Contains(normalized, "forbidden") ||
+		strings.Contains(normalized, "authentication") {
+		return &ProviderError{Class: "authentication"}
+	}
+	switch {
+	case status == 400:
+		return &ProviderError{Class: "invalid_request"}
+	case status == 401 || status == 403:
+		return &ProviderError{Class: "authentication"}
+	case status == 402:
+		return &ProviderError{Class: "quota"}
+	case status == 404:
+		return &ProviderError{Class: "model_unavailable"}
+	case status == 408:
+		return &ProviderError{Class: "network", Retryable: true}
+	case status == 429:
+		return &ProviderError{Class: "rate_limit", Retryable: true}
+	case status >= 500 && status <= 599:
+		return &ProviderError{Class: "provider_unavailable", Retryable: true}
+	}
+	if strings.Contains(normalized, "stream disconnected") ||
+		strings.Contains(normalized, "error sending request") ||
+		strings.Contains(normalized, "connection refused") ||
+		strings.Contains(normalized, "timed out") ||
+		strings.Contains(normalized, "timeout") ||
+		strings.Contains(normalized, "network") {
+		return &ProviderError{Class: "network", Retryable: true}
+	}
+	if strings.Contains(normalized, "invalid request") ||
+		strings.Contains(normalized, "invalid_request") ||
+		strings.Contains(normalized, "bad request") {
+		return &ProviderError{Class: "invalid_request"}
+	}
+	return nil
 }
 
 type boundedBuffer struct {

--- a/internal/infra/issueagentmodel/codex_cli_test.go
+++ b/internal/infra/issueagentmodel/codex_cli_test.go
@@ -178,9 +178,72 @@ func TestCodexCLIRunnerDoesNotLeakProcessFailure(t *testing.T) {
 	_, err = runner.RunRound(context.Background(), CodexRoundRequest{
 		Model: "gpt-5.6-sol", Prompt: "strict prompt", MaxBytes: 1 << 20,
 	})
-	require.EqualError(t, err, "Codex CLI process failed")
+	require.EqualError(t, err, "model provider request failed: codex_process")
 	require.NotContains(t, err.Error(), "strict prompt")
 	require.NotContains(t, err.Error(), "43123")
+}
+
+func TestClassifyCodexProcessFailureUsesOnlySafeDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		output    string
+		wantClass string
+		retryable bool
+	}{
+		{
+			name:      "authentication",
+			output:    `{"type":"error","status":401,"error":{"message":"secret upstream response"}}`,
+			wantClass: "authentication",
+		},
+		{
+			name:      "quota",
+			output:    `{"type":"turn.failed","error":{"status":402,"message":"secret upstream response"}}`,
+			wantClass: "quota",
+		},
+		{
+			name:      "rate limit",
+			output:    `{"type":"error","message":"unexpected status 429: secret upstream response"}`,
+			wantClass: "rate_limit",
+			retryable: true,
+		},
+		{
+			name:      "invalid request",
+			output:    `{"type":"error","status":"400","message":"secret upstream response"}`,
+			wantClass: "invalid_request",
+		},
+		{
+			name:      "model unavailable",
+			output:    `{"type":"error","message":"the selected model is not supported: secret upstream response"}`,
+			wantClass: "model_unavailable",
+		},
+		{
+			name:      "network",
+			output:    `{"type":"turn.failed","error":{"message":"stream disconnected before completion: error sending request"}}`,
+			wantClass: "network",
+			retryable: true,
+		},
+		{
+			name:      "unstructured failure",
+			output:    `{"type":"item.completed","message":"status 401 belongs to model-authored content"}`,
+			wantClass: "codex_process",
+			retryable: true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := classifyCodexProcessFailure([]byte(test.output))
+			var failure *ProviderError
+			require.ErrorAs(t, err, &failure)
+			require.Equal(t, test.wantClass, failure.Class)
+			require.Equal(t, test.retryable, failure.Retryable)
+			require.NotContains(t, err.Error(), "secret upstream response")
+		})
+	}
 }
 
 func writeFakeCodexCLI(

--- a/internal/infra/issueagentmodel/codex_test.go
+++ b/internal/infra/issueagentmodel/codex_test.go
@@ -3,6 +3,7 @@ package issueagentmodel_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/WuKongIM/WuKongIM/internal/contracts/issueagent"
@@ -13,6 +14,7 @@ import (
 type fakeCodexRoundRunner struct {
 	responses []issueagentmodel.CodexRoundResponse
 	requests  []issueagentmodel.CodexRoundRequest
+	err       error
 }
 
 func (runner *fakeCodexRoundRunner) RunRound(
@@ -20,6 +22,9 @@ func (runner *fakeCodexRoundRunner) RunRound(
 	request issueagentmodel.CodexRoundRequest,
 ) (issueagentmodel.CodexRoundResponse, error) {
 	runner.requests = append(runner.requests, request)
+	if runner.err != nil {
+		return issueagentmodel.CodexRoundResponse{}, runner.err
+	}
 	response := runner.responses[0]
 	runner.responses = runner.responses[1:]
 	return response, nil
@@ -83,6 +88,28 @@ func TestCodexAdapterDoesNotFallBackAfterMalformedEnvelope(t *testing.T) {
 		PromptSHA256: task.PromptDigest, MaxRounds: 2, MaxBytes: 1 << 20,
 	}, &recordingToolExecutor{})
 	require.Error(t, err)
+	require.Len(t, runner.requests, 1)
+}
+
+func TestCodexAdapterPreservesSafeProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	task, _ := validAdapterTaskAndResult(t)
+	task.Provider = issueagent.ProviderCodex
+	task.Model = "policy-codex-model"
+	runner := &fakeCodexRoundRunner{err: &issueagentmodel.ProviderError{
+		Class: "authentication",
+	}}
+	adapter, err := issueagentmodel.NewCodexAdapter(runner)
+	require.NoError(t, err)
+
+	_, err = adapter.Run(context.Background(), issueagentmodel.Request{
+		Task: task, SystemPrompt: "fixed prompt",
+		PromptSHA256: task.PromptDigest, MaxRounds: 2, MaxBytes: 1 << 20,
+	}, &recordingToolExecutor{})
+	var failure *issueagentmodel.ProviderError
+	require.True(t, errors.As(err, &failure))
+	require.Equal(t, "authentication", failure.Class)
 	require.Len(t, runner.requests, 1)
 }
 

--- a/internal/infra/issueagentmodel/deepseek.go
+++ b/internal/infra/issueagentmodel/deepseek.go
@@ -27,6 +27,22 @@ func (failure *ProviderError) Error() string {
 	return "model provider request failed: " + failure.Class
 }
 
+// SafeProviderFailureCode reduces internal provider classes to a fixed
+// credential- and response-free vocabulary suitable for Worker artifacts.
+func (failure *ProviderError) SafeProviderFailureCode() string {
+	if failure == nil {
+		return ""
+	}
+	switch failure.Class {
+	case "authentication", "quota", "rate_limit", "invalid_request",
+		"model_unavailable", "network", "provider_unavailable",
+		"output_limit", "codex_process":
+		return failure.Class
+	default:
+		return ""
+	}
+}
+
 // DeepSeekAdapter implements the OpenAI-compatible DeepSeek chat protocol.
 type DeepSeekAdapter struct {
 	endpoint *url.URL

--- a/internal/runtime/issueagentworker/FLOW.md
+++ b/internal/runtime/issueagentworker/FLOW.md
@@ -22,6 +22,9 @@ evidence, Artifact digest, diagnosis evidence digest, and token counts empty.
 The trusted Worker derives those values from the workspace, broker transcript,
 and Adapter response and validates the completed Artifact again. The Publisher
 replays the same validations before any GitHub write.
+Provider failures discard every partial workspace mutation and publish only a
+fixed safe diagnostic code supplied through the provider-neutral error
+contract; raw provider responses and credentials never enter the Artifact.
 Pre-existing relative symlinks may point in one hop only to regular files
 inside the workspace, outside `.git` and Worker scratch state. The Worker
 freezes each link path-to-target mapping across its before/after snapshots and

--- a/internal/runtime/issueagentworker/worker.go
+++ b/internal/runtime/issueagentworker/worker.go
@@ -148,7 +148,7 @@ func (worker *Worker) Run(ctx context.Context) (Artifact, error) {
 				RequestedAction: issueagent.ActionWaitForHuman,
 				Failure: &issueagent.Failure{
 					Class:   issueagent.FailureProvider,
-					Summary: "The selected model provider did not complete this bounded attempt.",
+					Summary: providerFailureSummary(err),
 				},
 			},
 			Usage: issueagent.ModelUsage{
@@ -259,6 +259,24 @@ func (worker *Worker) Run(ctx context.Context) (Artifact, error) {
 		Tools: toolEvidence, Binaries: worker.config.Binaries,
 		SHA256: digest(encoded),
 	}, nil
+}
+
+func providerFailureSummary(err error) string {
+	const summary = "The selected model provider did not complete this bounded attempt."
+	var classified interface {
+		SafeProviderFailureCode() string
+	}
+	if !errors.As(err, &classified) {
+		return summary
+	}
+	switch code := classified.SafeProviderFailureCode(); code {
+	case "authentication", "quota", "rate_limit", "invalid_request",
+		"model_unavailable", "network", "provider_unavailable",
+		"output_limit", "codex_process":
+		return summary + " Safe diagnostic: " + code + "."
+	default:
+		return summary
+	}
 }
 
 // ValidateArtifact replays every deterministic Worker-side validation before a

--- a/internal/runtime/issueagentworker/worker_test.go
+++ b/internal/runtime/issueagentworker/worker_test.go
@@ -20,6 +20,19 @@ type functionRunner func(
 	issueagentworker.ExecRequest,
 ) (issueagentworker.ExecResult, error)
 
+type safeProviderFailureForTest struct {
+	code   string
+	detail string
+}
+
+func (failure safeProviderFailureForTest) Error() string {
+	return failure.detail
+}
+
+func (failure safeProviderFailureForTest) SafeProviderFailureCode() string {
+	return failure.code
+}
+
 func (runner functionRunner) Run(
 	ctx context.Context,
 	request issueagentworker.ExecRequest,
@@ -375,7 +388,9 @@ func TestWorkerTurnsAdapterFailureIntoSanitizedPublishableArtifact(t *testing.T)
 			[]byte,
 			*issueagentworker.Broker,
 		) (issueagentworker.ModelOutput, error) {
-			return issueagentworker.ModelOutput{}, errors.New("secret provider detail")
+			return issueagentworker.ModelOutput{}, safeProviderFailureForTest{
+				code: "authentication", detail: "secret provider detail",
+			}
 		},
 		MaxArtifactBytes: 1 << 20,
 	})
@@ -389,6 +404,7 @@ func TestWorkerTurnsAdapterFailureIntoSanitizedPublishableArtifact(t *testing.T)
 	require.Empty(t, artifact.Result.Evidence.Commands)
 	require.Empty(t, artifact.Result.ChangeSet.Files)
 	require.NotContains(t, artifact.Result.Failure.Summary, "secret")
+	require.Contains(t, artifact.Result.Failure.Summary, "authentication")
 }
 
 func TestWorkerFreezesSafeInternalSymlinks(t *testing.T) {


### PR DESCRIPTION
## Summary

- classify only structured Codex failure events into a fixed safe vocabulary
- preserve provider classifications through the Codex adapter
- publish only allowlisted diagnostic codes in failed Worker artifacts
- keep raw provider responses, prompts, endpoints, and credentials process-local

## Validation

- GOWORK=off go test ./internal/infra/issueagentmodel ./internal/runtime/issueagentworker -count=1
- GOWORK=off go test -race ./internal/infra/issueagentmodel ./internal/runtime/issueagentworker -count=1
- GOWORK=off go vet ./internal/infra/issueagentmodel ./internal/runtime/issueagentworker
- GOWORK=off go test ./internal/app ./internal/access/issueagentcli ./cmd/wkissueagent -count=1
- git diff --check

## Review

Standards review: no findings.
Spec review: no findings.
