### PR TITLE
feat(issue-agent): add OpenRouter provider preflight

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,7 @@ for discovery and may become more specific over time.
 | `cloud-sim-cleanup.yml` | `Safety Automation - Reconcile Cloud Simulation Resources` | Every 15 minutes, destroys expired leases; also supports exact authorized cleanup | Autonomous billing and resource safety backstop |
 | `cloud-sim-monitor.yml` | `Safety Automation - Patrol Cloud Simulation Runs` | Every 30 minutes, patrols live runs and records bounded health evidence | Autonomous read-only safety patrol |
 | `issue-agent-control.yml` | `Safety Automation - Issue Agent Control` | Reconciles Issue, comment, PR, Review, validation-completion, and recovery hints against protected policy and signed Issue state | Autonomous stateless controller; capability is capped by reviewed rollout mode |
+| `issue-agent-provider-preflight.yml` | `Agent Tool - Issue Provider Preflight` | Runs one bounded synthetic structured Codex invocation through the pinned Action and selected OpenRouter model | Explicit provider-spend authorization required; no checkout or Artifact |
 | `issue-agent-reconcile.yml` | `Safety Automation - Issue Agent Sweeper` | Hourly bounded scan for missed authorized Issue work and expired leases | Autonomous recovery dispatcher; a saturated inventory fails closed |
 | `issue-agent-run.yml` | `Agent Tool - Issue Worker` | Runs one exact signed reproduction, diagnosis, or remediation task, then publishes its validated Artifact | Model Supervisor and GitHub Publisher use separate protected Environments |
 
@@ -65,17 +66,18 @@ than assuming capacity.
 Write-capable modes retain three credential boundaries:
 
 - `issue-agent-codex` exposes `OPENROUTER_API_KEY` only to the pinned official
-  Codex Action bootstrap, which sends Responses requests only to the fixed
-  OpenRouter endpoint;
+  Codex Action in the Worker bootstrap or synthetic provider preflight, both of
+  which send Responses requests only to the fixed OpenRouter endpoint;
 - `issue-agent-deepseek` exposes only `DEEPSEEK_API_KEY` to the selected
   DeepSeek Supervisor;
 - `issue-agent-publisher` exposes repository-scoped App and checkpoint signing
   material only to Publisher/dispatcher jobs that never execute target code.
 
-The Codex Action is pinned by full commit SHA and runs without a prompt. It
-installs the pinned CLI and matching Responses proxy, sends upstream requests
-only to the fixed `https://openrouter.ai/api/v1/responses` endpoint, writes one
-otherwise empty bootstrap home, accepts only the exact
+The Worker's Codex Action bootstrap is pinned by full commit SHA and runs
+without a prompt. It installs the pinned CLI and matching Responses proxy,
+sends upstream requests only to the fixed
+`https://openrouter.ai/api/v1/responses` endpoint, writes one otherwise empty
+bootstrap home, accepts only the exact
 `wukongim-issue-agent` App bot in addition to normal write-authorized actors,
 and irreversibly drops `sudo` before the repository-owned Worker starts. The
 immediately preceding step fails if that bootstrap-home path already exists or
@@ -87,6 +89,17 @@ the Action. `wkissueagent` receives only
 round. The API key must not appear in Worker arguments, environment dumps,
 Artifacts, prompts, responses, or logs. Action or CLI upgrades require a new
 full-SHA review plus the Issue Agent Workflow and model-Adapter contract tests.
+
+`issue-agent-provider-preflight.yml` is the only provider diagnostic that may
+consume the Codex Environment secret outside a signed Worker. It is manual,
+uses the same pinned Action, endpoint, CLI version, and repository model
+variable, validates that model before spending quota, runs one bounded
+synthetic JSON invocation with shell, unified-exec, app, browser, computer-use,
+and image-generation features disabled, checks a fixed schema, and checks out
+no repository content. It uploads no Artifact. The GitHub run log may retain
+only the synthetic exchange or provider diagnostic emitted by the pinned
+Action, never Issue or repository content. Run it after changing the OpenRouter
+secret or model and before authorizing another Issue attempt.
 
 The model calls only typed tools in a digest-pinned, no-network Docker sandbox.
 It cannot author trusted file/evidence/usage fields. The Publisher revalidates

