### PR TITLE
fix: unblock Issue Agent canary publication

### DIFF
--- a/.github/issue-agent/prompts/engineer.md
+++ b/.github/issue-agent/prompts/engineer.md
@@ -29,6 +29,22 @@ Then:
    test claims are advisory; a clean Verifier independently decides whether
    publication is allowed.
 
+Your final response MUST be exactly one JSON object, with no surrounding prose,
+Markdown fence, or extra keys. Copy `repository`, `issue_number`, and `task_id`
+verbatim from the Context Bundle. Include exactly these keys:
+`"schema_version"`, `"repository"`, `"issue_number"`, `"task_id"`,
+`"outcome"`, `"external_symptom"`, `"root_cause"`, `"causal_path"`,
+`"evidence_references"`, `"proposed_risk"`, `"tests_attempted"`,
+`"unresolved_uncertainty"`, `"summary"`, and `"ready"`.
+
+`schema_version` MUST be `2`. `outcome` MUST be one of `ready`,
+`needs_human`, `already_fixed`, or `failed`.
+Set `ready` to true if and only if `outcome` is `ready`. A ready result MUST
+include non-empty `root_cause`, `causal_path`, `evidence_references`, and
+`tests_attempted`. Use an empty string or empty array for an inapplicable value;
+never use `null`. Array entries MUST be non-empty and unique, and
+`proposed_risk` MUST be sorted lexicographically.
+
 If you cannot reproduce or directly evidence the failure, the root cause is
 uncertain, the required repair crosses the trusted risk ceiling, or tests do
 not pass, do not make a speculative production change. Return `needs_human` or

--- a/.github/issue-agent/prompts/review.md
+++ b/.github/issue-agent/prompts/review.md
@@ -18,3 +18,19 @@ credentials. Leave only the complete candidate in the working tree and emit
 the strict Engineer Result JSON. If the feedback conflicts, requires a
 high-risk change, or cannot be verified, return `needs_human` without a
 speculative production change.
+
+Your final response MUST be exactly one JSON object, with no surrounding prose,
+Markdown fence, or extra keys. Copy `repository`, `issue_number`, and `task_id`
+verbatim from the Context Bundle. Include exactly these keys:
+`"schema_version"`, `"repository"`, `"issue_number"`, `"task_id"`,
+`"outcome"`, `"external_symptom"`, `"root_cause"`, `"causal_path"`,
+`"evidence_references"`, `"proposed_risk"`, `"tests_attempted"`,
+`"unresolved_uncertainty"`, `"summary"`, and `"ready"`.
+
+`schema_version` MUST be `2`. `outcome` MUST be one of `ready`,
+`needs_human`, `already_fixed`, or `failed`.
+Set `ready` to true if and only if `outcome` is `ready`. A ready result MUST
+include non-empty `root_cause`, `causal_path`, `evidence_references`, and
+`tests_attempted`. Use an empty string or empty array for an inapplicable value;
+never use `null`. Array entries MUST be non-empty and unique, and
+`proposed_risk` MUST be sorted lexicographically.

--- a/.github/review-agent/policy.json
+++ b/.github/review-agent/policy.json
@@ -30,7 +30,7 @@
     "max_changed_files": 50,
     "max_changed_bytes": 131072,
     "max_changed_lines": 10000,
-    "max_context_bytes": 196608,
+    "max_context_bytes": 393216,
     "max_model_response_bytes": 4194304,
     "max_context_tokens": 240000,
     "auto_compact_tokens": 216000,

--- a/.github/workflows/issue-agent-engineer.yml
+++ b/.github/workflows/issue-agent-engineer.yml
@@ -248,6 +248,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          install -d -m 0700 "$RUNNER_TEMP/issue-agent-verifier"
           jq -n \
             --arg checkout "$GITHUB_WORKSPACE" \
             --arg temporary_root "$RUNNER_TEMP/issue-agent-verifier" \

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -715,8 +715,8 @@ jobs:
                 path:.path,risk:"high",
                 summary:"Not safely adjudicated in this generation."
               }],
