### PR TITLE
refactor: add online delivery contracts

### DIFF
--- a/internal/contracts/onlinedelivery/FLOW.md
+++ b/internal/contracts/onlinedelivery/FLOW.md
@@ -1,0 +1,16 @@
+# Online Delivery Contracts
+
+`internal/contracts/onlinedelivery` owns the canonical values that cross the
+Online Delivery seam.
+
+- A `RecipientDeliveryPlan` explicitly identifies Durable or Transient delivery
+  and carries a bounded set of recipients grouped by exact authority target.
+- Successful plan admission transfers shared immutable ownership. Callers must
+  not mutate the event, targets, or recipients after admission succeeds.
+- An `OwnerPush` groups exact online routes owned by one node. Its result keeps
+  accepted, retryable, and dropped routes distinct.
+- Clone methods exist for adapters and tests that retain or serialize values;
+  the Online Delivery admission hot path does not clone plans.
+
+Subscriber discovery, authority grouping, conversation projection, ACK tokens,
+worker queues, and retry state are not part of this contract package.

--- a/internal/contracts/onlinedelivery/types.go
+++ b/internal/contracts/onlinedelivery/types.go
@@ -1,0 +1,122 @@
+// Package onlinedelivery defines the canonical contracts crossing the Online Delivery seam.
+package onlinedelivery
+
+import (
+	"github.com/WuKongIM/WuKongIM/internal/contracts/authority"
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+)
+
+// Mode identifies whether a Recipient Delivery Plan follows a durable commit
+// or represents transient NoPersist delivery.
+type Mode uint8
+
+const (
+	// ModeDurable identifies Online Delivery after a quorum-backed message commit.
+	ModeDurable Mode = iota + 1
+	// ModeTransient identifies NoPersist Online Delivery.
+	ModeTransient
+)
+
+// Valid reports whether mode is a supported Online Delivery mode.
+func (m Mode) Valid() bool {
+	return m == ModeDurable || m == ModeTransient
+}
+
+// RecipientTargetBatch groups recipients that share one exact authority target.
+type RecipientTargetBatch struct {
+	// Target is the exact recipient authority fence resolved before admission.
+	Target authority.Target
+	// Recipients are the recipients owned by Target.
+	Recipients []channelappendcontract.Recipient
+}
+
+// Clone returns an independent recipient target batch.
+func (b RecipientTargetBatch) Clone() RecipientTargetBatch {
+	b.Recipients = append([]channelappendcontract.Recipient(nil), b.Recipients...)
+	return b
+}
+
+// RecipientDeliveryPlan carries one message and a bounded set of exact-target
+// recipient groups into Online Delivery.
+type RecipientDeliveryPlan struct {
+	// Mode explicitly distinguishes durable and transient Online Delivery.
+	Mode Mode
+	// Event is the immutable message being delivered.
+	Event channelappendcontract.CommittedEnvelope
+	// Targets preserve the exact authority fences resolved for the recipients.
+	Targets []RecipientTargetBatch
+}
+
+// Clone returns an independent delivery plan for adapters that retain input.
+func (p RecipientDeliveryPlan) Clone() RecipientDeliveryPlan {
+	p.Event = p.Event.Clone()
+	p.Targets = append([]RecipientTargetBatch(nil), p.Targets...)
+	for i := range p.Targets {
+		p.Targets[i] = p.Targets[i].Clone()
+	}
+	return p
+}
+
+// RecipientCount returns the number of recipient entries carried by the plan.
+func (p RecipientDeliveryPlan) RecipientCount() int {
+	total := 0
+	for _, target := range p.Targets {
+		total += len(target.Recipients)
+	}
+	return total
+}
+
+// Route describes one exact online recipient endpoint.
+type Route struct {
+	// UID is the recipient user ID for this endpoint.
+	UID string
+	// OwnerNodeID is the node that owns the recipient gateway session.
+	OwnerNodeID uint64
+	// OwnerBootID fences stale owner-node process incarnations.
+	OwnerBootID uint64
+	// OwnerSeq fences stale owner-session authority observations.
+	OwnerSeq uint64
+	// SessionID is the recipient owner-local gateway session identifier.
+	SessionID uint64
+	// DeviceID identifies the recipient client device.
+	DeviceID string
+	// DeviceFlag carries protocol device category metadata.
+	DeviceFlag uint8
+	// DeviceLevel carries protocol device priority metadata.
+	DeviceLevel uint8
+}
+
+// OwnerPush groups exact recipient routes owned by one node.
+type OwnerPush struct {
+	// OwnerNodeID is the recipient owner node that should accept the push.
+	OwnerNodeID uint64
+	// Event is the immutable message being pushed.
+	Event channelappendcontract.CommittedEnvelope
+	// Routes are the recipient endpoints owned by OwnerNodeID.
+	Routes []Route
+}
+
+// Clone returns an independent owner push for serialization or retention.
+func (p OwnerPush) Clone() OwnerPush {
+	p.Event = p.Event.Clone()
+	p.Routes = append([]Route(nil), p.Routes...)
+	return p
+}
+
+// OwnerPushResult reports how an owner node classified pushed routes.
+type OwnerPushResult struct {
+	// Accepted routes were accepted for delivery by the owner node.
+	Accepted []Route
+	// Retryable routes should be retried by Online Delivery.
+	Retryable []Route
+	// Dropped routes should not be retried.
+	Dropped []Route
+}
+
+// Clone returns an independent owner push result.
+func (r OwnerPushResult) Clone() OwnerPushResult {
+	r.Accepted = append([]Route(nil), r.Accepted...)
+	r.Retryable = append([]Route(nil), r.Retryable...)
+	r.Dropped = append([]Route(nil), r.Dropped...)
+	return r
+}

