### PR TITLE
docs: add Review Agent bootstrap validation

### DIFF
--- a/docs/superpowers/reports/2026-07-31-review-agent-bootstrap-validation.md
+++ b/docs/superpowers/reports/2026-07-31-review-agent-bootstrap-validation.md
@@ -1,0 +1,21 @@
+# Review Agent Bootstrap Validation
+
+Date: 2026-07-31
+
+This change is the first same-repository validation case for the Review Agent.
+It verifies that a ready pull request targeting `main` enters the event-driven
+review lifecycle after the direct replacement of the former label-based PR
+validation protocol.
+
+The validation succeeds only when the protected controller:
+
+- binds the generation to the exact pull request head and test-merge commit;
+- runs the configured deterministic documentation check;
+- uses one ephemeral Kimi 3 review session without repository write access;
+- publishes its formal Review and status comment through the Review Agent App;
+- writes signed state through the separate State Writer App; and
+- reports `Review Agent Verdict` from the Review Agent App.
+
+This document changes no product behavior, workflow, policy, permission, or
+control-plane path. The pull request remains subject to the same human merge
+authority as any other repository change.


### PR DESCRIPTION
## What changed

Adds a small documentation report defining the first same-repository Review Agent bootstrap validation case.

## Why

PR #709 replaced the former label-based PR validation protocol with the review-only Review Agent. This harmless docs-only change provides a real pull request on which to verify the protected controller, deterministic docs check, Kimi 3 review session, separate State Writer and Publisher identities, formal Review, and App-authored `Review Agent Verdict`.

## Impact

Documentation only. No product behavior, workflow, policy, permission, or control-plane path changes.

## Validation

- `GOWORK=off go test ./scripts/... -run "Docs|Markdown|Link" -count=1`

The pull request will be marked Ready to trigger the Review Agent after creation.