### PR TITLE
fix(review-agent): restore sandbox user namespace

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -2,6 +2,35 @@
 
 set -euo pipefail
 
+review_unshare_directory="/opt/wukongim-review-agent"
+review_unshare_binary="$review_unshare_directory/unshare"
+review_unshare_profile="/etc/apparmor.d/wukongim-review-agent-unshare"
+
+prepare_user_namespace() {
+  command -v sudo >/dev/null
+  command -v apparmor_parser >/dev/null
+  [[ -x /usr/bin/unshare ]]
+  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
+
+  sudo install -d -o root -g root -m 0755 "$review_unshare_directory"
+  sudo install -o root -g root -m 0755 \
+    /usr/bin/unshare "$review_unshare_binary"
+  [[ "$(stat -c '%U:%G:%a' "$review_unshare_binary")" == root:root:755 ]]
+  printf '%s\n' \
+    'abi <abi/4.0>,' \
+    'include <tunables/global>' \
+    '' \
+    "$review_unshare_binary flags=(unconfined) {" \
+    '  userns,' \
+    '}' \
+    | sudo tee "$review_unshare_profile" >/dev/null
+  sudo chmod 0644 "$review_unshare_profile"
+  sudo apparmor_parser -r "$review_unshare_profile"
+
+  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
+  "$review_unshare_binary" --user --map-root-user true
+}
+
 apply_network_rules() {
   local mode="$1"
   local prefix=()
@@ -116,7 +145,7 @@ apply_network_rules() {
 start_namespace() {
   local pid_file="$1"
   [[ "$pid_file" == "$RUNNER_TEMP/"* ]]
-  command -v unshare >/dev/null
+  [[ -x "$review_unshare_binary" ]]
   command -v nsenter >/dev/null
   command -v slirp4netns >/dev/null
   command -v setpriv >/dev/null
@@ -124,7 +153,7 @@ start_namespace() {
 
   local resolv_file="$RUNNER_TEMP/review-agent-resolv.conf"
   printf 'nameserver 10.0.2.3\noptions timeout:2 attempts:2\n' >"$resolv_file"
-  unshare --user --map-root-user --net --mount \
+  "$review_unshare_binary" --user --map-root-user --net --mount \
     bash -c \
       'mount --make-rprivate /; mount --bind "$1" /etc/resolv.conf; exec sleep 86400' \
       review-agent-netns "$resolv_file" &
@@ -184,6 +213,10 @@ limit_runner_worker() {
 }
 
 case "${1:-}" in
+  prepare-userns)
+    [[ $# -eq 1 ]]
+    prepare_user_namespace
+    ;;
   start)
     [[ $# -eq 2 ]]
     start_namespace "$2"
@@ -212,7 +245,7 @@ case "${1:-}" in
     limit_runner_worker
     ;;
   *)
-    echo "usage: network-fence.sh start PID_FILE | join PID_FILE COMMAND... | host keep-sudo|disable-sudo | model-host" >&2
+    echo "usage: network-fence.sh prepare-userns | start PID_FILE | join PID_FILE COMMAND... | host keep-sudo|disable-sudo | model-host" >&2
     exit 2
     ;;
 esac

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,6 +71,12 @@ is the only runner-loopback transport exception and the model permission
 profile still denies model-initiated localhost; private networks stay
 unreachable.
 
+Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
+Each candidate runner installs one root-owned Review Agent `unshare` copy and
+loads a path-specific profile granting only `userns`; the global restriction
+is never disabled. The job then applies the existing network namespace,
+private-CIDR, quota, connection, Docker, and sudo fences.
+
 Missing Context, reviewer, or trusted-baseline artifacts are evidence of an
 infrastructure failure, not reasons to abort the state machine. The Evidence
 job records the bounded retry or terminal `inconclusive` completion so signed

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -217,6 +217,7 @@ jobs:
           cp .github/review-agent/network-fence.sh \
             "$RUNNER_TEMP/review-agent-network-fence.sh"
           chmod 0555 "$RUNNER_TEMP/review-agent-network-fence.sh"
+          "$RUNNER_TEMP/review-agent-network-fence.sh" prepare-userns
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.recover.outputs.test_merge_sha }}
@@ -323,6 +324,7 @@ jobs:
           cp .github/review-agent/network-fence.sh \
             "$RUNNER_TEMP/review-agent-network-fence.sh"
           chmod 0555 "$RUNNER_TEMP/review-agent-network-fence.sh"
+          "$RUNNER_TEMP/review-agent-network-fence.sh" prepare-userns
           if [[ "$INPUT_OPERATION" == review ]]; then
             GOWORK=off go build -trimpath \
               -o "$RUNNER_TEMP/wkreviewcheckmcp" ./cmd/wkreviewcheckmcp

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -19,6 +19,10 @@
 - Review Agent evidence collection treats missing Context, reviewer, or
   baseline artifacts as bounded infrastructure failure; it must still produce
   signed retry or terminal `inconclusive` state and release the queue.
+- Review Agent hosted runners keep Ubuntu's global unprivileged-user-namespace
+  restriction enabled. Only a root-owned Review Agent `unshare` path receives
+  a narrow AppArmor `userns` profile before the existing network and privilege
+  fences are applied.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -253,7 +253,28 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	fence := readIssueAgentFile(t, ".github/review-agent/network-fence.sh")
 	require.Contains(t, fence, "prefix=(sudo)")
 	require.Contains(t, fence, `ip6tables -A OUTPUT`)
-	require.Contains(t, fence, "unshare --user --map-root-user --net")
+	require.Contains(
+		t,
+		fence,
+		`review_unshare_binary="$review_unshare_directory/unshare"`,
+	)
+	require.Contains(t, fence, `flags=(unconfined)`)
+	require.Contains(t, fence, `  userns,`)
+	require.Contains(t, fence, `sudo apparmor_parser -r`)
+	require.Equal(
+		t,
+		2,
+		strings.Count(
+			fence,
+			`/proc/sys/kernel/apparmor_restrict_unprivileged_userns`,
+		),
+		"the global userns restriction must remain enabled",
+	)
+	require.Contains(
+		t,
+		fence,
+		`"$review_unshare_binary" --user --map-root-user --net`,
+	)
 	require.Contains(t, fence, "slirp4netns --configure --disable-host-loopback")
 	require.Contains(t, fence, "nsenter")
 	require.Contains(t, fence, "--connlimit-above 128")
@@ -267,6 +288,15 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		1,
 		strings.Count(raw, "disable-sudo"),
 		"candidate baseline must disable sudo exactly once",
+	)
+	require.Equal(
+		t,
+		2,
+		strings.Count(
+			raw,
+			`"$RUNNER_TEMP/review-agent-network-fence.sh" prepare-userns`,
+		),
+		"baseline and model runners must prepare the narrow userns profile",
 	)
 	require.Contains(
 		t,


### PR DESCRIPTION
## Summary

- adapt the Review Agent sandbox to Ubuntu hosted-runner AppArmor user-namespace restrictions
- install a root-owned dedicated `/opt/wukongim-review-agent/unshare` copy
- load a path-specific AppArmor profile that grants `userns` only to that executable
- keep the global `kernel.apparmor_restrict_unprivileged_userns=1` setting enabled and assert it before and after profile loading
- preserve the existing slirp, private-CIDR, quota, connection, Docker, sudo, resource, and bubblewrap fences

## Root cause

GitHub hosted Ubuntu 24.04 now rejects the previous unprofiled `unshare --user --map-root-user` path with `write failed /proc/self/uid_map: Operation not permitted`. Ubuntu documents this as the AppArmor unprivileged-user-namespace restriction and recommends a path-specific profile for sandboxing applications: https://documentation.ubuntu.com/release-notes/24.04/#unprivileged-user-namespace-restrictions

## Security boundary

This does not disable the AppArmor restriction globally. The helper binary and profile are root-owned, the exact user namespace operation is canaried before candidate execution, and candidate code still runs after sudo and Docker access are removed.

## Validation

- `bash -n` and `shellcheck` for `network-fence.sh`
- `GOWORK=off go test ./scripts/... -run "Workflow|ReviewAgent" -count=1`
- focused Review Agent Go package tests
- `actionlint` for the three Review Agent workflows
- `git diff --check`

## Rollout proof

After merge, rerun PR #716 and require the real hosted runner to pass the namespace canary, baseline, Kimi K3 review, trusted validator, signed state writer, and Publisher.