### PR TITLE
fix(review-agent): use system bubblewrap sandbox

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -5,9 +5,6 @@ set -euo pipefail
 review_unshare_directory="/opt/wukongim-review-agent"
 review_unshare_binary="$review_unshare_directory/unshare"
 review_unshare_profile="/etc/apparmor.d/wukongim-review-agent-unshare"
-review_bwrap_binary="/usr/bin/bwrap"
-review_bwrap_profile="/etc/apparmor.d/bwrap-userns-restrict"
-review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
 
 cleanup_user_namespace_exception() {
   if [[ -f "$review_unshare_profile" ]]; then
@@ -55,40 +52,6 @@ prepare_user_namespace() {
     | sudo tee "$review_unshare_profile" >/dev/null
   sudo chmod 0644 "$review_unshare_profile"
   sudo apparmor_parser -r "$review_unshare_profile"
-
-  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
-}
-
-probe_model_sandbox() {
-  "$review_bwrap_binary" \
-    --die-with-parent \
-    --new-session \
-    --unshare-user \
-    --unshare-pid \
-    --uid 0 \
-    --gid 0 \
-    --ro-bind / / \
-    --dev /dev \
-    --proc /proc \
-    -- /usr/bin/true
-}
-
-prepare_model_sandbox() {
-  command -v sudo >/dev/null
-  command -v apparmor_parser >/dev/null
-  [[ -x "$review_bwrap_binary" ]]
-  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
-
-  if ! probe_model_sandbox; then
-    sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends \
-      apparmor-profiles apparmor-utils
-    [[ -f "$review_bwrap_profile_source" ]]
-    sudo install -o root -g root -m 0644 \
-      "$review_bwrap_profile_source" "$review_bwrap_profile"
-    sudo apparmor_parser -r "$review_bwrap_profile"
-    probe_model_sandbox
-  fi
 
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 }
@@ -263,7 +226,18 @@ case "${1:-}" in
     ;;
   review-host)
     [[ $# -eq 1 ]]
-    prepare_model_sandbox
+    [[ "$(command -v bwrap)" == /usr/bin/bwrap ]]
+    /usr/bin/bwrap \
+      --die-with-parent \
+      --new-session \
+      --unshare-user \
+      --unshare-pid \
+      --uid 0 \
+      --gid 0 \
+      --ro-bind / / \
+      --dev /dev \
+      --proc /proc \
+      -- /usr/bin/true
     sudo chmod 000 /var/run/docker.sock 2>/dev/null || true
     sudo_binary="$(command -v sudo)"
     sudo chmod 000 "$sudo_binary"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -74,11 +74,11 @@ profile denies model-initiated localhost and private-network access, while all
 candidate check commands remain inside the rootless network namespace. The
 pinned Codex Action installs the exact CLI and Responses proxy, then the
 Workflow invokes `codex exec` directly under model-only CPU, address-space,
-and process limits. The model sandbox uses the distribution
-`/usr/bin/bwrap`, probes user-namespace creation before removing `sudo`, and
-loads Ubuntu's official path-specific `bwrap-userns-restrict` AppArmor profile
-only when the probe requires it. The global Ubuntu restriction remains
-enabled.
+and process limits. Before removing host privileges, the Workflow proves that
+the distribution-owned `/usr/bin/bwrap` can create the model user namespace.
+Codex resolves that same binary through the normal system `PATH`, so Ubuntu's
+package-owned AppArmor policy applies and the global user-namespace restriction
+remains enabled.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -106,11 +106,12 @@ The trusted proxy is the sole loopback exception required by model transport;
 model-initiated localhost access remains denied. Candidate checks execute only
 through the Check MCP in per-command disposable worktrees with dedicated
 HOME/TMP directories and a rootless network namespace whose own loopback
-supports local test servers. The model sandbox uses the distribution
-`/usr/bin/bwrap`; the Workflow probes it before removing `sudo` and loads
-Ubuntu's official path-specific `bwrap-userns-restrict` profile only when
-needed, while leaving the global user-namespace restriction enabled. The job
-has no Docker socket, and `sudo` is disabled before the model process starts.
+supports local test servers. Before host privileges are removed, the Workflow
+proves that the distribution-owned `/usr/bin/bwrap` can create the model user
+namespace. Codex resolves that same system binary so Ubuntu's package-owned
+AppArmor policy applies and the global user-namespace restriction remains
+enabled. The job has no Docker socket, and `sudo` is disabled before the model
+process starts.
 
 Mandatory checks are selected deterministically from every changed path. The
 model may add a check only by protected catalog name through the local stdio

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -90,8 +90,8 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
   runner-host, and configured organization CIDRs blocked. The Action's local
   proxy is the sole transport loopback exception; the permission profile still
   denies model-initiated localhost. It has no Docker socket, loses `sudo`
-  before execution, and uses the distribution `bwrap` under Ubuntu's official
-  path-specific AppArmor profile.
+  before execution, and uses the distribution `/usr/bin/bwrap` only after a
+  fail-closed user-namespace probe succeeds.
 - The protected Check MCP is required at Codex startup; missing named-check
   tools fail closed instead of degrading to an evidence-free model session.
 - The State Writer App can write only Contents state refs.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -25,9 +25,9 @@
   directory are removed after the isolated namespace is ready and before any
   candidate command executes.
 - Review Agent model commands use the distribution `/usr/bin/bwrap`, not a
-  copied binary. The runner probes it before removing `sudo` and loads Ubuntu's
-  official path-specific `bwrap-userns-restrict` profile only when needed; the
-  protected Check MCP is required at Codex startup.
+  copied binary. The runner proves that it can create the model user namespace
+  before removing `sudo`; there is no runtime profile-installation fallback.
+  The protected Check MCP is required at Codex startup.
 - Review Agent baseline candidate-network rules live only in that rootless
   namespace, whose host loopback is disabled. The trusted host disables Docker
   and `sudo` but retains runner transport for pinned post-job Artifact actions.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -334,12 +334,12 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, fence, `sudo rmdir "$review_unshare_directory"`)
 	require.Equal(
 		t,
-		5,
+		3,
 		strings.Count(
 			fence,
 			`/proc/sys/kernel/apparmor_restrict_unprivileged_userns`,
 		),
-		"the global userns restriction must bracket both narrow exceptions",
+		"the global userns restriction must bracket the candidate exception",
 	)
 	require.Contains(
 		t,
@@ -364,19 +364,28 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.NotContains(t, fence, "apply_network_rules host")
 	require.NotContains(t, fence, "keep-sudo")
 	require.NotContains(t, fence, "limit_runner_worker")
+	require.NotContains(t, fence, "review_bwrap_binary")
+	require.NotContains(t, fence, "review_bwrap_profile")
+	require.NotContains(t, fence, "prepare_model_sandbox")
+	require.NotContains(t, fence, "wukongim-review-agent-bwrap")
+	require.Contains(t, fence, `[[ "$(command -v bwrap)" == /usr/bin/bwrap ]]`)
 	require.Contains(
 		t,
 		fence,
-		`review_bwrap_binary="/usr/bin/bwrap"`,
+		"/usr/bin/bwrap \\\n"+
+			"      --die-with-parent \\\n"+
+			"      --new-session \\\n"+
+			"      --unshare-user \\\n"+
+			"      --unshare-pid \\\n"+
+			"      --uid 0 \\\n"+
+			"      --gid 0 \\\n"+
+			"      --ro-bind / / \\\n"+
+			"      --dev /dev \\\n"+
+			"      --proc /proc \\\n"+
+			"      -- /usr/bin/true",
+		"the system bubblewrap and its Ubuntu AppArmor profile must work before privileges are removed",
 	)
-	require.Contains(
-		t,
-		fence,
-		`review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"`,
-	)
-	require.Contains(t, fence, `sudo apparmor_parser -r "$review_bwrap_profile"`)
 	require.Contains(t, fence, `--unshare-user`)
-	require.NotContains(t, fence, `wukongim-review-agent-bwrap`)
 	require.Equal(
 		t,
 		4,
@@ -484,6 +493,7 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		`--cd "$RUNNER_TEMP/review-agent-session"`,
 	)
 	require.NotContains(t, reviewer, `PATH="/opt/wukongim-review-agent:$PATH"`)
+	require.Contains(t, reviewer, "set -euo pipefail\n          prlimit \\")
 	require.Contains(t, reviewer, `extends = ":read-only"`)
 	require.Contains(
 		t,


### PR DESCRIPTION
## Summary

- delete the copied model-side `bwrap`, its custom AppArmor profile, and the `/opt` PATH override
- fail closed by preflighting distribution-owned `/usr/bin/bwrap` before disabling Docker and `sudo`
- keep the candidate-check `unshare` network namespace unchanged and keep Codex read-only
- update the protected workflow contract tests and operator documentation

## Why

Production generation 10 reached Kimi K3, but every shell command failed with `bwrap: setting up uid map: Permission denied`. The copied binary did not match Ubuntu's path-scoped AppArmor policy. Using the system binary restores that policy boundary without adding a compatibility fallback.

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- `bash -n .github/review-agent/network-fence.sh`
- `actionlint v1.7.9 .github/workflows/review-agent-run.yml`
- `git diff --check`
- Standards and Spec code-review axes: clean