### PR TITLE
fix: restore backup and failover E2E baselines

### DIFF
--- a/internal/infra/cluster/FLOW.md
+++ b/internal/infra/cluster/FLOW.md
@@ -584,7 +584,10 @@ For message permission checks, the adapter exposes channel metadata reads,
 subscriber point lookups, subscriber-set non-emptiness, and exact durable
 subscriber mutation counts. Production node reads use authoritative Slot-leader
 facades; alternate nodes must expose point lookups explicitly because the
-adapter never substitutes an unbounded page scan.
+adapter never substitutes an unbounded page scan. Permission reads translate
+unavailable cluster routes, node lifecycle, and transport dial failures into
+the message contract's retryable route-not-ready error instead of exposing
+infrastructure errors at entry boundaries.
 When configured with `ChannelAppendMetadataCache`, successful channel metadata
 upserts refresh append fanout metadata and deletes remove cached entries; final
 subscriber mutation versions are still refreshed by the channel usecase

--- a/internal/infra/cluster/channel_metadata.go
+++ b/internal/infra/cluster/channel_metadata.go
@@ -2,10 +2,13 @@ package cluster
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
+	"github.com/WuKongIM/WuKongIM/pkg/transport"
 )
 
 // ChannelMetadataNode exposes cluster Slot metadata operations used by the channel usecase.
@@ -72,7 +75,8 @@ func (s *ChannelMetadataStore) GetChannel(ctx context.Context, channelID string,
 
 // GetChannelForPermission reads channel metadata for send authorization.
 func (s *ChannelMetadataStore) GetChannelForPermission(ctx context.Context, channelID string, channelType int64) (metadb.Channel, error) {
-	return s.GetChannel(ctx, channelID, channelType)
+	channel, err := s.GetChannel(ctx, channelID, channelType)
+	return channel, mapChannelPermissionReadError(err)
 }
 
 // UpsertChannel persists channel metadata through Slot ownership.
@@ -206,25 +210,31 @@ func (s *ChannelMetadataStore) ContainsChannelSubscriber(ctx context.Context, ch
 		return false, nil
 	}
 	if s == nil || s.node == nil {
-		return false, clusterpkg.ErrRouteNotReady
+		return false, mapChannelPermissionReadError(clusterpkg.ErrRouteNotReady)
 	}
 	node, ok := s.node.(authoritativeChannelMetadataNode)
 	if !ok {
-		return false, clusterpkg.ErrRouteNotReady
+		return false, mapChannelPermissionReadError(clusterpkg.ErrRouteNotReady)
 	}
-	return node.ContainsChannelSubscriberAuthoritative(ctx, channelID, channelType, uid)
+	contains, err := node.ContainsChannelSubscriberAuthoritative(
+		ctx, channelID, channelType, uid,
+	)
+	return contains, mapChannelPermissionReadError(err)
 }
 
 // HasChannelSubscribers reports whether the channel has at least one subscriber row.
 func (s *ChannelMetadataStore) HasChannelSubscribers(ctx context.Context, channelID string, channelType int64) (bool, error) {
 	if s == nil || s.node == nil {
-		return false, clusterpkg.ErrRouteNotReady
+		return false, mapChannelPermissionReadError(clusterpkg.ErrRouteNotReady)
 	}
 	node, ok := s.node.(authoritativeChannelMetadataNode)
 	if !ok {
-		return false, clusterpkg.ErrRouteNotReady
+		return false, mapChannelPermissionReadError(clusterpkg.ErrRouteNotReady)
 	}
-	return node.HasChannelSubscribersAuthoritative(ctx, channelID, channelType)
+	hasSubscribers, err := node.HasChannelSubscribersAuthoritative(
+		ctx, channelID, channelType,
+	)
+	return hasSubscribers, mapChannelPermissionReadError(err)
 }
 
 // UpsertChannelMemberships projects normal channel subscribers into UID-owned memberships.
@@ -248,4 +258,22 @@ func firstSubscriberMutationVersion(values []uint64) uint64 {
 		return 1
 	}
 	return values[0]
+}
+
+func mapChannelPermissionReadError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, clusterpkg.ErrRouteNotReady),
+		errors.Is(err, clusterpkg.ErrNoSlotLeader),
+		errors.Is(err, clusterpkg.ErrNotStarted),
+		errors.Is(err, clusterpkg.ErrStopping),
+		errors.Is(err, transport.ErrDialFailed),
+		errors.Is(err, transport.ErrNodeNotFound),
+		errors.Is(err, transport.ErrStopped):
+		return fmt.Errorf("%w: %w", channelappend.ErrRouteNotReady, err)
+	default:
+		return err
+	}
 }

