### PR TITLE
fix: complete Issue Agent execution handoff

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,7 +27,7 @@ for discovery and may become more specific over time.
 | `cloud-sim-monitor.yml` | `Safety Automation - Patrol Cloud Simulation Runs` | Every 30 minutes, patrols live runs and records bounded health evidence | Autonomous read-only safety patrol |
 | `issue-agent.yml` | `Safety Automation - GitHub Issue Agent` | Reconciles Issue/PR hints and the bounded five-minute sweep from fresh GitHub facts | Controller writes only through the protected Publisher environment |
 | `issue-agent-pr-signal.yml` | `Safety Automation - Issue Agent PR Signal` | Converts PR lifecycle and Review events into a credential-free completed run that wakes the default-branch Controller | No token permissions, Secrets, checkout, artifacts, or candidate execution |
-| `issue-agent-engineer.yml` | `Agent Tool - Issue Engineer` | Runs one exact Context Builder, Codex Engineer, clean Verifier, and Publisher chain | OpenAI and Publisher credentials remain in separate jobs |
+| `issue-agent-engineer.yml` | `Agent Tool - Issue Engineer` | Runs one exact Context Builder, Codex Engineer, and clean Verifier chain | Only the Codex job receives the OpenAI key; the caller-owned Publisher remains separate |
 
 ## GitHub Issue Agent rollout
 
@@ -36,8 +36,10 @@ serializes all repository reconciliation and calls the reusable Engineer
 workflow. Controller and Publisher writes share one repository-wide
 concurrency group; credential-free engineering and verification can run in
 parallel for different Issues.
-The latter executes `recover-task -> context-builder -> engineer -> verifier
--> publisher`.
+The reusable workflow executes
+`recover-task -> context-builder -> engineer -> verifier`. The caller-owned
+Publisher then always finalizes an accepted task from the protected
+`issue-agent-publisher` Environment, including failed engineering attempts.
 
 PR lifecycle and Review events pass through
 `issue-agent-pr-signal.yml`. The Signal has no authority and executes no

--- a/.github/workflows/issue-agent-engineer.yml
+++ b/.github/workflows/issue-agent-engineer.yml
@@ -183,6 +183,7 @@ jobs:
           effort: high
           sandbox: workspace-write
           safety-strategy: drop-sudo
+          allow-bot-users: ${{ vars.ISSUE_AGENT_APP_LOGIN }}
           codex-args: '["--ephemeral","--output-schema","${{ runner.temp }}/engineer-result.schema.json","-c","sandbox_workspace_write.network_access=true"]'
       - name: Capture candidate without trusting Git
         if: always()
@@ -271,82 +272,3 @@ jobs:
           path: ${{ runner.temp }}/candidate-evidence.json
           if-no-files-found: error
           retention-days: 2