--- a/internal/contracts/onlinedelivery/types_test.go
+++ b/internal/contracts/onlinedelivery/types_test.go
@@ -1,0 +1,64 @@
+package onlinedelivery
+
+import (
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/authority"
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+)
+
+func TestRecipientDeliveryPlanCloneOwnsMutableStorage(t *testing.T) {
+	plan := RecipientDeliveryPlan{
+		Mode: ModeDurable,
+		Event: channelappendcontract.CommittedEnvelope{
+			MessageID: 1,
+			Payload:   []byte("payload"),
+		},
+		Targets: []RecipientTargetBatch{{
+			Target: authority.Target{SlotID: 7, LeaderNodeID: 2},
+			Recipients: []channelappendcontract.Recipient{{
+				UID:     "u1",
+				JoinSeq: 3,
+			}},
+		}},
+	}
+
+	cloned := plan.Clone()
+	plan.Event.Payload[0] = 'X'
+	plan.Targets[0].Recipients[0].UID = "changed"
+
+	if got := string(cloned.Event.Payload); got != "payload" {
+		t.Fatalf("cloned payload = %q, want payload", got)
+	}
+	if got := cloned.Targets[0].Recipients[0].UID; got != "u1" {
+		t.Fatalf("cloned recipient UID = %q, want u1", got)
+	}
+	if got := cloned.RecipientCount(); got != 1 {
+		t.Fatalf("RecipientCount() = %d, want 1", got)
+	}
+	if !cloned.Mode.Valid() || Mode(0).Valid() {
+		t.Fatalf("mode validity = %v/%v, want true/false", cloned.Mode.Valid(), Mode(0).Valid())
+	}
+}
+
+func TestOwnerPushCloneOwnsMutableStorage(t *testing.T) {
+	push := OwnerPush{
+		OwnerNodeID: 2,
+		Event: channelappendcontract.CommittedEnvelope{
+			MessageID: 1,
+			Payload:   []byte("payload"),
+		},
+		Routes: []Route{{UID: "u1", OwnerNodeID: 2, SessionID: 9}},
+	}
+
+	cloned := push.Clone()
+	push.Event.Payload[0] = 'X'
+	push.Routes[0].UID = "changed"
+
+	if got := string(cloned.Event.Payload); got != "payload" {
+		t.Fatalf("cloned payload = %q, want payload", got)
+	}
+	if got := cloned.Routes[0].UID; got != "u1" {
+		t.Fatalf("cloned route UID = %q, want u1", got)
+	}
+}

--- a/internal/contracts/onlinedelivery/types_test.go
+++ b/internal/contracts/onlinedelivery/types_test.go
@@ -36,8 +36,16 @@ func TestRecipientDeliveryPlanCloneOwnsMutableStorage(t *testing.T) {
 	if got := cloned.RecipientCount(); got != 1 {
 		t.Fatalf("RecipientCount() = %d, want 1", got)
 	}
-	if !cloned.Mode.Valid() || Mode(0).Valid() {
-		t.Fatalf("mode validity = %v/%v, want true/false", cloned.Mode.Valid(), Mode(0).Valid())
+}
+
+func TestModeValidRecognizesOnlySupportedModes(t *testing.T) {
+	if !ModeDurable.Valid() || !ModeTransient.Valid() {
+		t.Fatalf("supported mode validity = %v/%v, want true/true", ModeDurable.Valid(), ModeTransient.Valid())
+	}
+	for _, mode := range []Mode{0, ModeTransient + 1, Mode(255)} {
+		if mode.Valid() {
+			t.Fatalf("Mode(%d).Valid() = true, want false", mode)
+		}
 	}
 }
 
@@ -60,5 +68,28 @@ func TestOwnerPushCloneOwnsMutableStorage(t *testing.T) {
 	}
 	if got := cloned.Routes[0].UID; got != "u1" {
 		t.Fatalf("cloned route UID = %q, want u1", got)
+	}
+}
+
+func TestOwnerPushResultCloneOwnsRouteSlices(t *testing.T) {
+	result := OwnerPushResult{
+		Accepted:  []Route{{UID: "accepted"}},
+		Retryable: []Route{{UID: "retryable"}},
+		Dropped:   []Route{{UID: "dropped"}},
+	}
+
+	cloned := result.Clone()
+	result.Accepted[0].UID = "changed"
+	result.Retryable[0].UID = "changed"
+	result.Dropped[0].UID = "changed"
+
+	if got := cloned.Accepted[0].UID; got != "accepted" {
+		t.Fatalf("cloned accepted UID = %q, want accepted", got)
+	}
+	if got := cloned.Retryable[0].UID; got != "retryable" {
+		t.Fatalf("cloned retryable UID = %q, want retryable", got)
+	}
+	if got := cloned.Dropped[0].UID; got != "dropped" {
+		t.Fatalf("cloned dropped UID = %q, want dropped", got)
 	}
 }


### PR DESCRIPTION
## Summary

- add canonical Online Delivery DTOs for recipient plans, exact authority targets, routes, and owner-push results
- encode explicit durable/transient delivery modes and ownership-preserving clone helpers
- document the contract seam and cover validation plus clone isolation

## Architecture

This is the first review-sized slice of the Online Delivery convergence. It introduces contracts only and does not route production traffic. The previously combined dormant runtime is being split into prerequisites, runtime behavior, and extended-test slices so every formal Review Agent context stays within its exact byte budget.

## Validation

- `GOWORK=off go test ./internal/contracts/onlinedelivery -count=1`
- `git diff --check origin/main...HEAD`