--- a/internal/infra/cluster/channel_metadata_test.go
+++ b/internal/infra/cluster/channel_metadata_test.go
@@ -3,11 +3,13 @@ package cluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
+	"github.com/WuKongIM/WuKongIM/pkg/transport"
 )
 
 func TestChannelMetadataStoreProjectsUserMemberships(t *testing.T) {
@@ -84,6 +86,32 @@ func TestChannelMetadataStoreUsesAuthoritativeChannelReads(t *testing.T) {
 	}
 }
 
+func TestChannelMetadataStoreMapsUnavailablePermissionReadsToRouteNotReady(t *testing.T) {
+	node := &recordingChannelMetadataNode{
+		authoritativeErr: fmt.Errorf(
+			"%w: connection refused",
+			transport.ErrDialFailed,
+		),
+	}
+	store := NewChannelMetadataStore(node, nil)
+
+	if _, err := store.GetChannelForPermission(
+		context.Background(), "g1", 2,
+	); !errors.Is(err, channelappend.ErrRouteNotReady) {
+		t.Fatalf("GetChannelForPermission() error = %v, want %v", err, channelappend.ErrRouteNotReady)
+	}
+	if _, err := store.ContainsChannelSubscriber(
+		context.Background(), "g1", 2, "u1",
+	); !errors.Is(err, channelappend.ErrRouteNotReady) {
+		t.Fatalf("ContainsChannelSubscriber() error = %v, want %v", err, channelappend.ErrRouteNotReady)
+	}
+	if _, err := store.HasChannelSubscribers(
+		context.Background(), "g1", 2,
+	); !errors.Is(err, channelappend.ErrRouteNotReady) {
+		t.Fatalf("HasChannelSubscribers() error = %v, want %v", err, channelappend.ErrRouteNotReady)
+	}
+}
+
 func TestChannelMetadataStoreRejectsOrdinaryReadsWithoutAuthoritativeCapability(t *testing.T) {
 	node := &localOnlyChannelMetadataNode{}
 	store := NewChannelMetadataStore(node, nil)
@@ -157,6 +185,7 @@ type recordingChannelMetadataNode struct {
 	membershipDeletes      []membershipDeleteNodeCall
 	authoritativeChannel   metadb.Channel
 	authoritativeUIDs      []string
+	authoritativeErr       error
 	authoritativeReadCalls int
 	localReadCalls         int
 	addResult              metadb.SubscriberMutationResult
@@ -216,21 +245,33 @@ func (r *recordingChannelMetadataNode) HasChannelSubscribers(context.Context, st
 
 func (r *recordingChannelMetadataNode) GetChannelMetadataAuthoritative(context.Context, string, int64) (metadb.Channel, error) {
 	r.authoritativeReadCalls++
+	if r.authoritativeErr != nil {
+		return metadb.Channel{}, r.authoritativeErr
+	}
 	return r.authoritativeChannel, nil
 }
 
 func (r *recordingChannelMetadataNode) ListChannelSubscribersAuthoritative(context.Context, string, int64, string, int) ([]string, string, bool, error) {
 	r.authoritativeReadCalls++
+	if r.authoritativeErr != nil {
+		return nil, "", false, r.authoritativeErr
+	}
 	return append([]string(nil), r.authoritativeUIDs...), "", true, nil
 }
 
 func (r *recordingChannelMetadataNode) ContainsChannelSubscriberAuthoritative(_ context.Context, _ string, _ int64, uid string) (bool, error) {
 	r.authoritativeReadCalls++
+	if r.authoritativeErr != nil {
+		return false, r.authoritativeErr
+	}
 	return uid == "u1", nil
 }
 
 func (r *recordingChannelMetadataNode) HasChannelSubscribersAuthoritative(context.Context, string, int64) (bool, error) {
 	r.authoritativeReadCalls++
+	if r.authoritativeErr != nil {
+		return false, r.authoritativeErr
+	}
 	return len(r.authoritativeUIDs) > 0, nil
 }
 

--- a/pkg/slot/proxy/authoritative_rpc.go
+++ b/pkg/slot/proxy/authoritative_rpc.go
@@ -69,6 +69,16 @@ func callAuthoritativeRPCWithStatuses[T authoritativeRPCResponse](
 
 	tried := make(map[multiraft.NodeID]struct{}, len(peers))
 	candidates := append([]multiraft.NodeID(nil), peers...)
+	// Prefer the observed leader so an unavailable earlier peer cannot consume
+	// the request deadline before the authoritative node is attempted.
+	if leaderID, err := s.cluster.LeaderOf(slotID); err == nil {
+		for index, peer := range candidates {
+			if peer == leaderID {
+				candidates[0], candidates[index] = candidates[index], candidates[0]
+				break
+			}
+		}
+	}
 	var lastErr error
 
 	for len(candidates) > 0 {

--- a/pkg/slot/proxy/authoritative_rpc_test.go
+++ b/pkg/slot/proxy/authoritative_rpc_test.go
@@ -223,6 +223,41 @@ func TestRuntimeMetaRPCDoesNotFallbackToLegacyOnNonCodecError(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+func TestCallAuthoritativeRPCPrioritizesObservedLeaderBeforeUnreachablePeer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls []multiraft.NodeID
+	store := New(&proxyTestMigrationCluster{
+		nodeID:         3,
+		localNodeID:    3,
+		slotForKey:     1,
+		hashSlotForKey: 0,
+		leaders:        map[multiraft.SlotID]multiraft.NodeID{1: 2},
+		peers:          map[multiraft.SlotID][]multiraft.NodeID{1: {1, 2, 3}},
+		rpcService: func(ctx context.Context, nodeID multiraft.NodeID, _ multiraft.SlotID, _ uint8, _ []byte) ([]byte, error) {
+			calls = append(calls, nodeID)
+			if nodeID == 1 {
+				cancel()
+				return nil, ctx.Err()
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return encodeChannelRPCResponse(channelRPCResponse{Status: rpcStatusOK})
+		},
+	}, openTestDB(t))
+
+	_, err := store.callChannelRPC(ctx, 1, channelRPCRequest{
+		Op:          channelRPCGetForPermission,
+		SlotID:      1,
+		ChannelID:   "g1",
+		ChannelType: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []multiraft.NodeID{2}, calls)
+}
+
 func TestRuntimeMetaRPCRejectsJSONPayload(t *testing.T) {
 	store := New(nil, openTestDB(t))
 

--- a/test/e2e/backup/scheduled_restore/scheduled_restore_test.go
+++ b/test/e2e/backup/scheduled_restore/scheduled_restore_test.go
@@ -30,6 +30,12 @@ type managerLoginResponse struct {
 	AccessToken string `json:"access_token"`
 }
 
+type backupConfigureResponse struct {
+	Plan struct {
+		Revision uint64 `json:"revision"`
+	} `json:"plan"`
+}
+
 type backupDashboard struct {
 	State struct {
 		ActiveBackup  *backupJob  `json:"active_backup"`
@@ -151,18 +157,36 @@ func configureDailyFileBackup(
 	token string,
 ) {
 	t.Helper()
-	managerJSON(t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
-		map[string]any{
-			"expected_revision":   0,
-			"enabled":             true,
-			"store":               map[string]any{"kind": "file"},
-			"cron":                "0 1 * * *",
-			"time_zone":           "Asia/Shanghai",
-			"retention_count":     7,
-			"rate_mib_per_second": 64,
-			"workers_per_node":    4,
-			"max_duration_hours":  12,
-		}, nil)
+	plan := map[string]any{
+		"expected_revision":   0,
+		"enabled":             false,
+		"store":               map[string]any{"kind": "file"},
+		"cron":                "0 1 * * *",
+		"time_zone":           "Asia/Shanghai",
+		"retention_count":     7,
+		"rate_mib_per_second": 64,
+		"workers_per_node":    4,
+		"max_duration_hours":  12,
+	}
+	var saved backupConfigureResponse
+	managerJSON(
+		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
+		plan, &saved,
+	)
+	require.NotZero(t, saved.Plan.Revision)
+
+	managerJSON(
+		t, ctx, node, token, http.MethodPost,
+		"/manager/backups/repository/test",
+		map[string]any{"expected_plan_revision": saved.Plan.Revision}, nil,
+	)
+
+	plan["expected_revision"] = saved.Plan.Revision
+	plan["enabled"] = true
+	managerJSON(
+		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
+		plan, nil,
+	)
 }
 
 func sendBackupMessage(

--- a/test/e2e/backup/scheduled_restore/scheduled_restore_test.go
+++ b/test/e2e/backup/scheduled_restore/scheduled_restore_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,11 +39,16 @@ type backupConfigureResponse struct {
 
 type backupDashboard struct {
 	State struct {
+		Plan          *backupPlan `json:"plan"`
 		ActiveBackup  *backupJob  `json:"active_backup"`
 		ActiveRestore *restoreJob `json:"active_restore"`
 		History       []task      `json:"history"`
 	} `json:"state"`
 	Archives []archiveSummary `json:"archives"`
+}
+
+type backupPlan struct {
+	Revision uint64 `json:"revision"`
 }
 
 type backupJob struct {
@@ -158,7 +164,6 @@ func configureDailyFileBackup(
 ) {
 	t.Helper()
 	plan := map[string]any{
-		"expected_revision":   0,
 		"enabled":             false,
 		"store":               map[string]any{"kind": "file"},
 		"cron":                "0 1 * * *",
@@ -169,10 +174,7 @@ func configureDailyFileBackup(
 		"max_duration_hours":  12,
 	}
 	var saved backupConfigureResponse
-	managerJSON(
-		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
-		plan, &saved,
-	)
+	configureBackupPlanEventually(t, ctx, node, token, plan, &saved)
 	require.NotZero(t, saved.Plan.Revision)
 
 	managerJSON(
@@ -187,6 +189,60 @@ func configureDailyFileBackup(
 		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
 		plan, nil,
 	)
+}
+
+func configureBackupPlanEventually(
+	t *testing.T,
+	ctx context.Context,
+	node suite.StartedNode,
+	token string,
+	plan map[string]any,
+	saved *backupConfigureResponse,
+) {
+	t.Helper()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		var dashboard backupDashboard
+		lastErr = managerJSONE(
+			ctx, node, token, http.MethodGet, "/manager/backups", nil,
+			&dashboard,
+		)
+		if lastErr != nil {
+			require.NoError(t, lastErr, node.DumpDiagnostics())
+		}
+		expectedRevision := uint64(0)
+		if dashboard.State.Plan != nil {
+			expectedRevision = dashboard.State.Plan.Revision
+		}
+		plan["expected_revision"] = expectedRevision
+		lastErr = managerJSONE(
+			ctx, node, token, http.MethodPut, "/manager/backups/plan",
+			plan, saved,
+		)
+		if lastErr == nil {
+			return
+		}
+		if !isBackupPlanConflict(lastErr) {
+			require.NoError(t, lastErr, node.DumpDiagnostics())
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf(
+				"configure backup plan after revision refresh: %v\n%s",
+				lastErr, node.DumpDiagnostics(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func isBackupPlanConflict(err error) bool {
+	status, ok := err.(*suite.HTTPStatusError)
+	return ok &&
+		status.StatusCode == http.StatusConflict &&
+		strings.Contains(status.Body, `"error":"backup_plan_conflict"`)
 }
 
 func sendBackupMessage(

--- a/test/e2e/backup/three_node_restore/three_node_restore_test.go
+++ b/test/e2e/backup/three_node_restore/three_node_restore_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,11 +36,16 @@ type backupConfigureResponse struct {
 
 type backupDashboard struct {
 	State struct {
+		Plan          *backupPlan `json:"plan"`
 		ActiveBackup  *backupJob  `json:"active_backup"`
 		ActiveRestore *restoreJob `json:"active_restore"`
 		History       []task      `json:"history"`
 	} `json:"state"`
 	Archives []archiveSummary `json:"archives"`
+}
+
+type backupPlan struct {
+	Revision uint64 `json:"revision"`
 }
 
 type backupJob struct {
@@ -195,7 +201,6 @@ func configureDailyFileBackup(
 ) {
 	t.Helper()
 	plan := map[string]any{
-		"expected_revision":   0,
 		"enabled":             false,
 		"store":               map[string]any{"kind": "file"},
 		"cron":                "0 1 * * *",
@@ -206,10 +211,7 @@ func configureDailyFileBackup(
 		"max_duration_hours":  12,
 	}
 	var saved backupConfigureResponse
-	managerJSON(
-		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
-		plan, &saved,
-	)
+	configureBackupPlanEventually(t, ctx, node, token, plan, &saved)
 	require.NotZero(t, saved.Plan.Revision)
 
 	managerJSON(
@@ -224,6 +226,60 @@ func configureDailyFileBackup(
 		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
 		plan, nil,
 	)
+}
+
+func configureBackupPlanEventually(
+	t *testing.T,
+	ctx context.Context,
+	node suite.StartedNode,
+	token string,
+	plan map[string]any,
+	saved *backupConfigureResponse,
+) {
+	t.Helper()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		var dashboard backupDashboard
+		lastErr = managerJSONE(
+			ctx, node, token, http.MethodGet, "/manager/backups", nil,
+			&dashboard,
+		)
+		if lastErr != nil {
+			require.NoError(t, lastErr, node.DumpDiagnostics())
+		}
+		expectedRevision := uint64(0)
+		if dashboard.State.Plan != nil {
+			expectedRevision = dashboard.State.Plan.Revision
+		}
+		plan["expected_revision"] = expectedRevision
+		lastErr = managerJSONE(
+			ctx, node, token, http.MethodPut, "/manager/backups/plan",
+			plan, saved,
+		)
+		if lastErr == nil {
+			return
+		}
+		if !isBackupPlanConflict(lastErr) {
+			require.NoError(t, lastErr, node.DumpDiagnostics())
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf(
+				"configure backup plan after revision refresh: %v\n%s",
+				lastErr, node.DumpDiagnostics(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func isBackupPlanConflict(err error) bool {
+	status, ok := err.(*suite.HTTPStatusError)
+	return ok &&
+		status.StatusCode == http.StatusConflict &&
+		strings.Contains(status.Body, `"error":"backup_plan_conflict"`)
 }
 
 func waitForActiveBackupProgress(

--- a/test/e2e/backup/three_node_restore/three_node_restore_test.go
+++ b/test/e2e/backup/three_node_restore/three_node_restore_test.go
@@ -27,6 +27,12 @@ type managerLoginResponse struct {
 	AccessToken string `json:"access_token"`
 }
 
+type backupConfigureResponse struct {
+	Plan struct {
+		Revision uint64 `json:"revision"`
+	} `json:"plan"`
+}
+
 type backupDashboard struct {
 	State struct {
 		ActiveBackup  *backupJob  `json:"active_backup"`
@@ -188,18 +194,36 @@ func configureDailyFileBackup(
 	token string,
 ) {
 	t.Helper()
-	managerJSON(t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
-		map[string]any{
-			"expected_revision":   0,
-			"enabled":             true,
-			"store":               map[string]any{"kind": "file"},
-			"cron":                "0 1 * * *",
-			"time_zone":           "Asia/Shanghai",
-			"retention_count":     7,
-			"rate_mib_per_second": 256,
-			"workers_per_node":    4,
-			"max_duration_hours":  12,
-		}, nil)
+	plan := map[string]any{
+		"expected_revision":   0,
+		"enabled":             false,
+		"store":               map[string]any{"kind": "file"},
+		"cron":                "0 1 * * *",
+		"time_zone":           "Asia/Shanghai",
+		"retention_count":     7,
+		"rate_mib_per_second": 256,
+		"workers_per_node":    4,
+		"max_duration_hours":  12,
+	}
+	var saved backupConfigureResponse
+	managerJSON(
+		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
+		plan, &saved,
+	)
+	require.NotZero(t, saved.Plan.Revision)
+
+	managerJSON(
+		t, ctx, node, token, http.MethodPost,
+		"/manager/backups/repository/test",
+		map[string]any{"expected_plan_revision": saved.Plan.Revision}, nil,
+	)
+
+	plan["expected_revision"] = saved.Plan.Revision
+	plan["enabled"] = true
+	managerJSON(
+		t, ctx, node, token, http.MethodPut, "/manager/backups/plan",
+		plan, nil,
+	)
 }
 
 func waitForActiveBackupProgress(

--- a/test/e2e/message/channel_failover/channel_failover_contract_test.go
+++ b/test/e2e/message/channel_failover/channel_failover_contract_test.go
@@ -105,6 +105,47 @@ func TestControllerQuorumPreconditionAcceptsHealthyDataOnlySpare(t *testing.T) {
 	require.NoError(t, controllerQuorumPrecondition(healthyControllerQuorumNodes(), []uint64{1, 2, 3}, 4))
 }
 
+func TestPostStopControlPlaneFingerprintAcceptsConvergedSurvivors(t *testing.T) {
+	statuses, slots := convergedPostStopControlPlane()
+
+	fingerprint, err := postStopControlPlaneFingerprint(statuses, slots, 3)
+
+	require.NoError(t, err)
+	require.Equal(t, "controller=2/4;slot=1/2;slot=2/1;", fingerprint)
+}
+
+func TestPostStopControlPlaneFingerprintRejectsStoppedSlotLeader(t *testing.T) {
+	statuses, slots := convergedPostStopControlPlane()
+	slots[2][0].NodeLog.LeaderID = 3
+
+	_, err := postStopControlPlaneFingerprint(statuses, slots, 3)
+
+	require.ErrorContains(t, err, "still reports stopped leader 3")
+}
+
+func convergedPostStopControlPlane() ([]suite.ControllerRaftStatusDTO, map[uint64][]suite.SlotDTO) {
+	statuses := []suite.ControllerRaftStatusDTO{
+		{NodeID: 1, LeaderID: 2, Term: 4, Voters: []uint64{1, 2, 3}},
+		{NodeID: 2, LeaderID: 2, Term: 4, Voters: []uint64{1, 2, 3}},
+	}
+	slots := make(map[uint64][]suite.SlotDTO, 2)
+	for _, nodeID := range []uint64{1, 2} {
+		slots[nodeID] = []suite.SlotDTO{
+			{
+				SlotID:     1,
+				Assignment: suite.SlotAssignmentDTO{DesiredPeers: []uint64{1, 2, 3}},
+				NodeLog:    &suite.SlotNodeLogDTO{NodeID: nodeID, LeaderID: 2},
+			},
+			{
+				SlotID:     2,
+				Assignment: suite.SlotAssignmentDTO{DesiredPeers: []uint64{1, 2, 3}},
+				NodeLog:    &suite.SlotNodeLogDTO{NodeID: nodeID, LeaderID: 1},
+			},
+		}
+	}
+	return statuses, slots
+}
+
 func healthyControllerQuorumNodes() suite.NodeListDTO {
 	items := make([]suite.NodeDTO, 0, 4)
 	for nodeID := uint64(1); nodeID <= 4; nodeID++ {

--- a/test/e2e/message/channel_failover/channel_failover_test.go
+++ b/test/e2e/message/channel_failover/channel_failover_test.go
@@ -143,6 +143,14 @@ func TestChannelFollowerReplicaRepairAfterNodeKill(t *testing.T) {
 
 	require.NoError(t, cluster.MustNode(candidate.SecondStoppedFollower).Stop(), cluster.DumpDiagnostics())
 	requireNodeUnschedulableEventually(t, cluster, managerNode, candidate.SecondStoppedFollower)
+	requireControlPlaneConvergedAfterNodeStopEventually(
+		t,
+		cluster,
+		managerNode,
+		candidate,
+		45*time.Second,
+		2*time.Second,
+	)
 
 	afterSecondStop := sendGroupMessageWithin(t, managerNode, candidate.ChannelID, candidate.ChannelType, "follower-repair-after-second-stop", 20*time.Second)
 	require.Greater(t, afterSecondStop.Seq, afterRepair.Seq, cluster.DumpDiagnostics())
@@ -903,6 +911,169 @@ func requireControllerQuorumPreconditionEventually(t *testing.T, cluster *suite.
 		case <-ticker.C:
 		}
 	}
+}
+
+func requireControlPlaneConvergedAfterNodeStopEventually(
+	t *testing.T,
+	cluster *suite.StartedCluster,
+	managerNode *suite.StartedNode,
+	candidate followerRepairCandidate,
+	timeout time.Duration,
+	stableWindow time.Duration,
+) {
+	t.Helper()
+
+	survivingVoters := []uint64{candidate.Leader, candidate.StoppedFollower}
+	sort.Slice(survivingVoters, func(i, j int) bool { return survivingVoters[i] < survivingVoters[j] })
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	manager := cluster.ManagerClient(t, managerNode.Spec.ID)
+
+	var (
+		lastFingerprint string
+		stableSince     time.Time
+		lastErr         error
+	)
+	for {
+		controllerStatuses := make([]suite.ControllerRaftStatusDTO, 0, len(survivingVoters))
+		slotInventories := make(map[uint64][]suite.SlotDTO, len(survivingVoters))
+		var observationErr error
+		for _, nodeID := range survivingVoters {
+			reqCtx, reqCancel := context.WithTimeout(ctx, 2*time.Second)
+			status, err := manager.ControllerRaftStatus(reqCtx, nodeID)
+			reqCancel()
+			if err != nil {
+				observationErr = fmt.Errorf("read node %d Controller status: %w", nodeID, err)
+				break
+			}
+			controllerStatuses = append(controllerStatuses, status)
+
+			items, err := managerSlotsForNode(ctx, managerNode, nodeID)
+			if err != nil {
+				observationErr = fmt.Errorf("read node %d Slot leaders: %w", nodeID, err)
+				break
+			}
+			slotInventories[nodeID] = items
+		}
+
+		if observationErr == nil {
+			fingerprint, err := postStopControlPlaneFingerprint(
+				controllerStatuses,
+				slotInventories,
+				candidate.SecondStoppedFollower,
+			)
+			if err == nil {
+				now := time.Now()
+				if fingerprint != lastFingerprint {
+					lastFingerprint = fingerprint
+					stableSince = now
+				} else if now.Sub(stableSince) >= stableWindow {
+					t.Logf("control plane converged after node %d stop: %s", candidate.SecondStoppedFollower, fingerprint)
+					return
+				}
+				lastErr = fmt.Errorf("control-plane fingerprint %q stable for %s of %s", fingerprint, now.Sub(stableSince), stableWindow)
+			} else {
+				lastFingerprint = ""
+				stableSince = time.Time{}
+				lastErr = err
+			}
+		} else {
+			lastFingerprint = ""
+			stableSince = time.Time{}
+			lastErr = observationErr
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("control plane did not converge after node %d stop: lastErr=%v\n%s", candidate.SecondStoppedFollower, lastErr, cluster.DumpDiagnostics())
+		case <-ticker.C:
+		}
+	}
+}
+
+func postStopControlPlaneFingerprint(
+	controllerStatuses []suite.ControllerRaftStatusDTO,
+	slotInventories map[uint64][]suite.SlotDTO,
+	stoppedNodeID uint64,
+) (string, error) {
+	if len(controllerStatuses) == 0 {
+		return "", fmt.Errorf("Controller status observations are empty")
+	}
+	if len(slotInventories) == 0 {
+		return "", fmt.Errorf("Slot leader observations are empty")
+	}
+
+	sort.Slice(controllerStatuses, func(i, j int) bool {
+		return controllerStatuses[i].NodeID < controllerStatuses[j].NodeID
+	})
+	controllerLeaderID := controllerStatuses[0].LeaderID
+	controllerTerm := controllerStatuses[0].Term
+	if controllerLeaderID == 0 || controllerLeaderID == stoppedNodeID {
+		return "", fmt.Errorf("Controller leader=%d after node %d stop", controllerLeaderID, stoppedNodeID)
+	}
+	for _, status := range controllerStatuses {
+		if status.LeaderID != controllerLeaderID || status.Term != controllerTerm {
+			return "", fmt.Errorf("Controller observations disagree: %+v", controllerStatuses)
+		}
+		if !uint64InList(status.Voters, controllerLeaderID) {
+			return "", fmt.Errorf("Controller leader %d is not in node %d voters %v", controllerLeaderID, status.NodeID, status.Voters)
+		}
+	}
+
+	nodeIDs := make([]uint64, 0, len(slotInventories))
+	for nodeID := range slotInventories {
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+	sort.Slice(nodeIDs, func(i, j int) bool { return nodeIDs[i] < nodeIDs[j] })
+
+	slotLeaders := make(map[uint32]uint64)
+	slotObservationCounts := make(map[uint32]int)
+	for _, nodeID := range nodeIDs {
+		items := slotInventories[nodeID]
+		if len(items) == 0 {
+			return "", fmt.Errorf("node %d Slot leader observations are empty", nodeID)
+		}
+		for _, item := range items {
+			if item.NodeLog == nil || item.NodeLog.LeaderID == 0 {
+				return "", fmt.Errorf("node %d Slot %d leader is missing: %+v", nodeID, item.SlotID, item.NodeLog)
+			}
+			leaderID := item.NodeLog.LeaderID
+			if leaderID == stoppedNodeID {
+				return "", fmt.Errorf("node %d Slot %d still reports stopped leader %d", nodeID, item.SlotID, stoppedNodeID)
+			}
+			if !uint64InList(item.Assignment.DesiredPeers, leaderID) {
+				return "", fmt.Errorf("node %d Slot %d leader %d is outside desired peers %v", nodeID, item.SlotID, leaderID, item.Assignment.DesiredPeers)
+			}
+			if observedLeaderID, ok := slotLeaders[item.SlotID]; ok && observedLeaderID != leaderID {
+				return "", fmt.Errorf("Slot %d leader disagreement: %d and %d", item.SlotID, observedLeaderID, leaderID)
+			}
+			slotLeaders[item.SlotID] = leaderID
+			slotObservationCounts[item.SlotID]++
+		}
+	}
+	if len(slotLeaders) == 0 {
+		return "", fmt.Errorf("Slot leader observations contain no Slots")
+	}
+	for slotID, count := range slotObservationCounts {
+		if count != len(nodeIDs) {
+			return "", fmt.Errorf("Slot %d observations=%d, want %d", slotID, count, len(nodeIDs))
+		}
+	}
+
+	slotIDs := make([]uint32, 0, len(slotLeaders))
+	for slotID := range slotLeaders {
+		slotIDs = append(slotIDs, slotID)
+	}
+	sort.Slice(slotIDs, func(i, j int) bool { return slotIDs[i] < slotIDs[j] })
+	var fingerprint strings.Builder
+	fmt.Fprintf(&fingerprint, "controller=%d/%d;", controllerLeaderID, controllerTerm)
+	for _, slotID := range slotIDs {
+		fmt.Fprintf(&fingerprint, "slot=%d/%d;", slotID, slotLeaders[slotID])
+	}
+	return fingerprint.String(), nil
 }
 
 func controllerQuorumPrecondition(nodes suite.NodeListDTO, originalVoters []uint64, spareNodeID uint64) error {


### PR DESCRIPTION
## Summary

- update both backup/restore E2E scenarios to save a disabled repository plan, verify that exact plan revision, and only then enable scheduled backups
- refresh the Manager backup dashboard and retry only `backup_plan_conflict` responses when optimistic configuration races background state progress
- translate unavailable authoritative permission-read routes into the message contract retryable route-not-ready error
- prioritize the observed Slot Leader for authoritative RPC reads so an unavailable earlier peer cannot consume the request deadline
- make the follower-repair E2E wait for surviving Controller voters and physical Slot Leaders to agree for a stable window before asserting post-failure writes
- document the permission adapter error boundary and add regression coverage for metadata reads, authoritative RPC ordering, and post-stop convergence

## Root cause

Repository verification became mandatory before enabling backup plans, but the two E2E scenarios still attempted to create an enabled plan in one request. They therefore failed immediately with `backup_repository_unverified`.

After adopting the supported save-test-enable sequence, remote validation exposed the Manager plan's optimistic concurrency contract: background backup-state progress can win the state CAS while the plan revision remains unchanged. The E2E client treated the resulting `backup_plan_conflict` as permanent instead of refreshing the dashboard revision and retrying as required by the API.

When a stopped node still owned an authoritative Slot read, transport dial failures from send permission checks crossed the infrastructure boundary unchanged. The HTTP send entrypoint treated them as unknown errors and returned 500 instead of the retryable 503 route signal expected during failover.

Repeated failover runs exposed a second timing flaw: authoritative RPCs tried peers in placement order instead of preferring the observed Leader, and the follower-repair E2E sent while Controller election and Slot Leader transfer were still in progress. An unavailable first peer could consume the request deadline, while the test mistook node health convergence for control-plane convergence.

## Impact

The backup scenarios now exercise the supported Manager repository-verification and revision-refresh workflow without hiding unrelated conflicts. Foreground sends fail closed with a stable retryable contract while permission metadata is temporarily unavailable, and authoritative reads reach the observed Leader before fallback peers. The failover scenario now asserts the data plane only after surviving Controller and Slot observations have remained consistent for two seconds.

This restores the main E2E baseline needed to revalidate draft PR #710.

## Validation

- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `WK_E2E_BINARY=/tmp/wk-e2e-backup-conflict-fix GOWORK=off go test -tags=e2e ./test/e2e/... -count=1 -timeout=45m -p=1`
- scheduled backup/restore focused E2E repeated 5 times after the revision-refresh fix: 5/5 passed in 450.947s
- three-node backup, Controller Leader failover, and restore focused E2E: passed in 242.467s
- exact three-node smoke workflow reproduced locally 6 times after shortening the macOS data path: 6/6 passed with zero send errors
- `TestChannelFollowerReplicaRepairAfterNodeKill` repeated 10 times after the final failover fix
- complete `test/e2e/message/channel_failover` package
- message-event Leader-change scenario repeated 10 times
- `TestWaitNodeReadySucceedsForStartedSingleNodeCluster` repeated 10 times after removing interrupted local E2E processes