--- a/.github/workflows/issue-agent-provider-preflight.yml
+++ b/.github/workflows/issue-agent-provider-preflight.yml
@@ -1,0 +1,56 @@
+name: Agent Tool - Issue Provider Preflight
+run-name: Issue Agent OpenRouter preflight for ${{ vars.ISSUE_AGENT_CODEX_MODEL }}
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: issue-agent-provider-preflight-${{ github.repository }}
+  queue: max
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Verify one bounded synthetic Codex invocation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: issue-agent-codex
+    permissions:
+      contents: read
+    steps:
+      - name: Validate the selected OpenRouter model
+        shell: bash
+        env:
+          MODEL: ${{ vars.ISSUE_AGENT_CODEX_MODEL }}
+        run: |
+          set -euo pipefail
+          [[ "$MODEL" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._:-]*$ ]]
+      - name: Run the bounded synthetic invocation through the pinned Codex Action
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        with:
+          openai-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          responses-api-endpoint: https://openrouter.ai/api/v1/responses
+          codex-version: 0.145.0
+          codex-home: ${{ runner.temp }}/issue-agent-provider-preflight
+          safety-strategy: drop-sudo
+          sandbox: read-only
+          working-directory: ${{ runner.temp }}
+          model: ${{ vars.ISSUE_AGENT_CODEX_MODEL }}
+          prompt: 'Return the JSON object {"ok":true}.'
+          codex-args: '["--disable","shell_tool","--disable","unified_exec","--disable","apps","--disable","browser_use","--disable","computer_use","--disable","image_generation"]'
+          output-file: ${{ runner.temp }}/issue-agent-provider-preflight.json
+          output-schema: '{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}'
+      - name: Verify the synthetic structured response
+        shell: bash
+        env:
+          MODEL: ${{ vars.ISSUE_AGENT_CODEX_MODEL }}
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/issue-agent-provider-preflight.json"
+          test -f "$result"
+          jq -e 'type == "object" and .ok == true and (keys == ["ok"])' \
+            "$result" >/dev/null
+          echo "OpenRouter provider preflight succeeded for $MODEL." \
+            >>"$GITHUB_STEP_SUMMARY"

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -307,8 +307,14 @@ branch.
    `ISSUE_AGENT_APP_LOGIN`, `ISSUE_AGENT_CHECKPOINT_KEY_ID`,
    `ISSUE_AGENT_CODEX_MODEL`, and `ISSUE_AGENT_DEEPSEEK_MODEL`. Set
    `ISSUE_AGENT_CODEX_MODEL` to an exact OpenRouter model slug such as
-   `openai/gpt-5.6-sol`.
-7. Create or verify `needs-triage`, `needs-info`, `ready-for-agent`,
+   `openai/gpt-5.6-sol` or `moonshotai/kimi-k3`.
+7. Run `issue-agent-provider-preflight.yml` once after setting or rotating the
+   OpenRouter secret or model. It runs one bounded synthetic structured Codex
+   invocation through the same pinned official Action without checking out
+   repository code or uploading a response Artifact. Its Actions log can
+   retain only the synthetic exchange or provider diagnostic, never Issue or
+   repository content. Do not authorize an Issue attempt until it passes.
+8. Create or verify `needs-triage`, `needs-info`, `ready-for-agent`,
    `agent-priority/high`, and the Agent PR validation labels documented in
    `.github/workflows/README.md`.
 

--- a/scripts/agent-pr-validation-plan.sh
+++ b/scripts/agent-pr-validation-plan.sh
@@ -183,9 +183,11 @@ elif [[ "$attempt_count" -eq 1 ]]; then
       (ltrimstr($prefix) | test("^[1-9][0-9]*$")))
   ' >/dev/null <<<"$prior_run"
   prior_conclusion="$(jq -er '.conclusion' <<<"$prior_run")"
