### PR TITLE
fix(review-agent): verify publisher app with JWT

### DIFF
--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -9,6 +9,9 @@
   `Review Agent Verdict` may represent the current automated decision.
 - Review Agent `workflow_run` identity must be authenticated by its stable
   workflow path; dynamic run names are not an authority boundary.
+- Review Agent role identity must be verified with the App JWT before minting
+  a repository-scoped installation token. Installation tokens must not call
+  App-JWT-only identity endpoints such as `GET /installation`.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/internal/app/review_agent.go
+++ b/internal/app/review_agent.go
@@ -564,6 +564,7 @@ func appendReviewState(
 		config,
 		config.StateWriterApp,
 		github.AppRoleStateWriter,
+		policy.Apps.StateWriter.Slug,
 	)
 	if err != nil {
 		return cli.AppendStateResponse{}, err
@@ -676,6 +677,7 @@ func publishReview(
 		config,
 		config.ReviewApp,
 		github.AppRoleReviewPublisher,
+		policy.Apps.Review.Slug,
 	)
 	if err != nil {
 		return cli.PublishReviewResponse{}, err
@@ -741,6 +743,7 @@ func mintReviewAppToken(
 	config ReviewAgentConfig,
 	app *ReviewAgentAppConfig,
 	role github.AppRole,
+	appSlug string,
 ) (github.InstallationToken, error) {
 	if app == nil {
 		return github.InstallationToken{}, errors.New(
@@ -753,6 +756,7 @@ func mintReviewAppToken(
 	}
 	minter, err := github.NewAppTokenMinter(github.AppTokenConfig{
 		BaseURL: config.APIBaseURL, AppID: app.AppID,
+		AppSlug:        appSlug,
 		InstallationID: app.InstallationID,
 		RepositoryID:   app.RepositoryID,
 		Repository:     config.Repository,

--- a/internal/infra/reviewagentgithub/FLOW.md
+++ b/internal/infra/reviewagentgithub/FLOW.md
@@ -16,6 +16,8 @@ Review State Writer App token
   -> expected-head append only
 
 Review Agent App token
+  -> App JWT verifies the protected policy App ID and slug before minting
+     one exact repository-scoped installation token
   -> fresh generation/governance fences
   -> one mutable status comment
   -> one formal Review with bounded inline comments

--- a/internal/infra/reviewagentgithub/app_token.go
+++ b/internal/infra/reviewagentgithub/app_token.go
@@ -28,6 +28,10 @@ var repositoryPattern = regexp.MustCompile(
 	`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`,
 )
 
+var appSlugPattern = regexp.MustCompile(
+	`^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$`,
+)
+
 // AppRole selects one compile-time permission profile.
 type AppRole string
 
@@ -41,6 +45,7 @@ const (
 type AppTokenConfig struct {
 	BaseURL        string
 	AppID          int64
+	AppSlug        string
 	InstallationID int64
 	RepositoryID   int64
 	Repository     string
@@ -75,6 +80,7 @@ func NewAppTokenMinter(
 		return nil, err
 	}
 	if config.AppID <= 0 ||
+		!appSlugPattern.MatchString(config.AppSlug) ||
 		config.InstallationID <= 0 ||
 		config.RepositoryID <= 0 ||
 		!repositoryPattern.MatchString(config.Repository) ||
@@ -128,6 +134,9 @@ func (minter *AppTokenMinter) Mint(
 	).SignedString(minter.privateKey)
 	if err != nil {
 		return InstallationToken{}, errors.New("sign GitHub App JWT")
+	}
+	if err := minter.verifyAppIdentity(ctx, appJWT); err != nil {
+		return InstallationToken{}, err
 	}
 	requestBody := struct {
 		RepositoryIDs []int64           `json:"repository_ids"`
@@ -224,6 +233,63 @@ func (minter *AppTokenMinter) Mint(
 	return InstallationToken{
 		Token: payload.Token, ExpiresAt: payload.ExpiresAt,
 	}, nil
+}
+
+func (minter *AppTokenMinter) verifyAppIdentity(
+	ctx context.Context,
+	appJWT string,
+) error {
+	endpoint := *minter.baseURL
+	endpoint.Path = strings.TrimSuffix(endpoint.Path, "/") + "/app"
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		endpoint.String(),
+		nil,
+	)
+	if err != nil {
+		return errors.New("create GitHub App identity request")
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	request.Header.Set("Authorization", "Bearer "+appJWT)
+	response, err := minter.client.Do(request)
+	if err != nil {
+		return fmt.Errorf(
+			"request GitHub App identity: %w",
+			redactHTTPError(err),
+		)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+		return fmt.Errorf(
+			"GitHub App identity request failed with status %d",
+			response.StatusCode,
+		)
+	}
+	mediaType, _, err := mime.ParseMediaType(
+		response.Header.Get("Content-Type"),
+	)
+	if err != nil || mediaType != "application/json" {
+		return errors.New(
+			"GitHub App identity response has unexpected content type",
+		)
+	}
+	var payload struct {
+		ID   int64  `json:"id"`
+		Slug string `json:"slug"`
+	}
+	if err := json.NewDecoder(
+		io.LimitReader(response.Body, 64<<10),
+	).Decode(&payload); err != nil {
+		return errors.New("decode GitHub App identity response")
+	}
+	if payload.ID != minter.config.AppID ||
+		payload.Slug != minter.config.AppSlug {
+		return errors.New("GitHub App identity is inconsistent")
+	}
+	return nil
 }
 
 func permissionsForRole(role AppRole) (map[string]string, error) {

--- a/internal/infra/reviewagentgithub/app_token_test.go
+++ b/internal/infra/reviewagentgithub/app_token_test.go
@@ -28,6 +28,16 @@ func TestAppTokenMinterUsesExactCompileTimeRoleProfiles(t *testing.T) {
 		writer http.ResponseWriter,
 		request *http.Request,
 	) {
+		writer.Header().Set("Content-Type", "application/json")
+		if request.Method == http.MethodGet &&
+			request.URL.Path == "/app" {
+			require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
+				"id": 1, "slug": "review-app",
+			}))
+			return
+		}
+		require.Equal(t, http.MethodPost, request.Method)
+		require.Equal(t, "/app/installations/2/access_tokens", request.URL.Path)
 		var body struct {
 			RepositoryIDs []int64           `json:"repository_ids"`
 			Permissions   map[string]string `json:"permissions"`
@@ -35,7 +45,6 @@ func TestAppTokenMinterUsesExactCompileTimeRoleProfiles(t *testing.T) {
 		require.NoError(t, json.NewDecoder(request.Body).Decode(&body))
 		require.Equal(t, []int64{3}, body.RepositoryIDs)
 		requested <- body.Permissions
-		writer.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
 			"token":                "installation-token",
 			"expires_at":           now.Add(55 * time.Minute).Format(time.RFC3339),
@@ -64,6 +73,7 @@ func TestAppTokenMinterUsesExactCompileTimeRoleProfiles(t *testing.T) {
 		minter, err := github.NewAppTokenMinter(
 			github.AppTokenConfig{
 				BaseURL: server.URL, AppID: 1, InstallationID: 2,
+				AppSlug:      "review-app",
 				RepositoryID: 3, Repository: "WuKongIM/WuKongIM",
 				PrivateKeyPEM: privatePEM, Role: role,
 			},
@@ -98,6 +108,7 @@ func TestAppTokenMinterRejectsUnknownRoleAndRedactsResponse(t *testing.T) {
 	_, err = github.NewAppTokenMinter(
 		github.AppTokenConfig{
 			BaseURL: server.URL, AppID: 1, InstallationID: 2,
+			AppSlug:      "review-app",
 			RepositoryID: 3, Repository: "WuKongIM/WuKongIM",
 			PrivateKeyPEM: privatePEM, Role: github.AppRole("custom"),
 		},
@@ -109,6 +120,7 @@ func TestAppTokenMinterRejectsUnknownRoleAndRedactsResponse(t *testing.T) {
 	minter, err := github.NewAppTokenMinter(
 		github.AppTokenConfig{
 			BaseURL: server.URL, AppID: 1, InstallationID: 2,
+			AppSlug:      "review-app",
 			RepositoryID: 3, Repository: "WuKongIM/WuKongIM",
 			PrivateKeyPEM: privatePEM,
 			Role:          github.AppRoleReviewPublisher,
@@ -121,4 +133,42 @@ func TestAppTokenMinterRejectsUnknownRoleAndRedactsResponse(t *testing.T) {
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "installation-secret-token")
 	require.NotContains(t, err.Error(), string(privatePEM))
+}
+
+func TestAppTokenMinterRejectsUnexpectedAppIdentity(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	privatePEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		require.Equal(t, http.MethodGet, request.Method)
+		require.Equal(t, "/app", request.URL.Path)
+		writer.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
+			"id": 1, "slug": "unexpected-app",
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	minter, err := github.NewAppTokenMinter(
+		github.AppTokenConfig{
+			BaseURL: server.URL, AppID: 1, AppSlug: "review-app",
+			InstallationID: 2, RepositoryID: 3,
+			Repository:    "WuKongIM/WuKongIM",
+			PrivateKeyPEM: privatePEM,
+			Role:          github.AppRoleReviewPublisher,
+		},
+		server.Client(),
+		time.Now,
+	)
+	require.NoError(t, err)
+	_, err = minter.Mint(context.Background())
+	require.EqualError(t, err, "GitHub App identity is inconsistent")
 }

--- a/internal/infra/reviewagentgithub/projection_client.go
+++ b/internal/infra/reviewagentgithub/projection_client.go
@@ -10,22 +10,6 @@ import (
 	usecase "github.com/WuKongIM/WuKongIM/internal/usecase/reviewagent"
 )
 
-// InstallationAppSlug verifies the authenticated installation App.
-func (client *Client) InstallationAppSlug(
-	ctx context.Context,
-) (string, error) {
-	var payload struct {
-		AppSlug string `json:"app_slug"`
-	}
-	if err := client.getJSON(ctx, "/installation", &payload); err != nil {
-		return "", err
-	}
-	if payload.AppSlug == "" || len(payload.AppSlug) > 100 {
-		return "", errors.New("GitHub installation App is invalid")
-	}
-	return payload.AppSlug, nil
-}
-
 // CreateIssueComment creates the sole mutable Review status comment.
 func (client *Client) CreateIssueComment(
 	ctx context.Context,

--- a/internal/infra/reviewagentgithub/projections.go
+++ b/internal/infra/reviewagentgithub/projections.go
@@ -32,7 +32,6 @@ type InlineReviewComment struct {
 // ProjectionWriter is deliberately unable to merge, close, dismiss, resolve,
 // edit branches, or create commits.
 type ProjectionWriter interface {
-	InstallationAppSlug(context.Context) (string, error)
 	CreateIssueComment(context.Context, int64, string) (int64, error)
 	UpdateIssueComment(context.Context, int64, string) error
 	CreateReview(
@@ -226,12 +225,6 @@ func (publisher *ReviewPublisher) PublishDecision(
 		!samePublishedGeneration(snapshot.Facts, request.State.Generation) {
 		return ReviewPublication{}, errors.New(
 			"Review publication pull request is stale",
-		)
-	}
-	slug, err := publisher.writer.InstallationAppSlug(ctx)
-	if err != nil || slug != publisher.appSlug {
-		return ReviewPublication{}, errors.New(
-			"Review publication App identity is inconsistent",
 		)
 	}
 	if request.Explanation != nil {

--- a/internal/infra/reviewagentgithub/projections_test.go
+++ b/internal/infra/reviewagentgithub/projections_test.go
@@ -204,12 +204,6 @@ type recordingProjectionWriter struct {
 	issueCommentBodies []string
 }
 
-func (writer *recordingProjectionWriter) InstallationAppSlug(
-	context.Context,
-) (string, error) {
-	return "wukongim-review-agent", nil
-}
-
 func (writer *recordingProjectionWriter) CreateIssueComment(
 	_ context.Context,
 	_ int64,


### PR DESCRIPTION
## Summary

- verify the protected Review App ID and slug with the App JWT before minting a repository-scoped installation token
- remove the invalid `GET /installation` identity call made with an installation token
- preserve fail-closed publisher identity checks and document the invariant

## Validation

- `GOWORK=off go test ./internal/contracts/reviewagent ./internal/usecase/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/access/reviewagentcli ./internal/access/reviewagentcheckmcp ./internal/app ./cmd/wkreviewagent ./cmd/wkreviewcheckmcp ./scripts -count=1`
- `GOWORK=off go vet ./internal/contracts/reviewagent ./internal/usecase/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/access/reviewagentcli ./internal/access/reviewagentcheckmcp ./internal/app ./cmd/wkreviewagent ./cmd/wkreviewcheckmcp ./scripts`
- live App JWT probe: `GET /app` returned the configured App ID and slug; installation token probe confirmed `GET /installation` returns 404