### PR TITLE
fix(issue-agent): harden Kimi candidate handoff

### DIFF
--- a/.github/workflows/issue-agent-engineer.yml
+++ b/.github/workflows/issue-agent-engineer.yml
@@ -151,7 +151,8 @@ jobs:
           set -euo pipefail
           sudo install -d -o root -g root -m 0755 /opt/wukongim-issue-agent/baseline
           git archive HEAD | sudo tar -x -C /opt/wukongim-issue-agent/baseline
-          sudo chmod -R a-w /opt/wukongim-issue-agent/baseline
+          sudo chown -R root:root /opt/wukongim-issue-agent/baseline
+          sudo chmod -R u=rwX,go=rX /opt/wukongim-issue-agent/baseline
       - name: Download Context Bundle
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:

--- a/internal/contracts/issueagent/FLOW.md
+++ b/internal/contracts/issueagent/FLOW.md
@@ -20,7 +20,10 @@ fresh GitHub fences + exact candidate/evidence digests
   -> canonical IssueAgentState
 ```
 
-All decoders reject unknown fields, oversized input, malformed identities, and
-trailing JSON. `EngineerResult` never grants publication authority. Only a
-low-risk, passing `CandidateEvidence` bound to the exact task and candidate can
-enter a Publisher plan.
+All decoded JSON objects reject unknown fields, oversized input, malformed
+identities, and trailing JSON. `EngineerResult` may unwrap exactly one
+Markdown `json` fence from a model's final message before applying that strict
+JSON contract; ambiguous or multiple fences fail closed. `EngineerResult`
+never grants publication authority. Only a low-risk, passing
+`CandidateEvidence` bound to the exact task and candidate can enter a
+Publisher plan.

--- a/internal/contracts/issueagent/engineer_result.go
+++ b/internal/contracts/issueagent/engineer_result.go
@@ -1,6 +1,7 @@
 package issueagent
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"slices"
@@ -36,14 +37,63 @@ type EngineerResult struct {
 
 // DecodeEngineerResult decodes one bounded advisory Codex result.
 func DecodeEngineerResult(reader io.Reader, maxBytes int64) (EngineerResult, error) {
-	var result EngineerResult
-	if err := decodeStrictJSON(reader, maxBytes, &result); err != nil {
+	body, err := readBoundedJSON(reader, maxBytes)
+	if err != nil {
 		return EngineerResult{}, err
+	}
+	var result EngineerResult
+	rawErr := decodeStrictJSON(bytes.NewReader(body), maxBytes, &result)
+	if rawErr != nil {
+		fenced, ok := extractSingleJSONFence(body)
+		if !ok {
+			return EngineerResult{}, rawErr
+		}
+		result = EngineerResult{}
+		if err := decodeStrictJSON(
+			bytes.NewReader(fenced), maxBytes, &result,
+		); err != nil {
+			return EngineerResult{}, err
+		}
 	}
 	if err := ValidateEngineerResult(result); err != nil {
 		return EngineerResult{}, err
 	}
 	return result, nil
+}
+
+// extractSingleJSONFence unwraps one fenced result without choosing between
+// competing JSON objects or Markdown fences.
+func extractSingleJSONFence(body []byte) ([]byte, bool) {
+	lines := bytes.Split(body, []byte{'\n'})
+	open, close := -1, -1
+	for index, line := range lines {
+		trimmed := bytes.TrimSpace(line)
+		switch {
+		case bytes.Equal(trimmed, []byte("```json")):
+			if open >= 0 || close >= 0 {
+				return nil, false
+			}
+			open = index
+		case bytes.HasPrefix(trimmed, []byte("```")):
+			if open < 0 || close >= 0 ||
+				!bytes.Equal(trimmed, []byte("```")) {
+				return nil, false
+			}
+			close = index
+		}
+	}
+	if open < 0 || close <= open {
+		return nil, false
+	}
+	for index, line := range lines {
+		if index > open && index < close {
+			continue
+		}
+		if bytes.ContainsAny(line, "{}") {
+			return nil, false
+		}
+	}
+	return bytes.Join(lines[open+1:close], []byte{'\n'}), true
 }
 
 // ValidateEngineerResult rejects ambiguous or unbounded advisory output.

