### PR TITLE
fix(review-agent): bind trusted verifier paths

### DIFF
--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -242,6 +242,7 @@ jobs:
           REVIEW_AGENT_HOME: ${{ runner.temp }}/review-agent-home
           REVIEW_EVIDENCE_LEDGER: ${{ runner.temp }}/review-agent-evidence/ledger.jsonl
           REVIEW_POLICY_PATH: ${{ runner.temp }}/review-agent-policy.json
+          REVIEW_WORKSPACE: ${{ github.workspace }}
           DEADLINE_EPOCH: ${{ needs.recover.outputs.deadline_epoch }}
         run: |
           set -euo pipefail

--- a/cmd/wkreviewagent/main.go
+++ b/cmd/wkreviewagent/main.go
@@ -66,12 +66,22 @@ func reviewAgentConfig(args []string) app.ReviewAgentConfig {
 				"policy.json",
 			),
 		),
-		PromptPath:         filepath.Join(workingDirectory, ".github", "review-agent", "prompts", "review.md"),
-		ResultSchemaPath:   filepath.Join(workingDirectory, ".github", "review-agent", "review-result.schema.json"),
-		WorkspaceDirectory: workingDirectory,
-		EvidenceLedgerPath: filepath.Join(os.Getenv("RUNNER_TEMP"), "review-agent-evidence", "ledger.jsonl"),
-		ExecutorHome:       os.Getenv("REVIEW_AGENT_HOME"),
-		ExecutablePath:     os.Getenv("PATH"),
+		PromptPath:       filepath.Join(workingDirectory, ".github", "review-agent", "prompts", "review.md"),
+		ResultSchemaPath: filepath.Join(workingDirectory, ".github", "review-agent", "review-result.schema.json"),
+		WorkspaceDirectory: environmentOr(
+			"REVIEW_WORKSPACE",
+			workingDirectory,
+		),
+		EvidenceLedgerPath: environmentOr(
+			"REVIEW_EVIDENCE_LEDGER",
+			filepath.Join(
+				os.Getenv("RUNNER_TEMP"),
+				"review-agent-evidence",
+				"ledger.jsonl",
+			),
+		),
+		ExecutorHome:   os.Getenv("REVIEW_AGENT_HOME"),
+		ExecutablePath: os.Getenv("PATH"),
 		TemporaryDirectory: filepath.Join(
 			os.Getenv("REVIEW_AGENT_HOME"),
 			"tmp",

--- a/cmd/wkreviewagent/main_test.go
+++ b/cmd/wkreviewagent/main_test.go
@@ -26,11 +26,17 @@ func TestReviewAgentMainRejectsUnknownCommandWithoutEchoingInput(t *testing.T) {
 	require.NotContains(t, stderr.String(), "do-not-echo")
 }
 
-func TestReviewAgentConfigUsesTrustedPolicyOverride(t *testing.T) {
+func TestReviewAgentConfigUsesTrustedPathOverrides(t *testing.T) {
 	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	ledgerPath := filepath.Join(t.TempDir(), "ledger.jsonl")
+	workspacePath := t.TempDir()
 	t.Setenv("REVIEW_POLICY_PATH", policyPath)
+	t.Setenv("REVIEW_EVIDENCE_LEDGER", ledgerPath)
+	t.Setenv("REVIEW_WORKSPACE", workspacePath)
 
 	config := reviewAgentConfig([]string{"verify-baseline"})
 
 	require.Equal(t, policyPath, config.PolicyPath)
+	require.Equal(t, ledgerPath, config.EvidenceLedgerPath)
+	require.Equal(t, workspacePath, config.WorkspaceDirectory)
 }


### PR DESCRIPTION
## Summary

- bind the baseline verifier to the explicit trusted candidate workspace instead of namespace cwd
- honor the explicit evidence-ledger path supplied by the protected workflow
- cover both trusted path overrides with a config regression test

## Evidence

- hosted Ubuntu diagnostic: https://github.com/WuKongIM/WuKongIM/actions/runs/30612440369
- exact `go-format` baseline evidence passed and uploaded after the namespace and host privilege fences
- `GOWORK=off go test ./scripts/... -count=1`
- focused Review Agent packages and actionlint passed

No temporary diagnostic workflow or diagnostic error output is included.