### PR TITLE
fix: use Kimi K3 for Issue Agent

### DIFF
--- a/.github/issue-agent/policy.json
+++ b/.github/issue-agent/policy.json
@@ -7,7 +7,7 @@
   "engineer": {
     "action_sha": "52fe01ec70a42f454c9d2ebd47598f9fd6893d56",
     "codex_version": "0.146.0",
-    "model": "openai/gpt-5.6-sol",
+    "model": "moonshotai/kimi-k3",
     "reasoning_effort": "high",
     "sandbox": "workspace-write",
     "network_access": true,

--- a/.github/workflows/issue-agent-engineer.yml
+++ b/.github/workflows/issue-agent-engineer.yml
@@ -179,7 +179,7 @@ jobs:
           prompt-file: ${{ runner.temp }}/issue-agent-prompt.md
           output-file: ${{ runner.temp }}/engineer-result.json
           codex-version: 0.146.0
-          model: openai/gpt-5.6-sol
+          model: moonshotai/kimi-k3
           effort: high
           sandbox: workspace-write
           safety-strategy: drop-sudo

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -75,7 +75,7 @@ itself grants no authority.
 
 `.github/workflows/issue-agent-engineer.yml` invokes the full-SHA-pinned
 official `openai/codex-action` once for the complete task. It runs Codex
-`0.146.0`, OpenRouter model `openai/gpt-5.6-sol` through the fixed
+`0.146.0`, OpenRouter model `moonshotai/kimi-k3` through the fixed
 `https://openrouter.ai/api/v1/responses` endpoint, high reasoning effort, an
 ephemeral session, and a `workspace-write` sandbox with public internet access.
 Codex has normal local Git/search/edit/build/test tools, but it receives:

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -118,7 +118,7 @@ func TestIssueAgentCodexActionRunsTheWholeEphemeralTask(t *testing.T) {
 	require.Contains(t, raw,
 		"allow-bot-users: ${{ vars.ISSUE_AGENT_APP_LOGIN }}")
 	require.NotContains(t, raw, "allow-bots: true")
-	require.Contains(t, raw, "model: openai/gpt-5.6-sol")
+	require.Contains(t, raw, "model: moonshotai/kimi-k3")
 	require.Contains(t, raw, "effort: high")
 	require.Contains(t, raw, "secrets.OPENAI_API_KEY")
 	require.Contains(t, raw,
@@ -302,7 +302,7 @@ func TestIssueAgentPolicyIsCodexOnlyAndBounded(t *testing.T) {
 	require.Equal(t, strings.TrimPrefix(codexActionPin, "openai/codex-action@"),
 		policy.Engineer.ActionSHA)
 	require.Equal(t, codexVersion, policy.Engineer.CodexVersion)
-	require.Equal(t, "openai/gpt-5.6-sol", policy.Engineer.Model)
+	require.Equal(t, "moonshotai/kimi-k3", policy.Engineer.Model)
 	require.Equal(t, "workspace-write", policy.Engineer.Sandbox)
 	require.True(t, policy.Engineer.Ephemeral)
 	require.True(t, policy.Engineer.NetworkAccess)


### PR DESCRIPTION
## Summary

- switch the Issue Agent Engineer from `openai/gpt-5.6-sol` to OpenRouter's `moonshotai/kimi-k3`
- keep the protected Workflow, signed policy, contract tests, and operator documentation aligned
- preserve the Codex Action pin/version, fixed Responses endpoint, high reasoning effort, sandbox, public-network setting, permissions, and Secret boundaries

## Why

Canary issue #712 reached the Codex Engineer, but OpenRouter rejected the previous provider request with a provider Terms-of-Service 403 before Codex could produce an `EngineerResult`. Kimi K3 is available under the verified OpenRouter slug `moonshotai/kimi-k3` and supports the structured/tooling capabilities required by this flow.

This PR is observed from #712 but does not close it; after merge, the canary should be retried with `/agent retry`.

## Agent control review

Only the Engineer model identifier changes. Permissions, Secrets, action pins, Codex version, fixed Responses endpoint, reasoning effort, sandbox, safety strategy, bot allowlist, and network boundary are unchanged.

## Validation

- `GOWORK=off go test ./scripts -run '^(TestIssueAgentPRValidation.*|TestIssueAgentWorkflow.*|TestIssueAgent.*|TestLegacyAutomaticTestWorkflowsAreAbsent)$' -count=1`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/issue-agent.yml .github/workflows/issue-agent-engineer.yml`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check`

Two-axis review: Standards 0 findings; Spec 0 findings.