-
-  publisher:
-    name: Publish exact Draft PR
-    needs: [context-builder, engineer, verifier]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: issue-agent-publisher
-    permissions:
-      contents: read
-    concurrency:
-      group: issue-agent-state-${{ inputs.repository }}
-      cancel-in-progress: false
-    env:
-      ISSUE_AGENT_PRIVATE_KEY_SECRET: ISSUE_AGENT_APP_PRIVATE_KEY
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ inputs.control_sha }}
-          persist-credentials: false
-      - name: Download Context Bundle
-        continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: issue-agent-context-${{ inputs.issue_number }}
-          path: ${{ runner.temp }}/issue-agent-context
-      - name: Download candidate and advisory result
-        continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: issue-agent-candidate-${{ inputs.issue_number }}
-          path: ${{ runner.temp }}/issue-agent-candidate
-      - name: Download trusted evidence
-        continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: issue-agent-evidence-${{ inputs.issue_number }}
-          path: ${{ runner.temp }}/issue-agent-evidence
-      - name: Build protected Publisher
-        shell: bash
-        run: GOWORK=off go build -trimpath -o "$RUNNER_TEMP/wkissueagent" ./cmd/wkissueagent
-      - name: Mint short-lived repository-scoped App token
-        shell: bash
-        env:
-          ISSUE_AGENT_APP_ID: ${{ vars.ISSUE_AGENT_APP_ID }}
-          ISSUE_AGENT_APP_INSTALLATION_ID: ${{ vars.ISSUE_AGENT_APP_INSTALLATION_ID }}
-          ISSUE_AGENT_REPOSITORY_ID: ${{ github.repository_id }}
-          ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets[env.ISSUE_AGENT_PRIVATE_KEY_SECRET] }}
-        run: |
-          set -euo pipefail
-          jq -n --arg repository "${{ inputs.repository }}" \
-            '{repository:$repository}' >"$RUNNER_TEMP/mint.json"
-          "$RUNNER_TEMP/wkissueagent" mint-app-token \
-            --input "$RUNNER_TEMP/mint.json" >"$RUNNER_TEMP/app-token.json"
-          app_token="$(jq -er .token "$RUNNER_TEMP/app-token.json")"
-          echo "::add-mask::$app_token"
-          printf 'ISSUE_AGENT_GITHUB_TOKEN=%s\n' "$app_token" >>"$GITHUB_ENV"
-      - name: Publish without executing candidate code
-        shell: bash
-        env:
-          ISSUE_AGENT_APP_LOGIN: ${{ vars.ISSUE_AGENT_APP_LOGIN }}
-        run: |
-          set -euo pipefail
-          jq -n \
-            --arg repository "${{ inputs.repository }}" \
-            --argjson issue_number "${{ inputs.issue_number }}" \
-            --arg control_sha "${{ inputs.control_sha }}" \
-            --arg expected_state_head "${{ inputs.state_head_sha }}" \
-            --arg context "$RUNNER_TEMP/issue-agent-context/context-bundle.json" \
-            --arg engineer "$RUNNER_TEMP/issue-agent-candidate/engineer-result.json" \
-            --arg candidate "$RUNNER_TEMP/issue-agent-candidate/candidate.json" \
-            --arg evidence "$RUNNER_TEMP/issue-agent-evidence/candidate-evidence.json" \
-            --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{repository:$repository,issue_number:$issue_number,control_sha:$control_sha,
-              expected_state_head:$expected_state_head,context_path:$context,
-              engineer_result_path:$engineer,candidate_path:$candidate,
-              evidence_path:$evidence,now:$now}' >"$RUNNER_TEMP/publish.json"
-          "$RUNNER_TEMP/wkissueagent" publish-candidate \
-            --input "$RUNNER_TEMP/publish.json"

