### PR TITLE
test(review-agent): lock artifact consumer paths

### DIFF
--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -442,6 +442,24 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		strings.Count(evidence, "continue-on-error: true"),
 		"missing context, reviewer, and baseline artifacts must fail closed",
 	)
+	require.Contains(
+		t,
+		evidence,
+		"REVIEW_EVIDENCE_LEDGER: ${{ runner.temp }}/"+
+			"review-agent-result/ledger.jsonl",
+	)
+	require.Contains(
+		t,
+		evidence,
+		`result="$RUNNER_TEMP/review-agent-result/review-agent-output.json"`,
+	)
+	require.Contains(t, evidence, `review-agent-result/tree-before.txt`)
+	require.Contains(t, evidence, `review-agent-result/tree-after.txt`)
+	require.Contains(
+		t,
+		evidence,
+		`trusted_baseline="$RUNNER_TEMP/review-agent-trusted-baseline/baseline-evidence.json"`,
+	)
 
 	reviewer := issueAgentJobText(t, raw, "review")
 	require.Contains(t, reviewer, "timeout-minutes: 40")
@@ -464,7 +482,22 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(
 		t,
 		reviewer,
+		`"$RUNNER_TEMP/review-agent-baseline/ledger.jsonl"`,
+	)
+	require.Contains(
+		t,
+		reviewer,
 		`"$RUNNER_TEMP/review-agent-result-artifact/review-agent-output.json"`,
+	)
+	require.Contains(
+		t,
+		reviewer,
+		`>"$RUNNER_TEMP/review-agent-result-artifact/tree-before.txt"`,
+	)
+	require.Contains(
+		t,
+		reviewer,
+		`>"$RUNNER_TEMP/review-agent-result-artifact/tree-after.txt"`,
 	)
 	require.Equal(
 		t,


### PR DESCRIPTION
## Summary

- assert the Review job consumes the baseline ledger from the downloaded artifact root
- assert the Evidence job consumes flat reviewer output, ledger, immutable-tree evidence, and trusted baseline evidence
- lock both immutable-tree producer paths in the reviewer artifact root

## Why

PR #729 fixed the production Artifact layout after `upload-artifact` preserved relative directories for multi-path uploads. Its initial tests covered the new producer roots but did not lock every downstream consumer path. These assertions complete the producer/consumer contract without changing workflow behavior.

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go test ./scripts/... -run 'Workflow|ReviewAgent' -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-run.yml`
- `git diff --check`
