### PR TITLE
fix: make Issue Agent handoff artifacts runnable

### DIFF
--- a/.github/workflows/issue-agent-engineer.yml
+++ b/.github/workflows/issue-agent-engineer.yml
@@ -24,10 +24,6 @@ on:
     secrets:
       OPENAI_API_KEY:
         required: true
-      # Declared for expression validation; the Publisher job obtains the
-      # value from its protected Environment, never from the caller.
-      ISSUE_AGENT_APP_PRIVATE_KEY:
-        required: false
 
 permissions: {}
 
@@ -115,7 +111,7 @@ jobs:
       - name: Upload immutable Context Bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: issue-agent-context-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-context-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/context-bundle.json
           if-no-files-found: error
           retention-days: 2
@@ -159,7 +155,7 @@ jobs:
       - name: Download Context Bundle
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: issue-agent-context-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-context-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/issue-agent-context
       - name: Select prompt from signed task kind
         shell: bash
@@ -208,7 +204,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: issue-agent-candidate-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-candidate-${{ inputs.issue_number }}
           path: |
             ${{ runner.temp }}/engineer-result.json
             ${{ runner.temp }}/candidate.json
@@ -244,7 +240,7 @@ jobs:
       - name: Download captured candidate
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: issue-agent-candidate-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-candidate-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/issue-agent-candidate
       - name: Independently apply and verify candidate
         shell: bash
@@ -271,7 +267,7 @@ jobs:
       - name: Upload trusted Candidate Evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: issue-agent-evidence-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-evidence-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/candidate-evidence.json
           if-no-files-found: error
           retention-days: 2
@@ -288,6 +284,8 @@ jobs:
     concurrency:
       group: issue-agent-state-${{ inputs.repository }}
       cancel-in-progress: false
+    env:
+      ISSUE_AGENT_PRIVATE_KEY_SECRET: ISSUE_AGENT_APP_PRIVATE_KEY
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -297,19 +295,19 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: issue-agent-context-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-context-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/issue-agent-context
       - name: Download candidate and advisory result
         continue-on-error: true
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: issue-agent-candidate-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-candidate-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/issue-agent-candidate
       - name: Download trusted evidence
         continue-on-error: true
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: issue-agent-evidence-${{ inputs.issue_number }}-${{ inputs.task_id }}
+          name: issue-agent-evidence-${{ inputs.issue_number }}
           path: ${{ runner.temp }}/issue-agent-evidence
       - name: Build protected Publisher
         shell: bash
@@ -320,7 +318,7 @@ jobs:
           ISSUE_AGENT_APP_ID: ${{ vars.ISSUE_AGENT_APP_ID }}
           ISSUE_AGENT_APP_INSTALLATION_ID: ${{ vars.ISSUE_AGENT_APP_INSTALLATION_ID }}
           ISSUE_AGENT_REPOSITORY_ID: ${{ github.repository_id }}
-          ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets.ISSUE_AGENT_APP_PRIVATE_KEY }}
+          ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets[env.ISSUE_AGENT_PRIVATE_KEY_SECRET] }}
         run: |
           set -euo pipefail
           jq -n --arg repository "${{ inputs.repository }}" \

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -216,6 +216,37 @@ func TestIssueAgentTaskFailuresReachThePublisherFinalizer(t *testing.T) {
 		"- name: Download trusted evidence\n        continue-on-error: true")
 }
 
+func TestIssueAgentArtifactNamesAreFilesystemSafe(t *testing.T) {
+	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	for name, count := range map[string]int{
+		"issue-agent-context-${{ inputs.issue_number }}":   3,
+		"issue-agent-candidate-${{ inputs.issue_number }}": 3,
+		"issue-agent-evidence-${{ inputs.issue_number }}":  2,
+	} {
+		require.Equal(t, count, strings.Count(raw, "name: "+name), name)
+	}
+	require.NotContains(t, raw,
+		"name: issue-agent-context-${{ inputs.issue_number }}-${{ inputs.task_id }}")
+	require.NotContains(t, raw,
+		"name: issue-agent-candidate-${{ inputs.issue_number }}-${{ inputs.task_id }}")
+	require.NotContains(t, raw,
+		"name: issue-agent-evidence-${{ inputs.issue_number }}-${{ inputs.task_id }}")
+}
+
+func TestIssueAgentPublisherUsesOnlyItsEnvironmentSecret(t *testing.T) {
+	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	workflowCall, _, found := strings.Cut(raw, "\njobs:")
+	require.True(t, found)
+	require.NotContains(t, workflowCall, "ISSUE_AGENT_APP_PRIVATE_KEY")
+
+	publisher := issueAgentJobText(t, raw, "publisher")
+	require.Contains(t, publisher, "environment: issue-agent-publisher")
+	require.Contains(t, publisher,
+		"ISSUE_AGENT_PRIVATE_KEY_SECRET: ISSUE_AGENT_APP_PRIVATE_KEY")
+	require.Contains(t, publisher,
+		"ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets[env.ISSUE_AGENT_PRIVATE_KEY_SECRET] }}")
+}
+
 func TestIssueAgentControllerReportsCommittedProjectionWarnings(t *testing.T) {
 	raw := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
 	require.Contains(t, raw,


### PR DESCRIPTION
## What

- use run-scoped, filesystem-safe artifact names for Context, candidate, and evidence handoffs;
- obtain the App private key only from the protected `issue-agent-publisher` Environment instead of declaring an empty optional caller secret;
- add static workflow contracts for both regressions.

## Why

The live #703 canary successfully proved the signed-state dispatch repair, then failed before Codex because the artifact name contained the task ID `sha256:...`; GitHub rejects `:` in artifact names. The always-run Publisher then reached finalization but its private key was empty because the reusable workflow declared the Environment secret as an optional `workflow_call` secret while the caller intentionally did not pass Publisher credentials.

Artifact names are scoped to one workflow run and one serialized Issue task, so Issue number plus artifact kind is unique. Signed task ID and base SHA validation remain inside the artifact contents and trusted boundaries.

## Safety

The private key remains available only to the `publisher` job with `environment: issue-agent-publisher`. Codex and Verifier remain credential-free. Permissions, signed-state recovery, candidate isolation, protected paths, Publisher fencing, and human-only merge authority are unchanged.

## Validation

- `GOWORK=off go test ./scripts -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/issue-agent.yml .github/workflows/issue-agent-engineer.yml .github/workflows/issue-agent-pr-signal.yml`
- `git diff --check`
- Go formatting check
- independent Standards and Spec reviews: no findings

Refs #703 and run 30557451415.