### PR TITLE
fix(review-agent): isolate checks after MCP handshake

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -90,8 +90,12 @@ connection fences live inside the candidate namespace; Docker and `sudo` are
 disabled on the trusted baseline host without blocking its Artifact transport.
 Explanation-only sessions do not install that profile or create a candidate
 network namespace because they never execute candidate checks. The Check MCP
-is a required Codex dependency: failure to initialize it stops the model
-session instead of silently removing the protected check tools.
+is a required Codex dependency. Its credential-free stdio server completes the
+Codex handshake on the trusted model host, while each resolved protected check
+enters the pre-built private-network namespace before its disposable checkout
+and bubblewrap sandbox start.
+Failure to initialize the MCP stops the model session instead of silently
+removing the protected check tools.
 
 Worker dispatch is serialized per pull request. The exact run title derived
 from pull request, signed lease, and infrastructure attempt is the idempotency

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -433,6 +433,12 @@ jobs:
           if [[ "$INPUT_OPERATION" == review ]]; then
             "$RUNNER_TEMP/review-agent-network-fence.sh" start \
               "$RUNNER_TEMP/review-agent-netns.pid"
+            sudo chown root:root \
+              "$RUNNER_TEMP/review-agent-netns.pid" \
+              "$RUNNER_TEMP/review-agent-netns.pid.slirp"
+            sudo chmod 0444 \
+              "$RUNNER_TEMP/review-agent-netns.pid" \
+              "$RUNNER_TEMP/review-agent-netns.pid.slirp"
           fi
           mkdir -p "$RUNNER_TEMP/review-agent-home" "$RUNNER_TEMP/review-codex-home" \
             "$RUNNER_TEMP/review-agent-result-artifact"
@@ -472,8 +478,8 @@ jobs:
               'startup_timeout_sec = 30' \
               'default_tools_approval_mode = "approve"' \
               'enabled_tools = ["check_result", "check_run"]' \
-              "command = \"$RUNNER_TEMP/review-agent-network-fence.sh\"" \
-              "args = [\"join\", \"$RUNNER_TEMP/review-agent-netns.pid\", \"/usr/bin/env\", \"-i\", \"PATH=$PATH\", \"RUNNER_TEMP=$RUNNER_TEMP\", \"REVIEW_AGENT_HOME=$RUNNER_TEMP/review-agent-home\", \"REVIEW_WORKSPACE=$GITHUB_WORKSPACE\", \"REVIEW_POLICY_PATH=$RUNNER_TEMP/review-agent-policy.json\", \"REVIEW_CONTEXT_PATH=$RUNNER_TEMP/review-agent-context/review-context.json\", \"REVIEW_EVIDENCE_LEDGER=$RUNNER_TEMP/review-agent-result-artifact/ledger.jsonl\", \"$RUNNER_TEMP/wkreviewcheckmcp\"]" \
+              'command = "/usr/bin/env"' \
+              "args = [\"-i\", \"PATH=$PATH\", \"RUNNER_TEMP=$RUNNER_TEMP\", \"REVIEW_AGENT_HOME=$RUNNER_TEMP/review-agent-home\", \"REVIEW_WORKSPACE=$GITHUB_WORKSPACE\", \"REVIEW_POLICY_PATH=$RUNNER_TEMP/review-agent-policy.json\", \"REVIEW_CONTEXT_PATH=$RUNNER_TEMP/review-agent-context/review-context.json\", \"REVIEW_EVIDENCE_LEDGER=$RUNNER_TEMP/review-agent-result-artifact/ledger.jsonl\", \"REVIEW_NETWORK_FENCE=$RUNNER_TEMP/review-agent-network-fence.sh\", \"REVIEW_NETNS_PID_FILE=$RUNNER_TEMP/review-agent-netns.pid\", \"$RUNNER_TEMP/wkreviewcheckmcp\"]" \
               >>"$RUNNER_TEMP/review-codex-home/config.toml"
           fi
           git -c core.hooksPath=/dev/null -c core.fsmonitor=false \

