### PR TITLE
fix(review-agent): restore hosted Codex sandbox tools

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 review_unshare_directory="/opt/wukongim-review-agent"
 review_unshare_binary="$review_unshare_directory/unshare"
 review_unshare_profile="/etc/apparmor.d/wukongim-review-agent-unshare"
-review_bwrap_binary="$review_unshare_directory/bwrap"
-review_bwrap_profile="/etc/apparmor.d/wukongim-review-agent-bwrap"
+review_bwrap_binary="/usr/bin/bwrap"
+review_bwrap_profile="/etc/apparmor.d/bwrap-userns-restrict"
+review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
 
 cleanup_user_namespace_exception() {
   if [[ -f "$review_unshare_profile" ]]; then
@@ -58,26 +59,36 @@ prepare_user_namespace() {
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 }
 
+probe_model_sandbox() {
+  "$review_bwrap_binary" \
+    --die-with-parent \
+    --new-session \
+    --unshare-user \
+    --unshare-pid \
+    --uid 0 \
+    --gid 0 \
+    --ro-bind / / \
+    --dev /dev \
+    --proc /proc \
+    -- /usr/bin/true
+}
+
 prepare_model_sandbox() {
   command -v sudo >/dev/null
   command -v apparmor_parser >/dev/null
-  [[ -x /usr/bin/bwrap ]]
+  [[ -x "$review_bwrap_binary" ]]
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 
-  sudo install -d -o root -g root -m 0755 "$review_unshare_directory"
-  sudo install -o root -g root -m 0755 \
-    /usr/bin/bwrap "$review_bwrap_binary"
-  [[ "$(stat -c '%U:%G:%a' "$review_bwrap_binary")" == root:root:755 ]]
-  printf '%s\n' \
-    'abi <abi/4.0>,' \
-    'include <tunables/global>' \
-    '' \
-    "profile wukongim-review-agent-bwrap $review_bwrap_binary flags=(unconfined) {" \
-    '  userns,' \
-    '}' \
-    | sudo tee "$review_bwrap_profile" >/dev/null
-  sudo chmod 0644 "$review_bwrap_profile"
-  sudo apparmor_parser -r "$review_bwrap_profile"
+  if ! probe_model_sandbox; then
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends \
+      apparmor-profiles apparmor-utils
+    [[ -f "$review_bwrap_profile_source" ]]
+    sudo install -o root -g root -m 0644 \
+      "$review_bwrap_profile_source" "$review_bwrap_profile"
+    sudo apparmor_parser -r "$review_bwrap_profile"
+    probe_model_sandbox
+  fi
 
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -74,9 +74,11 @@ profile denies model-initiated localhost and private-network access, while all
 candidate check commands remain inside the rootless network namespace. The
 pinned Codex Action installs the exact CLI and Responses proxy, then the
 Workflow invokes `codex exec` directly under model-only CPU, address-space,
-and process limits. A root-owned, path-specific `bwrap` AppArmor profile
-grants only the model sandbox the required `userns`; the global Ubuntu
-restriction remains enabled.
+and process limits. The model sandbox uses the distribution
+`/usr/bin/bwrap`, probes user-namespace creation before removing `sudo`, and
+loads Ubuntu's official path-specific `bwrap-userns-restrict` AppArmor profile
+only when the probe requires it. The global Ubuntu restriction remains
+enabled.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and
@@ -87,7 +89,9 @@ directory before any candidate command can run. Private-CIDR, quota, and
 connection fences live inside the candidate namespace; Docker and `sudo` are
 disabled on the trusted baseline host without blocking its Artifact transport.
 Explanation-only sessions do not install that profile or create a candidate
-network namespace because they never execute candidate checks.
+network namespace because they never execute candidate checks. The Check MCP
+is a required Codex dependency: failure to initialize it stops the model
+session instead of silently removing the protected check tools.
 
 Worker dispatch is serialized per pull request. The exact run title derived
 from pull request, signed lease, and infrastructure attempt is the idempotency

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -351,6 +351,13 @@ jobs:
               "$RUNNER_TEMP/review-agent-session/recovery.json" \
               >>"$RUNNER_TEMP/review-agent-prompt.md"
           fi
+          {
+            printf '\nReturn exactly one raw JSON object with no Markdown fence or surrounding prose.\n'
+            printf 'The trusted output schema is reproduced below and every field must validate against it:\n'
+            printf '<trusted-output-schema>\n'
+            cat "$RUNNER_TEMP/review-output.schema.json"
+            printf '\n</trusted-output-schema>\n'
+          } >>"$RUNNER_TEMP/review-agent-prompt.md"
       - name: Install pinned Codex CLI and Responses proxy
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
@@ -461,6 +468,10 @@ jobs:
               "$RUNNER_TEMP/review-agent-result-artifact/ledger.jsonl"
             printf '%s\n' \
               '[mcp_servers.review_checks]' \
+              'required = true' \
+              'startup_timeout_sec = 30' \
+              'default_tools_approval_mode = "approve"' \
+              'enabled_tools = ["check_result", "check_run"]' \
               "command = \"$RUNNER_TEMP/review-agent-network-fence.sh\"" \
               "args = [\"join\", \"$RUNNER_TEMP/review-agent-netns.pid\", \"/usr/bin/env\", \"-i\", \"PATH=$PATH\", \"RUNNER_TEMP=$RUNNER_TEMP\", \"REVIEW_AGENT_HOME=$RUNNER_TEMP/review-agent-home\", \"REVIEW_WORKSPACE=$GITHUB_WORKSPACE\", \"REVIEW_POLICY_PATH=$RUNNER_TEMP/review-agent-policy.json\", \"REVIEW_CONTEXT_PATH=$RUNNER_TEMP/review-agent-context/review-context.json\", \"REVIEW_EVIDENCE_LEDGER=$RUNNER_TEMP/review-agent-result-artifact/ledger.jsonl\", \"$RUNNER_TEMP/wkreviewcheckmcp\"]" \
               >>"$RUNNER_TEMP/review-codex-home/config.toml"
@@ -497,7 +508,7 @@ jobs:
           FORCE_COLOR: 1
         run: |
           set -euo pipefail
-          PATH="/opt/wukongim-review-agent:$PATH" prlimit \
+          prlimit \
             --cpu=2400:2400 \
             --as=8589934592:8589934592 \
             --nproc=512:512 \

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -106,17 +106,20 @@ The trusted proxy is the sole loopback exception required by model transport;
 model-initiated localhost access remains denied. Candidate checks execute only
 through the Check MCP in per-command disposable worktrees with dedicated
 HOME/TMP directories and a rootless network namespace whose own loopback
-supports local test servers. The model sandbox uses one root-owned `bwrap`
-copy with a path-specific AppArmor `userns` profile; the global Ubuntu user
-namespace restriction remains enabled. The job has no Docker socket, and
-`sudo` is disabled before the model process starts.
+supports local test servers. The model sandbox uses the distribution
+`/usr/bin/bwrap`; the Workflow probes it before removing `sudo` and loads
+Ubuntu's official path-specific `bwrap-userns-restrict` profile only when
+needed, while leaving the global user-namespace restriction enabled. The job
+has no Docker socket, and `sudo` is disabled before the model process starts.
 
 Mandatory checks are selected deterministically from every changed path. The
 model may add a check only by protected catalog name through the local stdio
 Check MCP. The MCP resolves the immutable command and writes trusted results
-outside the read-only model session. The validator rejects unrecorded claims,
-generation mismatches, incomplete coverage, failed mandatory checks, invalid
-findings, excessive output, and unexpected tracked-file mutation.
+outside the read-only model session. Codex treats that MCP as required and
+fails the session if its protected tools cannot initialize. The validator
+rejects unrecorded claims, generation mismatches, incomplete coverage, failed
+mandatory checks, invalid findings, excessive output, and unexpected
+tracked-file mutation.
 
 The protected bounds admit at most 50 changed files, 128 KiB of captured
 change material, 10,000 changed lines, and a 192 KiB encoded Context. This

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -89,8 +89,11 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
 - The model receives public internet with private, link-local, metadata,
   runner-host, and configured organization CIDRs blocked. The Action's local
   proxy is the sole transport loopback exception; the permission profile still
-  denies model-initiated localhost. It has no Docker socket and uses
-  `drop-sudo`.
+  denies model-initiated localhost. It has no Docker socket, loses `sudo`
+  before execution, and uses the distribution `bwrap` under Ubuntu's official
+  path-specific AppArmor profile.
+- The protected Check MCP is required at Codex startup; missing named-check
+  tools fail closed instead of degrading to an evidence-free model session.
 - The State Writer App can write only Contents state refs.
 - The Review Agent App can write only Issues, Reviews, and Checks.
 - Publisher jobs do not check out or execute candidate code.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -24,6 +24,10 @@
   a narrow temporary AppArmor `userns` profile. The profile, copied binary, and
   directory are removed after the isolated namespace is ready and before any
   candidate command executes.
+- Review Agent model commands use the distribution `/usr/bin/bwrap`, not a
+  copied binary. The runner probes it before removing `sudo` and loads Ubuntu's
+  official path-specific `bwrap-userns-restrict` profile only when needed; the
+  protected Check MCP is required at Codex startup.
 - Review Agent baseline candidate-network rules live only in that rootless
   namespace, whose host loopback is disabled. The trusted host disables Docker
   and `sudo` but retains runner transport for pinned post-job Artifact actions.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -345,13 +345,16 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(
 		t,
 		fence,
-		`review_bwrap_binary="$review_unshare_directory/bwrap"`,
+		`review_bwrap_binary="/usr/bin/bwrap"`,
 	)
 	require.Contains(
 		t,
 		fence,
-		`profile wukongim-review-agent-bwrap $review_bwrap_binary flags=(unconfined)`,
+		`review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"`,
 	)
+	require.Contains(t, fence, `sudo apparmor_parser -r "$review_bwrap_profile"`)
+	require.Contains(t, fence, `--unshare-user`)
+	require.NotContains(t, fence, `wukongim-review-agent-bwrap`)
 	require.Equal(
 		t,
 		4,
@@ -449,12 +452,16 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, reviewer, "secrets.OPENAI_API_KEY")
 	require.Contains(t, reviewer, `--config 'default_permissions="review-agent"'`)
 	require.Contains(t, reviewer, "allow-bots: true")
+	require.Contains(t, reviewer, "required = true")
+	require.Contains(t, reviewer, `default_tools_approval_mode = "approve"`)
+	require.Contains(t, reviewer, `enabled_tools = ["check_result", "check_run"]`)
+	require.Contains(t, reviewer, "<trusted-output-schema>")
 	require.Contains(
 		t,
 		reviewer,
 		`--cd "$RUNNER_TEMP/review-agent-session"`,
 	)
-	require.Contains(t, reviewer, `PATH="/opt/wukongim-review-agent:$PATH"`)
+	require.NotContains(t, reviewer, `PATH="/opt/wukongim-review-agent:$PATH"`)
 	require.Contains(t, reviewer, `extends = ":read-only"`)
 	require.Contains(
 		t,


### PR DESCRIPTION
## Outcome

Restore the hosted-runner Codex execution path so the Kimi reviewer can use the normal Codex Linux sandbox and the trusted review-check MCP tools.

## Changes

- use the distro /usr/bin/bwrap identity and load Ubuntu official bwrap-userns-restrict AppArmor profile only when the sandbox probe needs it
- keep the global unprivileged-userns restriction enabled
- make the allowlisted review-check MCP server required and non-interactive
- include the exact trusted output schema in the prompt and require raw JSON
- update static contracts and operational documentation

## Validation

- GOWORK=off go test ./scripts/... -count=1
- GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-run.yml
- bash -n .github/review-agent/network-fence.sh
- shellcheck .github/review-agent/network-fence.sh
- git diff --check