### PR TITLE
fix(issue-agent): decode one prose-wrapped result

### DIFF
--- a/internal/contracts/issueagent/FLOW.md
+++ b/internal/contracts/issueagent/FLOW.md
@@ -22,8 +22,8 @@ fresh GitHub fences + exact candidate/evidence digests
 
 All decoded JSON objects reject unknown fields, oversized input, malformed
 identities, and trailing JSON. `EngineerResult` may unwrap exactly one
-Markdown `json` fence from a model's final message before applying that strict
-JSON contract; ambiguous or multiple fences fail closed. `EngineerResult`
-never grants publication authority. Only a low-risk, passing
-`CandidateEvidence` bound to the exact task and candidate can enter a
-Publisher plan.
+unambiguous JSON object from bounded model prose or one Markdown `json` fence
+before applying that strict JSON contract; competing containers and
+brace-bearing prose fail closed. `EngineerResult` never grants publication
+authority. Only a low-risk, passing `CandidateEvidence` bound to the exact task
+and candidate can enter a Publisher plan.

--- a/internal/contracts/issueagent/engineer_result.go
+++ b/internal/contracts/issueagent/engineer_result.go
@@ -92,7 +92,7 @@ func extractSingleJSONFence(body []byte) ([]byte, bool) {
 		if index > open && index < close {
 			continue
 		}
-		if bytes.ContainsAny(line, "{}") {
+		if bytes.ContainsAny(line, "{}[]") {
 			return nil, false
 		}
 	}
@@ -108,7 +108,9 @@ func extractSingleJSONObject(body []byte) ([]byte, bool) {
 		return nil, false
 	}
 	if bytes.ContainsAny(body[:start], "{}[]") ||
-		bytes.ContainsAny(body[end+1:], "{}[]") {
+		bytes.ContainsAny(body[end+1:], "{}[]") ||
+		bytes.Contains(body[:start], []byte("```")) ||
+		bytes.Contains(body[end+1:], []byte("```")) {
 		return nil, false
 	}
 	return bytes.TrimSpace(body[start : end+1]), true

--- a/internal/contracts/issueagent/engineer_result.go
+++ b/internal/contracts/issueagent/engineer_result.go
@@ -44,13 +44,16 @@ func DecodeEngineerResult(reader io.Reader, maxBytes int64) (EngineerResult, err
 	var result EngineerResult
 	rawErr := decodeStrictJSON(bytes.NewReader(body), maxBytes, &result)
 	if rawErr != nil {
-		fenced, ok := extractSingleJSONFence(body)
+		object, ok := extractSingleJSONFence(body)
+		if !ok {
+			object, ok = extractSingleJSONObject(body)
+		}
 		if !ok {
 			return EngineerResult{}, rawErr
 		}
 		result = EngineerResult{}
 		if err := decodeStrictJSON(
-			bytes.NewReader(fenced), maxBytes, &result,
+			bytes.NewReader(object), maxBytes, &result,
 		); err != nil {
 			return EngineerResult{}, err
 		}
@@ -94,6 +97,21 @@ func extractSingleJSONFence(body []byte) ([]byte, bool) {
 		}
 	}
 	return bytes.Join(lines[open+1:close], []byte{'\n'}), true
+}
+
+// extractSingleJSONObject rejects competing JSON containers while allowing a
+// model to prefix its only structured result with bounded prose.
+func extractSingleJSONObject(body []byte) ([]byte, bool) {
+	start := bytes.IndexByte(body, '{')
+	end := bytes.LastIndexByte(body, '}')
+	if start < 0 || end <= start {
+		return nil, false
+	}
+	if bytes.ContainsAny(body[:start], "{}[]") ||
+		bytes.ContainsAny(body[end+1:], "{}[]") {
+		return nil, false
+	}
+	return bytes.TrimSpace(body[start : end+1]), true
 }
 
 // ValidateEngineerResult rejects ambiguous or unbounded advisory output.

--- a/internal/contracts/issueagent/engineer_result_test.go
+++ b/internal/contracts/issueagent/engineer_result_test.go
@@ -18,6 +18,18 @@ const validEngineerResultJSON = `{"schema_version":2,"repository":"WuKongIM/WuKo
 	`"unresolved_uncertainty":"","summary":"guard missing route target",` +
 	`"ready":true}`
 
+func TestDecodeEngineerResultAcceptsProseBeforeSingleJSONObject(t *testing.T) {
+	t.Parallel()
+
+	result, err := issueagent.DecodeEngineerResult(strings.NewReader(
+		"All verification complete; the focused suite passes.\n\n"+
+			validEngineerResultJSON,
+	), 16<<10)
+	require.NoError(t, err)
+	require.Equal(t, issueagent.EngineerOutcomeReady, result.Outcome)
+	require.True(t, result.Ready)
+}
+
 func TestDecodeEngineerResultAcceptsSingleJSONFence(t *testing.T) {
 	t.Parallel()
 
@@ -49,6 +61,26 @@ func TestDecodeEngineerResultRejectsRawAndFencedResults(t *testing.T) {
 		validEngineerResultJSON+"\n```json\n"+validEngineerResultJSON+"\n```\n",
 	), 32<<10)
 	require.Error(t, err)
+}
+
+func TestDecodeEngineerResultRejectsAmbiguousProseWrappedJSON(t *testing.T) {
+	t.Parallel()
+
+	for name, input := range map[string]string{
+		"multiple objects": validEngineerResultJSON + "\n{}",
+		"array wrapper":    "[" + validEngineerResultJSON + "]",
+		"object in prose":  "Use {strict} output.\n" + validEngineerResultJSON,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := issueagent.DecodeEngineerResult(
+				strings.NewReader(input),
+				int64(len(input)),
+			)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestDecodeEngineerResultRejectsTrustedTestClaim(t *testing.T) {

--- a/internal/contracts/issueagent/engineer_result_test.go
+++ b/internal/contracts/issueagent/engineer_result_test.go
@@ -67,9 +67,11 @@ func TestDecodeEngineerResultRejectsAmbiguousProseWrappedJSON(t *testing.T) {
 	t.Parallel()
 
 	for name, input := range map[string]string{
-		"multiple objects": validEngineerResultJSON + "\n{}",
-		"array wrapper":    "[" + validEngineerResultJSON + "]",
-		"object in prose":  "Use {strict} output.\n" + validEngineerResultJSON,
+		"multiple objects":     validEngineerResultJSON + "\n{}",
+		"array wrapper":        "[" + validEngineerResultJSON + "]",
+		"fenced array wrapper": "[\n```json\n" + validEngineerResultJSON + "\n```\n]",
+		"object in prose":      "Use {strict} output.\n" + validEngineerResultJSON,
+		"unclosed JSON fence":  "```json\n" + validEngineerResultJSON,
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary

- accept one unambiguous schema-v2 EngineerResult surrounded by bounded model prose
- preserve strict unknown-field, identity, semantic, and byte-limit validation
- reject competing objects, array wrappers, malformed fences, and brace-bearing prose
- update the Issue Agent contract flow and add regression coverage

## Production evidence

Issue #744 run 30668407812 produced the correct patch and passed the clean trusted verifier, but Publisher stopped with Codex did not produce a valid complete result. The immutable engineer artifact contained one complete valid JSON object preceded by a plain verification summary.

## Validation

- GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1
- GOWORK=off go vet ./internal/contracts/issueagent ./internal/usecase/issueagent ./internal/app
- focused TDD regressions for prose wrapping, competing containers, fenced arrays, and unclosed fences
- Standards review: clean
- Spec review: clean
- git diff --check

This PR changes protected Issue Agent control code and requires owner review before merge.