### PR TITLE
fix(review-agent): decode one wrapped result object

### DIFF
--- a/internal/contracts/reviewagent/FLOW.md
+++ b/internal/contracts/reviewagent/FLOW.md
@@ -20,4 +20,7 @@ One immutable `GenerationIdentity` binds every document to the exact
 repository, pull request, head, base, test-merge revision, intent, generation
 number, and state parent. Decoders reject unknown fields, trailing JSON,
 oversized input, malformed identities, and unbounded collections. A
-model-authored result is advisory and contains no publication authority.
+model-authored Review result may contain bounded prose around exactly one
+strict JSON object; competing objects or containers fail closed. The decoded
+result is advisory and contains no publication authority. All trusted
+documents remain strict JSON-only.

--- a/internal/contracts/reviewagent/json.go
+++ b/internal/contracts/reviewagent/json.go
@@ -23,15 +23,9 @@ var (
 )
 
 func decodeStrictJSON(reader io.Reader, maxBytes int64, output any) error {
-	if reader == nil || maxBytes <= 0 {
-		return errors.New("JSON input limit must be positive")
-	}
-	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	body, err := readBoundedJSON(reader, maxBytes)
 	if err != nil {
-		return fmt.Errorf("read JSON input: %w", err)
-	}
-	if int64(len(body)) > maxBytes {
-		return errors.New("JSON input exceeds byte limit")
+		return err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
@@ -46,6 +40,20 @@ func decodeStrictJSON(reader io.Reader, maxBytes int64, output any) error {
 		return fmt.Errorf("decode trailing JSON input: %w", err)
 	}
 	return nil
+}
+
+func readBoundedJSON(reader io.Reader, maxBytes int64) ([]byte, error) {
+	if reader == nil || maxBytes <= 0 {
+		return nil, errors.New("JSON input limit must be positive")
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read JSON input: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, errors.New("JSON input exceeds byte limit")
+	}
+	return body, nil
 }
 
 func canonicalDigest(value any, message string) (string, error) {

--- a/internal/contracts/reviewagent/result.go
+++ b/internal/contracts/reviewagent/result.go
@@ -1,6 +1,7 @@
 package reviewagent
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -109,16 +110,48 @@ type ReviewResult struct {
 	UnresolvedUncertainty    string                    `json:"unresolved_uncertainty"`
 }
 
-// DecodeReviewResult strictly decodes one bounded advisory model response.
+// DecodeReviewResult decodes one bounded advisory model response. It accepts
+// strict JSON directly or one unambiguous JSON object wrapped in model prose.
 func DecodeReviewResult(reader io.Reader, maxBytes int64) (ReviewResult, error) {
-	var result ReviewResult
-	if err := decodeStrictJSON(reader, maxBytes, &result); err != nil {
+	body, err := readBoundedJSON(reader, maxBytes)
+	if err != nil {
 		return ReviewResult{}, err
+	}
+	var result ReviewResult
+	rawErr := decodeStrictJSON(bytes.NewReader(body), maxBytes, &result)
+	if rawErr != nil {
+		object, ok := extractSingleJSONObject(body)
+		if !ok {
+			return ReviewResult{}, rawErr
+		}
+		result = ReviewResult{}
+		if err := decodeStrictJSON(
+			bytes.NewReader(object),
+			maxBytes,
+			&result,
+		); err != nil {
+			return ReviewResult{}, err
+		}
 	}
 	if err := ValidateReviewResult(result); err != nil {
 		return ReviewResult{}, err
 	}
 	return result, nil
+}
+
+// extractSingleJSONObject rejects competing JSON containers while allowing a
+// model to surround its only structured result with bounded prose or a fence.
+func extractSingleJSONObject(body []byte) ([]byte, bool) {
+	start := bytes.IndexByte(body, '{')
+	end := bytes.LastIndexByte(body, '}')
+	if start < 0 || end <= start {
+		return nil, false
+	}
+	if bytes.ContainsAny(body[:start], "{}[]") ||
+		bytes.ContainsAny(body[end+1:], "{}[]") {
+		return nil, false
+	}
+	return bytes.TrimSpace(body[start : end+1]), true
 }
 
 // ValidateReviewResult rejects incomplete, contradictory, or unbounded model

--- a/internal/contracts/reviewagent/result_test.go
+++ b/internal/contracts/reviewagent/result_test.go
@@ -53,6 +53,39 @@ func TestDecodeReviewResultIsStrictAndBounded(t *testing.T) {
 	require.EqualError(t, err, "JSON input exceeds byte limit")
 }
 
+func TestDecodeReviewResultAcceptsOneProseWrappedJSONObject(t *testing.T) {
+	t.Parallel()
+
+	body := "The implementation is consistent and fail-closed.\n\n```json\n" +
+		validResultJSON() + "\n```\nReview complete."
+	result, err := reviewagent.DecodeReviewResult(
+		strings.NewReader(body),
+		int64(len(body)),
+	)
+	require.NoError(t, err)
+	require.Equal(t, reviewagent.DecisionChangesRequired, result.Decision)
+}
+
+func TestDecodeReviewResultRejectsAmbiguousWrappedJSON(t *testing.T) {
+	t.Parallel()
+
+	body := validResultJSON()
+	for name, input := range map[string]string{
+		"multiple objects": body + "\n{}",
+		"array wrapper":    "[" + body + "]",
+		"object in prose":  "Use {strict} output.\n" + body,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := reviewagent.DecodeReviewResult(
+				strings.NewReader(input),
+				int64(len(input)),
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestReviewResultLimitsFindingsAndRequiresCompleteInventory(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- accept bounded prose or a code fence around exactly one model-authored ReviewResult JSON object
- reject competing objects, array wrappers, and brace-bearing prose fail-closed
- keep trusted state, context, and evidence documents strict JSON-only

## Validation
- GOWORK=off go test ./internal/contracts/reviewagent ./internal/runtime/reviewagentverify ./internal/access/reviewagentcli ./cmd/wkreviewagent ./scripts/... -count=1
- GOWORK=off go vet ./internal/contracts/reviewagent
- git diff --check