### PR TITLE
fix(review-agent): normalize advisory model output

### DIFF
--- a/.github/review-agent/prompts/review.md
+++ b/.github/review-agent/prompts/review.md
@@ -48,7 +48,9 @@ Return exactly one schema-valid JSON object. Use `approved` only when the
 complete change is technically mergeable and no blocking risk remains. Use
 `changes_required` for concrete, high-confidence defects or failed mandatory
 checks attributable to the change. Use `inconclusive` for material uncertainty
-or incomplete evidence. Style preferences and optional refactors are advisory.
+or incomplete evidence. Set `unresolved_uncertainty` to exactly `""` for
+`approved`; for `inconclusive`, state the material uncertainty explicitly.
+Style preferences and optional refactors are advisory.
 
 Every blocking finding must name a failing scenario, concrete impact,
 supporting evidence, and a verifiable resolution condition. Keep locations

--- a/.github/review-agent/review-result.schema.json
+++ b/.github/review-agent/review-result.schema.json
@@ -243,6 +243,7 @@
     },
     "unresolved_uncertainty": {
       "type": "string",
+      "description": "Must be empty for approved; for inconclusive, must describe the material uncertainty.",
       "maxLength": 2048
     }
   },

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -105,6 +105,9 @@ Missing Context, reviewer, or trusted-baseline artifacts are evidence of an
 infrastructure failure, not reasons to abort the state machine. The Evidence
 job records the bounded retry or terminal `inconclusive` completion so signed
 state and the repository queue always advance.
+Before validation, that job normalizes the bounded model output through the
+Go ReviewResult decoder. Shell code does not implement a second JSON-shape
+policy.
 
 There is no scheduled Review Agent scan. A failed Controller effect is retried
 once; other recovery comes from a later event or an exact manual Controller

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -726,8 +726,9 @@ jobs:
           }
           if [[ -s "$result" &&
               "$(wc -c <"$result")" -le "$max_result_bytes" ]] &&
-              jq -e . "$result" >/dev/null 2>&1; then
-            cp "$result" "$RUNNER_TEMP/effective-result.json"
+              "$RUNNER_TEMP/wkreviewagent" normalize-review-result \
+                <"$result" >"$RUNNER_TEMP/effective-result.json"; then
+            :
           else
             synthesize
           fi

--- a/internal/access/reviewagentcli/FLOW.md
+++ b/internal/access/reviewagentcli/FLOW.md
@@ -1,16 +1,23 @@
 # Review Agent CLI Flow
 
-`internal/access/reviewagentcli` is a strict JSON-only process boundary. It
-accepts exactly one protected command name and one bounded JSON document on
-stdin, then emits exactly one JSON document on stdout.
+`internal/access/reviewagentcli` is a strict JSON control boundary. Every
+control command accepts exactly one bounded JSON document on stdin. The sole
+advisory-input exception is `normalize-review-result`, which accepts one
+bounded model-authored Review result and emits its validated, normalized JSON
+object.
 
 ```text
 GitHub Actions job
   -> exact command + strict JSON request
   -> internal/app Review Agent operation
   -> one bounded JSON response
+
+bounded model output
+  -> normalize-review-result
+  -> one validated ReviewResult JSON response
 ```
 
 The CLI does not parse shell plans, arbitrary commands, paths, URLs, secrets,
-or model instructions. Errors are generic and never echo input or credential
-material.
+or model instructions. Model-result normalization accepts only the contract's
+single unambiguous JSON object. Errors are generic and never echo input or
+credential material.

