### PR TITLE
fix: recover delayed Issue Agent state signatures

### DIFF
--- a/internal/app/sendack_smoke_test.go
+++ b/internal/app/sendack_smoke_test.go
@@ -206,7 +206,7 @@ func singleNodeClusterAppConfig(t *testing.T) Config {
 	cfg := Config{
 		NodeID:  nodeID,
 		DataDir: shortAppTestDataDir(t),
-		Log:      LogConfig{Dir: t.TempDir()},
+		Log:     LogConfig{Dir: t.TempDir()},
 		Plugin:  plugin,
 		Cluster: cluster.Config{
 			NodeID:     nodeID,

--- a/internal/infra/issueagentgithub/FLOW.md
+++ b/internal/infra/issueagentgithub/FLOW.md
@@ -25,10 +25,11 @@ author, and GitHub signature match. No method merges a PR or closes a Bug
 Issue.
 
 If a state publication reports an error or an untrusted immediate result after
-the remote write, the State Store re-reads the per-Issue ref once. It recovers
-only when the ref points to the exact expected parent, canonical state content,
+the remote write, the State Store re-reads the per-Issue ref through one
+context-cancellable, 3.1-second bounded consistency window. It recovers only
+when the ref points to the exact expected parent, canonical state content,
 path, configured App Bot author, and GitHub-signed commit. Missing, different,
-or unverifiable successors retain the original fail-closed result.
+or still-unverifiable successors retain the original fail-closed result.
 
 The scheduled inventory is a complete, sorted set of at most 40 open
 `ready-for-agent` Issues. A larger or paginated result fails closed.

--- a/internal/infra/issueagentgithub/state_store.go
+++ b/internal/infra/issueagentgithub/state_store.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	contract "github.com/WuKongIM/WuKongIM/internal/contracts/issueagent"
 )
@@ -17,6 +18,8 @@ import (
 var appBotLoginPattern = regexp.MustCompile(
 	`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\[bot\]$`,
 )
+
+const statePublicationRecoveryAttempts = 7
 
 // StateCommitRequest is one exact expected-head state publication.
 type StateCommitRequest struct {
@@ -135,18 +138,29 @@ func (store *StateStore) Advance(
 	recoverPublication := func(
 		publicationErr error,
 	) (StatePublication, error) {
-		recovered, recoverErr := store.recoverExactPublication(
-			ctx,
-			request.State.IssueNumber,
-			branch,
-			path,
-			request.ExpectedParentSHA,
-			content,
-		)
-		if recoverErr != nil {
-			return StatePublication{}, publicationErr
+		// Re-read twice immediately, then allow GitHub's signature and compare
+		// projections one short, bounded consistency window to converge.
+		for attempt := 0; attempt < statePublicationRecoveryAttempts; attempt++ {
+			delay := time.Duration(0)
+			if attempt >= 2 {
+				delay = (100 * time.Millisecond) << (attempt - 2)
+			}
+			if err := waitStatePublicationRecovery(ctx, delay); err != nil {
+				return StatePublication{}, publicationErr
+			}
+			recovered, recoverErr := store.recoverExactPublication(
+				ctx,
+				request.State.IssueNumber,
+				branch,
+				path,
+				request.ExpectedParentSHA,
+				content,
+			)
+			if recoverErr == nil {
+				return recovered, nil
+			}
 		}
-		return recovered, nil
+		return StatePublication{}, publicationErr
 	}
 	result, err := store.commits.PublishStateCommit(ctx, StateCommitRequest{
 		Branch: branch, Path: path,
@@ -175,6 +189,23 @@ func (store *StateStore) Advance(
 		)
 	}
 	return StatePublication{HeadSHA: result.CommitSHA}, nil
+}
+
+func waitStatePublicationRecovery(
+	ctx context.Context,
+	delay time.Duration,
+) error {
+	if delay == 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // recoverExactPublication performs one independent read after an ambiguous

--- a/internal/infra/issueagentgithub/state_store_test.go
+++ b/internal/infra/issueagentgithub/state_store_test.go
@@ -66,6 +66,25 @@ func TestStateStoreRecoversExactSignedStateAfterAmbiguousPublish(t *testing.T) {
 	require.Equal(t, stateStoreRecoveryHeadSHA, published.HeadSHA)
 }
 
+func TestStateStoreRetriesExactSignedStateDuringGitHubConsistencyWindow(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	state := stateStoreRecoveryState()
+	port := stateStoreRecoveryPort(t, state)
+	port.publishErr = errors.New("transient post-publish verification failure")
+	port.readFailures = 1
+
+	published, err := stateStoreForTest(t, port).Advance(
+		context.Background(),
+		stateStoreRecoveryRequest(state),
+	)
+	require.NoError(t, err)
+	require.Equal(t, stateStoreRecoveryHeadSHA, published.HeadSHA)
+	require.Equal(t, 2, port.readCalls)
+}
+
 func TestStateStoreRecoversExactSignedStateAfterAmbiguousTrustResult(t *testing.T) {
 	t.Parallel()
 
@@ -257,6 +276,8 @@ type stateCommitPortStub struct {
 	publishResult *issueagentgithub.StateCommitResult
 	head          string
 	records       map[string]issueagentgithub.StateCommitRecord
+	readFailures  int
+	readCalls     int
 }
 
 func (port *stateCommitPortStub) PublishStateCommit(
@@ -295,5 +316,11 @@ func (port *stateCommitPortStub) ReadStateCommit(
 	commitSHA string,
 	_ string,
 ) (issueagentgithub.StateCommitRecord, error) {
+	port.readCalls++
+	if port.readFailures > 0 {
+		port.readFailures--
+		return issueagentgithub.StateCommitRecord{},
+			errors.New("GitHub commit verification is not visible yet")
+	}
 	return port.records[commitSHA], nil
 }


### PR DESCRIPTION
## Summary

- retry exact signed state publication recovery inside a context-cancellable 3.1-second consistency window
- preserve every existing parent, content, path, App identity, and GitHub signature check
- document the bounded recovery contract and cover a transient first re-read failure

## Evidence

Issue Agent run 30662771083 committed state sequence 2 for issue #742, but failed in the same second that GitHub recorded the commit signature as verified. The next reconciliation loaded the exact signed state successfully but could not redispatch its already-recorded task.

## Validation

- GOWORK=off go test ./internal/infra/issueagentgithub ./internal/usecase/issueagent ./internal/contracts/issueagent -count=1
- GOWORK=off go test ./internal/app -count=1
- GOWORK=off go test ./scripts/... -count=1
- GOWORK=off go vet ./internal/infra/issueagentgithub ./internal/usecase/issueagent ./internal/contracts/issueagent ./internal/app