### PR TITLE
Fix Review Agent model isolation and dispatch idempotency

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 review_unshare_directory="/opt/wukongim-review-agent"
 review_unshare_binary="$review_unshare_directory/unshare"
 review_unshare_profile="/etc/apparmor.d/wukongim-review-agent-unshare"
+review_bwrap_binary="$review_unshare_directory/bwrap"
+review_bwrap_profile="/etc/apparmor.d/wukongim-review-agent-bwrap"
 
 cleanup_user_namespace_exception() {
   if [[ -f "$review_unshare_profile" ]]; then
@@ -52,6 +54,30 @@ prepare_user_namespace() {
     | sudo tee "$review_unshare_profile" >/dev/null
   sudo chmod 0644 "$review_unshare_profile"
   sudo apparmor_parser -r "$review_unshare_profile"
+
+  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
+}
+
+prepare_model_sandbox() {
+  command -v sudo >/dev/null
+  command -v apparmor_parser >/dev/null
+  [[ -x /usr/bin/bwrap ]]
+  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
+
+  sudo install -d -o root -g root -m 0755 "$review_unshare_directory"
+  sudo install -o root -g root -m 0755 \
+    /usr/bin/bwrap "$review_bwrap_binary"
+  [[ "$(stat -c '%U:%G:%a' "$review_bwrap_binary")" == root:root:755 ]]
+  printf '%s\n' \
+    'abi <abi/4.0>,' \
+    'include <tunables/global>' \
+    '' \
+    "profile wukongim-review-agent-bwrap $review_bwrap_binary flags=(unconfined) {" \
+    '  userns,' \
+    '}' \
+    | sudo tee "$review_bwrap_profile" >/dev/null
+  sudo chmod 0644 "$review_bwrap_profile"
+  sudo apparmor_parser -r "$review_bwrap_profile"
 
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 }
@@ -226,7 +252,10 @@ case "${1:-}" in
     ;;
   review-host)
     [[ $# -eq 1 ]]
+    prepare_model_sandbox
     sudo chmod 000 /var/run/docker.sock 2>/dev/null || true
+    sudo_binary="$(command -v sudo)"
+    sudo chmod 000 "$sudo_binary"
     ;;
   *)
     echo "usage: network-fence.sh start PID_FILE | join PID_FILE COMMAND... | baseline-host | review-host" >&2

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,7 +71,12 @@ disabled. The trusted baseline host keeps runner transport available only so
 pinned post-job Actions can upload evidence; candidate code never runs there.
 The model host keeps GitHub runner transport intact. Its read-only permission
 profile denies model-initiated localhost and private-network access, while all
-candidate check commands remain inside the rootless network namespace.
+candidate check commands remain inside the rootless network namespace. The
+pinned Codex Action installs the exact CLI and Responses proxy, then the
+Workflow invokes `codex exec` directly under model-only CPU, address-space,
+and process limits. A root-owned, path-specific `bwrap` AppArmor profile
+grants only the model sandbox the required `userns`; the global Ubuntu
+restriction remains enabled.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and
@@ -83,6 +88,11 @@ connection fences live inside the candidate namespace; Docker and `sudo` are
 disabled on the trusted baseline host without blocking its Artifact transport.
 Explanation-only sessions do not install that profile or create a candidate
 network namespace because they never execute candidate checks.
+
+Worker dispatch is serialized per pull request. The exact run title derived
+from pull request, signed lease, and infrastructure attempt is the idempotency
+key at both Controller and retry-drain boundaries, so concurrent recovery
+cannot start the same attempt twice.
 
 Missing Context, reviewer, or trusted-baseline artifacts are evidence of an
 infrastructure failure, not reasons to abort the state machine. The Evidence

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -352,6 +352,12 @@ jobs:
               "$RUNNER_TEMP/review-agent-session/recovery.json" \
               >>"$RUNNER_TEMP/review-agent-prompt.md"
           fi
+      - name: Install pinned Codex CLI and Responses proxy
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        with:
+          codex-version: 0.146.0
+          codex-home: ${{ runner.temp }}/review-codex-home
+          allow-bots: true
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.operation == 'review'
         with:
@@ -385,6 +391,32 @@ jobs:
               "$RUNNER_TEMP/review-agent-session/recovery.json"
           fi
           chmod -R a-w "$RUNNER_TEMP/review-agent-session"
+      - name: Start protected Responses API proxy
+        shell: bash
+        env:
+          PROXY_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          server_info="$RUNNER_TEMP/review-agent-proxy.json"
+          (
+            printenv PROXY_API_KEY |
+              env -u PROXY_API_KEY codex-responses-api-proxy \
+                --http-shutdown \
+                --server-info "$server_info" \
+                --upstream-url https://openrouter.ai/api/v1/responses
+          ) &
+          unset PROXY_API_KEY
+          for _ in {1..100}; do
+            if jq -e '.port | type == "number" and
+              . >= 1 and . <= 65535' "$server_info" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.1
+          done
+          jq -e '.port | type == "number" and
+            . >= 1 and . <= 65535' "$server_info" >/dev/null
+          sudo chown root:root "$server_info"
+          sudo chmod 0444 "$server_info"
       - name: Freeze private-network, MCP, and tree boundaries
         shell: bash
         env:
@@ -396,10 +428,12 @@ jobs:
             "$RUNNER_TEMP/review-agent-network-fence.sh" start \
               "$RUNNER_TEMP/review-agent-netns.pid"
           fi
-          "$RUNNER_TEMP/review-agent-network-fence.sh" review-host
           mkdir -p "$RUNNER_TEMP/review-agent-home" "$RUNNER_TEMP/review-codex-home" \
             "$RUNNER_TEMP/review-agent-evidence"
-          cat >>"$RUNNER_TEMP/review-codex-home/config.toml" <<EOF
+          proxy_port="$(jq -er .port "$RUNNER_TEMP/review-agent-proxy.json")"
+          cat >"$RUNNER_TEMP/review-codex-home/config.toml" <<EOF
+          model_provider = "review-agent-responses-proxy"
+
           [permissions.review-agent]
           description = "Read-only review with full public-network access."
           extends = ":read-only"
@@ -417,6 +451,11 @@ jobs:
           "localhost" = "deny"
           "127.0.0.1" = "deny"
           "::1" = "deny"
+
+          [model_providers.review-agent-responses-proxy]
+          name = "Review Agent Responses Proxy"
+          base_url = "http://127.0.0.1:${proxy_port}/v1"
+          wire_api = "responses"
           EOF
           if [[ "$INPUT_OPERATION" == review ]]; then
             cp "$RUNNER_TEMP/review-agent-baseline/ledger.jsonl" \
@@ -433,6 +472,7 @@ jobs:
               -c diff.external= diff --cached --quiet -- .
           git -c core.hooksPath=/dev/null -c core.fsmonitor=false \
             rev-parse 'HEAD^{tree}' >"$RUNNER_TEMP/tree-before.txt"
+          "$RUNNER_TEMP/review-agent-network-fence.sh" review-host
       - name: Preserve time for validation and signed state
         id: deadline
         shell: bash
@@ -450,21 +490,30 @@ jobs:
         id: codex
         if: steps.deadline.outputs.run == 'true'
         continue-on-error: true
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
-        with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          responses-api-endpoint: https://openrouter.ai/api/v1/responses
-          prompt-file: ${{ runner.temp }}/review-agent-prompt.md
-          output-file: ${{ runner.temp }}/review-agent-output.json
-          working-directory: ${{ runner.temp }}/review-agent-session
-          codex-version: 0.146.0
-          codex-home: ${{ runner.temp }}/review-codex-home
-          model: moonshotai/kimi-k3
-          effort: high
-          permission-profile: review-agent
-          safety-strategy: drop-sudo
-          allow-bots: true
-          codex-args: '["--ephemeral","--output-schema","${{ runner.temp }}/review-output.schema.json","-c","model_context_window=240000","-c","model_auto_compact_token_limit=216000","-c","shell_environment_policy.inherit=none"]'
+        shell: bash
+        env:
+          CODEX_HOME: ${{ runner.temp }}/review-codex-home
+          CODEX_INTERNAL_ORIGINATOR_OVERRIDE: codex_github_action
+          FORCE_COLOR: 1
+        run: |
+          set -euo pipefail
+          PATH="/opt/wukongim-review-agent:$PATH" prlimit \
+            --cpu=2400:2400 \
+            --as=8589934592:8589934592 \
+            --nproc=512:512 \
+            -- codex exec \
+              --skip-git-repo-check \
+              --cd "$RUNNER_TEMP/review-agent-session" \
+              --output-last-message "$RUNNER_TEMP/review-agent-output.json" \
+              --output-schema "$RUNNER_TEMP/review-output.schema.json" \
+              --model moonshotai/kimi-k3 \
+              --config 'model_reasoning_effort="high"' \
+              --ephemeral \
+              --config model_context_window=240000 \
+              --config model_auto_compact_token_limit=216000 \
+              --config shell_environment_policy.inherit=none \
+              --config 'default_permissions="review-agent"' \
+              <"$RUNNER_TEMP/review-agent-prompt.md"
       - name: Record immutable-tree result
         if: always()
         shell: bash
@@ -964,6 +1013,9 @@ jobs:
     name: Wake the next signed queue entry
     needs: state-writer
     if: always() && needs.state-writer.result == 'success'
+    concurrency:
+      group: review-agent-drain-${{ inputs.pull_request }}
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -992,6 +1044,21 @@ jobs:
             [[ "$lease" =~ ^[1-9][0-9]{0,19}$ ]]
             [[ "$attempt" =~ ^[0-9]{1,2}$ ]]
             [[ "$STATE_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+            title="Review Agent PR #${INPUT_PULL_REQUEST} generation from lease ${lease} attempt ${attempt}"
+            mapfile -t exact_runs < <(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/review-agent-run.yml/runs?per_page=100" \
+                --jq '.workflow_runs[] |
+                  select(.display_title == "'"$title"'") | .id'
+            )
+            if (( ${#exact_runs[@]} > 1 )); then
+              echo "multiple Review Agent workers match the exact signed retry" >&2
+              exit 1
+            fi
+            if (( ${#exact_runs[@]} == 1 )); then
+              echo "Review Agent worker ${exact_runs[0]} already records the exact signed retry"
+              exit 0
+            fi
             gh workflow run review-agent-run.yml \
               --repo "$GITHUB_REPOSITORY" \
               --ref main \

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -403,6 +403,9 @@ jobs:
       (needs.state-writer.outputs.dispatch == 'true' ||
        needs.state-writer.outputs.cancel_run_id != '0' ||
        needs.state-writer.outputs.next_pull_request != '0')
+    concurrency:
+      group: review-agent-dispatch-${{ needs.state-writer.outputs.pull_request }}
+      cancel-in-progress: false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -452,6 +455,21 @@ jobs:
             [[ "$CONTROL_SHA" =~ ^[0-9a-f]{40}$ ]]
             [[ "$state_head" =~ ^[0-9a-f]{40}$ ]]
             [[ "$OPERATION" == review || "$OPERATION" == explain ]]
+            title="Review Agent PR #${PR_NUMBER} generation from lease ${LEASE_RUN_ID} attempt ${INFRASTRUCTURE_ATTEMPT}"
+            mapfile -t exact_runs < <(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/review-agent-run.yml/runs?per_page=100" \
+                --jq '.workflow_runs[] |
+                  select(.display_title == "'"$title"'") | .id'
+            )
+            if (( ${#exact_runs[@]} > 1 )); then
+              echo "multiple Review Agent workers match the exact signed attempt" >&2
+              exit 1
+            fi
+            if (( ${#exact_runs[@]} == 1 )); then
+              echo "Review Agent worker ${exact_runs[0]} already records the exact signed attempt"
+              exit 0
+            fi
             gh workflow run review-agent-run.yml \
               --repo "$GITHUB_REPOSITORY" \
               --ref main \

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -52,8 +52,11 @@ The scheduler permits three repository-wide sessions, one per pull request,
 and one first-time external contributor session. Fresh-read expected-head CAS
 transactions retry bounded contention while preserving every event; an
 isolated `actions: write` dispatcher starts the exact worker after the state
-commit. Terminal work wakes the next signed queue entry. Partial state writes
-and dispatches are recoverable from signed checkpoints and leases.
+commit. Dispatch is serialized per pull request, and the exact worker title
+derived from pull request, signed lease, and infrastructure attempt is its
+idempotency key at both initial and retry boundaries. Terminal work wakes the
+next signed queue entry. Partial state writes and dispatches are recoverable
+from signed checkpoints and leases.
 
 ## Review inputs
 
@@ -94,14 +97,19 @@ authorized bounded reconsideration is accepted.
 The model receives no GitHub/App, cloud, deploy, package-publish, or
 organization-private credential. It runs from a trusted external session
 directory and sees the candidate checkout read-only. Public internet is
-allowed, while private, link-local, cloud metadata, runner-host, and configured
-organization CIDRs are blocked by the model permission profile. The pinned
-Action's local proxy is the sole loopback exception required by the model
-transport; model-initiated localhost access remains denied. Candidate checks
-execute only through the Check MCP in per-command disposable worktrees with
-dedicated HOME/TMP directories and a rootless network namespace whose own
-loopback supports local test servers. The job has no Docker socket and uses
-the Action's `drop-sudo` strategy.
+allowed, while private, link-local, cloud metadata, and runner-host access is
+blocked by the model permission profile. Configured organization CIDRs are
+also blocked inside the candidate-check namespace. The pinned Action installs
+the exact Codex CLI and Responses proxy; the protected Workflow then runs
+`codex exec` directly with CPU, address-space, and process limits.
+The trusted proxy is the sole loopback exception required by model transport;
+model-initiated localhost access remains denied. Candidate checks execute only
+through the Check MCP in per-command disposable worktrees with dedicated
+HOME/TMP directories and a rootless network namespace whose own loopback
+supports local test servers. The model sandbox uses one root-owned `bwrap`
+copy with a path-specific AppArmor `userns` profile; the global Ubuntu user
+namespace restriction remains enabled. The job has no Docker socket, and
+`sudo` is disabled before the model process starts.
 
 Mandatory checks are selected deterministically from every changed path. The
 model may add a check only by protected catalog name through the local stdio

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -147,7 +147,24 @@ func TestReviewAgentControllerWorkflowSeparatesAuthority(t *testing.T) {
 
 	dispatch := issueAgentJobText(t, raw, "dispatch")
 	require.Contains(t, dispatch, "actions: write")
+	require.Contains(
+		t,
+		dispatch,
+		"group: review-agent-dispatch-${{ needs.state-writer.outputs.pull_request }}",
+	)
+	require.Contains(t, dispatch, "cancel-in-progress: false")
 	require.Contains(t, dispatch, "gh workflow run review-agent-run.yml")
+	require.Contains(
+		t,
+		dispatch,
+		`title="Review Agent PR #${PR_NUMBER} generation from lease ${LEASE_RUN_ID} attempt ${INFRASTRUCTURE_ATTEMPT}"`,
+	)
+	require.Contains(t, dispatch, `select(.display_title == "'"$title"'")`)
+	require.Contains(
+		t,
+		dispatch,
+		"already records the exact signed attempt",
+	)
 	require.Contains(
 		t,
 		dispatch,
@@ -206,10 +223,16 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		strings.Count(raw, "persist-credentials: false"))
 	require.Contains(t, raw, "ref: ${{ needs.recover.outputs.test_merge_sha }}")
 	require.Equal(t, 1, strings.Count(raw, "openai/codex-action@"))
-	require.Contains(t, raw, "model: moonshotai/kimi-k3")
-	require.Contains(t, raw, "effort: high")
+	require.Contains(t, raw, "--model moonshotai/kimi-k3")
+	require.Contains(t, raw, `--config 'model_reasoning_effort="high"'`)
 	require.Contains(t, raw, "codex-version: 0.146.0")
-	require.Contains(t, raw, "safety-strategy: drop-sudo")
+	require.Contains(t, raw, "codex-responses-api-proxy")
+	require.Contains(t, raw, "env -u PROXY_API_KEY")
+	require.Contains(t, raw, "--upstream-url https://openrouter.ai/api/v1/responses")
+	require.Contains(t, raw, "--cpu=2400:2400")
+	require.Contains(t, raw, "--as=8589934592:8589934592")
+	require.Contains(t, raw, "--nproc=512:512")
+	require.Contains(t, raw, `--config 'default_permissions="review-agent"'`)
 	require.Contains(t, raw, "review_reason:$recovery[0].next_state.reason")
 	require.Contains(t, raw, "retention-days: 7")
 	require.Contains(t, raw, "retention-days: 30")
@@ -272,12 +295,12 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, fence, `sudo rmdir "$review_unshare_directory"`)
 	require.Equal(
 		t,
-		3,
+		5,
 		strings.Count(
 			fence,
 			`/proc/sys/kernel/apparmor_restrict_unprivileged_userns`,
 		),
-		"the global userns restriction must be checked before and after the narrow exception",
+		"the global userns restriction must bracket both narrow exceptions",
 	)
 	require.Contains(
 		t,
@@ -301,6 +324,17 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.NotContains(t, fence, "model-host)")
 	require.NotContains(t, fence, "apply_network_rules host")
 	require.NotContains(t, fence, "keep-sudo")
+	require.NotContains(t, fence, "limit_runner_worker")
+	require.Contains(
+		t,
+		fence,
+		`review_bwrap_binary="$review_unshare_directory/bwrap"`,
+	)
+	require.Contains(
+		t,
+		fence,
+		`profile wukongim-review-agent-bwrap $review_bwrap_binary flags=(unconfined)`,
+	)
 	require.Equal(
 		t,
 		4,
@@ -396,13 +430,14 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, reviewer, "timeout-minutes: 40")
 	require.Contains(t, reviewer, "environment: review-agent-model")
 	require.Contains(t, reviewer, "secrets.OPENAI_API_KEY")
-	require.Contains(t, reviewer, "permission-profile: review-agent")
+	require.Contains(t, reviewer, `--config 'default_permissions="review-agent"'`)
 	require.Contains(t, reviewer, "allow-bots: true")
 	require.Contains(
 		t,
 		reviewer,
-		"working-directory: ${{ runner.temp }}/review-agent-session",
+		`--cd "$RUNNER_TEMP/review-agent-session"`,
 	)
+	require.Contains(t, reviewer, `PATH="/opt/wukongim-review-agent:$PATH"`)
 	require.Contains(t, reviewer, `extends = ":read-only"`)
 	require.NotContains(t, reviewer, "sandbox: workspace-write")
 	require.NotContains(t, reviewer, "REVIEW_AGENT_APP_PRIVATE_KEY")
@@ -427,6 +462,19 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 
 	drain := issueAgentJobText(t, raw, "drain")
 	require.Contains(t, drain, "actions: write")
+	require.Contains(
+		t,
+		drain,
+		"group: review-agent-drain-${{ inputs.pull_request }}",
+	)
+	require.Contains(t, drain, "cancel-in-progress: false")
+	require.Contains(t, drain, "gh workflow run review-agent-run.yml")
+	require.Contains(
+		t,
+		drain,
+		`title="Review Agent PR #${INPUT_PULL_REQUEST} generation from lease ${lease} attempt ${attempt}"`,
+	)
+	require.Contains(t, drain, "already records the exact signed retry")
 	require.NotContains(t, drain, "APP_PRIVATE_KEY")
 	require.NotContains(t, drain, "actions/checkout")
 }


### PR DESCRIPTION
## Summary
- run Codex CLI under model-only resource limits instead of constraining GitHub Runner.Worker
- keep the global AppArmor userns restriction enabled with a path-specific bwrap profile
- preserve the trusted loopback Responses proxy while blocking model-initiated localhost
- make fail-closed evidence continue through signed state and publication
- serialize and deduplicate initial and retry Worker dispatches

## Production evidence
Generation 8 baseline passed all mandatory checks, then the model job crashed the .NET runner after RLIMIT_AS was applied to Runner.Worker: https://github.com/WuKongIM/WuKongIM/actions/runs/30613080421

## Validation
- GOWORK=off go test ./scripts/... -count=1
- actionlint review-agent.yml review-agent-run.yml
- bash -n .github/review-agent/network-fence.sh
- git diff --check