--- a/internal/access/reviewagentcli/command.go
+++ b/internal/access/reviewagentcli/command.go
@@ -1,4 +1,4 @@
-// Package reviewagentcli exposes the standalone Review Agent as strict JSON.
+// Package reviewagentcli exposes the standalone Review Agent process boundary.
 package reviewagentcli
 
 import (
@@ -158,6 +158,8 @@ func Run(
 	var output any
 	var err error
 	switch args[0] {
+	case "normalize-review-result":
+		output, err = contract.DecodeReviewResult(stdin, maxCLIInputBytes)
 	case "reconcile-github":
 		var request ReconcileGitHubRequest
 		if err = decodeStrict(stdin, &request); err == nil &&

--- a/internal/access/reviewagentcli/command_test.go
+++ b/internal/access/reviewagentcli/command_test.go
@@ -3,12 +3,14 @@ package reviewagentcli_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	cli "github.com/WuKongIM/WuKongIM/internal/access/reviewagentcli"
+	contract "github.com/WuKongIM/WuKongIM/internal/contracts/reviewagent"
 	verify "github.com/WuKongIM/WuKongIM/internal/runtime/reviewagentverify"
 )
 
@@ -86,6 +88,51 @@ func TestReviewAgentCLIDecodesWorkflowRiskSelection(t *testing.T) {
 	)
 	require.Zero(t, code)
 	require.Empty(t, stderr.String())
+}
+
+func TestReviewAgentCLINormalizesOneWrappedReviewResult(t *testing.T) {
+	t.Parallel()
+
+	result := contract.ReviewResult{
+		SchemaVersion: 1,
+		Generation: contract.GenerationIdentity{
+			Repository:     "WuKongIM/WuKongIM",
+			PullRequest:    716,
+			HeadSHA:        strings.Repeat("1", 40),
+			BaseSHA:        strings.Repeat("2", 40),
+			TestMergeSHA:   strings.Repeat("3", 40),
+			IntentDigest:   "sha256:" + strings.Repeat("4", 64),
+			Generation:     1,
+			StateParentSHA: strings.Repeat("5", 40),
+		},
+		Decision:          contract.DecisionApproved,
+		Summary:           "The complete change is safe.",
+		InventoryComplete: true,
+		FileAssessments: []contract.FileAssessment{{
+			Path:    "internal/example.go",
+			Risk:    contract.FileRiskLow,
+			Summary: "The implementation matches the stated intent.",
+		}},
+	}
+	body, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := cli.Run(
+		context.Background(),
+		[]string{"normalize-review-result"},
+		strings.NewReader("All checks pass.\n\n"+string(body)),
+		&stdout,
+		&stderr,
+		cli.Operations{},
+	)
+	require.Zero(t, code)
+	require.Empty(t, stderr.String())
+
+	var normalized contract.ReviewResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &normalized))
+	require.Equal(t, result, normalized)
 }
 
 func TestReviewAgentCLIRejectsFlagsUnknownFieldsAndTrailingInput(

--- a/scripts/review_agent_schema_test.go
+++ b/scripts/review_agent_schema_test.go
@@ -146,6 +146,7 @@ func TestReviewAgentPolicy(t *testing.T) {
 		"approved",
 		"changes_required",
 		"inconclusive",
+		"unresolved_uncertainty",
 		"must not modify",
 		"Check MCP",
 	} {
@@ -310,6 +311,8 @@ func hardenReviewAgentSchema(schema *jsonschema.Schema) {
 			setMinLength(property.Items, 1)
 		case "unresolved_uncertainty":
 			setMaxLength(property, reviewagent.MaxSummaryBytes)
+			property.Description = "Must be empty for approved; for inconclusive, " +
+				"must describe the material uncertainty."
 		case "interaction_request":
 			setMaxLength(property, 4096)
 		}

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -457,6 +457,17 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 		strings.Count(evidence, "continue-on-error: true"),
 		"missing context, reviewer, and baseline artifacts must fail closed",
 	)
+	require.Contains(
+		t,
+		evidence,
+		`"$RUNNER_TEMP/wkreviewagent" normalize-review-result`,
+	)
+	require.Equal(
+		t,
+		1,
+		strings.Count(evidence, `jq -e . "$result"`),
+		"only the distinct explanation contract remains strict JSON-only",
+	)
 
 	reviewer := issueAgentJobText(t, raw, "review")
 	require.Contains(t, reviewer, "timeout-minutes: 40")


### PR DESCRIPTION
## Summary

- normalize bounded Codex model output through the Go ReviewResult decoder before trusted validation
- keep every control command strict JSON while allowing exactly one unambiguous model-authored JSON object
- make the approved/inconclusive uncertainty contract explicit in the prompt and supported output schema

## Validation

- GOWORK=off go test ./internal/contracts/reviewagent ./internal/access/reviewagentcli ./internal/runtime/reviewagentverify ./cmd/wkreviewagent ./scripts/... -count=1
- GOWORK=off go vet ./internal/access/reviewagentcli ./cmd/wkreviewagent
- GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-run.yml
- git diff --check

Repository-wide actionlint still reports the pre-existing workflow_dispatch input-count issue in cloud-sim-provision.yml, which this PR does not modify.