### PR TITLE
fix(review-agent): authenticate workflow runs by path

### DIFF
--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -1,5 +1,7 @@
 name: Agent Tool - Review Pull Request
-run-name: Review Agent PR #${{ inputs.pull_request }} generation from lease ${{ inputs.lease_run_id }} attempt ${{ inputs.infrastructure_attempt }}
+run-name: >-
+  Review Agent PR #${{ inputs.pull_request }} generation from lease
+  ${{ inputs.lease_run_id }} attempt ${{ inputs.infrastructure_attempt }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -26,10 +26,10 @@ jobs:
     name: Re-read and reconcile
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.name == 'Safety Automation - Review Agent PR Signal' &&
+      (github.event.workflow_run.path == '.github/workflows/review-agent-pr-signal.yml' &&
        github.event.workflow_run.conclusion == 'success' &&
        endsWith(github.event.workflow_run.display_title, ' accepted true')) ||
-      (github.event.workflow_run.name == 'Agent Tool - Review Pull Request' &&
+      (github.event.workflow_run.path == '.github/workflows/review-agent-run.yml' &&
        github.event.workflow_run.conclusion != 'success')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -85,11 +85,9 @@ jobs:
              .event == "issue_comment" or .event == "workflow_dispatch")
           ' "$RUNNER_TEMP/signal-run.json" >/dev/null
           title="$(jq -er .display_title "$RUNNER_TEMP/signal-run.json")"
-          name="$(jq -er .name "$RUNNER_TEMP/signal-run.json")"
           path="$(jq -er .path "$RUNNER_TEMP/signal-run.json")"
           conclusion="$(jq -er .conclusion "$RUNNER_TEMP/signal-run.json")"
-          if [[ "$name" == "Agent Tool - Review Pull Request" ]]; then
-            test "$path" = ".github/workflows/review-agent-run.yml"
+          if [[ "$path" == ".github/workflows/review-agent-run.yml" ]]; then
             test "$conclusion" != success
             [[ "$title" =~ ^Review\ Agent\ PR\ \#([1-9][0-9]{0,9})\ generation\ from\ lease\ ([1-9][0-9]{0,19})\ attempt\ ([0-9]{1,2})$ ]]
             printf 'pull_request=%s\nsignal_kind=worker_failure\ncomment_id=0\nrun_id=%s\nworker_attempt=%s\n' \
@@ -97,7 +95,6 @@ jobs:
               "${BASH_REMATCH[3]}" >>"$GITHUB_OUTPUT"
             exit 0
           fi
-          test "$name" = "Safety Automation - Review Agent PR Signal"
           test "$path" = ".github/workflows/review-agent-pr-signal.yml"
           test "$conclusion" = success
           gh api \

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -7,6 +7,8 @@
 - Review Agent invalidation is generation-bound. Fresh PR facts and signed
   scheduler state supersede stale workers; only the dedicated App-owned
   `Review Agent Verdict` may represent the current automated decision.
+- Review Agent `workflow_run` identity must be authenticated by its stable
+  workflow path; dynamic run names are not an authority boundary.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/internal/access/reviewagentcli/command_test.go
+++ b/internal/access/reviewagentcli/command_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cli "github.com/WuKongIM/WuKongIM/internal/access/reviewagentcli"
+	verify "github.com/WuKongIM/WuKongIM/internal/runtime/reviewagentverify"
 )
 
 func TestReviewAgentCLIUsesOneStrictJSONDocument(t *testing.T) {
@@ -36,6 +37,54 @@ func TestReviewAgentCLIUsesOneStrictJSONDocument(t *testing.T) {
 	)
 	require.Zero(t, code)
 	require.Contains(t, stdout.String(), `"state_changed":false`)
+	require.Empty(t, stderr.String())
+}
+
+func TestReviewAgentCLIDecodesWorkflowRiskSelection(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := cli.Run(
+		context.Background(),
+		[]string{"build-context"},
+		strings.NewReader(`{
+			"pull_request":716,
+			"generation":{
+				"repository":"WuKongIM/WuKongIM",
+				"pull_request":716,
+				"head_sha":"1111111111111111111111111111111111111111",
+				"base_sha":"2222222222222222222222222222222222222222",
+				"test_merge_sha":"3333333333333333333333333333333333333333",
+				"intent_digest":"sha256:4444444444444444444444444444444444444444444444444444444444444444",
+				"generation":1,
+				"state_parent_sha":"5555555555555555555555555555555555555555"
+			},
+			"review_reason":"review requested",
+			"prior_findings":null,
+			"risk":{
+				"race":true,
+				"integration":true,
+				"e2e":true,
+				"three_node_cluster":true
+			}
+		}`),
+		&stdout,
+		&stderr,
+		cli.Operations{
+			BuildContext: func(
+				_ context.Context,
+				request cli.BuildContextRequest,
+			) (cli.BuildContextResponse, error) {
+				require.Equal(t, verify.RiskSelection{
+					Race: true, Integration: true,
+					E2E: true, ThreeNodeCluster: true,
+				}, request.Risk)
+				return cli.BuildContextResponse{}, nil
+			},
+		},
+	)
+	require.Zero(t, code)
 	require.Empty(t, stderr.String())
 }
 

--- a/internal/runtime/reviewagentverify/policy.go
+++ b/internal/runtime/reviewagentverify/policy.go
@@ -37,10 +37,10 @@ type Policy struct {
 // RiskSelection adds bounded expensive checks justified by actual change
 // risk. It never removes deterministic minimum checks.
 type RiskSelection struct {
-	Race             bool
-	Integration      bool
-	E2E              bool
-	ThreeNodeCluster bool
+	Race             bool `json:"race"`
+	Integration      bool `json:"integration"`
+	E2E              bool `json:"e2e"`
+	ThreeNodeCluster bool `json:"three_node_cluster"`
 }
 
 // PlanChecks returns the sorted complete named-check plan.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -93,12 +93,26 @@ func TestReviewAgentControllerWorkflowSeparatesAuthority(t *testing.T) {
 	require.Contains(t, raw, "worker_attempt:$worker_attempt")
 	require.Contains(t, raw, "infrastructure_attempt")
 	require.Contains(t, raw, "workflow_dispatch:")
+	require.Contains(
+		t,
+		raw,
+		"github.event.workflow_run.path == '.github/workflows/review-agent-pr-signal.yml'",
+	)
+	require.Contains(
+		t,
+		raw,
+		"github.event.workflow_run.path == '.github/workflows/review-agent-run.yml'",
+	)
 	require.Contains(t, raw, "github.event.workflow_run.conclusion == 'success'")
 	require.Contains(
 		t,
 		raw,
 		"endsWith(github.event.workflow_run.display_title, ' accepted true')",
 	)
+	require.Contains(t, raw, `if [[ "$path" == ".github/workflows/review-agent-run.yml" ]]`)
+	require.Contains(t, raw, `test "$path" = ".github/workflows/review-agent-pr-signal.yml"`)
+	require.NotContains(t, raw, "github.event.workflow_run.name")
+	require.NotContains(t, raw, "jq -er .name")
 	require.NotContains(t, raw, "group: review-agent-state-")
 	require.Contains(t, raw, "ref: ${{ steps.control.outputs.sha }}")
 	require.Contains(t, raw, "persist-credentials: false")

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -167,8 +167,17 @@ func TestReviewAgentControllerWorkflowSeparatesAuthority(t *testing.T) {
 
 func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	raw := readIssueAgentFile(t, ".github/workflows/review-agent-run.yml")
-	var document any
+	var document struct {
+		RunName string `yaml:"run-name"`
+	}
 	require.NoError(t, yaml.Unmarshal([]byte(raw), &document))
+	require.Equal(
+		t,
+		"Review Agent PR #${{ inputs.pull_request }} generation from lease "+
+			"${{ inputs.lease_run_id }} attempt "+
+			"${{ inputs.infrastructure_attempt }}",
+		document.RunName,
+	)
 	for _, job := range []string{
 		"recover:",
 		"context:",


### PR DESCRIPTION
## Summary
- authenticate workflow-run dispatches with the stable workflow file path
- preserve the structured worker run name by using a folded YAML scalar
- define the strict snake_case JSON contract for workflow risk selection
- add control-plane regressions and the repository knowledge invariant

## Evidence
Bootstrap runs exposed three independent failures:
1. successful PR signals skipped every Controller because dynamic run-name replaces workflow_run.name;
2. the unquoted worker run-name treated the PR-number marker as a YAML comment;
3. build-context rejected three_node_cluster as an unknown strict-JSON field before any network request.

The exact #716 build-context payload now succeeds locally through the real CLI boundary. No Kimi request was made by the failed worker.

## Validation
- GOWORK=off go test ./internal/access/reviewagentcli ./internal/runtime/reviewagentverify ./scripts/... -count=1
- actionlint v1.7.9 on all Review Agent workflows
- exact read-only build-context replay for PR #716
- git diff --check