### PR TITLE
fix(review-agent): tolerate signed state visibility lag

### DIFF
--- a/internal/infra/reviewagentgithub/FLOW.md
+++ b/internal/infra/reviewagentgithub/FLOW.md
@@ -30,6 +30,11 @@ The bounded scheduler recovery never rewinds or rewrites the protected state
 ref. A strict successor may name that one legacy checkpoint; after the next
 successor, it leaves the two-checkpoint verification window.
 
+After a signed GraphQL commit, the State Writer tolerates bounded ref
+read-your-write lag only while GitHub still reports the exact expected parent.
+The committed head must become visible within the retry budget; any third head
+is real contention and fails immediately.
+
 The Review App adapter exposes no contents, branch, commit, merge, close,
 dismiss, resolve, Ruleset, Actions, or Secrets operation. The State Writer
 adapter accepts no caller-selected ref or path and exposes no Review, comment,

--- a/internal/infra/reviewagentgithub/state_git.go
+++ b/internal/infra/reviewagentgithub/state_git.go
@@ -16,10 +16,17 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var reviewStateRefPattern = regexp.MustCompile(
 	`^review-state/(?:scheduler|pr-[1-9][0-9]{0,9})$`,
+)
+
+const (
+	stateRefVisibilityAttempts     = 8
+	stateRefVisibilityInitialDelay = 100 * time.Millisecond
+	stateRefVisibilityMaxDelay     = time.Second
 )
 
 type gitCommitFacts struct {
@@ -224,8 +231,14 @@ func (client *Client) PublishStateCommit(
 			"Review state signed-commit mutation failed",
 		)
 	}
-	head, found, err := client.StateRefHead(ctx, request.Branch)
-	if err != nil || !found || head != commitSHA {
+	if err := client.waitForStateRefHead(
+		ctx,
+		request.Branch,
+		request.ExpectedParentSHA,
+		commitSHA,
+		stateRefVisibilityAttempts,
+		stateRefVisibilityInitialDelay,
+	); err != nil {
 		return StateCommitResult{}, errors.New(
 			"Review state ref re-read is inconsistent",
 		)
@@ -242,6 +255,71 @@ func (client *Client) PublishStateCommit(
 		AuthorLogin:   record.AuthorLogin, AuthorType: record.AuthorType,
 		Verified: record.Verified, SignedByGitHub: record.SignedByGitHub,
 	}, nil
+}
+
+// waitForStateRefHead tolerates only bounded GitHub visibility lag that still
+// reports the exact pre-mutation parent. Any third head is real contention and
+// fails immediately.
+func (client *Client) waitForStateRefHead(
+	ctx context.Context,
+	branch string,
+	expectedParentSHA string,
+	expectedHeadSHA string,
+	attempts int,
+	initialDelay time.Duration,
+) error {
+	if client == nil || ctx == nil ||
+		!reviewStateRefPattern.MatchString(branch) ||
+		!gitSHAPattern.MatchString(expectedParentSHA) ||
+		!gitSHAPattern.MatchString(expectedHeadSHA) ||
+		expectedParentSHA == expectedHeadSHA ||
+		attempts <= 0 ||
+		initialDelay < 0 {
+		return errors.New("Review state ref re-read request is invalid")
+	}
+	delay := initialDelay
+	for attempt := 0; attempt < attempts; attempt++ {
+		head, found, err := client.StateRefHead(ctx, branch)
+		if err != nil {
+			return err
+		}
+		if found && head == expectedHeadSHA {
+			return nil
+		}
+		if !found || head != expectedParentSHA {
+			return errors.New("Review state ref re-read is inconsistent")
+		}
+		if attempt+1 == attempts {
+			break
+		}
+		if err := waitForStateRefVisibility(ctx, delay); err != nil {
+			return err
+		}
+		if delay > 0 && delay < stateRefVisibilityMaxDelay {
+			delay *= 2
+			if delay > stateRefVisibilityMaxDelay {
+				delay = stateRefVisibilityMaxDelay
+			}
+		}
+	}
+	return errors.New("Review state ref re-read is inconsistent")
+}
+
+func waitForStateRefVisibility(
+	ctx context.Context,
+	delay time.Duration,
+) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // ReadStateCommit proves that one verified App commit changed exactly one

--- a/internal/infra/reviewagentgithub/state_git_visibility_test.go
+++ b/internal/infra/reviewagentgithub/state_git_visibility_test.go
@@ -1,0 +1,112 @@
+package reviewagentgithub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestWaitForStateRefHeadRetriesExactPreviousParent(t *testing.T) {
+	parent := strings.Repeat("1", 40)
+	committed := strings.Repeat("2", 40)
+	var reads atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		if request.URL.Path !=
+			"/repos/WuKongIM/WuKongIM/git/ref/heads/review-state/pr-718" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		head := parent
+		if reads.Add(1) > 1 {
+			head = committed
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"ref": "refs/heads/review-state/pr-718",
+			"object": map[string]string{
+				"type": "commit",
+				"sha":  head,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newStateVisibilityTestClient(t, server)
+	err := client.waitForStateRefHead(
+		context.Background(),
+		"review-state/pr-718",
+		parent,
+		committed,
+		2,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("waitForStateRefHead() error = %v", err)
+	}
+	if got := reads.Load(); got != 2 {
+		t.Fatalf("ref reads = %d, want 2", got)
+	}
+}
+
+func TestWaitForStateRefHeadRejectsThirdHeadWithoutRetry(t *testing.T) {
+	parent := strings.Repeat("1", 40)
+	committed := strings.Repeat("2", 40)
+	contended := strings.Repeat("3", 40)
+	var reads atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		reads.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"ref": "refs/heads/review-state/scheduler",
+			"object": map[string]string{
+				"type": "commit",
+				"sha":  contended,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newStateVisibilityTestClient(t, server)
+	err := client.waitForStateRefHead(
+		context.Background(),
+		"review-state/scheduler",
+		parent,
+		committed,
+		3,
+		0,
+	)
+	if err == nil || err.Error() != "Review state ref re-read is inconsistent" {
+		t.Fatalf("waitForStateRefHead() error = %v", err)
+	}
+	if got := reads.Load(); got != 1 {
+		t.Fatalf("ref reads = %d, want 1", got)
+	}
+}
+
+func newStateVisibilityTestClient(
+	t *testing.T,
+	server *httptest.Server,
+) *Client {
+	t.Helper()
+	client, err := NewClient(ClientConfig{
+		BaseURL:      server.URL,
+		GraphQLURL:   server.URL + "/graphql",
+		Repository:   "WuKongIM/WuKongIM",
+		Token:        "test-token",
+		MaxPages:     1,
+		MaxBodyBytes: 1 << 20,
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	return client
+}


### PR DESCRIPTION
## Summary

- retry the post-mutation state-ref read only while GitHub still exposes the exact expected parent
- accept the signed commit once its head becomes visible within a bounded exponential-backoff budget
- fail immediately when a third head proves real contention
- document and test both visibility-lag and contention behavior

## Root cause

GitHub can briefly return the previous ref head after `createCommitOnBranch` has already created the signed commit. The State Writer treated that read-your-write lag as a failed append. The PR state commit was durable, but the Controller stopped before appending the scheduler state, leaving a reviewing generation without its matching lease.

## Validation

- `GOWORK=off go test ./internal/infra/reviewagentgithub -count=1`
- `GOWORK=off go test ./cmd/wkreviewagent ./internal/access/reviewagentcli ./internal/contracts/reviewagent ./internal/usecase/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/app -count=1`
- `git diff --check`