### PR TITLE
fix(review-agent): preserve trusted artifact transport

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -58,6 +58,7 @@ prepare_user_namespace() {
 
 apply_network_rules() {
   local mode="$1"
+  [[ "$mode" == namespace || "$mode" == model ]]
   local prefix=()
   local resolvers=()
   if [[ "$mode" == namespace ]]; then
@@ -119,16 +120,11 @@ apply_network_rules() {
     224.0.0.0/4
   )
   local ipv6=(::/128 fc00::/7 fe80::/10 ff00::/8)
-  if [[ "$mode" == host ]]; then
-    ipv4+=(127.0.0.0/8)
-    ipv6+=(::1/128)
-  elif [[ "$mode" == namespace || "$mode" == model ]]; then
-    # The namespace needs local process communication. The model host needs
-    # the Codex Action's loopback model proxy; its permission profile still
-    # denies localhost/private destinations to model-initiated requests.
-    "${prefix[@]}" iptables -A INPUT -i lo -j ACCEPT
-    "${prefix[@]}" ip6tables -A INPUT -i lo -j ACCEPT
-  fi
+  # The namespace needs local process communication. The model host needs
+  # the Codex Action's loopback model proxy; its permission profile still
+  # denies localhost/private destinations to model-initiated requests.
+  "${prefix[@]}" iptables -A INPUT -i lo -j ACCEPT
+  "${prefix[@]}" ip6tables -A INPUT -i lo -j ACCEPT
   local cidr
   for cidr in "${ipv4[@]}"; do
     "${prefix[@]}" iptables -A OUTPUT -d "$cidr" -j REJECT
@@ -256,16 +252,11 @@ case "${1:-}" in
     shift
     join_namespace "$@"
     ;;
-  host)
-    [[ $# -eq 2 &&
-      ( "$2" == keep-sudo || "$2" == disable-sudo ) ]]
-    REVIEW_NETNS_PID=""
-    apply_network_rules host
+  baseline-host)
+    [[ $# -eq 1 ]]
     sudo chmod 000 /var/run/docker.sock 2>/dev/null || true
-    if [[ "$2" == disable-sudo ]]; then
-      sudo_binary="$(command -v sudo)"
-      sudo chmod 000 "$sudo_binary"
-    fi
+    sudo_binary="$(command -v sudo)"
+    sudo chmod 000 "$sudo_binary"
     ;;
   model-host)
     [[ $# -eq 1 ]]
@@ -275,7 +266,7 @@ case "${1:-}" in
     limit_runner_worker
     ;;
   *)
-    echo "usage: network-fence.sh start PID_FILE | join PID_FILE COMMAND... | host keep-sudo|disable-sudo | model-host" >&2
+    echo "usage: network-fence.sh start PID_FILE | join PID_FILE COMMAND... | baseline-host | model-host" >&2
     exit 2
     ;;
 esac

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,18 +66,20 @@ failure is retried once inside that same generation and deadline; a late result
 is forced to `inconclusive`. A merge conflict bypasses the model and publishes
 `changes_required`. Candidate baseline commands run only after the shared
 network fence disables both Docker access and `sudo`. Candidate checks receive
-isolated loopback inside a rootless network namespace. The pinned Action proxy
-is the only runner-loopback transport exception and the model permission
-profile still denies model-initiated localhost; private networks stay
-unreachable.
+isolated loopback inside a rootless network namespace whose host loopback is
+disabled. The trusted baseline host keeps runner transport available only so
+pinned post-job Actions can upload evidence; candidate code never runs there.
+The model host has a separate network fence, and the model permission profile
+still denies model-initiated localhost; private networks stay unreachable.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and
 loads a path-specific profile granting only `userns`; the global restriction
 is never disabled. After the namespace and its network rules are ready, the
 job unloads the temporary profile and removes both the copied binary and its
-directory before any candidate command can run. It then applies the existing
-private-CIDR, quota, connection, Docker, and sudo fences.
+directory before any candidate command can run. Private-CIDR, quota, and
+connection fences live inside the candidate namespace; Docker and `sudo` are
+disabled on the trusted baseline host without blocking its Artifact transport.
 Explanation-only sessions do not install that profile or create a candidate
 network namespace because they never execute candidate checks.
 

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -10,6 +10,11 @@ on:
         description: Exact protected control revision
         required: true
         type: string
+      diagnostic:
+        description: Temporary hosted baseline diagnostic
+        required: false
+        default: false
+        type: boolean
       infrastructure_attempt:
         description: Exact signed infrastructure attempt
         required: true
@@ -37,8 +42,100 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  diagnostic:
+    name: Diagnose baseline connectivity
+    if: inputs.diagnostic == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Freeze diagnostic boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v slirp4netns >/dev/null ||
+              ! command -v bwrap >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends \
+              bubblewrap slirp4netns
+          fi
+          GOWORK=off go build -trimpath \
+            -o "$RUNNER_TEMP/wkreviewagent" ./cmd/wkreviewagent
+          GOWORK=off go build -trimpath \
+            -o "$RUNNER_TEMP/wkreviewcheck" ./cmd/wkreviewcheck
+          cp .github/review-agent/policy.json \
+            "$RUNNER_TEMP/review-agent-policy.json"
+          cp .github/review-agent/network-fence.sh \
+            "$RUNNER_TEMP/review-agent-network-fence.sh"
+          chmod 0555 "$RUNNER_TEMP/review-agent-network-fence.sh"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/pull/716/merge
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Verify exact diagnostic candidate
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = 8731acbd00c961f1f18136e3af9cc2c9b584ab6a
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: review-agent-context-716-30610200973
+          path: ${{ runner.temp }}/review-agent-context
+          github-token: ${{ github.token }}
+          run-id: "30610501502"
+      - name: Narrow diagnostic to one fixed check
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq '.mandatory_checks = ["go-format"]' \
+            "$RUNNER_TEMP/review-agent-context/review-context.json" \
+            >"$RUNNER_TEMP/review-context.json"
+      - name: Apply candidate and host privilege fences
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/review-agent-network-fence.sh" start \
+            "$RUNNER_TEMP/review-agent-netns.pid"
+          "$RUNNER_TEMP/review-agent-network-fence.sh" baseline-host
+          mkdir -p \
+            "$RUNNER_TEMP/review-agent-home" \
+            "$RUNNER_TEMP/review-agent-evidence"
+      - name: Run one fixed mandatory check
+        shell: bash
+        env:
+          REVIEW_AGENT_HOME: ${{ runner.temp }}/review-agent-home
+          REVIEW_EVIDENCE_LEDGER: ${{ runner.temp }}/review-agent-evidence/ledger.jsonl
+          REVIEW_POLICY_PATH: ${{ runner.temp }}/review-agent-policy.json
+        run: |
+          set -euo pipefail
+          jq -n \
+            --slurpfile context "$RUNNER_TEMP/review-context.json" \
+            '{context:$context[0],collect_only:false}' \
+            | REVIEW_AGENT_READ_TOKEN= REVIEW_AGENT_APP_PRIVATE_KEY= \
+              REVIEW_STATE_WRITER_APP_PRIVATE_KEY= \
+              timeout --foreground 600s \
+              "$RUNNER_TEMP/review-agent-network-fence.sh" join \
+              "$RUNNER_TEMP/review-agent-netns.pid" \
+              "$RUNNER_TEMP/wkreviewagent" verify-baseline \
+              >"$RUNNER_TEMP/baseline-evidence.json"
+      - name: Upload diagnostic evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: review-agent-baseline-connectivity-diagnostic
+          path: |
+            ${{ runner.temp }}/baseline-evidence.json
+            ${{ runner.temp }}/review-agent-evidence/ledger.jsonl
+          if-no-files-found: warn
+          retention-days: 1
+
   recover:
     name: Recover exact signed generation
+    if: inputs.diagnostic != true
     runs-on: ubuntu-24.04
     timeout-minutes: 8
     permissions:
@@ -234,7 +331,7 @@ jobs:
           set -euo pipefail
           "$RUNNER_TEMP/review-agent-network-fence.sh" start \
             "$RUNNER_TEMP/review-agent-netns.pid"
-          "$RUNNER_TEMP/review-agent-network-fence.sh" host disable-sudo
+          "$RUNNER_TEMP/review-agent-network-fence.sh" baseline-host
           mkdir -p "$RUNNER_TEMP/review-agent-home" "$RUNNER_TEMP/review-agent-evidence"
       - name: Run fixed mandatory checks without credentials
         shell: bash

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -10,11 +10,6 @@ on:
         description: Exact protected control revision
         required: true
         type: string
-      diagnostic:
-        description: Temporary hosted baseline diagnostic
-        required: false
-        default: false
-        type: boolean
       infrastructure_attempt:
         description: Exact signed infrastructure attempt
         required: true
@@ -42,100 +37,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  diagnostic:
-    name: Diagnose baseline connectivity
-    if: inputs.diagnostic == true
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    permissions:
-      actions: read
-      contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - name: Freeze diagnostic boundary
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v slirp4netns >/dev/null ||
-              ! command -v bwrap >/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y --no-install-recommends \
-              bubblewrap slirp4netns
-          fi
-          GOWORK=off go build -trimpath \
-            -o "$RUNNER_TEMP/wkreviewagent" ./cmd/wkreviewagent
-          GOWORK=off go build -trimpath \
-            -o "$RUNNER_TEMP/wkreviewcheck" ./cmd/wkreviewcheck
-          cp .github/review-agent/policy.json \
-            "$RUNNER_TEMP/review-agent-policy.json"
-          cp .github/review-agent/network-fence.sh \
-            "$RUNNER_TEMP/review-agent-network-fence.sh"
-          chmod 0555 "$RUNNER_TEMP/review-agent-network-fence.sh"
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: refs/pull/716/merge
-          fetch-depth: 1
-          persist-credentials: false
-      - name: Verify exact diagnostic candidate
-        shell: bash
-        run: test "$(git rev-parse HEAD)" = 8731acbd00c961f1f18136e3af9cc2c9b584ab6a
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: review-agent-context-716-30610200973
-          path: ${{ runner.temp }}/review-agent-context
-          github-token: ${{ github.token }}
-          run-id: "30610501502"
-      - name: Narrow diagnostic to one fixed check
-        shell: bash
-        run: |
-          set -euo pipefail
-          jq '.mandatory_checks = ["go-format"]' \
-            "$RUNNER_TEMP/review-agent-context/review-context.json" \
-            >"$RUNNER_TEMP/review-context.json"
-      - name: Apply candidate and host privilege fences
-        shell: bash
-        run: |
-          set -euo pipefail
-          "$RUNNER_TEMP/review-agent-network-fence.sh" start \
-            "$RUNNER_TEMP/review-agent-netns.pid"
-          "$RUNNER_TEMP/review-agent-network-fence.sh" baseline-host
-          mkdir -p \
-            "$RUNNER_TEMP/review-agent-home" \
-            "$RUNNER_TEMP/review-agent-evidence"
-      - name: Run one fixed mandatory check
-        shell: bash
-        env:
-          REVIEW_AGENT_HOME: ${{ runner.temp }}/review-agent-home
-          REVIEW_EVIDENCE_LEDGER: ${{ runner.temp }}/review-agent-evidence/ledger.jsonl
-          REVIEW_POLICY_PATH: ${{ runner.temp }}/review-agent-policy.json
-        run: |
-          set -euo pipefail
-          jq -n \
-            --slurpfile context "$RUNNER_TEMP/review-context.json" \
-            '{context:$context[0],collect_only:false}' \
-            | REVIEW_AGENT_READ_TOKEN= REVIEW_AGENT_APP_PRIVATE_KEY= \
-              REVIEW_STATE_WRITER_APP_PRIVATE_KEY= \
-              timeout --foreground 600s \
-              "$RUNNER_TEMP/review-agent-network-fence.sh" join \
-              "$RUNNER_TEMP/review-agent-netns.pid" \
-              "$RUNNER_TEMP/wkreviewagent" verify-baseline \
-              >"$RUNNER_TEMP/baseline-evidence.json"
-      - name: Upload diagnostic evidence
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: review-agent-baseline-connectivity-diagnostic
-          path: |
-            ${{ runner.temp }}/baseline-evidence.json
-            ${{ runner.temp }}/review-agent-evidence/ledger.jsonl
-          if-no-files-found: warn
-          retention-days: 1
-
   recover:
     name: Recover exact signed generation
-    if: inputs.diagnostic != true
     runs-on: ubuntu-24.04
     timeout-minutes: 8
     permissions:

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -24,6 +24,9 @@
   a narrow temporary AppArmor `userns` profile. The profile, copied binary, and
   directory are removed after the isolated namespace is ready and before any
   candidate command executes.
+- Review Agent baseline candidate-network rules live only in that rootless
+  namespace, whose host loopback is disabled. The trusted host disables Docker
+  and `sudo` but retains runner transport for pinned post-job Artifact actions.
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -12,18 +12,18 @@ import (
 )
 
 var workflowCatalog = map[string]string{
-	"cloud-sim-analyze.yml":         "Agent Tool - Analyze Cloud Simulation",
-	"cloud-sim-cleanup.yml":         "Safety Automation - Reconcile Cloud Simulation Resources",
-	"cloud-sim-monitor.yml":         "Safety Automation - Patrol Cloud Simulation Runs",
-	"cloud-sim-oidc-subject.yml":    "Agent Tool - Configure Cloud Simulation OIDC Subject",
-	"cloud-sim-provision.yml":       "Agent Tool - Provision Cloud Simulation",
-	"issue-agent-engineer.yml":      "Agent Tool - Issue Engineer",
-	"issue-agent-pr-signal.yml":     "Safety Automation - Issue Agent PR Signal",
-	"issue-agent.yml":               "Safety Automation - GitHub Issue Agent",
-	"review-agent-pr-signal.yml":    "Safety Automation - Review Agent PR Signal",
-	"review-agent-issue-signal.yml": "Safety Automation - Review Agent Issue Signal",
-	"review-agent-run.yml":          "Agent Tool - Review Pull Request",
-	"review-agent.yml":              "Safety Automation - Review Agent Controller",
+	"cloud-sim-analyze.yml":                "Agent Tool - Analyze Cloud Simulation",
+	"cloud-sim-cleanup.yml":                "Safety Automation - Reconcile Cloud Simulation Resources",
+	"cloud-sim-monitor.yml":                "Safety Automation - Patrol Cloud Simulation Runs",
+	"cloud-sim-oidc-subject.yml":           "Agent Tool - Configure Cloud Simulation OIDC Subject",
+	"cloud-sim-provision.yml":              "Agent Tool - Provision Cloud Simulation",
+	"issue-agent-engineer.yml":             "Agent Tool - Issue Engineer",
+	"issue-agent-pr-signal.yml":            "Safety Automation - Issue Agent PR Signal",
+	"issue-agent.yml":                      "Safety Automation - GitHub Issue Agent",
+	"review-agent-pr-signal.yml":           "Safety Automation - Review Agent PR Signal",
+	"review-agent-issue-signal.yml":        "Safety Automation - Review Agent Issue Signal",
+	"review-agent-run.yml":                 "Agent Tool - Review Pull Request",
+	"review-agent.yml":                     "Safety Automation - Review Agent Controller",
 }
 
 var externalActionPattern = regexp.MustCompile(

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -12,18 +12,18 @@ import (
 )
 
 var workflowCatalog = map[string]string{
-	"cloud-sim-analyze.yml":                "Agent Tool - Analyze Cloud Simulation",
-	"cloud-sim-cleanup.yml":                "Safety Automation - Reconcile Cloud Simulation Resources",
-	"cloud-sim-monitor.yml":                "Safety Automation - Patrol Cloud Simulation Runs",
-	"cloud-sim-oidc-subject.yml":           "Agent Tool - Configure Cloud Simulation OIDC Subject",
-	"cloud-sim-provision.yml":              "Agent Tool - Provision Cloud Simulation",
-	"issue-agent-engineer.yml":             "Agent Tool - Issue Engineer",
-	"issue-agent-pr-signal.yml":            "Safety Automation - Issue Agent PR Signal",
-	"issue-agent.yml":                      "Safety Automation - GitHub Issue Agent",
-	"review-agent-pr-signal.yml":           "Safety Automation - Review Agent PR Signal",
-	"review-agent-issue-signal.yml":        "Safety Automation - Review Agent Issue Signal",
-	"review-agent-run.yml":                 "Agent Tool - Review Pull Request",
-	"review-agent.yml":                     "Safety Automation - Review Agent Controller",
+	"cloud-sim-analyze.yml":         "Agent Tool - Analyze Cloud Simulation",
+	"cloud-sim-cleanup.yml":         "Safety Automation - Reconcile Cloud Simulation Resources",
+	"cloud-sim-monitor.yml":         "Safety Automation - Patrol Cloud Simulation Runs",
+	"cloud-sim-oidc-subject.yml":    "Agent Tool - Configure Cloud Simulation OIDC Subject",
+	"cloud-sim-provision.yml":       "Agent Tool - Provision Cloud Simulation",
+	"issue-agent-engineer.yml":      "Agent Tool - Issue Engineer",
+	"issue-agent-pr-signal.yml":     "Safety Automation - Issue Agent PR Signal",
+	"issue-agent.yml":               "Safety Automation - GitHub Issue Agent",
+	"review-agent-pr-signal.yml":    "Safety Automation - Review Agent PR Signal",
+	"review-agent-issue-signal.yml": "Safety Automation - Review Agent Issue Signal",
+	"review-agent-run.yml":          "Agent Tool - Review Pull Request",
+	"review-agent.yml":              "Safety Automation - Review Agent Controller",
 }
 
 var externalActionPattern = regexp.MustCompile(

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -323,9 +323,9 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, fence, `sudo chmod 000 "$sudo_binary"`)
 	require.Equal(
 		t,
-		2,
+		1,
 		strings.Count(raw, "baseline-host"),
-		"production and temporary diagnostic baselines must each apply the host privilege fence",
+		"the production baseline must apply the host privilege fence exactly once",
 	)
 	require.NotContains(
 		t,

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -229,8 +229,9 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(
 		t,
 		raw,
-		`"$RUNNER_TEMP/review-agent-network-fence.sh" host disable-sudo`,
+		`"$RUNNER_TEMP/review-agent-network-fence.sh" baseline-host`,
 	)
+	require.NotContains(t, raw, `network-fence.sh" host disable-sudo`)
 	require.Contains(
 		t,
 		raw,
@@ -291,6 +292,9 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	)
 	require.NotContains(t, fence, "prepare-userns")
 	require.Contains(t, fence, "slirp4netns --configure --disable-host-loopback")
+	require.Contains(t, fence, "baseline-host)")
+	require.NotContains(t, fence, "apply_network_rules host")
+	require.NotContains(t, fence, "keep-sudo")
 	require.Equal(
 		t,
 		4,
@@ -319,9 +323,9 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, fence, `sudo chmod 000 "$sudo_binary"`)
 	require.Equal(
 		t,
-		1,
-		strings.Count(raw, "disable-sudo"),
-		"candidate baseline must disable sudo exactly once",
+		2,
+		strings.Count(raw, "baseline-host"),
+		"production and temporary diagnostic baselines must each apply the host privilege fence",
 	)
 	require.NotContains(
 		t,


### PR DESCRIPTION
## Summary

- keep candidate private-network, quota, and connection fencing inside the rootless namespace
- replace the old baseline host network mode with a narrow `baseline-host` privilege fence that disables only Docker and `sudo`
- retain trusted runner transport for pinned post-job Artifact actions while leaving `model-host` unchanged
- remove the temporary fixed-PR diagnostic path completely

## Live evidence

Production run [30610501502](https://github.com/WuKongIM/WuKongIM/actions/runs/30610501502) proved the namespace/AppArmor fence starts successfully, then the prior host iptables fence blocked the trusted `upload-artifact` step for about ten minutes and produced no baseline artifact. Candidate commands already execute only through the rootless namespace with host loopback disabled, so host iptables did not protect candidate code.

## Validation

- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `GOWORK=off go test ./scripts/... -run TestReviewAgentRunWorkflowMaintainsRoleIsolation -count=1`
- `GOWORK=off go test ./scripts/... -count=1`
- actionlint v1.7.9 on all Review Agent workflows
- `bash -n .github/review-agent/network-fence.sh`
- `git diff --check origin/main`
- Standards review: clean
- Spec/security review: clean
