### PR TITLE
fix(review-agent): restore hosted bwrap profile

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 review_unshare_directory="/opt/wukongim-review-agent"
 review_unshare_binary="$review_unshare_directory/unshare"
 review_unshare_profile="/etc/apparmor.d/wukongim-review-agent-unshare"
+review_bwrap_binary="/usr/bin/bwrap"
+review_bwrap_profile="/etc/apparmor.d/bwrap-userns-restrict"
+review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
 
 cleanup_user_namespace_exception() {
   if [[ -f "$review_unshare_profile" ]]; then
@@ -52,6 +55,41 @@ prepare_user_namespace() {
     | sudo tee "$review_unshare_profile" >/dev/null
   sudo chmod 0644 "$review_unshare_profile"
   sudo apparmor_parser -r "$review_unshare_profile"
+
+  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
+}
+
+probe_model_sandbox() {
+  "$review_bwrap_binary" \
+    --die-with-parent \
+    --new-session \
+    --unshare-user \
+    --unshare-pid \
+    --uid 0 \
+    --gid 0 \
+    --ro-bind / / \
+    --dev /dev \
+    --proc /proc \
+    -- /usr/bin/true
+}
+
+prepare_model_sandbox() {
+  command -v sudo >/dev/null
+  command -v apparmor_parser >/dev/null
+  [[ "$(command -v bwrap)" == "$review_bwrap_binary" ]]
+  [[ -x "$review_bwrap_binary" ]]
+  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
+
+  if ! probe_model_sandbox; then
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends \
+      apparmor-profiles apparmor-utils
+    [[ -f "$review_bwrap_profile_source" ]]
+    sudo install -o root -g root -m 0644 \
+      "$review_bwrap_profile_source" "$review_bwrap_profile"
+    sudo apparmor_parser -r "$review_bwrap_profile"
+    probe_model_sandbox
+  fi
 
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 }
@@ -226,18 +264,7 @@ case "${1:-}" in
     ;;
   review-host)
     [[ $# -eq 1 ]]
-    [[ "$(command -v bwrap)" == /usr/bin/bwrap ]]
-    /usr/bin/bwrap \
-      --die-with-parent \
-      --new-session \
-      --unshare-user \
-      --unshare-pid \
-      --uid 0 \
-      --gid 0 \
-      --ro-bind / / \
-      --dev /dev \
-      --proc /proc \
-      -- /usr/bin/true
+    prepare_model_sandbox
     sudo chmod 000 /var/run/docker.sock 2>/dev/null || true
     sudo_binary="$(command -v sudo)"
     sudo chmod 000 "$sudo_binary"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,9 +76,11 @@ pinned Codex Action installs the exact CLI and Responses proxy, then the
 Workflow invokes `codex exec` directly under model-only CPU, address-space,
 and process limits. Before removing host privileges, the Workflow proves that
 the distribution-owned `/usr/bin/bwrap` can create the model user namespace.
-Codex resolves that same binary through the normal system `PATH`, so Ubuntu's
-package-owned AppArmor policy applies and the global user-namespace restriction
-remains enabled.
+If Ubuntu's hosted-runner restriction blocks that probe, the Workflow installs
+the distribution's official path-specific `bwrap-userns-restrict` AppArmor
+profile and repeats the probe. Codex resolves the same system binary through
+the normal `PATH`; no copied binary or custom model profile exists, and the
+global user-namespace restriction remains enabled.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -108,8 +108,10 @@ through the Check MCP in per-command disposable worktrees with dedicated
 HOME/TMP directories and a rootless network namespace whose own loopback
 supports local test servers. Before host privileges are removed, the Workflow
 proves that the distribution-owned `/usr/bin/bwrap` can create the model user
-namespace. Codex resolves that same system binary so Ubuntu's package-owned
-AppArmor policy applies and the global user-namespace restriction remains
+namespace. If the hosted-runner restriction blocks that probe, the Workflow
+installs Ubuntu's official path-specific `bwrap-userns-restrict` profile and
+repeats it. Codex resolves that same system binary; no copied binary or custom
+model profile exists, and the global user-namespace restriction remains
 enabled. The job has no Docker socket, and `sudo` is disabled before the model
 process starts.
 

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -91,7 +91,8 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
   proxy is the sole transport loopback exception; the permission profile still
   denies model-initiated localhost. It has no Docker socket, loses `sudo`
   before execution, and uses the distribution `/usr/bin/bwrap` only after a
-  fail-closed user-namespace probe succeeds.
+  fail-closed user-namespace probe succeeds. A blocked probe loads only
+  Ubuntu's official path-specific AppArmor profile and must then pass.
 - The protected Check MCP is required at Codex startup; missing named-check
   tools fail closed instead of degrading to an evidence-free model session.
 - The State Writer App can write only Contents state refs.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -26,8 +26,9 @@
   candidate command executes.
 - Review Agent model commands use the distribution `/usr/bin/bwrap`, not a
   copied binary. The runner proves that it can create the model user namespace
-  before removing `sudo`; there is no runtime profile-installation fallback.
-  The protected Check MCP is required at Codex startup.
+  before removing `sudo`; a blocked probe installs only Ubuntu's official
+  path-specific `bwrap-userns-restrict` profile and must then pass. The
+  protected Check MCP is required at Codex startup.
 - Review Agent baseline candidate-network rules live only in that rootless
   namespace, whose host loopback is disabled. The trusted host disables Docker
   and `sudo` but retains runner transport for pinned post-job Artifact actions.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -334,12 +334,12 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, fence, `sudo rmdir "$review_unshare_directory"`)
 	require.Equal(
 		t,
-		3,
+		5,
 		strings.Count(
 			fence,
 			`/proc/sys/kernel/apparmor_restrict_unprivileged_userns`,
 		),
-		"the global userns restriction must bracket the candidate exception",
+		"the global userns restriction must bracket both narrow exceptions",
 	)
 	require.Contains(
 		t,
@@ -364,28 +364,19 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.NotContains(t, fence, "apply_network_rules host")
 	require.NotContains(t, fence, "keep-sudo")
 	require.NotContains(t, fence, "limit_runner_worker")
-	require.NotContains(t, fence, "review_bwrap_binary")
-	require.NotContains(t, fence, "review_bwrap_profile")
-	require.NotContains(t, fence, "prepare_model_sandbox")
-	require.NotContains(t, fence, "wukongim-review-agent-bwrap")
-	require.Contains(t, fence, `[[ "$(command -v bwrap)" == /usr/bin/bwrap ]]`)
 	require.Contains(
 		t,
 		fence,
-		"/usr/bin/bwrap \\\n"+
-			"      --die-with-parent \\\n"+
-			"      --new-session \\\n"+
-			"      --unshare-user \\\n"+
-			"      --unshare-pid \\\n"+
-			"      --uid 0 \\\n"+
-			"      --gid 0 \\\n"+
-			"      --ro-bind / / \\\n"+
-			"      --dev /dev \\\n"+
-			"      --proc /proc \\\n"+
-			"      -- /usr/bin/true",
-		"the system bubblewrap and its Ubuntu AppArmor profile must work before privileges are removed",
+		`review_bwrap_binary="/usr/bin/bwrap"`,
 	)
+	require.Contains(
+		t,
+		fence,
+		`review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"`,
+	)
+	require.Contains(t, fence, `sudo apparmor_parser -r "$review_bwrap_profile"`)
 	require.Contains(t, fence, `--unshare-user`)
+	require.NotContains(t, fence, `wukongim-review-agent-bwrap`)
 	require.Equal(
 		t,
 		4,


### PR DESCRIPTION
## Summary
- keep the system `/usr/bin/bwrap` boundary introduced by #731
- when the hosted-runner user-namespace probe fails, install and load Ubuntu official `bwrap-userns-restrict`, then probe again
- preserve the #733 direct MCP startup and per-check network namespace boundary

## Production evidence
Generation 11 on PR #716 failed `/usr/bin/bwrap` with `setting up uid map: Permission denied`. The same runner passed immediately after Ubuntu official `apparmor-profiles` and `apparmor-utils` were installed and `/usr/share/apparmor/extra-profiles/bwrap-userns-restrict` was loaded. PR #731 removed that conditional preparation, so the current main branch regressed the demonstrated hosted-runner path.

## Validation
- `GOWORK=off go test ./scripts/... -count=1`
- focused actionlint for `.github/workflows/review-agent-run.yml`
- `bash -n .github/review-agent/network-fence.sh`
- shellcheck for the network-fence script
- `git diff --check`