-              findings:[.prior_findings[].finding],
-              prior_finding_dispositions:[.prior_findings[] | {
+              findings:[(.prior_findings // [])[].finding],
+              prior_finding_dispositions:[(.prior_findings // [])[] | {
                 finding_digest:.digest,status:"retained",
                 reason:"Trusted fallback retains this finding because adjudication was incomplete."
               }],

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -122,7 +122,7 @@ mandatory checks, invalid findings, excessive output, and unexpected
 tracked-file mutation.
 
 The protected bounds admit at most 50 changed files, 128 KiB of captured
-change material, 10,000 changed lines, and a 192 KiB encoded Context. This
+change material, 10,000 changed lines, and a 384 KiB encoded Context. This
 conservatively enforces the 240,000-token model window and keeps three
 concurrent exact-content reads within the repository API budget.
 

--- a/internal/app/review_agent_policy.go
+++ b/internal/app/review_agent_policy.go
@@ -175,7 +175,7 @@ func ValidateReviewAgentPolicy(document ReviewAgentPolicy) error {
 		document.Limits.MaxChangedFiles != contract.MaxChangedFiles ||
 		document.Limits.MaxChangedBytes != 131072 ||
 		document.Limits.MaxChangedLines != 10000 ||
-		document.Limits.MaxContextBytes != 196608 ||
+		document.Limits.MaxContextBytes != 393216 ||
 		document.Limits.MaxModelResponseBytes <= 0 ||
 		document.Limits.MaxContextTokens != 240000 ||
 		document.Limits.AutoCompactTokens != 216000 ||

--- a/internal/app/sendack_smoke_test.go
+++ b/internal/app/sendack_smoke_test.go
@@ -178,6 +178,9 @@ func seedGroupSendPermission(t *testing.T, node *cluster.Node, channelID channel
 
 func TestSingleNodeClusterAppConfigUsesStableLeaseAndExplicitlyDisablesPlugins(t *testing.T) {
 	cfg := singleNodeClusterAppConfig(t)
+	if cfg.Log.Dir == "" {
+		t.Fatal("log directory is empty, want an isolated test directory")
+	}
 	if cfg.Cluster.HealthReport.Interval != 20*time.Millisecond {
 		t.Fatalf("health interval = %v, want 20ms", cfg.Cluster.HealthReport.Interval)
 	}
@@ -203,6 +206,7 @@ func singleNodeClusterAppConfig(t *testing.T) Config {
 	cfg := Config{
 		NodeID:  nodeID,
 		DataDir: shortAppTestDataDir(t),
+		Log:      LogConfig{Dir: t.TempDir()},
 		Plugin:  plugin,
 		Cluster: cluster.Config{
 			NodeID:     nodeID,

--- a/internal/runtime/reviewagentverify/inventory.go
+++ b/internal/runtime/reviewagentverify/inventory.go
@@ -87,8 +87,14 @@ func BuildInventory(
 			return Inventory{}, errors.New("duplicate changed-file path")
 		}
 		seen[key] = struct{}{}
-		result.TotalBytes += int64(len(file.Patch) + len(file.Content))
-		result.TotalLines += countLines(file.Patch) + countLines(file.Content)
+		// A complete text patch already contains both revisions, including the
+		// head content. Charge that representation once. Binary patches are
+		// empty, so charge the exact blob retained only for its digest.
+		result.TotalBytes += int64(len(file.Patch))
+		result.TotalLines += countLines(file.Patch)
+		if file.Type == FileTypeBinary {
+			result.TotalBytes += int64(len(file.Content))
+		}
 		if result.TotalBytes > limits.MaxTotalBytes {
 			return Inventory{}, errors.New("changed-byte budget exceeded")
 		}

--- a/internal/runtime/reviewagentverify/inventory_test.go
+++ b/internal/runtime/reviewagentverify/inventory_test.go
@@ -106,7 +106,7 @@ func TestInventoryFailsClosedOnTruncationOrCountMismatch(t *testing.T) {
 		})
 	}
 
-	_, err := verify.BuildInventory(
+	inventory, err := verify.BuildInventory(
 		1,
 		[]verify.RawFile{{
 			Path: "README.md", Status: contract.FileStatusModified,
@@ -115,7 +115,23 @@ func TestInventoryFailsClosedOnTruncationOrCountMismatch(t *testing.T) {
 			Content: []byte(strings.Repeat("x", 100)),
 		}},
 		verify.InventoryLimits{
-			MaxFiles: 10, MaxTotalBytes: 50, MaxLines: 1000,
+			MaxFiles: 10, MaxTotalBytes: 100, MaxLines: 1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), inventory.TotalBytes)
+	require.Equal(t, int64(1), inventory.TotalLines)
+
+	_, err = verify.BuildInventory(
+		1,
+		[]verify.RawFile{{
+			Path: "README.md", Status: contract.FileStatusModified,
+			Mode: "100644", Type: verify.FileTypeText,
+			Patch:   []byte(strings.Repeat("x", 101)),
+			Content: []byte(strings.Repeat("x", 100)),
+		}},
+		verify.InventoryLimits{
+			MaxFiles: 10, MaxTotalBytes: 100, MaxLines: 1,
 		},
 	)
 	require.EqualError(t, err, "changed-byte budget exceeded")

--- a/scripts/issue_agent_workflows_test.go
+++ b/scripts/issue_agent_workflows_test.go
@@ -154,6 +154,15 @@ func TestIssueAgentImmutableBaselineKeepsCanonicalGitModes(t *testing.T) {
 	require.NotContains(t, engineer, "sudo chmod -R a-w")
 }
 
+func TestIssueAgentVerifierCreatesItsTemporaryRoot(t *testing.T) {
+	engineer := readIssueAgentFile(t, ".github/workflows/issue-agent-engineer.yml")
+	create := `install -d -m 0700 "$RUNNER_TEMP/issue-agent-verifier"`
+	verify := `"$RUNNER_TEMP/wkissueagent" verify-candidate`
+	require.Contains(t, engineer, create)
+	require.Contains(t, engineer, verify)
+	require.Less(t, strings.Index(engineer, create), strings.Index(engineer, verify))
+}
+
 func TestIssueAgentReusableCallerGrantsOnlyRequiredReadScopes(t *testing.T) {
 	raw := readIssueAgentFile(t, ".github/workflows/issue-agent.yml")
 	caller := issueAgentJobText(t, raw, "engineer")
@@ -334,6 +343,12 @@ func TestIssueAgentPolicyIsCodexOnlyAndBounded(t *testing.T) {
 }
 
 func TestIssueAgentPromptsMakeAuthorityAndOutcomeExplicit(t *testing.T) {
+	requiredResultFields := []string{
+		"schema_version", "repository", "issue_number", "task_id", "outcome",
+		"external_symptom", "root_cause", "causal_path", "evidence_references",
+		"proposed_risk", "tests_attempted", "unresolved_uncertainty", "summary",
+		"ready",
+	}
 	for _, name := range []string{"engineer.md", "review.md"} {
 		raw := readIssueAgentFile(
 			t,
@@ -346,6 +361,12 @@ func TestIssueAgentPromptsMakeAuthorityAndOutcomeExplicit(t *testing.T) {
 		require.Contains(t, strings.ToLower(raw), "do not commit")
 		require.Contains(t, strings.ToLower(raw), "three modify/test")
 		require.NotContains(t, strings.ToLower(raw), "deepseek")
+		require.Contains(t, raw,
+			"exactly one JSON object, with no surrounding prose")
+		require.Contains(t, raw, "never use `null`")
+		for _, field := range requiredResultFields {
+			require.Contains(t, raw, `"`+field+`"`, name+": "+field)
+		}
 	}
 }
 

--- a/scripts/review_agent_schema_test.go
+++ b/scripts/review_agent_schema_test.go
@@ -45,6 +45,7 @@ func TestReviewAgentPolicy(t *testing.T) {
 	require.Equal(t, reviewagent.MaxInlineComments, policy.Limits.MaxInlineComments)
 	require.Equal(t, reviewagent.MaxFindings, policy.Limits.MaxFindings)
 	require.Equal(t, reviewagent.MaxChangedFiles, policy.Limits.MaxChangedFiles)
+	require.Equal(t, 393216, policy.Limits.MaxContextBytes)
 	require.Equal(t, 240000, policy.Limits.MaxContextTokens)
 	require.Equal(t, 216000, policy.Limits.AutoCompactTokens)
 	require.Equal(t, 3600, policy.Limits.MaxCPUSecondsPerProcess)

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -293,6 +293,7 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, raw, "for attempt in {1..20}")
 	require.Contains(t, raw, "terminal-request.json")
 	require.Contains(t, raw, "prior_finding_dispositions")
+	require.Equal(t, 2, strings.Count(raw, "(.prior_findings // [])[]"))
 	require.Contains(t, raw, "gh workflow run review-agent-run.yml")
 	require.Contains(t, raw, `-f "infrastructure_attempt=$attempt"`)
 	require.Contains(t, raw, "review-agent-trusted-baseline")


### PR DESCRIPTION
## Summary

- create the verifier temporary root before constructing its isolated process runner
- make both Issue Agent Codex prompts require the exact EngineerResult contract
- isolate single-node cluster smoke-test logs so trusted verification leaves the checkout unchanged
- admit complete Review Agent contexts without double-charging duplicated head content
- make the Review Agent trusted fallback null-safe when no prior findings exist
- add contract regressions for every failure found by the live canary

## Evidence

The first Issue #712 canary reached Kimi and produced the correct one-line documentation candidate. Run 30657019719 then failed closed because the verifier temporary root did not exist and Kimi emitted an obsolete result shape.

The first Review Agent pass on this PR exposed two more deterministic control-plane defects: a small change to a large file exceeded the context budget because head content was counted twice, and the trusted fallback iterated a null prior_findings value. Replaying the exact signed PR #741 generation now builds a complete five-file Context of 249,368 bytes under the protected 384 KiB limit.

Using this branch as the exact base, the captured #712 candidate produces trusted CandidateEvidence with risk low, publication_eligible true, and the full fixed Go verification command exiting 0.

## Validation

- GOWORK=off go test ./internal/app -count=1
- GOWORK=off go test ./internal/runtime/issueagentverify ./internal/contracts/issueagent ./scripts/... -count=1
- GOWORK=off go test ./cmd/wkreviewagent ./internal/access/reviewagentcli ./internal/contracts/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/usecase/reviewagent -count=1
- GOWORK=off go test -tags=integration ./internal/runtime/issueagentverify -run TestProcessRunnerExecutesArgvWithoutShell -count=1
- GOWORK=off go vet ./cmd/wkreviewagent ./internal/access/reviewagentcli ./internal/contracts/reviewagent ./internal/runtime/reviewagentverify ./internal/infra/reviewagentgithub ./internal/usecase/reviewagent ./internal/app ./scripts/...
- actionlint v1.7.9 for the changed workflows
- exact #712 candidate clean-verifier replay: publication_eligible true
- exact signed #741 Context Builder replay: complete, 5 files, 249,368 bytes
- null prior-findings fallback jq replay
- git diff --check

This PR changes protected Issue Agent and Review Agent control files and therefore requires owner review before merge.