### PR TITLE
fix(review-agent): recover canonical scheduler state

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -14,6 +14,8 @@
   App-JWT-only identity endpoints such as `GET /installation`.
 - Review Agent scheduler canonical JSON normalizes zero-length queue and active
   collections to `null`; empty slice representation is never a state change.
+  The loader may recover one semantically identical legacy duplicate and its
+  strict successor without rewinding the append-only scheduler ref.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -12,6 +12,8 @@
 - Review Agent role identity must be verified with the App JWT before minting
   a repository-scoped installation token. Installation tokens must not call
   App-JWT-only identity endpoints such as `GET /installation`.
+- Review Agent scheduler canonical JSON normalizes zero-length queue and active
+  collections to `null`; empty slice representation is never a state change.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/internal/app/review_agent_internal_test.go
+++ b/internal/app/review_agent_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	contract "github.com/WuKongIM/WuKongIM/internal/contracts/reviewagent"
 	reviewagentgithub "github.com/WuKongIM/WuKongIM/internal/infra/reviewagentgithub"
+	reviewagent "github.com/WuKongIM/WuKongIM/internal/usecase/reviewagent"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,4 +95,27 @@ func TestReviewDiscussionPreservesEveryGitHubSurface(t *testing.T) {
 			Line: 7, Side: "RIGHT", InReplyToID: 0,
 		},
 	}, discussion)
+}
+
+func TestSchedulerDigestChangedIgnoresEmptyCollections(t *testing.T) {
+	t.Parallel()
+
+	left := reviewagent.SchedulerState{
+		SchemaVersion: 1,
+		SourceSHA:     strings.Repeat("a", 40),
+		Sequence:      1,
+		UpdatedAt:     time.Date(2026, 7, 31, 4, 0, 0, 0, time.UTC),
+	}
+	right := left
+	right.Queue = []reviewagent.QueueEntry{}
+	right.Active = []reviewagent.Lease{}
+
+	require.False(t, schedulerDigestChanged(
+		left,
+		right,
+		reviewagent.SchedulerLimits{
+			MaxActive: 3, MaxPerPullRequest: 1,
+			MaxFirstTimeExternal: 1,
+		},
+	))
 }

--- a/internal/infra/reviewagentgithub/FLOW.md
+++ b/internal/infra/reviewagentgithub/FLOW.md
@@ -13,6 +13,8 @@ Review State Writer App token
   -> exact review-state/pr-N or review-state/scheduler ref
   -> verified latest + immediate predecessor rolling checkpoint
      (older commits remain append-only audit history)
+  -> one legacy scheduler checkpoint that only repeats its canonical
+     predecessor with empty JSON collections may be loaded for the next append
   -> expected-head append only
 
 Review Agent App token