-  if [[ "$latest_prior_state" == failure || "$latest_prior_state" == error ]]; then
-    test "$prior_conclusion" = failure
-  elif [[ "$latest_prior_state" == pending ]]; then
+  if [[
+    "$latest_prior_state" == failure ||
+      "$latest_prior_state" == error ||
+      "$latest_prior_state" == pending
+  ]]; then
     [[
       "$prior_conclusion" == failure ||
         "$prior_conclusion" == cancelled ||

--- a/scripts/agent_pr_validation_plan_test.go
+++ b/scripts/agent_pr_validation_plan_test.go
@@ -574,6 +574,34 @@ func TestAgentPRValidationPlanAcceptsSingleEvidenceBoundRetry(t *testing.T) {
 	if output, err := newCommand().CombinedOutput(); err != nil {
 		t.Fatalf("validation rejected a terminally cancelled evidence-bound retry: %v\n%s", err, output)
 	}
+
+	failedStatuses := agentValidationStatuses(t, 47, `[
+  {
+    "state": "failure",
+    "context": "Agent Validation Evidence / PR #47 / Gate #7001",
+    "target_url": "https://github.com/WuKongIM/WuKongIM/actions/runs/555"
+  }
+]`)
+	if err := os.WriteFile(statusesPath, []byte(failedStatuses), 0o600); err != nil {
+		t.Fatalf("write failed retry status fixture: %v", err)
+	}
+	cancelledRunCommand := newCommand()
+	attemptRuns, err = os.ReadFile(attemptRunsPath)
+	if err != nil {
+		t.Fatalf("read failed retry run metadata: %v", err)
+	}
+	cancelledRun := strings.Replace(
+		string(attemptRuns),
+		`"conclusion":"failure"`,
+		`"conclusion":"cancelled"`,
+		1,
+	)
+	if err := os.WriteFile(attemptRunsPath, []byte(cancelledRun), 0o600); err != nil {
+		t.Fatalf("write cancelled retry run metadata: %v", err)
+	}
+	if output, err := cancelledRunCommand.CombinedOutput(); err != nil {
+		t.Fatalf("validation rejected failed evidence from a cancelled run: %v\n%s", err, output)
+	}
 }
 
 func TestAgentPRValidationPlanRejectsThirdAttemptAfterSuccessfulRetry(t *testing.T) {

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -138,17 +138,18 @@ func verifyGoToolchainStep() ciStep {
 }
 
 var catalogedWorkflowNames = map[string]string{
-	"agent-pr-merge-gate.yml":         "Safety Automation - Agent PR Merge Gate",
-	"agent-pr-validation.yml":         "Agent Tool - Validate PR",
-	"agent-pr-validation-control.yml": "Safety Automation - Agent PR Validation Control",
-	"cloud-sim-analyze.yml":           "Agent Tool - Analyze Cloud Simulation",
-	"cloud-sim-cleanup.yml":           "Safety Automation - Reconcile Cloud Simulation Resources",
-	"cloud-sim-monitor.yml":           "Safety Automation - Patrol Cloud Simulation Runs",
-	"cloud-sim-oidc-subject.yml":      "Agent Tool - Configure Cloud Simulation OIDC Subject",
-	"cloud-sim-provision.yml":         "Agent Tool - Provision Cloud Simulation",
-	"issue-agent-control.yml":         "Safety Automation - Issue Agent Control",
-	"issue-agent-reconcile.yml":       "Safety Automation - Issue Agent Sweeper",
-	"issue-agent-run.yml":             "Agent Tool - Issue Worker",
+	"agent-pr-merge-gate.yml":            "Safety Automation - Agent PR Merge Gate",
+	"agent-pr-validation.yml":            "Agent Tool - Validate PR",
+	"agent-pr-validation-control.yml":    "Safety Automation - Agent PR Validation Control",
+	"cloud-sim-analyze.yml":              "Agent Tool - Analyze Cloud Simulation",
+	"cloud-sim-cleanup.yml":              "Safety Automation - Reconcile Cloud Simulation Resources",
+	"cloud-sim-monitor.yml":              "Safety Automation - Patrol Cloud Simulation Runs",
+	"cloud-sim-oidc-subject.yml":         "Agent Tool - Configure Cloud Simulation OIDC Subject",
+	"cloud-sim-provision.yml":            "Agent Tool - Provision Cloud Simulation",
+	"issue-agent-control.yml":            "Safety Automation - Issue Agent Control",
+	"issue-agent-provider-preflight.yml": "Agent Tool - Issue Provider Preflight",
+	"issue-agent-reconcile.yml":          "Safety Automation - Issue Agent Sweeper",
+	"issue-agent-run.yml":                "Agent Tool - Issue Worker",
 }
 
 var autonomousSafetyWorkflows = map[string]struct{}{

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -57,6 +57,7 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 
 	for _, name := range []string{
 		"issue-agent-control.yml",
+		"issue-agent-provider-preflight.yml",
 		"issue-agent-reconcile.yml",
 		"issue-agent-run.yml",
 	} {
@@ -128,6 +129,14 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
 				require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
+			case name == "issue-agent-provider-preflight.yml" &&
+				jobName == "preflight":
+				require.Equal(t, "issue-agent-codex", job.Environment)
+				require.Contains(t, jobText, "OPENROUTER_API_KEY")
+				require.NotContains(t, jobText, "CODEX_API_KEY")
+				require.NotContains(t, jobText, "DEEPSEEK_API_KEY")
+				require.NotContains(t, jobText, "ISSUE_AGENT_APP_PRIVATE_KEY")
+				require.NotContains(t, jobText, "ISSUE_AGENT_CHECKPOINT_PRIVATE_KEY")
 			case name == "issue-agent-run.yml" && jobName == "deepseek-worker":
 				require.Equal(t, "issue-agent-deepseek", job.Environment)
 				require.Contains(t, jobText, "DEEPSEEK_API_KEY")
@@ -162,6 +171,11 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 				"issue-agent-${{ inputs.issue_number }}",
 				workflow.Concurrency.Group,
 			)
+		} else if name == "issue-agent-provider-preflight.yml" {
+			require.Equal(t,
+				"issue-agent-provider-preflight-${{ github.repository }}",
+				workflow.Concurrency.Group,
+			)
 		} else {
 			require.Equal(t,
 				"issue-agent-scheduler-${{ github.repository }}",
@@ -172,6 +186,72 @@ func TestIssueAgentWorkflowSecurityContracts(t *testing.T) {
 		require.NotNil(t, workflow.Concurrency.CancelInProgress)
 		require.False(t, *workflow.Concurrency.CancelInProgress)
 	}
+}
+
+func TestIssueAgentCodexProviderPreflightIsSyntheticAndBounded(t *testing.T) {
+	t.Parallel()
+
+	raw := readWorkflow(t, "issue-agent-provider-preflight.yml")
+	_, workflow, err := decodeWorkflow(raw)
+	require.NoError(t, err)
+	require.Empty(t, workflow.Permissions)
+	require.Len(t, workflow.Jobs, 1)
+
+	job, ok := workflow.Jobs["preflight"]
+	require.True(t, ok)
+	require.Equal(t, "issue-agent-codex", job.Environment)
+	require.Equal(t, map[string]string{"contents": "read"}, job.Permissions)
+	require.Equal(t, 10, job.TimeoutMinutes)
+	require.Len(t, job.Steps, 3)
+
+	validate := job.Steps[0]
+	require.Equal(t, "Validate the selected OpenRouter model", validate.Name)
+	require.Equal(t, "bash", validate.Shell)
+	require.Equal(t, map[string]string{
+		"MODEL": "${{ vars.ISSUE_AGENT_CODEX_MODEL }}",
+	}, validate.Env)
+	require.Contains(t, validate.Run,
+		`[[ "$MODEL" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/`+
+			`[A-Za-z0-9][A-Za-z0-9._:-]*$ ]]`)
+
+	action := job.Steps[1]
+	require.Equal(t,
+		"Run the bounded synthetic invocation through the pinned Codex Action",
+		action.Name,
+	)
+	require.Equal(t,
+		"openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56",
+		action.Uses,
+	)
+	require.Equal(t, map[string]any{
+		"openai-api-key":         "${{ secrets.OPENROUTER_API_KEY }}",
+		"responses-api-endpoint": "https://openrouter.ai/api/v1/responses",
+		"codex-version":          "0.145.0",
+		"codex-home":             "${{ runner.temp }}/issue-agent-provider-preflight",
+		"safety-strategy":        "drop-sudo",
+		"sandbox":                "read-only",
+		"working-directory":      "${{ runner.temp }}",
+		"model":                  "${{ vars.ISSUE_AGENT_CODEX_MODEL }}",
+		"prompt":                 "Return the JSON object {\"ok\":true}.",
+		"codex-args":             "[\"--disable\",\"shell_tool\",\"--disable\",\"unified_exec\",\"--disable\",\"apps\",\"--disable\",\"browser_use\",\"--disable\",\"computer_use\",\"--disable\",\"image_generation\"]",
+		"output-file":            "${{ runner.temp }}/issue-agent-provider-preflight.json",
+		"output-schema":          `{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}`,
+	}, action.With)
+
+	verify := job.Steps[2]
+	require.Equal(t, "Verify the synthetic structured response", verify.Name)
+	require.Equal(t, "bash", verify.Shell)
+	require.Contains(t, verify.Run,
+		`jq -e 'type == "object" and .ok == true and (keys == ["ok"])'`)
+	require.Contains(t, verify.Run, "$RUNNER_TEMP/issue-agent-provider-preflight.json")
+
+	text := string(raw)
+	require.Equal(t, 1, strings.Count(text, "secrets.OPENROUTER_API_KEY"))
+	require.NotContains(t, text, "actions/checkout")
+	require.NotContains(t, text, "upload-artifact")
+	require.NotContains(t, text, "github.event.")
+	require.NotContains(t, text, "CODEX_API_KEY")
+	require.NotContains(t, text, "DEEPSEEK_API_KEY")
 }
 
 func TestIssueAgentWorkflowRunUsesSeparateReadOnlyCheckouts(t *testing.T) {


### PR DESCRIPTION
## What changed

- add a manual `Agent Tool - Issue Provider Preflight` workflow
- validate the configured OpenRouter model before consuming quota
- send one bounded synthetic structured invocation through the same pinned `openai/codex-action`, OpenRouter Responses endpoint, Environment secret, CLI version, and repository model variable used by the Issue Worker
- disable shell, unified-exec, app, browser, computer-use, and image-generation feature families
- verify an exact synthetic JSON result without checking out repository content or uploading an Artifact
- document the credential boundary, expected Actions-log retention, and administrator run order
- extend the authoritative workflow catalog and protected workflow security tests

## Why

Issue #685 reached the Kimi Worker but returned only a generic provider failure, with no branch or Draft PR. The existing signed Worker is intentionally slow and heavily isolated, so it is a poor feedback loop for distinguishing OpenRouter transport/model compatibility from the full Worker adapter and E2E path. This preflight provides a small, explicit-spend diagnostic using the exact official Action boundary without exposing the OpenRouter key to repository code.

## User and developer impact

Maintainers can validate a newly configured or rotated OpenRouter secret/model before authorizing another Issue Agent attempt. A passing preflight proves the pinned Action, endpoint, secret, and selected model can complete the fixed structured invocation; it does not claim the full Issue Worker or E2E reproduction is valid.

## Validation

- `GOWORK=off go test ./scripts -count=1`
- `git diff --check`
- two-axis review against `origin/main`: Standards 0 findings, Spec 0 findings
