### PR TITLE
fix(review-agent): preserve terminal fail-closed path

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -57,26 +57,11 @@ prepare_user_namespace() {
 }
 
 apply_network_rules() {
-  local mode="$1"
-  [[ "$mode" == namespace || "$mode" == model ]]
-  local prefix=()
-  local resolvers=()
-  if [[ "$mode" == namespace ]]; then
-    prefix=(nsenter --preserve-credentials -t "$REVIEW_NETNS_PID" -U -m -n)
-    "${prefix[@]}" ip link set lo up
-    resolvers=(10.0.2.3)
-  else
-    prefix=(sudo)
-    local resolver
-    while read -r resolver; do
-      [[ -n "$resolver" ]] || continue
-      if [[ "$resolver" != *:* && "$resolver" == *[!0-9.]* ]]; then
-        echo "invalid runner DNS resolver" >&2
-        exit 1
-      fi
-      resolvers+=("$resolver")
-    done < <(awk '/^nameserver[[:space:]]+/ { print $2 }' /etc/resolv.conf)
-  fi
+  local prefix=(
+    nsenter --preserve-credentials -t "$REVIEW_NETNS_PID" -U -m -n
+  )
+  local resolvers=(10.0.2.3)
+  "${prefix[@]}" ip link set lo up
 
   # Ingress and egress each receive 1 GiB, enforcing the protected 2 GiB
   # aggregate ceiling per address family. DNS is intentionally added after
@@ -120,9 +105,8 @@ apply_network_rules() {
     224.0.0.0/4
   )
   local ipv6=(::/128 fc00::/7 fe80::/10 ff00::/8)
-  # The namespace needs local process communication. The model host needs
-  # the Codex Action's loopback model proxy; its permission profile still
-  # denies localhost/private destinations to model-initiated requests.
+  # The namespace needs local process communication. slirp4netns separately
+  # prevents namespace processes from reaching the host loopback.
   "${prefix[@]}" iptables -A INPUT -i lo -j ACCEPT
   "${prefix[@]}" ip6tables -A INPUT -i lo -j ACCEPT
   local cidr
@@ -189,7 +173,7 @@ start_namespace() {
   for _ in {1..50}; do
     if nsenter --preserve-credentials -t "$REVIEW_NETNS_PID" -U -m -n \
       ip link show tap0 >/dev/null 2>&1; then
-      apply_network_rules namespace
+      apply_network_rules
       return 0
     fi
     sleep 0.1
@@ -220,24 +204,6 @@ join_namespace() {
   exec nsenter --preserve-credentials -t "$pid" -U -m -n "$@"
 }
 
-limit_runner_worker() {
-  local pid="$$"
-  while [[ "$pid" =~ ^[1-9][0-9]{0,9}$ && "$pid" -gt 1 ]]; do
-    local command_name
-    command_name="$(<"/proc/$pid/comm")"
-    if [[ "$command_name" == Runner.Worker ]]; then
-      sudo prlimit --pid "$pid" \
-        --cpu=3600:3600 \
-        --as=8589934592:8589934592 \
-        --nproc=512:512
-      return 0
-    fi
-    pid="$(awk '/^PPid:/ { print $2 }' "/proc/$pid/status")"
-  done
-  echo "GitHub Runner.Worker ancestor is unavailable" >&2
-  return 1
-}
-
 case "${1:-}" in
   start)
     [[ $# -eq 2 ]]
@@ -258,15 +224,12 @@ case "${1:-}" in
     sudo_binary="$(command -v sudo)"
     sudo chmod 000 "$sudo_binary"
     ;;
-  model-host)
+  review-host)
     [[ $# -eq 1 ]]
-    REVIEW_NETNS_PID=""
-    apply_network_rules model
     sudo chmod 000 /var/run/docker.sock 2>/dev/null || true
-    limit_runner_worker
     ;;
   *)
-    echo "usage: network-fence.sh start PID_FILE | join PID_FILE COMMAND... | baseline-host | model-host" >&2
+    echo "usage: network-fence.sh start PID_FILE | join PID_FILE COMMAND... | baseline-host | review-host" >&2
     exit 2
     ;;
 esac

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,8 +69,9 @@ network fence disables both Docker access and `sudo`. Candidate checks receive
 isolated loopback inside a rootless network namespace whose host loopback is
 disabled. The trusted baseline host keeps runner transport available only so
 pinned post-job Actions can upload evidence; candidate code never runs there.
-The model host has a separate network fence, and the model permission profile
-still denies model-initiated localhost; private networks stay unreachable.
+The model host keeps GitHub runner transport intact. Its read-only permission
+profile denies model-initiated localhost and private-network access, while all
+candidate check commands remain inside the rootless network namespace.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -396,7 +396,7 @@ jobs:
             "$RUNNER_TEMP/review-agent-network-fence.sh" start \
               "$RUNNER_TEMP/review-agent-netns.pid"
           fi
-          "$RUNNER_TEMP/review-agent-network-fence.sh" model-host
+          "$RUNNER_TEMP/review-agent-network-fence.sh" review-host
           mkdir -p "$RUNNER_TEMP/review-agent-home" "$RUNNER_TEMP/review-codex-home" \
             "$RUNNER_TEMP/review-agent-evidence"
           cat >>"$RUNNER_TEMP/review-codex-home/config.toml" <<EOF
@@ -774,7 +774,7 @@ jobs:
     name: Append terminal signed state
     needs: [recover, evidence]
     if: >-
-      needs.evidence.result == 'success' &&
+      always() && needs.evidence.result == 'success' &&
       (inputs.operation == 'review' || inputs.operation == 'explain')
     runs-on: ubuntu-24.04
     timeout-minutes: 7
@@ -900,7 +900,7 @@ jobs:
     name: Publish formal Review, Verdict, or explanation
     needs: [evidence, state-writer]
     if: >-
-      needs.state-writer.result == 'success' &&
+      always() && needs.state-writer.result == 'success' &&
       (inputs.operation == 'review' || inputs.operation == 'explain')
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -963,7 +963,7 @@ jobs:
   drain:
     name: Wake the next signed queue entry
     needs: state-writer
-    if: needs.state-writer.result == 'success'
+    if: always() && needs.state-writer.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -235,8 +235,9 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(
 		t,
 		raw,
-		`"$RUNNER_TEMP/review-agent-network-fence.sh" model-host`,
+		`"$RUNNER_TEMP/review-agent-network-fence.sh" review-host`,
 	)
+	require.NotContains(t, raw, `"$RUNNER_TEMP/review-agent-network-fence.sh" model-host`)
 	require.Contains(t, raw, `"$RUNNER_TEMP/review-agent-network-fence.sh" join`)
 	require.Contains(t, raw, "model_context_window=240000")
 	require.Contains(t, raw, "model_auto_compact_token_limit=216000")
@@ -252,7 +253,10 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, raw, "$trusted[0].checks[]")
 
 	fence := readIssueAgentFile(t, ".github/review-agent/network-fence.sh")
-	require.Contains(t, fence, "prefix=(sudo)")
+	require.NotContains(t, fence, "prefix=(sudo)")
+	require.NotContains(t, fence, "apply_network_rules model")
+	require.NotContains(t, fence, "limit_runner_worker")
+	require.NotContains(t, fence, "sudo prlimit")
 	require.Contains(t, fence, `ip6tables -A OUTPUT`)
 	require.Contains(
 		t,
@@ -293,6 +297,8 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.NotContains(t, fence, "prepare-userns")
 	require.Contains(t, fence, "slirp4netns --configure --disable-host-loopback")
 	require.Contains(t, fence, "baseline-host)")
+	require.Contains(t, fence, "review-host)")
+	require.NotContains(t, fence, "model-host)")
 	require.NotContains(t, fence, "apply_network_rules host")
 	require.NotContains(t, fence, "keep-sudo")
 	require.Equal(
@@ -339,6 +345,27 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		"if [[ \"$INPUT_OPERATION\" == review ]]; then\n"+
 			"            \"$RUNNER_TEMP/review-agent-network-fence.sh\" start",
 		"explanation sessions must not create a candidate network namespace",
+	)
+	terminalStateWriter := issueAgentJobText(t, raw, "state-writer")
+	require.Contains(
+		t,
+		terminalStateWriter,
+		"always() && needs.evidence.result == 'success'",
+		"validated fail-closed evidence must reach signed state after an upstream failure",
+	)
+	terminalPublisher := issueAgentJobText(t, raw, "review-publisher")
+	require.Contains(
+		t,
+		terminalPublisher,
+		"always() && needs.state-writer.result == 'success'",
+		"terminal Review and Verdict publication must survive an upstream failure",
+	)
+	terminalDrain := issueAgentJobText(t, raw, "drain")
+	require.Contains(
+		t,
+		terminalDrain,
+		"always() && needs.state-writer.result == 'success'",
+		"the signed queue must drain after fail-closed completion",
 	)
 	require.Contains(
 		t,


### PR DESCRIPTION
## Summary

- keep GitHub runner transport intact during the model phase
- retain private-CIDR, traffic, and connection fences only inside the candidate namespace
- continue signed state, formal verdict publication, and queue drain after an upstream Review failure
- delete the obsolete host iptables and Runner.Worker prlimit path

## Production evidence

Run 30613080421 proved the deterministic baseline and Artifact transport succeed, then lost the runner during model-host boundary setup. Trusted evidence still produced an inconclusive completion, but downstream terminal jobs were skipped because their job conditions lacked always().

## Validation

- GOWORK=off go test ./scripts/... -count=1
- GOWORK=off go test ./scripts/... -run Workflow|ReviewAgent -count=1
- bash -n .github/review-agent/network-fence.sh
- actionlint v1.7.9 .github/workflows/review-agent-run.yml
- git diff --check