### PR TITLE
fix(review-agent): fail closed on missing baseline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,6 +71,11 @@ is the only runner-loopback transport exception and the model permission
 profile still denies model-initiated localhost; private networks stay
 unreachable.
 
+Missing Context, reviewer, or trusted-baseline artifacts are evidence of an
+infrastructure failure, not reasons to abort the state machine. The Evidence
+job records the bounded retry or terminal `inconclusive` completion so signed
+state and the repository queue always advance.
+
 There is no scheduled Review Agent scan. A failed Controller effect is retried
 once; other recovery comes from a later event or an exact manual Controller
 dispatch.

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -534,6 +534,7 @@ jobs:
           path: ${{ runner.temp }}/review-agent-result
       - name: Download trusted baseline
         if: inputs.operation == 'review'
+        continue-on-error: true
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: review-agent-baseline-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -16,6 +16,9 @@
   collections to `null`; empty slice representation is never a state change.
   The loader may recover one semantically identical legacy duplicate and its
   strict successor without rewinding the append-only scheduler ref.
+- Review Agent evidence collection treats missing Context, reviewer, or
+  baseline artifacts as bounded infrastructure failure; it must still produce
+  signed retry or terminal `inconclusive` state and release the queue.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -278,6 +278,20 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		raw,
 		"steps.finalize.outputs.retention == 'long'",
 	)
+	evidence := issueAgentJobText(t, raw, "evidence")
+	require.Contains(
+		t,
+		evidence,
+		"name: Download trusted baseline\n"+
+			"        if: inputs.operation == 'review'\n"+
+			"        continue-on-error: true",
+	)
+	require.Equal(
+		t,
+		3,
+		strings.Count(evidence, "continue-on-error: true"),
+		"missing context, reviewer, and baseline artifacts must fail closed",
+	)
 
 	reviewer := issueAgentJobText(t, raw, "review")
 	require.Contains(t, reviewer, "timeout-minutes: 40")


### PR DESCRIPTION
## Summary

- let the Evidence job continue when the trusted-baseline artifact is absent
- reuse the existing bounded infrastructure-failure completion path instead of aborting the Worker
- preserve the one-retry budget, terminal `inconclusive` verdict, signed state append, and queue drain
- document and contract-test the fail-closed artifact semantics

## Root cause

PR #718 exceeded the exact 128 KiB changed-byte budget while building its complete Context Bundle. The Context and baseline jobs therefore produced no artifacts. Evidence already tolerated a missing Context and reviewer artifact, but its trusted-baseline download was mandatory, so the job failed before it could create the existing `infrastructure_failure` completion. That left terminal state and queue progression dependent on a later event.

## Behavior

This does not raise the changed-byte limit and does not call Kimi when Context construction fails. The first missing-artifact completion consumes the existing single infrastructure retry. A repeated failure becomes signed terminal `inconclusive`, publishes the fail-closed verdict, and releases the repository queue.

## Validation

- `GOWORK=off go test ./scripts/... -run 'Workflow|ReviewAgent' -count=1`
- `GOWORK=off go test ./internal/access/reviewagentcli ./internal/contracts/reviewagent ./internal/usecase/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/app -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-pr-signal.yml .github/workflows/review-agent.yml .github/workflows/review-agent-run.yml`
- `git diff --check`