--- a/cmd/wkreviewcheckmcp/main.go
+++ b/cmd/wkreviewcheckmcp/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -23,7 +24,7 @@ func main() {
 	)
 	defer cancel()
 	if err := run(ctx, os.Args[1:]); err != nil {
-		_, _ = os.Stderr.WriteString("review check MCP failed\n")
+		_, _ = fmt.Fprintf(os.Stderr, "review check MCP failed: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -64,6 +65,12 @@ func run(ctx context.Context, args []string) error {
 		WorkspaceRoot: os.Getenv("REVIEW_WORKSPACE"),
 		SandboxBinary: "/usr/bin/bwrap",
 		HelperBinary:  filepath.Join(os.Getenv("RUNNER_TEMP"), "wkreviewcheck"),
+		NetworkFenceBinary: os.Getenv(
+			"REVIEW_NETWORK_FENCE",
+		),
+		NetworkNamespacePIDFile: os.Getenv(
+			"REVIEW_NETNS_PID_FILE",
+		),
 	})
 	if err != nil {
 		return err

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -115,8 +115,11 @@ has no Docker socket, and `sudo` is disabled before the model process starts.
 Mandatory checks are selected deterministically from every changed path. The
 model may add a check only by protected catalog name through the local stdio
 Check MCP. The MCP resolves the immutable command and writes trusted results
-outside the read-only model session. Codex treats that MCP as required and
-fails the session if its protected tools cannot initialize. The validator
+outside the read-only model session. Its credential-free stdio handshake runs
+on the trusted model host; each resolved check enters the pre-built
+private-network namespace before its disposable checkout and filesystem
+sandbox start. Codex treats that MCP as required and fails the session if its
+protected tools cannot initialize. The validator
 rejects unrecorded claims, generation mismatches, incomplete coverage, failed
 mandatory checks, invalid findings, excessive output, and unexpected
 tracked-file mutation.

--- a/internal/access/reviewagentcheckmcp/FLOW.md
+++ b/internal/access/reviewagentcheckmcp/FLOW.md
@@ -9,6 +9,7 @@ check_list
 
 check_run(name)
   -> exact catalog lookup
+  -> enter the pre-built private-network namespace before disposable checkout
   -> bounded credential-free runner
   -> append-only external evidence ledger
 
@@ -16,6 +17,9 @@ check_result(name)
   -> latest trusted ledger result for the exact generation
 ```
 
-The adapter accepts no command, argument list, path, environment, URL, ref,
-test pattern, output location, or network selector. It exposes no Resources,
-Prompts, Sampling, Roots, GitHub, state, or publication operation.
+The stdio adapter itself starts on the credential-free trusted host so Codex
+can complete its required MCP handshake. Only a resolved protected check
+enters the pre-built private-network namespace. The adapter accepts no command,
+argument list, path, environment, URL, ref, test pattern, output location, or
+network selector. It exposes no Resources, Prompts, Sampling, Roots, GitHub,
+state, or publication operation.

--- a/internal/runtime/reviewagentverify/FLOW.md
+++ b/internal/runtime/reviewagentverify/FLOW.md
@@ -13,6 +13,7 @@ exact base/control tree + changed paths
   -> frozen applicable AGENTS.md / FLOW.md blobs
 
 fixed named check catalog + credential-free per-command disposable worktree
+  -> enter the pre-built private-network namespace before Git checkout or command
   -> read-only root/PID filesystem sandbox
      (only disposable worktree + dedicated HOME/TMP writable)
   -> frozen review-agent-check helper for composite checks

--- a/internal/runtime/reviewagentverify/os_executor.go
+++ b/internal/runtime/reviewagentverify/os_executor.go
@@ -17,12 +17,14 @@ import (
 
 // OSExecutorConfig contains only non-secret process environment roots.
 type OSExecutorConfig struct {
-	HomeDir       string
-	Path          string
-	TempDir       string
-	WorkspaceRoot string
-	SandboxBinary string
-	HelperBinary  string
+	HomeDir                 string
+	Path                    string
+	TempDir                 string
+	WorkspaceRoot           string
+	SandboxBinary           string
+	HelperBinary            string
+	NetworkFenceBinary      string
+	NetworkNamespacePIDFile string
 }
 
 // OSExecutor runs already-resolved catalog commands with a minimal
@@ -35,6 +37,9 @@ type OSExecutor struct {
 	sandboxBinary string
 	gitBinary     string
 	helperBinary  string
+	networkFence  string
+	networkPID    string
+	runnerTemp    string
 }
 
 // NewOSExecutor constructs an executor without inheriting the job
@@ -71,6 +76,9 @@ func NewOSExecutor(config OSExecutorConfig) (*OSExecutor, error) {
 	sandboxBinary := ""
 	gitBinary := ""
 	helperBinary := ""
+	networkFence := ""
+	networkPID := ""
+	runnerTemp := ""
 	if config.SandboxBinary != "" || config.WorkspaceRoot != "" {
 		workspaceRoot, sandboxBinary, err = validateProcessSandbox(config)
 		if err != nil {
@@ -84,6 +92,19 @@ func NewOSExecutor(config OSExecutorConfig) (*OSExecutor, error) {
 			return nil, err
 		}
 		gitBinary, err = executableInPath(config.Path, "git")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if config.NetworkFenceBinary != "" ||
+		config.NetworkNamespacePIDFile != "" {
+		if sandboxBinary == "" {
+			return nil, errors.New(
+				"named-check network fence requires process sandbox",
+			)
+		}
+		networkFence, networkPID, runnerTemp, err =
+			validateNetworkNamespace(config)
 		if err != nil {
 			return nil, err
 		}
@@ -104,6 +125,9 @@ func NewOSExecutor(config OSExecutorConfig) (*OSExecutor, error) {
 		sandboxBinary: sandboxBinary,
 		gitBinary:     gitBinary,
 		helperBinary:  helperBinary,
+		networkFence:  networkFence,
+		networkPID:    networkPID,
+		runnerTemp:    runnerTemp,
 	}, nil
 }
 
@@ -255,6 +279,32 @@ func validateExecutable(pathValue string, label string) (string, error) {
 	return pathValue, nil
 }
 
+func validateNetworkNamespace(
+	config OSExecutorConfig,
+) (string, string, string, error) {
+	networkFence, err := validateExecutable(
+		config.NetworkFenceBinary,
+		"named-check network fence",
+	)
+	if err != nil {
+		return "", "", "", err
+	}
+	pidFile := config.NetworkNamespacePIDFile
+	if !filepath.IsAbs(pidFile) {
+		return "", "", "", errors.New(
+			"named-check network namespace PID path is not absolute",
+		)
+	}
+	info, err := os.Lstat(pidFile)
+	if err != nil || !info.Mode().IsRegular() ||
+		info.Mode()&os.ModeSymlink != 0 {
+		return "", "", "", errors.New(
+			"named-check network namespace PID file is unsafe",
+		)
+	}
+	return networkFence, pidFile, filepath.Dir(pidFile), nil
+}
+
 func secureDirectoryWithin(root string, target string) error {
 	relative, err := filepath.Rel(root, target)
 	if err != nil || relative == ".." ||
@@ -336,15 +386,13 @@ func (executor *OSExecutor) prepareSandbox(
 		cleanupOnError()
 		return nil, errors.New("create isolated named-check temporary directory")
 	}
-	command := exec.Command(
-		executor.gitBinary,
+	command := executor.trustedGitCommand(
 		"-c", "core.hooksPath=/dev/null",
 		"-c", "core.fsmonitor=false",
 		"-c", "diff.external=",
 		"-C", executor.workspaceRoot,
 		"worktree", "add", "--detach", sandbox.workspace, "HEAD",
 	)
-	command.Env = trustedGitEnvironment(executor.gitBinary)
 	if output, err := command.CombinedOutput(); err != nil {
 		cleanupOnError()
 		return nil, fmt.Errorf(
@@ -379,17 +427,41 @@ func (sandbox *processSandbox) cleanup() {
 	if sandbox == nil || sandbox.executor == nil {
 		return
 	}
-	command := exec.Command(
-		sandbox.executor.gitBinary,
+	command := sandbox.executor.trustedGitCommand(
 		"-c", "core.hooksPath=/dev/null",
 		"-c", "core.fsmonitor=false",
 		"-c", "diff.external=",
 		"-C", sandbox.executor.workspaceRoot,
 		"worktree", "remove", "--force", sandbox.workspace,
 	)
-	command.Env = trustedGitEnvironment(sandbox.executor.gitBinary)
 	_ = command.Run()
 	_ = os.RemoveAll(sandbox.root)
+}
+
+func (executor *OSExecutor) trustedGitCommand(arguments ...string) *exec.Cmd {
+	if executor.networkFence == "" {
+		command := exec.Command(executor.gitBinary, arguments...)
+		command.Env = trustedGitEnvironment(executor.gitBinary)
+		return command
+	}
+	command := exec.Command(
+		executor.networkFence,
+		append(
+			[]string{"join", executor.networkPID, executor.gitBinary},
+			arguments...,
+		)...,
+	)
+	command.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"RUNNER_TEMP=" + executor.runnerTemp,
+		"HOME=/nonexistent",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_OPTIONAL_LOCKS=0",
+		"LANG=C.UTF-8",
+		"LC_ALL=C.UTF-8",
+	}
+	return command
 }
 
 func (executor *OSExecutor) processCommand(
@@ -440,6 +512,22 @@ func (executor *OSExecutor) processCommand(
 	sandboxArguments = append(sandboxArguments, "--cap-drop", "ALL")
 	sandboxArguments = append(sandboxArguments, "--")
 	sandboxArguments = append(sandboxArguments, arguments...)
+	if executor.networkFence != "" {
+		return executor.networkFence,
+			append(
+				[]string{
+					"join",
+					executor.networkPID,
+					executor.sandboxBinary,
+				},
+				sandboxArguments...,
+			),
+			string(filepath.Separator),
+			[]string{
+				"PATH=" + os.Getenv("PATH"),
+				"RUNNER_TEMP=" + executor.runnerTemp,
+			}
+	}
 	return executor.sandboxBinary,
 		sandboxArguments,
 		string(filepath.Separator),

--- a/internal/runtime/reviewagentverify/os_executor_test.go
+++ b/internal/runtime/reviewagentverify/os_executor_test.go
@@ -1,0 +1,73 @@
+package reviewagentverify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessCommandEntersNetworkNamespaceBeforeSandbox(t *testing.T) {
+	t.Parallel()
+
+	executor := &OSExecutor{
+		environment:   []string{"PATH=/usr/bin", "HOME=/tmp/home"},
+		homeDir:       "/tmp/home",
+		tempDir:       "/tmp/check-tmp",
+		sandboxBinary: "/usr/bin/bwrap",
+		gitBinary:     "/usr/bin/git",
+		helperBinary:  "/tmp/wkreviewcheck",
+		networkFence:  "/tmp/review-agent-network-fence.sh",
+		networkPID:    "/tmp/review-agent-netns.pid",
+		runnerTemp:    "/tmp",
+	}
+	sandbox := &processSandbox{
+		workspace:  "/tmp/workspace",
+		home:       "/tmp/sandbox-home",
+		temp:       "/tmp/sandbox-tmp",
+		workingDir: "/tmp/workspace/internal",
+	}
+
+	executable, arguments, commandDir, environment := executor.processCommand(
+		[]string{"review-agent-check", "go-unit"},
+		sandbox.workingDir,
+		sandbox,
+	)
+
+	require.Equal(t, executor.networkFence, executable)
+	require.Equal(
+		t,
+		[]string{
+			"join",
+			executor.networkPID,
+			executor.sandboxBinary,
+		},
+		arguments[:3],
+	)
+	require.Contains(t, arguments, "--ro-bind")
+	require.Contains(t, arguments, executor.helperBinary)
+	require.Equal(t, string(filepath.Separator), commandDir)
+	require.Equal(
+		t,
+		[]string{"PATH=" + os.Getenv("PATH"), "RUNNER_TEMP=/tmp"},
+		environment,
+	)
+
+	gitCommand := executor.trustedGitCommand("status", "--short")
+	require.Equal(t, executor.networkFence, gitCommand.Path)
+	require.Equal(
+		t,
+		[]string{
+			executor.networkFence,
+			"join",
+			executor.networkPID,
+			executor.gitBinary,
+			"status",
+			"--short",
+		},
+		gitCommand.Args,
+	)
+	require.Contains(t, gitCommand.Env, "HOME=/nonexistent")
+	require.Contains(t, gitCommand.Env, "RUNNER_TEMP=/tmp")
+}

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -262,6 +262,28 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	)
 	require.NotContains(t, raw, `"$RUNNER_TEMP/review-agent-network-fence.sh" model-host`)
 	require.Contains(t, raw, `"$RUNNER_TEMP/review-agent-network-fence.sh" join`)
+	require.Contains(t, raw, `'command = "/usr/bin/env"'`)
+	require.Contains(
+		t,
+		raw,
+		`\"REVIEW_NETWORK_FENCE=$RUNNER_TEMP/review-agent-network-fence.sh\"`,
+	)
+	require.Contains(
+		t,
+		raw,
+		`\"REVIEW_NETNS_PID_FILE=$RUNNER_TEMP/review-agent-netns.pid\"`,
+	)
+	require.NotContains(
+		t,
+		raw,
+		`"command = \"$RUNNER_TEMP/review-agent-network-fence.sh\""`,
+	)
+	require.Contains(
+		t,
+		raw,
+		`sudo chown root:root \`+"\n"+
+			`              "$RUNNER_TEMP/review-agent-netns.pid"`,
+	)
 	require.Contains(t, raw, "model_context_window=240000")
 	require.Contains(t, raw, "model_auto_compact_token_limit=216000")
 	require.NotContains(t, raw, `[[ "${{ inputs.`)


### PR DESCRIPTION
## Summary

- start the credential-free Check MCP on the trusted model host so required stdio initialization can complete
- enter the existing private-network namespace before every disposable checkout and bubblewrap check command
- freeze the namespace PID files and retain actionable MCP startup diagnostics
- update flow documentation and workflow contracts

## Validation

- `GOWORK=off go test ./cmd/wkreviewcheckmcp ./internal/access/reviewagentcheckmcp ./internal/runtime/reviewagentverify ./scripts/... -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-run.yml`
- `bash -n .github/review-agent/network-fence.sh`
- `git diff --check`

## Evidence

Generation 11 reached the Codex session but failed before model invocation because the required `review_checks` MCP process closed during initialization. The previous launcher nested the whole MCP server under `nsenter`; this change limits namespace entry to candidate-triggerable Git and check processes.