### PR TITLE
fix(review-agent): accept signed no-op drain plan

### DIFF
--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -1030,7 +1030,12 @@ jobs:
           INPUT_PULL_REQUEST: ${{ inputs.pull_request }}
         run: |
           set -euo pipefail
-          retry="$(jq -er .plan.dispatch \
+          retry="$(jq -r \
+            'if (.plan.dispatch | type) == "boolean" then
+              .plan.dispatch
+            else
+              error("plan.dispatch must be boolean")
+            end' \
             "$RUNNER_TEMP/review-agent-terminal/terminal-plan.json")"
           if [[ "$retry" == true ]]; then
             lease="$(jq -er .plan.lease_run_id \

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -546,6 +546,18 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.NotContains(t, drain, "actions/checkout")
 }
 
+func TestReviewAgentDrainAcceptsSignedNoOpPlan(t *testing.T) {
+	raw := readIssueAgentFile(t, ".github/workflows/review-agent-run.yml")
+	drain := issueAgentJobText(t, raw, "drain")
+	require.Contains(
+		t,
+		drain,
+		`(.plan.dispatch | type) == "boolean"`,
+		"a signed false dispatch value is a valid no-op, not a jq error",
+	)
+	require.NotContains(t, drain, "jq -er .plan.dispatch")
+}
+
 func TestLegacyAgentPRValidationIsAbsent(t *testing.T) {
 	root := repoRoot(t)
 	for _, relative := range []string{


### PR DESCRIPTION
## Summary

- treat a signed `dispatch: false` terminal plan as a successful drain no-op
- retain fail-closed rejection for non-boolean dispatch values
- add a workflow contract regression test forbidding `jq -e` on the boolean field

## Evidence

- observed in generation 18: the review, trusted validation, signed state, and formal APPROVED publication succeeded, while the drain job failed because `jq -e` returns 1 for valid `false`
- failing run: https://github.com/WuKongIM/WuKongIM/actions/runs/30637024222

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-run.yml`
- direct jq probe: false and true accepted; non-boolean rejected
- `git diff --check`