### PR TITLE
fix: recover ambiguous Issue Agent state publication

### DIFF
--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -29,6 +29,12 @@ must be contiguous, authored by the configured App Bot, and GitHub-signed.
 The Issue contains one mutable App-owned status comment as a repairable
 projection of that state.
 
+GitHub may report an ambiguous error while immediately verifying a state commit
+that was already created. The Controller accepts that publication only after
+one independent re-read proves the exact expected parent, canonical state
+content, path, App Bot identity, and GitHub signature. Any mismatch remains a
+failure; a merely advanced or externally written ref is never adopted.
+
 PR lifecycle and Review events first run
 `.github/workflows/issue-agent-pr-signal.yml`. That Workflow has no token
 permissions, Secrets, checkout, artifacts, or candidate execution. Its

--- a/internal/infra/issueagentgithub/FLOW.md
+++ b/internal/infra/issueagentgithub/FLOW.md
@@ -24,5 +24,11 @@ when their exact parent, message, paths, blob identities, configured App Bot
 author, and GitHub signature match. No method merges a PR or closes a Bug
 Issue.
 
+If a state publication reports an error or an untrusted immediate result after
+the remote write, the State Store re-reads the per-Issue ref once. It recovers
+only when the ref points to the exact expected parent, canonical state content,
+path, configured App Bot author, and GitHub-signed commit. Missing, different,
+or unverifiable successors retain the original fail-closed result.
+
 The scheduled inventory is a complete, sorted set of at most 40 open
 `ready-for-agent` Issues. A larger or paginated result fails closed.

--- a/internal/infra/issueagentgithub/state_store.go
+++ b/internal/infra/issueagentgithub/state_store.go
@@ -132,6 +132,22 @@ func (store *StateStore) Advance(
 		request.State.IssueNumber,
 		request.State.Sequence,
 	)