@@ -23,6 +25,10 @@ Review Agent App token
   -> one formal Review with bounded inline comments
   -> one Review Agent Verdict Check Run
 ```
+
+The bounded scheduler recovery never rewinds or rewrites the protected state
+ref. A strict successor may name that one legacy checkpoint; after the next
+successor, it leaves the two-checkpoint verification window.
 
 The Review App adapter exposes no contents, branch, commit, merge, close,
 dismiss, resolve, Ruleset, Actions, or Secrets operation. The State Writer

--- a/internal/infra/reviewagentgithub/scheduler_store.go
+++ b/internal/infra/reviewagentgithub/scheduler_store.go
@@ -3,6 +3,7 @@ package reviewagentgithub
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -69,12 +70,12 @@ func (store *SchedulerStore) Load(
 		)
 	}
 
-	latestRecord, latest, err := store.readCheckpoint(ctx, head)
+	latestRecord, latest, latestLegacy, err := store.readCheckpoint(ctx, head)
 	if err != nil {
 		return LoadedSchedulerState{}, false, err
 	}
 	if latest.Sequence == 1 {
-		if latestRecord.ParentSHA != latest.SourceSHA {
+		if latestLegacy || latestRecord.ParentSHA != latest.SourceSHA {
 			return LoadedSchedulerState{}, false, errors.New(
 				"initial Review scheduler has the wrong source parent",
 			)
@@ -86,34 +87,70 @@ func (store *SchedulerStore) Load(
 			"Review scheduler predecessor is invalid",
 		)
 	}
-	_, previous, err := store.readCheckpoint(ctx, latestRecord.ParentSHA)
+	_, previous, previousLegacy, err := store.readCheckpoint(
+		ctx,
+		latestRecord.ParentSHA,
+	)
 	if err != nil {
 		return LoadedSchedulerState{}, false, err
 	}
-	digest, err := usecase.SchedulerStateDigest(previous, store.limits)
-	if err != nil ||
-		latest.PreviousStateDigest != digest ||
-		previous.Sequence+1 != latest.Sequence ||
-		previous.UpdatedAt.After(latest.UpdatedAt) ||
-		previous.SourceSHA != latest.SourceSHA {
+	previousDigest, err := usecase.SchedulerStateDigest(
+		previous,
+		store.limits,
+	)
+	if err != nil {
 		return LoadedSchedulerState{}, false, errors.New(
 			"Review scheduler rolling checkpoint is not contiguous",
 		)
 	}
-	return LoadedSchedulerState{HeadSHA: head, State: latest}, true, nil
+	if !latestLegacy &&
+		latest.PreviousStateDigest == previousDigest &&
+		previous.Sequence+1 == latest.Sequence &&
+		!previous.UpdatedAt.After(latest.UpdatedAt) &&
+		previous.SourceSHA == latest.SourceSHA {
+		return LoadedSchedulerState{HeadSHA: head, State: latest}, true, nil
+	}
+	if latestLegacy && !previousLegacy &&
+		latest.Sequence == previous.Sequence {
+		latestDigest, digestErr := usecase.SchedulerStateDigest(
+			latest,
+			store.limits,
+		)
+		if digestErr != nil || latestDigest != previousDigest {
+			return LoadedSchedulerState{}, false, errors.New(
+				"Review scheduler rolling checkpoint is not contiguous",
+			)
+		}
+		normalized, normalizeErr := normalizeLoadedScheduler(
+			latest,
+			store.limits,
+		)
+		if normalizeErr != nil {
+			return LoadedSchedulerState{}, false, errors.New(
+				"Review scheduler rolling checkpoint is not contiguous",
+			)
+		}
+		return LoadedSchedulerState{
+			HeadSHA: head,
+			State:   normalized,
+		}, true, nil
+	}
+	return LoadedSchedulerState{}, false, errors.New(
+		"Review scheduler rolling checkpoint is not contiguous",
+	)
 }
 
 func (store *SchedulerStore) readCheckpoint(
 	ctx context.Context,
 	commitSHA string,
-) (StateCommitRecord, usecase.SchedulerState, error) {
+) (StateCommitRecord, usecase.SchedulerState, bool, error) {
 	record, err := store.commits.ReadStateCommit(
 		ctx,
 		commitSHA,
 		schedulerStatePath,
 	)
 	if err != nil {
-		return StateCommitRecord{}, usecase.SchedulerState{}, err
+		return StateCommitRecord{}, usecase.SchedulerState{}, false, err
 	}
 	if err := validateStateRecordTrust(
 		record,
@@ -121,7 +158,7 @@ func (store *SchedulerStore) readCheckpoint(
 		schedulerStatePath,
 		store.appLogin,
 	); err != nil {
-		return StateCommitRecord{}, usecase.SchedulerState{}, err
+		return StateCommitRecord{}, usecase.SchedulerState{}, false, err
 	}
 	state, err := usecase.DecodeSchedulerState(
 		bytes.NewReader(record.Content),
@@ -133,17 +170,41 @@ func (store *SchedulerStore) readCheckpoint(
 			"review(scheduler): sequence %d",
 			state.Sequence,
 		) {
-		return StateCommitRecord{}, usecase.SchedulerState{}, errors.New(
+		return StateCommitRecord{}, usecase.SchedulerState{}, false, errors.New(
 			"Review scheduler commit content is invalid",
 		)
 	}
 	canonical, err := usecase.CanonicalSchedulerState(state, store.limits)
-	if err != nil || !bytes.Equal(canonical, record.Content) {
-		return StateCommitRecord{}, usecase.SchedulerState{}, errors.New(
+	if err != nil {
+		return StateCommitRecord{}, usecase.SchedulerState{}, false, errors.New(
 			"Review scheduler commit is not canonical",
 		)
 	}
-	return record, state, nil
+	if bytes.Equal(canonical, record.Content) {
+		return record, state, false, nil
+	}
+	legacy, legacyErr := json.Marshal(state)
+	if legacyErr != nil || !bytes.Equal(legacy, record.Content) {
+		return StateCommitRecord{}, usecase.SchedulerState{}, false, errors.New(
+			"Review scheduler commit is not canonical",
+		)
+	}
+	return record, state, true, nil
+}
+
+func normalizeLoadedScheduler(
+	state usecase.SchedulerState,
+	limits usecase.SchedulerLimits,
+) (usecase.SchedulerState, error) {
+	body, err := usecase.CanonicalSchedulerState(state, limits)
+	if err != nil {
+		return usecase.SchedulerState{}, err
+	}
+	return usecase.DecodeSchedulerState(
+		bytes.NewReader(body),
+		512<<10,
+		limits,
+	)
 }
 
 // Advance appends one canonical scheduler state at the exact expected head.

--- a/internal/infra/reviewagentgithub/state_store_test.go
+++ b/internal/infra/reviewagentgithub/state_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -278,6 +279,172 @@ func TestSchedulerStoreLoadsHighSequenceFromRollingCheckpoint(t *testing.T) {
 	require.Equal(t, 2, port.reads)
 }
 
+func TestSchedulerStoreLoadsLegacyDuplicateEmptyCheckpointForRepair(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	limits := usecase.SchedulerLimits{
+		MaxActive: 3, MaxPerPullRequest: 1, MaxFirstTimeExternal: 1,
+	}
+	previous := schedulerStateFixture(4)
+	previousBody, err := usecase.CanonicalSchedulerState(previous, limits)
+	require.NoError(t, err)
+	legacyLatest := previous
+	legacyLatest.Queue = []usecase.QueueEntry{}
+	legacyLatest.Active = []usecase.Lease{}
+	legacyBody, err := json.Marshal(legacyLatest)
+	require.NoError(t, err)
+	require.NotEqual(t, previousBody, legacyBody)
+
+	previousCommit := strings.Repeat("b", 40)
+	head := strings.Repeat("c", 40)
+	port := &stateCommitStub{
+		head: head,
+		records: map[string]reviewagentgithub.StateCommitRecord{
+			head: trustedRecord(
+				head,
+				previousCommit,
+				"review(scheduler): sequence 4",
+				".review-agent-state/scheduler.json",
+				legacyBody,
+			),
+			previousCommit: trustedRecord(
+				previousCommit,
+				strings.Repeat("d", 40),
+				"review(scheduler): sequence 4",
+				".review-agent-state/scheduler.json",
+				previousBody,
+			),
+		},
+	}
+	store, err := reviewagentgithub.NewSchedulerStore(
+		"wukongim-review-state-writer[bot]",
+		port,
+		limits,
+	)
+	require.NoError(t, err)
+
+	loaded, found, err := store.Load(context.Background())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, head, loaded.HeadSHA)
+	require.Equal(t, previous, loaded.State)
+}
+
+func TestSchedulerStoreLoadsStrictSuccessorAfterLegacyRepairCheckpoint(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	limits := usecase.SchedulerLimits{
+		MaxActive: 3, MaxPerPullRequest: 1, MaxFirstTimeExternal: 1,
+	}
+	legacyPrevious := schedulerStateFixture(4)
+	legacyPrevious.Queue = []usecase.QueueEntry{}
+	legacyPrevious.Active = []usecase.Lease{}
+	legacyBody, err := json.Marshal(legacyPrevious)
+	require.NoError(t, err)
+	previousDigest, err := usecase.SchedulerStateDigest(
+		legacyPrevious,
+		limits,
+	)
+	require.NoError(t, err)
+	latest := schedulerStateFixture(5)
+	latest.PreviousStateDigest = previousDigest
+	latest.UpdatedAt = legacyPrevious.UpdatedAt.Add(time.Minute)
+	latestBody, err := usecase.CanonicalSchedulerState(latest, limits)
+	require.NoError(t, err)
+
+	previousCommit := strings.Repeat("b", 40)
+	head := strings.Repeat("c", 40)
+	port := &stateCommitStub{
+		head: head,
+		records: map[string]reviewagentgithub.StateCommitRecord{
+			head: trustedRecord(
+				head,
+				previousCommit,
+				"review(scheduler): sequence 5",
+				".review-agent-state/scheduler.json",
+				latestBody,
+			),
+			previousCommit: trustedRecord(
+				previousCommit,
+				strings.Repeat("d", 40),
+				"review(scheduler): sequence 4",
+				".review-agent-state/scheduler.json",
+				legacyBody,
+			),
+		},
+	}
+	store, err := reviewagentgithub.NewSchedulerStore(
+		"wukongim-review-state-writer[bot]",
+		port,
+		limits,
+	)
+	require.NoError(t, err)
+
+	loaded, found, err := store.Load(context.Background())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, latest, loaded.State)
+}
+
+func TestSchedulerStoreRejectsLegacyNonDuplicateCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	limits := usecase.SchedulerLimits{
+		MaxActive: 3, MaxPerPullRequest: 1, MaxFirstTimeExternal: 1,
+	}
+	previous := schedulerStateFixture(4)
+	previousBody, err := usecase.CanonicalSchedulerState(previous, limits)
+	require.NoError(t, err)
+	previousDigest, err := usecase.SchedulerStateDigest(previous, limits)
+	require.NoError(t, err)
+	legacyLatest := schedulerStateFixture(5)
+	legacyLatest.PreviousStateDigest = previousDigest
+	legacyLatest.Queue = []usecase.QueueEntry{}
+	legacyLatest.Active = []usecase.Lease{}
+	legacyLatest.UpdatedAt = previous.UpdatedAt.Add(time.Minute)
+	legacyBody, err := json.Marshal(legacyLatest)
+	require.NoError(t, err)
+
+	previousCommit := strings.Repeat("b", 40)
+	head := strings.Repeat("c", 40)
+	port := &stateCommitStub{
+		head: head,
+		records: map[string]reviewagentgithub.StateCommitRecord{
+			head: trustedRecord(
+				head,
+				previousCommit,
+				"review(scheduler): sequence 5",
+				".review-agent-state/scheduler.json",
+				legacyBody,
+			),
+			previousCommit: trustedRecord(
+				previousCommit,
+				strings.Repeat("d", 40),
+				"review(scheduler): sequence 4",
+				".review-agent-state/scheduler.json",
+				previousBody,
+			),
+		},
+	}
+	store, err := reviewagentgithub.NewSchedulerStore(
+		"wukongim-review-state-writer[bot]",
+		port,
+		limits,
+	)
+	require.NoError(t, err)
+
+	_, _, err = store.Load(context.Background())
+	require.EqualError(
+		t,
+		err,
+		"Review scheduler rolling checkpoint is not contiguous",
+	)
+}
+
 type stateCommitStub struct {
 	head          string
 	ref           string
@@ -324,6 +491,18 @@ func trustedRecord(
 		Path: path, Content: content,
 		AuthorLogin: "wukongim-review-state-writer[bot]",
 		AuthorType:  "Bot", Verified: true, SignedByGitHub: true,
+	}
+}
+
+func schedulerStateFixture(sequence uint64) usecase.SchedulerState {
+	return usecase.SchedulerState{
+		SchemaVersion:       1,
+		SourceSHA:           strings.Repeat("a", 40),
+		Sequence:            sequence,
+		PreviousStateDigest: "sha256:" + strings.Repeat("1", 64),
+		UpdatedAt: time.Date(
+			2026, 7, 31, 1, 0, 0, 0, time.UTC,
+		),
 	}
 }
 

--- a/internal/usecase/reviewagent/scheduler.go
+++ b/internal/usecase/reviewagent/scheduler.go
@@ -114,6 +114,7 @@ func CanonicalSchedulerState(
 	state SchedulerState,
 	limits SchedulerLimits,
 ) ([]byte, error) {
+	state = normalizeSchedulerCollections(state)
 	if err := ValidateSchedulerState(state, limits); err != nil {
 		return nil, err
 	}
@@ -127,6 +128,18 @@ func CanonicalSchedulerState(
 		)
 	}
 	return body, nil
+}
+
+// normalizeSchedulerCollections gives semantically empty scheduler
+// collections one canonical signed representation.
+func normalizeSchedulerCollections(state SchedulerState) SchedulerState {
+	if len(state.Queue) == 0 {
+		state.Queue = nil
+	}
+	if len(state.Active) == 0 {
+		state.Active = nil
+	}
+	return state
 }
 
 // SchedulerStateDigest identifies one canonical scheduler state.

--- a/internal/usecase/reviewagent/scheduler_test.go
+++ b/internal/usecase/reviewagent/scheduler_test.go
@@ -128,6 +128,40 @@ func TestSchedulerCanonicalStateRejectsBrokenChain(t *testing.T) {
 	)
 }
 
+func TestSchedulerCanonicalStateNormalizesEmptyCollections(t *testing.T) {
+	t.Parallel()
+
+	nilCollections := testScheduler()
+	emptyCollections := nilCollections
+	emptyCollections.Queue = []reviewagent.QueueEntry{}
+	emptyCollections.Active = []reviewagent.Lease{}
+
+	nilBody, err := reviewagent.CanonicalSchedulerState(
+		nilCollections,
+		testPolicy().Scheduler,
+	)
+	require.NoError(t, err)
+	emptyBody, err := reviewagent.CanonicalSchedulerState(
+		emptyCollections,
+		testPolicy().Scheduler,
+	)
+	require.NoError(t, err)
+	require.Equal(t, nilBody, emptyBody)
+	require.Contains(t, string(emptyBody), `"queue":null,"active":null`)
+
+	nilDigest, err := reviewagent.SchedulerStateDigest(
+		nilCollections,
+		testPolicy().Scheduler,
+	)
+	require.NoError(t, err)
+	emptyDigest, err := reviewagent.SchedulerStateDigest(
+		emptyCollections,
+		testPolicy().Scheduler,
+	)
+	require.NoError(t, err)
+	require.Equal(t, nilDigest, emptyDigest)
+}
+
 func TestSchedulerCanonicalStateEnforcesStorageByteBound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- canonicalize zero-length scheduler queue and active collections to one signed `null` representation
- prevent nil-versus-empty representation changes from requesting an append with an unchanged sequence
- recover the one existing semantically identical legacy duplicate checkpoint without rewinding or rewriting the append-only scheduler ref
- accept its strict successor so the legacy record naturally leaves the rolling verification window
- reject arbitrary legacy or discontinuous latest checkpoints

## Root cause

The scheduler persisted an unchanged sequence 4 twice because `queue: null` and `queue: []` produced different digests. The ref remained append-only, but the loader correctly rejected the duplicate sequence and blocked every Controller.

## Recovery boundary

Recovery is allowed only when the latest old-format checkpoint and its strict canonical predecessor have the same sequence and the same new canonical digest. The loader returns the exact current head and normalized state; the next ordinary state change appends sequence 5. No ref is deleted, force-moved, or replayed.

## Validation

- `GOWORK=off go test ./internal/contracts/reviewagent ./internal/usecase/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/access/reviewagentcli ./internal/access/reviewagentcheckmcp ./internal/app ./cmd/wkreviewagent ./cmd/wkreviewcheckmcp ./scripts -count=1`
- `GOWORK=off go vet` over the same Review Agent packages
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/*.yml`
- live read-only replay of the current scheduler head `3edf9e9` produced a valid sequence 5 plan
- `git diff --check`