### PR TITLE
fix(review-agent): collect evidence without executor

### DIFF
--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -26,6 +26,8 @@ GitHub-Actions composition roots. They do not call `New`, join a WuKongIM
 cluster, or start product runtimes. Review Agent composition keeps fresh
 GitHub reads, deterministic lifecycle, credential-free verification, signed
 state writes, and Review/Check publication behind separate role boundaries.
+Terminal `collect_only` verification reads and validates the frozen ledger
+without constructing the command executor used by the earlier baseline job.
 It also owns strict loading and cross-layer validation of the protected Review
 Agent policy before projecting narrow lifecycle and verifier configurations.
 

--- a/internal/app/review_agent.go
+++ b/internal/app/review_agent.go
@@ -499,6 +499,16 @@ func verifyReviewBaseline(
 	if err != nil {
 		return contract.ReviewEvidence{}, err
 	}
+	verificationPolicy := policy.VerificationPolicy()
+	if request.CollectOnly {
+		return verify.CollectEvidence(
+			ledger,
+			verificationPolicy,
+			now,
+			request.Context.Generation,
+			request.Context.MandatoryChecks,
+		)
+	}
 	executor, err := verify.NewOSExecutor(verify.OSExecutorConfig{
 		HomeDir: config.ExecutorHome, Path: config.ExecutablePath,
 		TempDir:       config.TemporaryDirectory,
@@ -511,19 +521,13 @@ func verifyReviewBaseline(
 	}
 	runner, err := verify.NewRunner(verify.RunnerConfig{
 		WorkspaceRoot: config.WorkspaceDirectory,
-		Policy:        policy.VerificationPolicy(),
+		Policy:        verificationPolicy,
 		Executor:      executor,
 		Ledger:        ledger,
 		Now:           now,
 	})
 	if err != nil {
 		return contract.ReviewEvidence{}, err
-	}
-	if request.CollectOnly {
-		return runner.CollectEvidence(
-			request.Context.Generation,
-			request.Context.MandatoryChecks,
-		)
 	}
 	checks := make([]contract.CheckEvidence, 0, len(request.Context.MandatoryChecks))
 	for _, name := range request.Context.MandatoryChecks {

--- a/internal/app/review_agent_internal_test.go
+++ b/internal/app/review_agent_internal_test.go
@@ -2,15 +2,101 @@ package app
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	cli "github.com/WuKongIM/WuKongIM/internal/access/reviewagentcli"
 	contract "github.com/WuKongIM/WuKongIM/internal/contracts/reviewagent"
 	reviewagentgithub "github.com/WuKongIM/WuKongIM/internal/infra/reviewagentgithub"
+	verify "github.com/WuKongIM/WuKongIM/internal/runtime/reviewagentverify"
 	reviewagent "github.com/WuKongIM/WuKongIM/internal/usecase/reviewagent"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCollectOnlyReviewBaselineNeedsNoProcessExecutor(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	ledgerPath := filepath.Join(t.TempDir(), "ledger.jsonl")
+	ledger, err := verify.NewFileLedger(ledgerPath, workspace)
+	require.NoError(t, err)
+	generation := contract.GenerationIdentity{
+		Repository:     "WuKongIM/WuKongIM",
+		PullRequest:    716,
+		HeadSHA:        strings.Repeat("1", 40),
+		BaseSHA:        strings.Repeat("2", 40),
+		TestMergeSHA:   strings.Repeat("3", 40),
+		IntentDigest:   "sha256:" + strings.Repeat("4", 64),
+		Generation:     17,
+		StateParentSHA: strings.Repeat("5", 40),
+	}
+	require.NoError(t, ledger.Append(generation, contract.CheckEvidence{
+		Name:          "go-format",
+		CommandDigest: testReviewDigest("command"),
+		Outcome:       contract.CheckOutcomePassed,
+		DurationMS:    1,
+		StdoutDigest:  testReviewDigest(""),
+		StderrDigest:  testReviewDigest(""),
+	}))
+	contextValue := contract.ReviewContext{
+		SchemaVersion:      1,
+		Generation:         generation,
+		PolicyDigest:       testReviewDigest("policy"),
+		PromptDigest:       testReviewDigest("prompt"),
+		OutputSchemaDigest: testReviewDigest("schema"),
+		ReviewReason:       "synchronize",
+		Title:              "Collect trusted evidence",
+		ChangedFiles: []contract.ChangedFile{{
+			Path:          "internal/example.go",
+			Status:        contract.FileStatusModified,
+			Mode:          "100644",
+			Type:          "text",
+			Patch:         "@@ -1 +1 @@",
+			PatchDigest:   testReviewDigest("@@ -1 +1 @@"),
+			ContentDigest: testReviewDigest(""),
+		}},
+		MandatoryChecks: []string{"go-format"},
+	}
+	now := time.Date(2026, 7, 31, 13, 42, 20, 0, time.UTC)
+	evidence, err := verifyReviewBaseline(
+		context.Background(),
+		ReviewAgentConfig{
+			PolicyPath: filepath.Join(
+				"..", "..", ".github", "review-agent", "policy.json",
+			),
+			WorkspaceDirectory: workspace,
+			EvidenceLedgerPath: ledgerPath,
+			ExecutorHome:       t.TempDir(),
+			ExecutablePath:     os.Getenv("PATH"),
+			ProcessSandboxPath: filepath.Join(t.TempDir(), "missing-bwrap"),
+			ProcessHelperPath:  filepath.Join(t.TempDir(), "missing-helper"),
+		},
+		func() time.Time { return now },
+		cli.VerifyBaselineRequest{
+			Context: contextValue, CollectOnly: true,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, generation, evidence.Generation)
+	require.Equal(t, []contract.CheckEvidence{{
+		Name:          "go-format",
+		CommandDigest: testReviewDigest("command"),
+		Outcome:       contract.CheckOutcomePassed,
+		DurationMS:    1,
+		StdoutDigest:  testReviewDigest(""),
+		StderrDigest:  testReviewDigest(""),
+	}}, evidence.Checks)
+}
+
+func testReviewDigest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
 
 func TestResolveReviewCommandIgnoresOrdinaryStatusComment(t *testing.T) {
 	t.Parallel()

--- a/internal/runtime/reviewagentverify/runner.go
+++ b/internal/runtime/reviewagentverify/runner.go
@@ -122,16 +122,47 @@ func (runner *Runner) CollectEvidence(
 	generation contract.GenerationIdentity,
 	mandatory []string,
 ) (contract.ReviewEvidence, error) {
+	if runner == nil {
+		return contract.ReviewEvidence{}, errors.New(
+			"evidence collector is unavailable",
+		)
+	}
+	return CollectEvidence(
+		runner.ledger,
+		runner.policy,
+		runner.now,
+		generation,
+		mandatory,
+	)
+}
+
+// CollectEvidence reads and validates trusted ledger evidence without
+// constructing a process executor.
+func CollectEvidence(
+	ledger EvidenceLedger,
+	policy Policy,
+	now func() time.Time,
+	generation contract.GenerationIdentity,
+	mandatory []string,
+) (contract.ReviewEvidence, error) {
+	if ledger == nil || len(policy.TrustedChecks) == 0 {
+		return contract.ReviewEvidence{}, errors.New(
+			"invalid evidence collector configuration",
+		)
+	}
+	if now == nil {
+		now = time.Now
+	}
 	if err := contract.ValidateGenerationIdentity(generation); err != nil {
 		return contract.ReviewEvidence{}, err
 	}
-	records, err := runner.ledger.List(generation)
+	records, err := ledger.List(generation)
 	if err != nil {
 		return contract.ReviewEvidence{}, err
 	}
 	latest := make(map[string]contract.CheckEvidence)
 	for _, record := range records {
-		if _, protected := runner.policy.TrustedChecks[record.Evidence.Name]; !protected {
+		if _, protected := policy.TrustedChecks[record.Evidence.Name]; !protected {
 			return contract.ReviewEvidence{}, errors.New(
 				"evidence ledger names an unknown trusted check",
 			)
@@ -139,7 +170,7 @@ func (runner *Runner) CollectEvidence(
 		latest[record.Evidence.Name] = record.Evidence
 	}
 	for _, name := range mandatory {
-		if _, exists := runner.policy.TrustedChecks[name]; !exists {
+		if _, exists := policy.TrustedChecks[name]; !exists {
 			return contract.ReviewEvidence{}, errors.New(
 				"mandatory evidence names an unknown trusted check",
 			)
@@ -164,7 +195,7 @@ func (runner *Runner) CollectEvidence(
 		Generation:    generation,
 		Complete:      true,
 		Checks:        checks,
-		CreatedAt:     runner.now().UTC(),
+		CreatedAt:     now().UTC(),
 	}
 	if err := contract.ValidateReviewEvidence(evidence); err != nil {
 		return contract.ReviewEvidence{}, err


### PR DESCRIPTION
## Summary

- collect a frozen Review Agent ledger without constructing the command executor
- keep command execution and sandbox validation on the earlier baseline path only
- add a regression test proving collect_only succeeds when process sandbox/helper binaries are absent

## Evidence

Generation 17 produced a valid Kimi approval and five passing checks, but the terminal validator failed before reading the ledger because its clean job intentionally has no command helper. Replaying the exact generation-17 context, ledger, tree digests, and model result with this change produces approved with non-empty evidence and result digests.

## Validation

- GOWORK=off go test ./internal/runtime/reviewagentverify ./internal/app ./internal/access/reviewagentcli ./cmd/wkreviewagent ./scripts/... -count=1
- GOWORK=off go vet ./internal/runtime/reviewagentverify ./internal/app ./internal/access/reviewagentcli ./cmd/wkreviewagent
- exact generation-17 artifact replay through verify-baseline and validate-review-result
- git diff --check