+	recoverPublication := func(
+		publicationErr error,
+	) (StatePublication, error) {
+		recovered, recoverErr := store.recoverExactPublication(
+			ctx,
+			request.State.IssueNumber,
+			branch,
+			path,
+			request.ExpectedParentSHA,
+			content,
+		)
+		if recoverErr != nil {
+			return StatePublication{}, publicationErr
+		}
+		return recovered, nil
+	}
 	result, err := store.commits.PublishStateCommit(ctx, StateCommitRequest{
 		Branch: branch, Path: path,
 		ExpectedParentSHA: request.ExpectedParentSHA,
@@ -141,18 +157,7 @@ func (store *StateStore) Advance(
 		Content:           content,
 	})
 	if err != nil {
-		recovered, recoverErr := store.recoverExactPublication(
-			ctx,
-			request.State.IssueNumber,
-			branch,
-			path,
-			request.ExpectedParentSHA,
-			content,
-		)
-		if recoverErr == nil {
-			return recovered, nil
-		}
-		return StatePublication{}, err
+		return recoverPublication(err)
 	}
 	sum := sha256.Sum256(content)
 	expectedDigest := "sha256:" + hex.EncodeToString(sum[:])
@@ -165,22 +170,17 @@ func (store *StateStore) Advance(
 		result.AuthorType != "Bot" ||
 		!result.Verified ||
 		!result.SignedByGitHub {
-		recovered, recoverErr := store.recoverExactPublication(
-			ctx,
-			request.State.IssueNumber,
-			branch,
-			path,
-			request.ExpectedParentSHA,
-			content,
+		return recoverPublication(
+			errors.New("published state commit is untrusted"),
 		)
-		if recoverErr == nil {
-			return recovered, nil
-		}
-		return StatePublication{}, errors.New("published state commit is untrusted")
 	}
 	return StatePublication{HeadSHA: result.CommitSHA}, nil
 }
 
+// recoverExactPublication performs one independent read after an ambiguous
+// state write. It accepts only the exact canonical App-authored, GitHub-signed
+// successor of the expected parent; every missing or mismatched ref fails
+// closed.
 func (store *StateStore) recoverExactPublication(
 	ctx context.Context,
 	issueNumber int64,

--- a/internal/infra/issueagentgithub/state_store.go
+++ b/internal/infra/issueagentgithub/state_store.go
@@ -141,6 +141,17 @@ func (store *StateStore) Advance(
 		Content:           content,
 	})
 	if err != nil {
+		recovered, recoverErr := store.recoverExactPublication(
+			ctx,
+			request.State.IssueNumber,
+			branch,
+			path,
+			request.ExpectedParentSHA,
+			content,
+		)
+		if recoverErr == nil {
+			return recovered, nil
+		}
 		return StatePublication{}, err
 	}
 	sum := sha256.Sum256(content)
@@ -154,9 +165,49 @@ func (store *StateStore) Advance(
 		result.AuthorType != "Bot" ||
 		!result.Verified ||
 		!result.SignedByGitHub {
+		recovered, recoverErr := store.recoverExactPublication(
+			ctx,
+			request.State.IssueNumber,
+			branch,
+			path,
+			request.ExpectedParentSHA,
+			content,
+		)
+		if recoverErr == nil {
+			return recovered, nil
+		}
 		return StatePublication{}, errors.New("published state commit is untrusted")
 	}
 	return StatePublication{HeadSHA: result.CommitSHA}, nil
+}
+
+func (store *StateStore) recoverExactPublication(
+	ctx context.Context,
+	issueNumber int64,
+	branch string,
+	path string,
+	expectedParentSHA string,
+	expectedContent []byte,
+) (StatePublication, error) {
+	head, found, err := store.commits.StateRefHead(ctx, branch)
+	if err != nil || !found || head == expectedParentSHA ||
+		!gitObjectPattern.MatchString(head) || len(head) != 40 {
+		return StatePublication{}, errors.New("published state commit is unavailable")
+	}
+	record, err := store.commits.ReadStateCommit(ctx, head, path)
+	if err != nil || record.ParentSHA != expectedParentSHA ||
+		!bytes.Equal(record.Content, expectedContent) {
+		return StatePublication{}, errors.New("published state commit does not match")
+	}
+	if _, err := store.validateStateRecord(
+		record,
+		head,
+		path,
+		issueNumber,
+	); err != nil {
+		return StatePublication{}, err
+	}
+	return StatePublication{HeadSHA: head}, nil
 }
 
 // Load verifies the complete bounded App-signed state chain.

--- a/internal/infra/issueagentgithub/state_store_test.go
+++ b/internal/infra/issueagentgithub/state_store_test.go
@@ -54,153 +54,55 @@ func TestStateStorePublishesCanonicalStateToPerIssueRef(t *testing.T) {
 func TestStateStoreRecoversExactSignedStateAfterAmbiguousPublish(t *testing.T) {
 	t.Parallel()
 
-	const (
-		sourceSHA = "0123456789abcdef0123456789abcdef01234567"
-		headSHA   = "fedcba9876543210fedcba9876543210fedcba98"
-	)
-	state := contract.IssueAgentState{
-		SchemaVersion:       2,
-		Repository:          "WuKongIM/WuKongIM",
-		IssueNumber:         42,
-		Sequence:            1,
-		State:               contract.IssueStateWaitingForAuthorization,
-		Reason:              "waiting for authorization",
-		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		SourceSHA:           sourceSHA,
-		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
-	}
-	content, err := contract.CanonicalIssueAgentState(state)
-	require.NoError(t, err)
-	port := &stateCommitPortStub{
-		publishErr: errors.New("transient post-publish verification failure"),
-		head:       headSHA,
-		records: map[string]issueagentgithub.StateCommitRecord{
-			headSHA: {
-				CommitSHA: headSHA, ParentSHA: sourceSHA,
-				Message: "agent(state): issue 42 sequence 1",
-				Path:    ".issue-agent-state/issue-42.json",
-				Content: content, AuthorLogin: "wukongim-issue-agent[bot]",
-				AuthorType: "Bot", Verified: true, SignedByGitHub: true,
-			},
-		},
-	}
-	store, err := issueagentgithub.NewStateStore(
-		"WuKongIM/WuKongIM", "wukongim-issue-agent[bot]", port,
-	)
-	require.NoError(t, err)
+	state := stateStoreRecoveryState()
+	port := stateStoreRecoveryPort(t, state)
+	port.publishErr = errors.New("transient post-publish verification failure")
 
-	published, err := store.Advance(context.Background(),
-		issueagentgithub.StateAdvanceRequest{
-			State: state, ExpectedParentSHA: sourceSHA,
-			BaseTreeSHA:    "1234567890abcdef1234567890abcdef12345678",
-			ExistingBranch: false,
-		})
+	published, err := stateStoreForTest(t, port).Advance(
+		context.Background(),
+		stateStoreRecoveryRequest(state),
+	)
 	require.NoError(t, err)
-	require.Equal(t, headSHA, published.HeadSHA)
+	require.Equal(t, stateStoreRecoveryHeadSHA, published.HeadSHA)
 }
 
 func TestStateStoreRecoversExactSignedStateAfterAmbiguousTrustResult(t *testing.T) {
 	t.Parallel()
 
-	const (
-		sourceSHA = "0123456789abcdef0123456789abcdef01234567"
-		headSHA   = "fedcba9876543210fedcba9876543210fedcba98"
-		path      = ".issue-agent-state/issue-42.json"
-	)
-	state := contract.IssueAgentState{
-		SchemaVersion:       2,
-		Repository:          "WuKongIM/WuKongIM",
-		IssueNumber:         42,
-		Sequence:            1,
-		State:               contract.IssueStateWaitingForAuthorization,
-		Reason:              "waiting for authorization",
-		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		SourceSHA:           sourceSHA,
-		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
+	state := stateStoreRecoveryState()
+	port := stateStoreRecoveryPort(t, state)
+	sum := sha256.Sum256(port.records[stateStoreRecoveryHeadSHA].Content)
+	port.publishResult = &issueagentgithub.StateCommitResult{
+		CommitSHA: stateStoreRecoveryHeadSHA,
+		ParentSHA: stateStoreRecoverySourceSHA,
+		Path:      stateStoreRecoveryPath,
+		ContentDigest: "sha256:" +
+			hex.EncodeToString(sum[:]),
+		AuthorLogin: "wukongim-issue-agent[bot]", AuthorType: "Bot",
 	}
-	content, err := contract.CanonicalIssueAgentState(state)
-	require.NoError(t, err)
-	sum := sha256.Sum256(content)
-	port := &stateCommitPortStub{
-		publishResult: &issueagentgithub.StateCommitResult{
-			CommitSHA: headSHA, ParentSHA: sourceSHA, Path: path,
-			ContentDigest: "sha256:" + hex.EncodeToString(sum[:]),
-			AuthorLogin:   "wukongim-issue-agent[bot]", AuthorType: "Bot",
-		},
-		head: headSHA,
-		records: map[string]issueagentgithub.StateCommitRecord{
-			headSHA: {
-				CommitSHA: headSHA, ParentSHA: sourceSHA,
-				Message: "agent(state): issue 42 sequence 1",
-				Path:    path, Content: content,
-				AuthorLogin: "wukongim-issue-agent[bot]",
-				AuthorType:  "Bot", Verified: true, SignedByGitHub: true,
-			},
-		},
-	}
-	store, err := issueagentgithub.NewStateStore(
-		"WuKongIM/WuKongIM", "wukongim-issue-agent[bot]", port,
-	)
-	require.NoError(t, err)
 
-	published, err := store.Advance(context.Background(),
-		issueagentgithub.StateAdvanceRequest{
-			State: state, ExpectedParentSHA: sourceSHA,
-			BaseTreeSHA:    "1234567890abcdef1234567890abcdef12345678",
-			ExistingBranch: false,
-		})
+	published, err := stateStoreForTest(t, port).Advance(
+		context.Background(),
+		stateStoreRecoveryRequest(state),
+	)
 	require.NoError(t, err)
-	require.Equal(t, headSHA, published.HeadSHA)
+	require.Equal(t, stateStoreRecoveryHeadSHA, published.HeadSHA)
 }
 
 func TestStateStoreRejectsDifferentStateAfterAmbiguousPublish(t *testing.T) {
 	t.Parallel()
 
-	const (
-		sourceSHA = "0123456789abcdef0123456789abcdef01234567"
-		headSHA   = "fedcba9876543210fedcba9876543210fedcba98"
-	)
-	state := contract.IssueAgentState{
-		SchemaVersion:       2,
-		Repository:          "WuKongIM/WuKongIM",
-		IssueNumber:         42,
-		Sequence:            1,
-		State:               contract.IssueStateWaitingForAuthorization,
-		Reason:              "waiting for authorization",
-		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		SourceSHA:           sourceSHA,
-		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
-	}
+	state := stateStoreRecoveryState()
 	different := state
 	different.Reason = "different durable state"
-	differentContent, err := contract.CanonicalIssueAgentState(different)
-	require.NoError(t, err)
 	publishErr := errors.New("transient post-publish verification failure")
-	port := &stateCommitPortStub{
-		publishErr: publishErr,
-		head:       headSHA,
-		records: map[string]issueagentgithub.StateCommitRecord{
-			headSHA: {
-				CommitSHA: headSHA, ParentSHA: sourceSHA,
-				Message:     "agent(state): issue 42 sequence 1",
-				Path:        ".issue-agent-state/issue-42.json",
-				Content:     differentContent,
-				AuthorLogin: "wukongim-issue-agent[bot]",
-				AuthorType:  "Bot", Verified: true, SignedByGitHub: true,
-			},
-		},
-	}
-	store, err := issueagentgithub.NewStateStore(
-		"WuKongIM/WuKongIM", "wukongim-issue-agent[bot]", port,
-	)
-	require.NoError(t, err)
+	port := stateStoreRecoveryPort(t, different)
+	port.publishErr = publishErr
 
-	_, err = store.Advance(context.Background(),
-		issueagentgithub.StateAdvanceRequest{
-			State: state, ExpectedParentSHA: sourceSHA,
-			BaseTreeSHA:    "1234567890abcdef1234567890abcdef12345678",
-			ExistingBranch: false,
-		})
+	_, err := stateStoreForTest(t, port).Advance(
+		context.Background(),
+		stateStoreRecoveryRequest(state),
+	)
 	require.EqualError(t, err, publishErr.Error())
 }
 
@@ -277,6 +179,76 @@ func TestStateStoreLoadsVerifiedAppendOnlyStateChain(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, port.head, loaded.HeadSHA)
 	require.Equal(t, successor, loaded.State)
+}
+
+const (
+	stateStoreRecoverySourceSHA = "0123456789abcdef0123456789abcdef01234567"
+	stateStoreRecoveryHeadSHA   = "fedcba9876543210fedcba9876543210fedcba98"
+	stateStoreRecoveryTreeSHA   = "1234567890abcdef1234567890abcdef12345678"
+	stateStoreRecoveryPath      = ".issue-agent-state/issue-42.json"
+)
+
+func stateStoreRecoveryState() contract.IssueAgentState {
+	return contract.IssueAgentState{
+		SchemaVersion:       2,
+		Repository:          "WuKongIM/WuKongIM",
+		IssueNumber:         42,
+		Sequence:            1,
+		State:               contract.IssueStateWaitingForAuthorization,
+		Reason:              "waiting for authorization",
+		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		SourceSHA:           stateStoreRecoverySourceSHA,
+		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
+	}
+}
+
+func stateStoreRecoveryPort(
+	t *testing.T,
+	state contract.IssueAgentState,
+) *stateCommitPortStub {
+	t.Helper()
+	content, err := contract.CanonicalIssueAgentState(state)
+	require.NoError(t, err)
+	return &stateCommitPortStub{
+		head: stateStoreRecoveryHeadSHA,
+		records: map[string]issueagentgithub.StateCommitRecord{
+			stateStoreRecoveryHeadSHA: {
+				CommitSHA:   stateStoreRecoveryHeadSHA,
+				ParentSHA:   stateStoreRecoverySourceSHA,
+				Message:     "agent(state): issue 42 sequence 1",
+				Path:        stateStoreRecoveryPath,
+				Content:     content,
+				AuthorLogin: "wukongim-issue-agent[bot]",
+				AuthorType:  "Bot",
+				Verified:    true, SignedByGitHub: true,
+			},
+		},
+	}
+}
+
+func stateStoreForTest(
+	t *testing.T,
+	port *stateCommitPortStub,
+) *issueagentgithub.StateStore {
+	t.Helper()
+	store, err := issueagentgithub.NewStateStore(
+		"WuKongIM/WuKongIM",
+		"wukongim-issue-agent[bot]",
+		port,
+	)
+	require.NoError(t, err)
+	return store
+}
+
+func stateStoreRecoveryRequest(
+	state contract.IssueAgentState,
+) issueagentgithub.StateAdvanceRequest {
+	return issueagentgithub.StateAdvanceRequest{
+		State:             state,
+		ExpectedParentSHA: stateStoreRecoverySourceSHA,
+		BaseTreeSHA:       stateStoreRecoveryTreeSHA,
+		ExistingBranch:    false,
+	}
 }
 
 type stateCommitPortStub struct {

--- a/internal/infra/issueagentgithub/state_store_test.go
+++ b/internal/infra/issueagentgithub/state_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"testing"
 	"time"
 
@@ -48,6 +49,159 @@ func TestStateStorePublishesCanonicalStateToPerIssueRef(t *testing.T) {
 	canonical, err := contract.CanonicalIssueAgentState(state)
 	require.NoError(t, err)
 	require.Equal(t, canonical, port.request.Content)
+}
+
+func TestStateStoreRecoversExactSignedStateAfterAmbiguousPublish(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceSHA = "0123456789abcdef0123456789abcdef01234567"
+		headSHA   = "fedcba9876543210fedcba9876543210fedcba98"
+	)
+	state := contract.IssueAgentState{
+		SchemaVersion:       2,
+		Repository:          "WuKongIM/WuKongIM",
+		IssueNumber:         42,
+		Sequence:            1,
+		State:               contract.IssueStateWaitingForAuthorization,
+		Reason:              "waiting for authorization",
+		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		SourceSHA:           sourceSHA,
+		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
+	}
+	content, err := contract.CanonicalIssueAgentState(state)
+	require.NoError(t, err)
+	port := &stateCommitPortStub{
+		publishErr: errors.New("transient post-publish verification failure"),
+		head:       headSHA,
+		records: map[string]issueagentgithub.StateCommitRecord{
+			headSHA: {
+				CommitSHA: headSHA, ParentSHA: sourceSHA,
+				Message: "agent(state): issue 42 sequence 1",
+				Path:    ".issue-agent-state/issue-42.json",
+				Content: content, AuthorLogin: "wukongim-issue-agent[bot]",
+				AuthorType: "Bot", Verified: true, SignedByGitHub: true,
+			},
+		},
+	}
+	store, err := issueagentgithub.NewStateStore(
+		"WuKongIM/WuKongIM", "wukongim-issue-agent[bot]", port,
+	)
+	require.NoError(t, err)
+
+	published, err := store.Advance(context.Background(),
+		issueagentgithub.StateAdvanceRequest{
+			State: state, ExpectedParentSHA: sourceSHA,
+			BaseTreeSHA:    "1234567890abcdef1234567890abcdef12345678",
+			ExistingBranch: false,
+		})
+	require.NoError(t, err)
+	require.Equal(t, headSHA, published.HeadSHA)
+}
+
+func TestStateStoreRecoversExactSignedStateAfterAmbiguousTrustResult(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceSHA = "0123456789abcdef0123456789abcdef01234567"
+		headSHA   = "fedcba9876543210fedcba9876543210fedcba98"
+		path      = ".issue-agent-state/issue-42.json"
+	)
+	state := contract.IssueAgentState{
+		SchemaVersion:       2,
+		Repository:          "WuKongIM/WuKongIM",
+		IssueNumber:         42,
+		Sequence:            1,
+		State:               contract.IssueStateWaitingForAuthorization,
+		Reason:              "waiting for authorization",
+		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		SourceSHA:           sourceSHA,
+		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
+	}
+	content, err := contract.CanonicalIssueAgentState(state)
+	require.NoError(t, err)
+	sum := sha256.Sum256(content)
+	port := &stateCommitPortStub{
+		publishResult: &issueagentgithub.StateCommitResult{
+			CommitSHA: headSHA, ParentSHA: sourceSHA, Path: path,
+			ContentDigest: "sha256:" + hex.EncodeToString(sum[:]),
+			AuthorLogin:   "wukongim-issue-agent[bot]", AuthorType: "Bot",
+		},
+		head: headSHA,
+		records: map[string]issueagentgithub.StateCommitRecord{
+			headSHA: {
+				CommitSHA: headSHA, ParentSHA: sourceSHA,
+				Message: "agent(state): issue 42 sequence 1",
+				Path:    path, Content: content,
+				AuthorLogin: "wukongim-issue-agent[bot]",
+				AuthorType:  "Bot", Verified: true, SignedByGitHub: true,
+			},
+		},
+	}
+	store, err := issueagentgithub.NewStateStore(
+		"WuKongIM/WuKongIM", "wukongim-issue-agent[bot]", port,
+	)
+	require.NoError(t, err)
+
+	published, err := store.Advance(context.Background(),
+		issueagentgithub.StateAdvanceRequest{
+			State: state, ExpectedParentSHA: sourceSHA,
+			BaseTreeSHA:    "1234567890abcdef1234567890abcdef12345678",
+			ExistingBranch: false,
+		})
+	require.NoError(t, err)
+	require.Equal(t, headSHA, published.HeadSHA)
+}
+
+func TestStateStoreRejectsDifferentStateAfterAmbiguousPublish(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceSHA = "0123456789abcdef0123456789abcdef01234567"
+		headSHA   = "fedcba9876543210fedcba9876543210fedcba98"
+	)
+	state := contract.IssueAgentState{
+		SchemaVersion:       2,
+		Repository:          "WuKongIM/WuKongIM",
+		IssueNumber:         42,
+		Sequence:            1,
+		State:               contract.IssueStateWaitingForAuthorization,
+		Reason:              "waiting for authorization",
+		IssueSnapshotDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		SourceSHA:           sourceSHA,
+		UpdatedAt:           time.Date(2026, 7, 30, 1, 2, 3, 0, time.UTC),
+	}
+	different := state
+	different.Reason = "different durable state"
+	differentContent, err := contract.CanonicalIssueAgentState(different)
+	require.NoError(t, err)
+	publishErr := errors.New("transient post-publish verification failure")
+	port := &stateCommitPortStub{
+		publishErr: publishErr,
+		head:       headSHA,
+		records: map[string]issueagentgithub.StateCommitRecord{
+			headSHA: {
+				CommitSHA: headSHA, ParentSHA: sourceSHA,
+				Message:     "agent(state): issue 42 sequence 1",
+				Path:        ".issue-agent-state/issue-42.json",
+				Content:     differentContent,
+				AuthorLogin: "wukongim-issue-agent[bot]",
+				AuthorType:  "Bot", Verified: true, SignedByGitHub: true,
+			},
+		},
+	}
+	store, err := issueagentgithub.NewStateStore(
+		"WuKongIM/WuKongIM", "wukongim-issue-agent[bot]", port,
+	)
+	require.NoError(t, err)
+
+	_, err = store.Advance(context.Background(),
+		issueagentgithub.StateAdvanceRequest{
+			State: state, ExpectedParentSHA: sourceSHA,
+			BaseTreeSHA:    "1234567890abcdef1234567890abcdef12345678",
+			ExistingBranch: false,
+		})
+	require.EqualError(t, err, publishErr.Error())
 }
 
 func TestStateStoreLoadsVerifiedAppendOnlyStateChain(t *testing.T) {
@@ -126,9 +280,11 @@ func TestStateStoreLoadsVerifiedAppendOnlyStateChain(t *testing.T) {
 }
 
 type stateCommitPortStub struct {
-	request issueagentgithub.StateCommitRequest
-	head    string
-	records map[string]issueagentgithub.StateCommitRecord
+	request       issueagentgithub.StateCommitRequest
+	publishErr    error
+	publishResult *issueagentgithub.StateCommitResult
+	head          string
+	records       map[string]issueagentgithub.StateCommitRecord
 }
 
 func (port *stateCommitPortStub) PublishStateCommit(
@@ -136,6 +292,12 @@ func (port *stateCommitPortStub) PublishStateCommit(
 	request issueagentgithub.StateCommitRequest,
 ) (issueagentgithub.StateCommitResult, error) {
 	port.request = request
+	if port.publishErr != nil {
+		return issueagentgithub.StateCommitResult{}, port.publishErr
+	}
+	if port.publishResult != nil {
+		return *port.publishResult, nil
+	}
 	sum := sha256.Sum256(request.Content)
 	return issueagentgithub.StateCommitResult{
 		CommitSHA:      "fedcba9876543210fedcba9876543210fedcba98",


### PR DESCRIPTION
## Summary

- recover an Issue Agent state transition when GitHub durably created the signed state commit but the immediate publish result is ambiguous or temporarily untrusted
- accept recovery only after one independent read proves the exact expected head, parent, path, canonical content, GitHub App Bot author, and GitHub-verified signature
- keep every mismatch fail-closed and preserve the original publication error
- document the recovery boundary and add regression coverage for both ambiguous result forms and mismatched durable state

## Root cause

The Controller treated an immediate post-write verification failure as a failed transition even when GitHub had already advanced the per-Issue state ref. Later reconciliations observed an active `engineering` task, so they correctly refused to create a second task, but the original run had exited before emitting `dispatch=true`. This stranded the Issue with durable state and no Worker dispatch.

The failure was reproduced by Canary Issue #708. This PR fixes the Controller handoff behavior observed there; it does not close the canary issue.

## Impact

A transient or ambiguous response after a successful signed state commit no longer strands an Issue between durable publication and Worker dispatch. Recovery cannot adopt arbitrary external state because all expected commit invariants must match exactly.

## Validation

- `GOWORK=off go test ./internal/infra/issueagentgithub -count=1`
- `GOWORK=off go test ./internal/contracts/issueagent ./internal/usecase/issueagent ./internal/runtime/issueagentverify ./internal/access/issueagentcli ./internal/app ./cmd/wkissueagent -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check origin/main...HEAD`
- standards review: no findings
- specification review: no findings
