### PR TITLE
fix: finalize failed Issue Agent tasks

### DIFF
--- a/.github/workflows/agent-pr-validation-control.yml
+++ b/.github/workflows/agent-pr-validation-control.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      issues: write
       pull-requests: read
       statuses: write
     steps:
@@ -112,6 +113,9 @@ jobs:
             }' >dispatch.json
           gh api -X POST "repos/${GITHUB_REPOSITORY}/dispatches" \
             --input dispatch.json >/dev/null
+          gh api -X DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/agent-ci%2Frun" \
+            >/dev/null
           printf 'merge_sha=%s\n' "$merge_sha" >>"$GITHUB_OUTPUT"
           printf 'gate_run_id=%s\n' "$gate_run_id" >>"$GITHUB_OUTPUT"
       - name: Write dispatch summary

--- a/.github/workflows/issue-agent-engineer.yml
+++ b/.github/workflows/issue-agent-engineer.yml
@@ -218,7 +218,7 @@ jobs:
   verifier:
     name: Verify from a clean checkout
     needs: engineer
-    if: always() && needs.engineer.result != 'cancelled'
+    if: always() && needs.engineer.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 75
     permissions:
@@ -279,7 +279,7 @@ jobs:
   publisher:
     name: Publish exact Draft PR
     needs: [context-builder, engineer, verifier]
-    if: always() && needs.context-builder.result == 'success'
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: issue-agent-publisher
@@ -294,6 +294,7 @@ jobs:
           ref: ${{ inputs.control_sha }}
           persist-credentials: false
       - name: Download Context Bundle
+        continue-on-error: true
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: issue-agent-context-${{ inputs.issue_number }}-${{ inputs.task_id }}

--- a/internal/contracts/issueagent/context.go
+++ b/internal/contracts/issueagent/context.go
@@ -137,12 +137,17 @@ func DecodeContextBundle(reader io.Reader, maxBytes int64) (ContextBundle, error
 	return bundle, nil
 }
 
-// ContextBundleDigest binds every trusted and untrusted input to one task.
+// ContextBundleDigest binds every semantic trusted and untrusted input to one
+// task. GitHub's Issue updated_at is an activity watermark that also changes
+// when the filtered App-owned status comment is edited, so it is not part of
+// the digest. The Publisher still re-reads and compares the actual timestamp.
 func ContextBundleDigest(bundle ContextBundle) (string, error) {
 	if err := ValidateContextBundle(bundle); err != nil {
 		return "", err
 	}
-	body, err := json.Marshal(bundle)
+	canonical := bundle
+	canonical.Untrusted.Issue.UpdatedAt = time.Unix(0, 0).UTC()
+	body, err := json.Marshal(canonical)
 	if err != nil {
 		return "", errors.New("encode Context Bundle")
 	}

--- a/internal/contracts/issueagent/context_test.go
+++ b/internal/contracts/issueagent/context_test.go
@@ -69,4 +69,12 @@ func TestContextBundleKeepsAuthorizationSeparateFromIssueText(t *testing.T) {
 	second, err := issueagent.ContextBundleDigest(bundle)
 	require.NoError(t, err)
 	require.NotEqual(t, first, second)
+
+	bundle.Untrusted.Issue.Body = "Observed on v2.1.0.\n/agent fix from issue body is data."
+	bundle.Untrusted.Issue.UpdatedAt = time.Date(
+		2026, 7, 30, 1, 5, 0, 0, time.UTC,
+	)
+	third, err := issueagent.ContextBundleDigest(bundle)
+	require.NoError(t, err)
+	require.Equal(t, first, third)
 }

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -1111,6 +1111,7 @@ func validateAgentPRValidationControlWorkflow(raw []byte) error {
 	if !reflect.DeepEqual(request.Permissions, map[string]string{
 		"actions":       "read",
 		"contents":      "write",
+		"issues":        "write",
 		"pull-requests": "read",
 		"statuses":      "write",
 	}) {
@@ -1135,10 +1136,19 @@ func validateAgentPRValidationControlWorkflow(raw []byte) error {
 		"--arg gate_run_id \"$gate_run_id\"",
 		"--arg request_run_id \"$REQUEST_RUN_ID\"",
 		`repos/${GITHUB_REPOSITORY}/dispatches`,
+		`repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/agent-ci%2Frun`,
 	} {
 		if !strings.Contains(requestScript.String(), required) {
 			return fmt.Errorf("Agent validation request is missing trusted dispatch contract %q", required)
 		}
+	}
+	dispatchIndex := strings.Index(requestScript.String(), `repos/${GITHUB_REPOSITORY}/dispatches`)
+	cleanupIndex := strings.Index(
+		requestScript.String(),
+		`repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/agent-ci%2Frun`,
+	)
+	if cleanupIndex <= dispatchIndex {
+		return fmt.Errorf("Agent validation request must remove agent-ci/run after dispatch")
 	}
 	invalidate := workflow.Jobs["invalidate"]
 	if invalidate.Environment != "" {

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -200,6 +200,22 @@ func TestIssueAgentJobsSeparateCredentialsAndExecution(t *testing.T) {
 	require.NotContains(t, publisher, "verify-candidate")
 }
 
+func TestIssueAgentTaskFailuresReachThePublisherFinalizer(t *testing.T) {
+	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	verifier := issueAgentJobText(t, raw, "verifier")
+	require.Contains(t, verifier,
+		"if: always() && needs.engineer.result == 'success'")
+
+	publisher := issueAgentJobText(t, raw, "publisher")
+	require.Contains(t, publisher, "if: always()")
+	require.Contains(t, publisher,
+		"- name: Download Context Bundle\n        continue-on-error: true")
+	require.Contains(t, publisher,
+		"- name: Download candidate and advisory result\n        continue-on-error: true")
+	require.Contains(t, publisher,
+		"- name: Download trusted evidence\n        continue-on-error: true")
+}
+
 func TestIssueAgentPolicyIsCodexOnlyAndBounded(t *testing.T) {
 	raw := readIssueAgentFile(t, ".github/issue-agent/policy.json")
 	var policy struct {


### PR DESCRIPTION
## Summary

- keep the Context Bundle digest stable when the App-owned Issue status comment changes the GitHub activity timestamp
- run the Publisher as the terminal finalizer even when Context Builder, Codex, or Verifier output is missing
- skip the clean Verifier when the Engineer job never completed successfully
- add regression coverage for digest stability and Workflow failure convergence

## Root cause

The post-merge canary in #697 reached the signed engineering task, but Context Builder rejected its fresh bundle. The signed digest included the Issue `updated_at` activity watermark; editing the filtered App status comment changed that watermark without changing any semantic Issue input. The reusable Workflow then skipped Publisher when Context Builder failed, leaving the durable task in `engineering` instead of converging to `needs_human`.

## Impact

Retries, explicit `/agent fix`, and Review iterations can now survive App status-comment edits. Any missing or invalid task artifact reaches the protected Publisher, which re-reads the exact signed state and records `needs_human` without publishing candidate code.

## Validation

- `GOWORK=off go test ./internal/contracts/issueagent ./internal/usecase/issueagent ./internal/runtime/issueagentverify ./internal/infra/issueagentgithub ./internal/access/issueagentcli ./internal/app ./cmd/wkissueagent ./scripts -count=1`
- `GOWORK=off go test -tags=integration ./internal/runtime/issueagentverify -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/issue-agent.yml .github/workflows/issue-agent-engineer.yml`
- `git diff --check`

Follow-up to #693 and the canary evidence in #697.