### PR TITLE
fix(review-agent): grant Codex full runner access

### DIFF
--- a/.github/review-agent/network-fence.sh
+++ b/.github/review-agent/network-fence.sh
@@ -5,9 +5,6 @@ set -euo pipefail
 review_unshare_directory="/opt/wukongim-review-agent"
 review_unshare_binary="$review_unshare_directory/unshare"
 review_unshare_profile="/etc/apparmor.d/wukongim-review-agent-unshare"
-review_bwrap_binary="/usr/bin/bwrap"
-review_bwrap_profile="/etc/apparmor.d/bwrap-userns-restrict"
-review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
 
 cleanup_user_namespace_exception() {
   if [[ -f "$review_unshare_profile" ]]; then
@@ -55,41 +52,6 @@ prepare_user_namespace() {
     | sudo tee "$review_unshare_profile" >/dev/null
   sudo chmod 0644 "$review_unshare_profile"
   sudo apparmor_parser -r "$review_unshare_profile"
-
-  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
-}
-
-probe_model_sandbox() {
-  "$review_bwrap_binary" \
-    --die-with-parent \
-    --new-session \
-    --unshare-user \
-    --unshare-pid \
-    --uid 0 \
-    --gid 0 \
-    --ro-bind / / \
-    --dev /dev \
-    --proc /proc \
-    -- /usr/bin/true
-}
-
-prepare_model_sandbox() {
-  command -v sudo >/dev/null
-  command -v apparmor_parser >/dev/null
-  [[ "$(command -v bwrap)" == "$review_bwrap_binary" ]]
-  [[ -x "$review_bwrap_binary" ]]
-  [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
-
-  if ! probe_model_sandbox; then
-    sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends \
-      apparmor-profiles apparmor-utils
-    [[ -f "$review_bwrap_profile_source" ]]
-    sudo install -o root -g root -m 0644 \
-      "$review_bwrap_profile_source" "$review_bwrap_profile"
-    sudo apparmor_parser -r "$review_bwrap_profile"
-    probe_model_sandbox
-  fi
 
   [[ "$(< /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" == 1 ]]
 }
@@ -264,7 +226,6 @@ case "${1:-}" in
     ;;
   review-host)
     [[ $# -eq 1 ]]
-    prepare_model_sandbox
     sudo chmod 000 /var/run/docker.sock 2>/dev/null || true
     sudo_binary="$(command -v sudo)"
     sudo chmod 000 "$sudo_binary"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,18 +69,15 @@ network fence disables both Docker access and `sudo`. Candidate checks receive
 isolated loopback inside a rootless network namespace whose host loopback is
 disabled. The trusted baseline host keeps runner transport available only so
 pinned post-job Actions can upload evidence; candidate code never runs there.
-The model host keeps GitHub runner transport intact. Its read-only permission
-profile denies model-initiated localhost and private-network access, while all
-candidate check commands remain inside the rootless network namespace. The
-pinned Codex Action installs the exact CLI and Responses proxy, then the
-Workflow invokes `codex exec` directly under model-only CPU, address-space,
-and process limits. Before removing host privileges, the Workflow proves that
-the distribution-owned `/usr/bin/bwrap` can create the model user namespace.
-If Ubuntu's hosted-runner restriction blocks that probe, the Workflow installs
-the distribution's official path-specific `bwrap-userns-restrict` AppArmor
-profile and repeats the probe. Codex resolves the same system binary through
-the normal `PATH`; no copied binary or custom model profile exists, and the
-global user-namespace restriction remains enabled.
+The model host keeps GitHub runner transport intact. The pinned Codex Action
+installs the exact CLI and Responses proxy, then the Workflow invokes
+`codex exec --dangerously-bypass-approvals-and-sandbox` under model-only CPU,
+address-space, and process limits. This gives Codex full runner-user filesystem
+and public-network access without its internal Bubblewrap sandbox. The model
+receives no GitHub or App credential, inherits no host environment, and starts
+only after Docker and `sudo` are disabled. Candidate check commands still run
+inside the rootless network namespace and their Bubblewrap sandboxes. The
+trusted validator rejects any tracked candidate-tree mutation.
 
 Ubuntu AppArmor may restrict unprivileged user namespaces on hosted runners.
 Each candidate runner installs one root-owned Review Agent `unshare` copy and
@@ -142,7 +139,7 @@ See
 ## Workflow maintenance
 
 - Keep external Actions pinned by full commit SHA.
-- Keep candidate checkouts read-only with `persist-credentials: false`.
+- Keep candidate checkouts credential-free and reject tracked-tree mutation.
 - Never expose App keys to candidate or model jobs.
 - Update policy, schemas, Workflows, docs, and their contract tests together.
 - Read this file before invoking or changing any Workflow.

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -446,24 +446,6 @@ jobs:
           cat >"$RUNNER_TEMP/review-codex-home/config.toml" <<EOF
           model_provider = "review-agent-responses-proxy"
 
-          [permissions.review-agent]
-          description = "Read-only review with full public-network access."
-          extends = ":read-only"
-
-          [permissions.review-agent.workspace_roots]
-          "$GITHUB_WORKSPACE" = true
-
-          [permissions.review-agent.network]
-          enabled = true
-          mode = "full"
-          allow_local_binding = false
-
-          [permissions.review-agent.network.domains]
-          "*" = "allow"
-          "localhost" = "deny"
-          "127.0.0.1" = "deny"
-          "::1" = "deny"
-
           [model_providers.review-agent-responses-proxy]
           name = "Review Agent Responses Proxy"
           base_url = "http://127.0.0.1:${proxy_port}/v1"
@@ -519,6 +501,7 @@ jobs:
             --as=8589934592:8589934592 \
             --nproc=512:512 \
             -- codex exec \
+              --dangerously-bypass-approvals-and-sandbox \
               --skip-git-repo-check \
               --cd "$RUNNER_TEMP/review-agent-session" \
               --output-last-message \
@@ -530,7 +513,6 @@ jobs:
               --config model_context_window=240000 \
               --config model_auto_compact_token_limit=216000 \
               --config shell_environment_policy.inherit=none \
-              --config 'default_permissions="review-agent"' \
               <"$RUNNER_TEMP/review-agent-prompt.md"
       - name: Record immutable-tree result
         if: always()

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -96,30 +96,24 @@ authorized bounded reconsideration is accepted.
 
 The model receives no GitHub/App, cloud, deploy, package-publish, or
 organization-private credential. It runs from a trusted external session
-directory and sees the candidate checkout read-only. Public internet is
-allowed, while private, link-local, cloud metadata, and runner-host access is
-blocked by the model permission profile. Configured organization CIDRs are
-also blocked inside the candidate-check namespace. The pinned Action installs
-the exact Codex CLI and Responses proxy; the protected Workflow then runs
-`codex exec` directly with CPU, address-space, and process limits.
-The trusted proxy is the sole loopback exception required by model transport;
-model-initiated localhost access remains denied. Candidate checks execute only
-through the Check MCP in per-command disposable worktrees with dedicated
-HOME/TMP directories and a rootless network namespace whose own loopback
-supports local test servers. Before host privileges are removed, the Workflow
-proves that the distribution-owned `/usr/bin/bwrap` can create the model user
-namespace. If the hosted-runner restriction blocks that probe, the Workflow
-installs Ubuntu's official path-specific `bwrap-userns-restrict` profile and
-repeats it. Codex resolves that same system binary; no copied binary or custom
-model profile exists, and the global user-namespace restriction remains
-enabled. The job has no Docker socket, and `sudo` is disabled before the model
-process starts.
+directory. The pinned Action installs the exact Codex CLI and Responses proxy;
+the protected Workflow then runs
+`codex exec --dangerously-bypass-approvals-and-sandbox` with CPU,
+address-space, and process limits. Codex therefore has full runner-user
+filesystem and public-network access without an internal Bubblewrap sandbox.
+It inherits no host environment, the job has no Docker socket, and `sudo` is
+disabled before the model process starts. The trusted validator compares the
+candidate tree before and after the model and rejects any tracked mutation.
+Candidate checks execute only through the Check MCP in per-command disposable
+worktrees with dedicated HOME/TMP directories and a rootless network namespace
+whose own loopback supports local test servers. Configured organization CIDRs
+remain blocked inside that candidate-check namespace.
 
 Mandatory checks are selected deterministically from every changed path. The
 model may add a check only by protected catalog name through the local stdio
-Check MCP. The MCP resolves the immutable command and writes trusted results
-outside the read-only model session. Its credential-free stdio handshake runs
-on the trusted model host; each resolved check enters the pre-built
+Check MCP. The MCP resolves the immutable command and appends catalog-bound
+results to the evidence ledger. Its credential-free stdio handshake runs on
+the trusted model host; each resolved check enters the pre-built
 private-network namespace before its disposable checkout and filesystem
 sandbox start. Codex treats that MCP as required and fails the session if its
 protected tools cannot initialize. The validator

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -70,8 +70,8 @@ deterministic validation.
 The model can inspect the checkout, but model-authored commands and outcomes
 never count as evidence. It can request a protected check name through the
 local Check MCP. The trusted runner resolves fixed arguments, timeouts,
-working directories, and output bounds, then records a ledger outside the
-read-only model session.
+working directories, and output bounds, then appends catalog-bound records to
+the evidence ledger.
 
 All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
 `./...` is forbidden because Go package discovery ignores `.gitignore`.
@@ -86,13 +86,11 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
   network namespace with isolated loopback for local test servers.
 - The deterministic baseline disables the runner's `sudo` binary before
   candidate commands execute.
-- The model receives public internet with private, link-local, metadata,
-  runner-host, and configured organization CIDRs blocked. The Action's local
-  proxy is the sole transport loopback exception; the permission profile still
-  denies model-initiated localhost. It has no Docker socket, loses `sudo`
-  before execution, and uses the distribution `/usr/bin/bwrap` only after a
-  fail-closed user-namespace probe succeeds. A blocked probe loads only
-  Ubuntu's official path-specific AppArmor profile and must then pass.
+- Codex runs with full runner-user filesystem and public-network access through
+  `--dangerously-bypass-approvals-and-sandbox`. It receives no GitHub/App
+  credential or inherited host environment, has no Docker socket, and loses
+  `sudo` before execution. Candidate checks still use the private-network and
+  Bubblewrap boundary, and tracked candidate-tree mutation fails validation.
 - The protected Check MCP is required at Codex startup; missing named-check
   tools fail closed instead of degrading to an evidence-free model session.
 - The State Writer App can write only Contents state refs.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -24,11 +24,12 @@
   a narrow temporary AppArmor `userns` profile. The profile, copied binary, and
   directory are removed after the isolated namespace is ready and before any
   candidate command executes.
-- Review Agent model commands use the distribution `/usr/bin/bwrap`, not a
-  copied binary. The runner proves that it can create the model user namespace
-  before removing `sudo`; a blocked probe installs only Ubuntu's official
-  path-specific `bwrap-userns-restrict` profile and must then pass. The
-  protected Check MCP is required at Codex startup.
+- Review Agent Codex runs with full runner-user access through
+  `--dangerously-bypass-approvals-and-sandbox`. It receives no GitHub/App
+  credential or inherited host environment; Docker and `sudo` are disabled,
+  and tracked candidate-tree mutation is rejected. The protected Check MCP is
+  required at Codex startup and keeps candidate checks inside the rootless
+  network namespace and per-command Bubblewrap sandbox.
 - Review Agent baseline candidate-network rules live only in that rootless
   namespace, whose host loopback is disabled. The trusted host disables Docker
   and `sudo` but retains runner transport for pinned post-job Artifact actions.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -232,7 +232,8 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, raw, "--cpu=2400:2400")
 	require.Contains(t, raw, "--as=8589934592:8589934592")
 	require.Contains(t, raw, "--nproc=512:512")
-	require.Contains(t, raw, `--config 'default_permissions="review-agent"'`)
+	require.Contains(t, raw, "--dangerously-bypass-approvals-and-sandbox")
+	require.NotContains(t, raw, "default_permissions")
 	require.Contains(t, raw, "review_reason:$recovery[0].next_state.reason")
 	require.Contains(t, raw, "retention-days: 7")
 	require.Contains(t, raw, "retention-days: 30")
@@ -334,12 +335,12 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, fence, `sudo rmdir "$review_unshare_directory"`)
 	require.Equal(
 		t,
-		5,
+		3,
 		strings.Count(
 			fence,
 			`/proc/sys/kernel/apparmor_restrict_unprivileged_userns`,
 		),
-		"the global userns restriction must bracket both narrow exceptions",
+		"the global userns restriction must bracket the narrow namespace exception",
 	)
 	require.Contains(
 		t,
@@ -364,19 +365,8 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.NotContains(t, fence, "apply_network_rules host")
 	require.NotContains(t, fence, "keep-sudo")
 	require.NotContains(t, fence, "limit_runner_worker")
-	require.Contains(
-		t,
-		fence,
-		`review_bwrap_binary="/usr/bin/bwrap"`,
-	)
-	require.Contains(
-		t,
-		fence,
-		`review_bwrap_profile_source="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"`,
-	)
-	require.Contains(t, fence, `sudo apparmor_parser -r "$review_bwrap_profile"`)
-	require.Contains(t, fence, `--unshare-user`)
-	require.NotContains(t, fence, `wukongim-review-agent-bwrap`)
+	require.NotContains(t, fence, "prepare_model_sandbox")
+	require.NotContains(t, fence, "bwrap-userns-restrict")
 	require.Equal(
 		t,
 		4,
@@ -472,7 +462,8 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, reviewer, "timeout-minutes: 40")
 	require.Contains(t, reviewer, "environment: review-agent-model")
 	require.Contains(t, reviewer, "secrets.OPENAI_API_KEY")
-	require.Contains(t, reviewer, `--config 'default_permissions="review-agent"'`)
+	require.Contains(t, reviewer, "--dangerously-bypass-approvals-and-sandbox")
+	require.NotContains(t, reviewer, "default_permissions")
 	require.Contains(t, reviewer, "allow-bots: true")
 	require.Contains(t, reviewer, "required = true")
 	require.Contains(t, reviewer, `default_tools_approval_mode = "approve"`)
@@ -485,7 +476,7 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	)
 	require.NotContains(t, reviewer, `PATH="/opt/wukongim-review-agent:$PATH"`)
 	require.Contains(t, reviewer, "set -euo pipefail\n          prlimit \\")
-	require.Contains(t, reviewer, `extends = ":read-only"`)
+	require.NotContains(t, reviewer, "[permissions.review-agent]")
 	require.Contains(
 		t,
 		reviewer,


### PR DESCRIPTION
## Summary
- run the pinned Codex CLI with `--dangerously-bypass-approvals-and-sandbox`
- remove the custom read-only permissions profile and the now-unused model Bubblewrap/AppArmor preparation
- retain the ephemeral runner, empty inherited shell environment, disabled Docker/sudo, immutable candidate-tree check, protected Check MCP, trusted baseline, and validator

## Production evidence
PR #716 generation 14 proved that OpenRouter/Kimi and the required Check MCP both start successfully, but every Codex shell command still failed inside the CLI internal Bubblewrap layer with `setting up uid map: Permission denied`. The trusted validator safely forced that generation to `inconclusive`. Full runner access removes that failing internal layer as explicitly requested while keeping candidate checks in their separate protected namespace and Bubblewrap boundary.

## Validation
- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-run.yml`
- `bash -n .github/review-agent/network-fence.sh`
- shellcheck for the network-fence script
- `git diff --check`