### PR TITLE
fix: preserve committed Issue Agent dispatch

### DIFF
--- a/.github/workflows/issue-agent.yml
+++ b/.github/workflows/issue-agent.yml
@@ -77,6 +77,8 @@ jobs:
               control_sha:$control_sha,now:$now}' >"$RUNNER_TEMP/reconcile.json"
           "$RUNNER_TEMP/wkissueagent" reconcile-github \
             --input "$RUNNER_TEMP/reconcile.json" >"$RUNNER_TEMP/decision.json"
+          jq -r '.warnings[]? | "::warning::Issue Agent \(.projection) projection: \(.reason)"' \
+            "$RUNNER_TEMP/decision.json"
           jq -r '"dispatch=\(.dispatch)"' "$RUNNER_TEMP/decision.json" >>"$GITHUB_OUTPUT"
           jq -r '"repository=\(.repository)"' "$RUNNER_TEMP/decision.json" >>"$GITHUB_OUTPUT"
           jq -r '"issue_number=\(.issue_number)"' "$RUNNER_TEMP/decision.json" >>"$GITHUB_OUTPUT"

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -1159,3 +1159,10 @@ Controller admission requires the binary's exact checkout SHA to match the
 fresh protected `main` head. The reusable task freezes that SHA for every
 trusted control role while the candidate workspace uses the task's separate
 exact base SHA.
+
+After the Controller commits a signed transition, that transition and its
+dispatch result remain authoritative if a GitHub status projection fails.
+Status repair runs before terminal tracking-label removal; a status failure
+therefore retains `ready-for-agent` so the bounded sweep retries the projection.
+Projection failures are emitted as typed Workflow warnings without discarding
+the committed result.

--- a/internal/app/issue_agent.go
+++ b/internal/app/issue_agent.go
@@ -84,16 +84,24 @@ type issueAgentPolicy struct {
 }
 
 type reconcileResult struct {
-	Dispatch     bool   `json:"dispatch"`
-	Repository   string `json:"repository"`
-	IssueNumber  int64  `json:"issue_number"`
-	TaskID       string `json:"task_id"`
-	BaseSHA      string `json:"base_sha"`
-	ControlSHA   string `json:"control_sha"`
-	StateHeadSHA string `json:"state_head_sha"`
-	State        string `json:"state"`
-	Reason       string `json:"reason"`
+	Dispatch     bool               `json:"dispatch"`
+	Repository   string             `json:"repository"`
+	IssueNumber  int64              `json:"issue_number"`
+	TaskID       string             `json:"task_id"`
+	BaseSHA      string             `json:"base_sha"`
+	ControlSHA   string             `json:"control_sha"`
+	StateHeadSHA string             `json:"state_head_sha"`
+	State        string             `json:"state"`
+	Reason       string             `json:"reason"`
+	Warnings     []reconcileWarning `json:"warnings,omitempty"`
 }