--- a/.github/workflows/issue-agent.yml
+++ b/.github/workflows/issue-agent.yml
@@ -105,3 +105,80 @@ jobs:
       state_head_sha: ${{ needs.controller.outputs.state_head_sha }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  publisher:
+    name: Publish exact Draft PR
+    needs: [controller, engineer]
+    if: always() && needs.controller.result == 'success' && needs.controller.outputs.dispatch == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: issue-agent-publisher
+    permissions:
+      contents: read
+    concurrency:
+      group: issue-agent-state-${{ github.repository }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.controller.outputs.control_sha }}
+          persist-credentials: false
+      - name: Download Context Bundle
+        continue-on-error: true
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: issue-agent-context-${{ needs.controller.outputs.issue_number }}
+          path: ${{ runner.temp }}/issue-agent-context
+      - name: Download candidate and advisory result
+        continue-on-error: true
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: issue-agent-candidate-${{ needs.controller.outputs.issue_number }}
+          path: ${{ runner.temp }}/issue-agent-candidate
+      - name: Download trusted evidence
+        continue-on-error: true
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: issue-agent-evidence-${{ needs.controller.outputs.issue_number }}
+          path: ${{ runner.temp }}/issue-agent-evidence
+      - name: Build protected Publisher
+        shell: bash
+        run: GOWORK=off go build -trimpath -o "$RUNNER_TEMP/wkissueagent" ./cmd/wkissueagent
+      - name: Mint short-lived repository-scoped App token
+        shell: bash
+        env:
+          ISSUE_AGENT_APP_ID: ${{ vars.ISSUE_AGENT_APP_ID }}
+          ISSUE_AGENT_APP_INSTALLATION_ID: ${{ vars.ISSUE_AGENT_APP_INSTALLATION_ID }}
+          ISSUE_AGENT_REPOSITORY_ID: ${{ github.repository_id }}
+          ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets.ISSUE_AGENT_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          jq -n --arg repository "${{ needs.controller.outputs.repository }}" \
+            '{repository:$repository}' >"$RUNNER_TEMP/mint.json"
+          "$RUNNER_TEMP/wkissueagent" mint-app-token \
+            --input "$RUNNER_TEMP/mint.json" >"$RUNNER_TEMP/app-token.json"
+          app_token="$(jq -er .token "$RUNNER_TEMP/app-token.json")"
+          echo "::add-mask::$app_token"
+          printf 'ISSUE_AGENT_GITHUB_TOKEN=%s\n' "$app_token" >>"$GITHUB_ENV"
+      - name: Publish without executing candidate code
+        shell: bash
+        env:
+          ISSUE_AGENT_APP_LOGIN: ${{ vars.ISSUE_AGENT_APP_LOGIN }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg repository "${{ needs.controller.outputs.repository }}" \
+            --argjson issue_number "${{ needs.controller.outputs.issue_number }}" \
+            --arg control_sha "${{ needs.controller.outputs.control_sha }}" \
+            --arg expected_state_head "${{ needs.controller.outputs.state_head_sha }}" \
+            --arg context "$RUNNER_TEMP/issue-agent-context/context-bundle.json" \
+            --arg engineer "$RUNNER_TEMP/issue-agent-candidate/engineer-result.json" \
+            --arg candidate "$RUNNER_TEMP/issue-agent-candidate/candidate.json" \
+            --arg evidence "$RUNNER_TEMP/issue-agent-evidence/candidate-evidence.json" \
+            --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{repository:$repository,issue_number:$issue_number,control_sha:$control_sha,
+              expected_state_head:$expected_state_head,context_path:$context,
+              engineer_result_path:$engineer,candidate_path:$candidate,
+              evidence_path:$evidence,now:$now}' >"$RUNNER_TEMP/publish.json"
+          "$RUNNER_TEMP/wkissueagent" publish-candidate \
+            --input "$RUNNER_TEMP/publish.json"

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -99,6 +99,11 @@ modes, symlink changes, oversized scope, unexpected
 post-test filesystem changes, or failed trusted commands. It has no model key
 and no Publisher credential.
 
+The reusable Engineer workflow ends at the Verifier. The always-running
+Publisher is a job in the top-level protected Controller workflow so its
+`issue-agent-publisher` Environment secret resolves directly; that private key
+is not passed into the reusable workflow.
+
 Only low-risk passing `CandidateEvidence` can be published. Invalid, missing,
 non-ready, or rejected task output is finalized as `needs_human` without
 writing candidate code. The scheduled Controller also finalizes any active

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -115,6 +115,9 @@ func TestIssueAgentCodexActionRunsTheWholeEphemeralTask(t *testing.T) {
 	require.Contains(t, raw, "sandbox: workspace-write")
 	require.Contains(t, raw, "sandbox_workspace_write.network_access=true")
 	require.Contains(t, raw, "safety-strategy: drop-sudo")
+	require.Contains(t, raw,
+		"allow-bot-users: ${{ vars.ISSUE_AGENT_APP_LOGIN }}")
+	require.NotContains(t, raw, "allow-bots: true")
 	require.Contains(t, raw, "model: openai/gpt-5.6-sol")
 	require.Contains(t, raw, "effort: high")
 	require.Contains(t, raw, "secrets.OPENAI_API_KEY")
@@ -154,27 +157,29 @@ func TestIssueAgentReusableCallerGrantsOnlyRequiredReadScopes(t *testing.T) {
 func TestIssueAgentControllerSerializesFiveMinuteRecovery(t *testing.T) {
 	controller := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
 	require.Contains(t, controller, `cron: "*/5 * * * *"`)
-	require.Contains(t, controller,
-		"group: issue-agent-state-${{ github.repository }}")
-	engineer := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
-	require.Contains(t, engineer,
-		"group: issue-agent-state-${{ inputs.repository }}")
+	require.Equal(t, 2, strings.Count(controller,
+		"group: issue-agent-state-${{ github.repository }}"))
 	require.Contains(t, controller, "cancel-in-progress: false")
 	require.NotContains(t, controller, "github.event.pull_request.number")
 }
 
 func TestIssueAgentJobsSeparateCredentialsAndExecution(t *testing.T) {
-	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	engineerWorkflow := readIssueAgentFile(
+		t,
+		".github/workflows/issue-agent-engineer.yml",
+	)
 	for _, job := range []string{
 		"recover-task:",
 		"context-builder:",
 		"engineer:",
 		"verifier:",
-		"publisher:",
 	} {
-		require.Contains(t, raw, "\n  "+job)
+		require.Contains(t, engineerWorkflow, "\n  "+job)
 	}
-	engineer := issueAgentJobText(t, raw, "engineer")
+	require.NotContains(t, engineerWorkflow, "\n  publisher:")
+	require.NotContains(t, engineerWorkflow, "ISSUE_AGENT_APP_PRIVATE_KEY")
+
+	engineer := issueAgentJobText(t, engineerWorkflow, "engineer")
 	require.Contains(t, engineer, "persist-credentials: false")
 	require.Contains(t, engineer, "OPENAI_API_KEY")
 	require.Contains(t, engineer, "/opt/wukongim-issue-agent/baseline")
@@ -185,13 +190,14 @@ func TestIssueAgentJobsSeparateCredentialsAndExecution(t *testing.T) {
 	require.NotContains(t, engineer, "git push")
 	require.NotContains(t, engineer, "gh api")
 
-	verifier := issueAgentJobText(t, raw, "verifier")
+	verifier := issueAgentJobText(t, engineerWorkflow, "verifier")
 	require.Contains(t, verifier, "verify-candidate")
 	require.Contains(t, verifier, "persist-credentials: false")
 	require.NotContains(t, verifier, "OPENAI_API_KEY")
 	require.NotContains(t, verifier, "ISSUE_AGENT_APP_PRIVATE_KEY")
 
-	publisher := issueAgentJobText(t, raw, "publisher")
+	controller := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
+	publisher := issueAgentJobText(t, controller, "publisher")
 	require.Contains(t, publisher, "environment: issue-agent-publisher")
 	require.Contains(t, publisher, "ISSUE_AGENT_APP_PRIVATE_KEY")
 	require.Contains(t, publisher, "publish-candidate")
@@ -201,13 +207,15 @@ func TestIssueAgentJobsSeparateCredentialsAndExecution(t *testing.T) {
 }
 
 func TestIssueAgentTaskFailuresReachThePublisherFinalizer(t *testing.T) {
-	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
-	verifier := issueAgentJobText(t, raw, "verifier")
+	engineer := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	verifier := issueAgentJobText(t, engineer, "verifier")
 	require.Contains(t, verifier,
 		"if: always() && needs.engineer.result == 'success'")
 
-	publisher := issueAgentJobText(t, raw, "publisher")
-	require.Contains(t, publisher, "if: always()")
+	controller := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
+	publisher := issueAgentJobText(t, controller, "publisher")
+	require.Contains(t, publisher,
+		"if: always() && needs.controller.result == 'success' && needs.controller.outputs.dispatch == 'true'")
 	require.Contains(t, publisher,
 		"- name: Download Context Bundle\n        continue-on-error: true")
 	require.Contains(t, publisher,
@@ -217,34 +225,47 @@ func TestIssueAgentTaskFailuresReachThePublisherFinalizer(t *testing.T) {
 }
 
 func TestIssueAgentArtifactNamesAreFilesystemSafe(t *testing.T) {
-	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	engineer := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
 	for name, count := range map[string]int{
-		"issue-agent-context-${{ inputs.issue_number }}":   3,
-		"issue-agent-candidate-${{ inputs.issue_number }}": 3,
-		"issue-agent-evidence-${{ inputs.issue_number }}":  2,
+		"issue-agent-context-${{ inputs.issue_number }}":   2,
+		"issue-agent-candidate-${{ inputs.issue_number }}": 2,
+		"issue-agent-evidence-${{ inputs.issue_number }}":  1,
 	} {
-		require.Equal(t, count, strings.Count(raw, "name: "+name), name)
+		require.Equal(t, count, strings.Count(engineer, "name: "+name), name)
 	}
-	require.NotContains(t, raw,
+	require.NotContains(t, engineer,
 		"name: issue-agent-context-${{ inputs.issue_number }}-${{ inputs.task_id }}")
-	require.NotContains(t, raw,
+	require.NotContains(t, engineer,
 		"name: issue-agent-candidate-${{ inputs.issue_number }}-${{ inputs.task_id }}")
-	require.NotContains(t, raw,
+	require.NotContains(t, engineer,
 		"name: issue-agent-evidence-${{ inputs.issue_number }}-${{ inputs.task_id }}")
+
+	controller := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
+	for _, name := range []string{
+		"issue-agent-context-${{ needs.controller.outputs.issue_number }}",
+		"issue-agent-candidate-${{ needs.controller.outputs.issue_number }}",
+		"issue-agent-evidence-${{ needs.controller.outputs.issue_number }}",
+	} {
+		require.Equal(t, 1, strings.Count(controller, "name: "+name), name)
+	}
 }
 
-func TestIssueAgentPublisherUsesOnlyItsEnvironmentSecret(t *testing.T) {
-	raw := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
-	workflowCall, _, found := strings.Cut(raw, "\njobs:")
-	require.True(t, found)
-	require.NotContains(t, workflowCall, "ISSUE_AGENT_APP_PRIVATE_KEY")
+func TestIssueAgentPublisherUsesOnlyTopLevelEnvironmentSecret(t *testing.T) {
+	controller := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
+	engineer := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	require.NotContains(t, engineer, "\n  publisher:")
+	require.NotContains(t, engineer, "ISSUE_AGENT_APP_PRIVATE_KEY")
 
-	publisher := issueAgentJobText(t, raw, "publisher")
+	caller := issueAgentJobText(t, controller, "engineer")
+	require.NotContains(t, caller, "ISSUE_AGENT_APP_PRIVATE_KEY")
+	publisher := issueAgentJobText(t, controller, "publisher")
+	require.Contains(t, publisher, "needs: [controller, engineer]")
+	require.Contains(t, publisher,
+		"if: always() && needs.controller.result == 'success' && needs.controller.outputs.dispatch == 'true'")
 	require.Contains(t, publisher, "environment: issue-agent-publisher")
 	require.Contains(t, publisher,
-		"ISSUE_AGENT_PRIVATE_KEY_SECRET: ISSUE_AGENT_APP_PRIVATE_KEY")
-	require.Contains(t, publisher,
-		"ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets[env.ISSUE_AGENT_PRIVATE_KEY_SECRET] }}")
+		"ISSUE_AGENT_APP_PRIVATE_KEY: ${{ secrets.ISSUE_AGENT_APP_PRIVATE_KEY }}")
+	require.NotContains(t, publisher, "ISSUE_AGENT_PRIVATE_KEY_SECRET")
 }
 
 func TestIssueAgentControllerReportsCommittedProjectionWarnings(t *testing.T) {


### PR DESCRIPTION
## What changed

- allow only the configured Issue Agent App Bot to pass the official Codex Action actor check
- move Publisher from the reusable Engineer workflow into the top-level protected workflow
- resolve the Publisher App private key directly from the issue-agent-publisher Environment
- remove the obsolete reusable Publisher path and update workflow contracts and documentation

## Root cause

The #705 canary showed two blockers: the official Codex Action rejected wukongim-issue-agent[bot] because no trusted bot was allowlisted, and Environment secrets resolved empty inside the reusable Publisher workflow. The capture failure was a consequence of Codex never producing engineer-result.json.

## Validation

- GOWORK=off go test ./scripts -count=1
- Issue Agent contract/use-case/runtime/infra/access/app/CLI package tests
- actionlint v1.7.9 on all Issue Agent workflows
- git diff --check
- independent Standards and Spec reviews: no findings

The change preserves credential separation: Codex and Verifier do not receive the App private key, Publisher executes no candidate code, and human-only merge remains unchanged.