--- a/internal/contracts/issueagent/engineer_result_test.go
+++ b/internal/contracts/issueagent/engineer_result_test.go
@@ -8,6 +8,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const validEngineerResultJSON = `{"schema_version":2,"repository":"WuKongIM/WuKongIM",` +
+	`"issue_number":42,` +
+	`"task_id":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",` +
+	`"outcome":"ready","external_symptom":"server exits",` +
+	`"root_cause":"nil route target","causal_path":"reconnect -> route -> panic",` +
+	`"evidence_references":["internal/runtime/example.go:42"],` +
+	`"proposed_risk":["low"],"tests_attempted":["go test ./internal/runtime/example"],` +
+	`"unresolved_uncertainty":"","summary":"guard missing route target",` +
+	`"ready":true}`
+
+func TestDecodeEngineerResultAcceptsSingleJSONFence(t *testing.T) {
+	t.Parallel()
+
+	result, err := issueagent.DecodeEngineerResult(strings.NewReader(
+		"The fix is complete and verified.\n\n```json\n"+
+			validEngineerResultJSON+
+			"\n```\n"),
+		16<<10,
+	)
+	require.NoError(t, err)
+	require.Equal(t, issueagent.EngineerOutcomeReady, result.Outcome)
+	require.True(t, result.Ready)
+}
+
+func TestDecodeEngineerResultRejectsMultipleJSONFences(t *testing.T) {
+	t.Parallel()
+
+	_, err := issueagent.DecodeEngineerResult(strings.NewReader(
+		"```json\n"+validEngineerResultJSON+"\n```\n```json\n"+
+			validEngineerResultJSON+"\n```\n",
+	), 32<<10)
+	require.Error(t, err)
+}
+
+func TestDecodeEngineerResultRejectsRawAndFencedResults(t *testing.T) {
+	t.Parallel()
+
+	_, err := issueagent.DecodeEngineerResult(strings.NewReader(
+		validEngineerResultJSON+"\n```json\n"+validEngineerResultJSON+"\n```\n",
+	), 32<<10)
+	require.Error(t, err)
+}
+
 func TestDecodeEngineerResultRejectsTrustedTestClaim(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contracts/issueagent/json.go
+++ b/internal/contracts/issueagent/json.go
@@ -19,15 +19,9 @@ var (
 )
 
 func decodeStrictJSON(reader io.Reader, maxBytes int64, output any) error {
-	if reader == nil || maxBytes <= 0 {
-		return errors.New("JSON input limit must be positive")
-	}
-	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	body, err := readBoundedJSON(reader, maxBytes)
 	if err != nil {
-		return fmt.Errorf("read JSON input: %w", err)
-	}
-	if int64(len(body)) > maxBytes {
-		return errors.New("JSON input exceeds byte limit")
+		return err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
@@ -42,6 +36,20 @@ func decodeStrictJSON(reader io.Reader, maxBytes int64, output any) error {
 		return fmt.Errorf("decode trailing JSON input: %w", err)
 	}
 	return nil
+}
+
+func readBoundedJSON(reader io.Reader, maxBytes int64) ([]byte, error) {
+	if reader == nil || maxBytes <= 0 {
+		return nil, errors.New("JSON input limit must be positive")
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read JSON input: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, errors.New("JSON input exceeds byte limit")
+	}
+	return body, nil
 }
 
 func validRepository(repository string) bool {

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -145,6 +145,15 @@ func TestIssueAgentTaskFreezesExactControlSource(t *testing.T) {
 	require.Contains(t, engineer, "$RUNNER_TEMP/issue-agent-prompt.md")
 }
 
+func TestIssueAgentImmutableBaselineKeepsCanonicalGitModes(t *testing.T) {
+	engineer := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	require.Contains(t, engineer,
+		"sudo chown -R root:root /opt/wukongim-issue-agent/baseline")
+	require.Contains(t, engineer,
+		"sudo chmod -R u=rwX,go=rX /opt/wukongim-issue-agent/baseline")
+	require.NotContains(t, engineer, "sudo chmod -R a-w")
+}
+
 func TestIssueAgentReusableCallerGrantsOnlyRequiredReadScopes(t *testing.T) {
 	raw := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
 	caller := issueAgentJobText(t, raw, "engineer")


### PR DESCRIPTION
## Summary

- keep the immutable candidate baseline root-owned and Engineer-read-only while preserving canonical `0644`/`0755` Git modes
- accept either strict raw `EngineerResult` JSON or exactly one Markdown `json` fence, then apply the existing bounded strict decoder and schema validation
- reject multiple fences and raw-plus-fenced competing results
- add workflow and decoder regression coverage, and update the applicable `FLOW.md`

## Root cause

The [Kimi canary run](https://github.com/WuKongIM/WuKongIM/actions/runs/30600874798) completed the Codex task and produced the correct one-line documentation repair, but the post-model capture failed for two independent reasons:

1. the workflow froze the baseline with `chmod -R a-w`, changing regular files to `0444`/`0555`, while `CaptureCandidate` accepts canonical Git modes `0644`/`0755`;
2. Kimi returned the otherwise valid advisory JSON inside a Markdown fence with surrounding prose, while the Publisher accepted only raw JSON.

The first issue stopped candidate capture. The second would have stopped publication immediately afterward.

## Impact

Kimi/OpenRouter tasks can now cross the Engineer → CandidateSnapshot → Publisher handoff without weakening candidate authority, evidence validation, credential isolation, or model settings.

## Validation

- `GOWORK=off go test ./internal/contracts/issueagent ./internal/runtime/issueagentverify ./internal/access/issueagentcli ./internal/app ./cmd/wkissueagent -count=1`
- `GOWORK=off go test ./scripts/... -run "Workflow|ReviewAgent" -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/issue-agent-engineer.yml`
- exact filesystem candidate-capture replay against `origin/main` with canonical frozen-baseline modes
- Spec review: no findings
- Standards review: one ambiguous raw-plus-fenced fallback finding fixed and re-reviewed with no remaining findings

Repository-wide Actionlint still reports the pre-existing 11-input `workflow_dispatch` limit in `.github/workflows/cloud-sim-provision.yml`; that file is unchanged from `origin/main` and is outside this PR.