+
+type reconcileWarning struct {
+	Projection string `json:"projection"`
+	Reason     string `json:"reason"`
+}
+
+type committedIssueProjection func() error
 
 type issueAgentPullRequest struct {
 	Number int64 `json:"number"`
@@ -501,24 +509,6 @@ func reconcileGitHub(
 	if err != nil {
 		return reconcileResult{}, err
 	}
-	if err := repairIssueStatus(
-		ctx,
-		client,
-		config.AppLogin,
-		next,
-	); err != nil {
-		return reconcileResult{}, err
-	}
-	if !trackIssue {
-		if _, _, err := setIssueAgentTracking(
-			ctx,
-			client,
-			issue,
-			false,
-		); err != nil {
-			return reconcileResult{}, err
-		}
-	}
 	result := reconcileResult{
 		Dispatch: decision.Kind == issueagent.IssueDecisionDispatchEngineer ||
 			decision.Kind == issueagent.IssueDecisionDispatchReview,
@@ -531,7 +521,56 @@ func reconcileGitHub(
 		result.TaskID = next.Task.ID
 		result.BaseSHA = next.Task.BaseSHA
 	}
-	return result, nil
+	statusProjection := func() error {
+		return repairIssueStatus(
+			ctx,
+			client,
+			config.AppLogin,
+			next,
+		)
+	}
+	var trackingProjection committedIssueProjection
+	if !trackIssue {
+		trackingProjection = func() error {
+			_, _, projectionErr := setIssueAgentTracking(
+				ctx,
+				client,
+				issue,
+				false,
+			)
+			return projectionErr
+		}
+	}
+	return finalizeCommittedReconcile(
+		result,
+		statusProjection,
+		trackingProjection,
+	), nil
+}
+
+// finalizeCommittedReconcile preserves the authoritative signed transition
+// while retaining the sweep label until its ordered GitHub projections succeed.
+func finalizeCommittedReconcile(
+	result reconcileResult,
+	statusProjection committedIssueProjection,
+	trackingProjection committedIssueProjection,
+) reconcileResult {
+	if err := statusProjection(); err != nil {
+		result.Warnings = append(result.Warnings, reconcileWarning{
+			Projection: "status",
+			Reason:     err.Error(),
+		})
+		return result
+	}
+	if trackingProjection != nil {
+		if err := trackingProjection(); err != nil {
+			result.Warnings = append(result.Warnings, reconcileWarning{
+				Projection: "tracking",
+				Reason:     err.Error(),
+			})
+		}
+	}
+	return result
 }
 
 func recoverIssueTask(

--- a/internal/app/issue_agent_internal_test.go
+++ b/internal/app/issue_agent_internal_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +17,74 @@ import (
 	issueagent "github.com/WuKongIM/WuKongIM/internal/usecase/issueagent"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCommittedIssueTransitionKeepsDispatchWhenProjectionFails(t *testing.T) {
+	t.Parallel()
+
+	expected := reconcileResult{
+		Dispatch: true, Repository: "WuKongIM/WuKongIM",
+		IssueNumber:  700,
+		TaskID:       "sha256:task",
+		BaseSHA:      "base",
+		ControlSHA:   "control",
+		StateHeadSHA: "state",
+		State:        string(contract.IssueStateEngineering),
+		Reason:       "authorized low-risk Bug is ready for engineering",
+	}
+	actual := finalizeCommittedReconcile(
+		expected,
+		func() error {
+			return errors.New("transient status projection failure")
+		},
+		nil,
+	)
+	require.True(t, actual.Dispatch)
+	require.Equal(t, expected.TaskID, actual.TaskID)
+	require.Equal(t, expected.StateHeadSHA, actual.StateHeadSHA)
+	require.Equal(t, []reconcileWarning{{
+		Projection: "status",
+		Reason:     "transient status projection failure",
+	}}, actual.Warnings)
+}
+
+func TestCommittedTerminalTransitionKeepsTrackingWhenStatusProjectionFails(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	trackingRemoved := false
+	actual := finalizeCommittedReconcile(
+		reconcileResult{State: string(contract.IssueStateCompleted)},
+		func() error {
+			return errors.New("transient status projection failure")
+		},
+		func() error {
+			trackingRemoved = true
+			return nil
+		},
+	)
+	require.False(t, trackingRemoved)
+	require.Equal(t, []reconcileWarning{{
+		Projection: "status",
+		Reason:     "transient status projection failure",
+	}}, actual.Warnings)
+}
+
+func TestCommittedIssueTransitionReportsTrackingRemovalFailure(t *testing.T) {
+	t.Parallel()
+
+	actual := finalizeCommittedReconcile(
+		reconcileResult{State: string(contract.IssueStateCompleted)},
+		func() error { return nil },
+		func() error {
+			return errors.New("transient tracking projection failure")
+		},
+	)
+	require.Equal(t, []reconcileWarning{{
+		Projection: "tracking",
+		Reason:     "transient tracking projection failure",
+	}}, actual.Warnings)
+}
 
 func TestResolveIssueNumberRotatesScheduledTrackedIssues(t *testing.T) {
 	t.Parallel()

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -216,6 +216,12 @@ func TestIssueAgentTaskFailuresReachThePublisherFinalizer(t *testing.T) {
 		"- name: Download trusted evidence\n        continue-on-error: true")
 }
 
+func TestIssueAgentControllerReportsCommittedProjectionWarnings(t *testing.T) {
+	raw := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
+	require.Contains(t, raw,
+		`jq -r '.warnings[]? | "::warning::Issue Agent \(.projection) projection: \(.reason)"'`)
+}
+
 func TestIssueAgentPolicyIsCodexOnlyAndBounded(t *testing.T) {
 	raw := readIssueAgentFile(t, ".github/issue-agent/policy.json")
 	var policy struct {


### PR DESCRIPTION
## What

Preserve the exact Controller result after a signed Issue Agent state transition commits, even when the subsequent GitHub status projection fails.

- construct the dispatch result immediately after the signed state-ref advance;
- report projection failures as structured GitHub Actions warnings;
- run status repair before terminal `ready-for-agent` removal;
- retain the tracking label when status repair fails so the five-minute sweep retries it;
- document the post-commit recovery contract in `internal/app/FLOW.md`.

## Why

The real #700 canary exposed a consistency gap: Controller run 30552161534 durably committed the `engineering` transition, then a repairable status-comment operation failed before `decision.json` and `dispatch=true` were published. Later reconciliations correctly observed the durable active state and waited, so no Engineer run was dispatched.

The signed `agent-state/issue-N` ref is authoritative. Its already-committed task and dispatch decision must not be discarded by failure of the mutable Issue status projection.

## Safety

This does not weaken permissions, signed-state validation, candidate isolation, Publisher credentials, protected paths, or the human-only merge boundary. Only post-commit GitHub projections fail open, with warnings and an autonomous retry path.

## Validation

- `GOWORK=off go test ./internal/contracts/issueagent ./internal/usecase/issueagent ./internal/infra/issueagentgithub ./internal/access/issueagentcli ./internal/app ./cmd/wkissueagent ./scripts -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/issue-agent.yml .github/workflows/issue-agent-engineer.yml`
- `git diff --check`
- Go formatting check
- Independent Standards and Spec reviews: no remaining findings

Refs #700.