### PR TITLE
ci: allow validation trigger cleanup

### DIFF
--- a/.github/workflows/agent-pr-validation-control.yml
+++ b/.github/workflows/agent-pr-validation-control.yml
@@ -16,8 +16,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Authorize and dispatch the commit-bound request

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -1111,8 +1111,7 @@ func validateAgentPRValidationControlWorkflow(raw []byte) error {
 	if !reflect.DeepEqual(request.Permissions, map[string]string{
 		"actions":       "read",
 		"contents":      "write",
-		"issues":        "write",
-		"pull-requests": "read",
+		"pull-requests": "write",
 		"statuses":      "write",
 	}) {
 		return fmt.Errorf("Agent validation request permissions = %#v", request.Permissions)


### PR DESCRIPTION
## What changed

- grant the trusted PR validation control job `pull-requests: write`
- remove the ineffective `issues: write` permission
- update the workflow contract to require the corrected least-privilege permission set

## Root cause

The control workflow successfully authorized the actor, published the request
status, and dispatched the commit-bound worker, but then failed while consuming
the `agent-ci/run` label with `Resource not accessible by integration (HTTP
403)`. The target is a pull request, while the job only had
`pull-requests: read`.

The failed control conclusion makes the merge gate reject otherwise successful
validation evidence, which currently blocks PR #699.

## Impact

The control run can remove its one-shot trigger label after dispatch and
complete successfully. No product runtime behavior changes.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml`
- `GOWORK=off go test ./scripts -run '^(TestAgentPRValidation.*|TestAgentWorkflow.*|TestLegacyAutomaticTestWorkflowsAreAbsent)$' -count=1`
- `git diff --check`

## Review note

This changes a protected GitHub Actions workflow and its contract test. It
requires explicit Agent review before requesting `agent-ci/run`.
