### PR TITLE
fix(issue-agent): trust current author permission

### DIFF
--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -61,12 +61,12 @@ unbounded repair attempts.
 
 ## Authorization
 
-An Issue by an `OWNER`, `MEMBER`, or `COLLABORATOR` with current `write`,
-`maintain`, or `admin` permission may start automatically. Other reports need
-an exact first-line `/agent fix` from an actor whose permission is re-read.
-For a trusted Issue author, failed or temporarily non-write permission reads
-are retried for at most 3.1 seconds. Only a fresh `write`, `maintain`, or
-`admin` result authorizes admission; API errors abort and non-write results wait.
+An Issue whose author currently has `write`, `maintain`, or `admin` permission
+may start automatically. GitHub's credential-sensitive `author_association`
+is context only and never gates that decision. Other reports need an exact
+first-line `/agent fix` from an actor whose permission is re-read. Transient
+permission API failures are retried for at most 3.1 seconds; a definitive
+non-write result waits and an unresolved API failure aborts reconciliation.
 The other commands are:
 
 - `/agent retry` — one fresh ephemeral attempt after `needs_human`;

--- a/internal/app/issue_agent.go
+++ b/internal/app/issue_agent.go
@@ -927,21 +927,13 @@ func currentAuthorization(
 	comments []issueagentgithub.IssueComment,
 	current *contract.IssueAgentState,
 ) (*contract.AuthorizationRecord, string, error) {
-	trustedAuthor := issueagent.TrustedAssociation(issue.AuthorAssociation)
 	authorPermission, err := readIssueAuthorPermission(
 		ctx,
 		client,
 		issue.Author,
-		trustedAuthor,
 	)
 	if err != nil {
-		if trustedAuthor {
-			return nil, "", fmt.Errorf(
-				"read trusted Issue author permission: %w",
-				err,
-			)
-		}
-		authorPermission = issueagentgithub.PermissionRead
+		return nil, "", fmt.Errorf("read Issue author permission: %w", err)
 	}
 	for index := len(comments) - 1; index >= 0; index-- {
 		command, ok := issueagent.ParseIssueCommand(comments[index].Body)
@@ -972,8 +964,7 @@ func currentAuthorization(
 			Command:    string(command),
 		}, string(authorPermission), nil
 	}
-	if trustedAuthor &&
-		issueagent.WritePermission(string(authorPermission)) {
+	if issueagent.WritePermission(string(authorPermission)) {
 		return &contract.AuthorizationRecord{
 			Actor: issue.Author, Permission: string(authorPermission),
 			EventID: "issue:" + strconv.FormatInt(issue.Number, 10),
@@ -982,43 +973,43 @@ func currentAuthorization(
 	return nil, string(authorPermission), nil
 }
 
+// readIssueAuthorPermission retries ambiguous failures but accepts a definitive
+// permission immediately; a missing collaborator has no repository write access.
 func readIssueAuthorPermission(
 	ctx context.Context,
 	client *issueagentgithub.Client,
 	author string,
-	retry bool,
 ) (issueagentgithub.Permission, error) {
-	permissionContext := ctx
-	cancel := func() {}
-	if retry {
-		permissionContext, cancel = context.WithTimeout(
-			ctx,
-			issueAuthorPermissionRecoveryWindow,
-		)
-	}
+	permissionContext, cancel := context.WithTimeout(
+		ctx,
+		issueAuthorPermissionRecoveryWindow,
+	)
 	defer cancel()
 
-	permission, err := client.ActorPermission(permissionContext, author)
-	if !retry || err == nil && issueagent.WritePermission(string(permission)) {
-		return permission, err
-	}
-	for attempt := 1; attempt < issueAuthorPermissionRecoveryAttempts; attempt++ {
-		delay := time.Duration(0)
-		if attempt >= 2 {
-			delay = (100 * time.Millisecond) << (attempt - 2)
+	var lastErr error
+	for attempt := 0; attempt < issueAuthorPermissionRecoveryAttempts; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(0)
+			if attempt >= 2 {
+				delay = (100 * time.Millisecond) << (attempt - 2)
+			}
+			if waitErr := waitIssueAuthorPermissionRecovery(
+				permissionContext,
+				delay,
+			); waitErr != nil {
+				return "", waitErr
+			}
 		}
-		if waitErr := waitIssueAuthorPermissionRecovery(
-			permissionContext,
-			delay,
-		); waitErr != nil {
-			return "", waitErr
-		}
-		permission, err = client.ActorPermission(permissionContext, author)
-		if err == nil && issueagent.WritePermission(string(permission)) {
+		permission, err := client.ActorPermission(permissionContext, author)
+		if err == nil {
 			return permission, nil
 		}
+		if errors.Is(err, issueagentgithub.ErrNotFound) {
+			return issueagentgithub.PermissionRead, nil
+		}
+		lastErr = err
 	}
-	return permission, err
+	return "", lastErr
 }
 
 func waitIssueAuthorPermissionRecovery(

--- a/internal/app/issue_agent_permission_recovery_test.go
+++ b/internal/app/issue_agent_permission_recovery_test.go
@@ -13,72 +13,110 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCurrentAuthorizationRetriesTrustedIssueAuthorPermission(t *testing.T) {
+func TestCurrentAuthorizationUsesPermissionWhenAuthorAssociationLags(t *testing.T) {
 	t.Parallel()
 
-	for _, test := range []struct {
-		name            string
-		firstPermission string
-	}{
-		{name: "stale read", firstPermission: "read"},
-		{name: "transient API error"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			var attempts atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(
-				writer http.ResponseWriter,
-				request *http.Request,
-			) {
-				require.Equal(t,
-					"/repos/WuKongIM/WuKongIM/collaborators/reporter/permission",
-					request.URL.Path,
-				)
-				if attempts.Add(1) == 1 && test.firstPermission == "" {
-					http.Error(writer, "transient failure", http.StatusInternalServerError)
-					return
-				}
-				permission := "admin"
-				if attempts.Load() == 1 {
-					permission = test.firstPermission
-				}
-				writer.Header().Set("Content-Type", "application/json")
-				require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
-					"permission": permission,
-					"user":       map[string]string{"login": "reporter"},
-				}))
-			}))
-			t.Cleanup(server.Close)
-			client, err := issueagentgithub.NewClient(
-				issueagentgithub.ClientConfig{
-					BaseURL: server.URL, Repository: "WuKongIM/WuKongIM",
-					Token: "token", MaxPages: 2, MaxBodyBytes: 1 << 20,
-				},
-				server.Client(),
-			)
-			require.NoError(t, err)
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		attempts.Add(1)
+		require.Equal(t,
+			"/repos/WuKongIM/WuKongIM/collaborators/reporter/permission",
+			request.URL.Path,
+		)
+		writer.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
+			"permission": "admin",
+			"user":       map[string]string{"login": "reporter"},
+		}))
+	}))
+	client := issueAuthorPermissionTestClient(t, server)
 
-			authorization, permission, err := currentAuthorization(
-				context.Background(),
-				client,
-				issueagentgithub.IssueFacts{
-					Number: 42, Author: "reporter", AuthorAssociation: "MEMBER",
-				},
-				nil,
-				nil,
-			)
-			require.NoError(t, err)
-			require.NotNil(t, authorization)
-			require.Equal(t, "reporter", authorization.Actor)
-			require.Equal(t, "admin", authorization.Permission)
-			require.Equal(t, "issue:42", authorization.EventID)
-			require.Empty(t, authorization.Command)
-			require.Equal(t, "admin", permission)
-			require.Equal(t, int32(2), attempts.Load())
-		})
-	}
+	authorization, permission, err := currentAuthorization(
+		context.Background(),
+		client,
+		issueagentgithub.IssueFacts{
+			Number: 42, Author: "reporter", AuthorAssociation: "CONTRIBUTOR",
+		},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, authorization)
+	require.Equal(t, "reporter", authorization.Actor)
+	require.Equal(t, "admin", authorization.Permission)
+	require.Equal(t, "issue:42", authorization.EventID)
+	require.Empty(t, authorization.Command)
+	require.Equal(t, "admin", permission)
+	require.Equal(t, int32(1), attempts.Load())
 }
 
-func TestCurrentAuthorizationStopsTrustedPermissionRecoveryOnCancellation(
+func TestCurrentAuthorizationRetriesTransientIssueAuthorPermission(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		if attempts.Add(1) == 1 {
+			http.Error(writer, "transient failure", http.StatusInternalServerError)
+			return
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
+			"permission": "admin",
+			"user":       map[string]string{"login": "reporter"},
+		}))
+	}))
+	client := issueAuthorPermissionTestClient(t, server)
+
+	authorization, permission, err := currentAuthorization(
+		context.Background(),
+		client,
+		issueagentgithub.IssueFacts{
+			Number: 42, Author: "reporter", AuthorAssociation: "CONTRIBUTOR",
+		},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, authorization)
+	require.Equal(t, "admin", permission)
+	require.Equal(t, int32(2), attempts.Load())
+}
+
+func TestCurrentAuthorizationTreatsMissingIssueAuthorPermissionAsRead(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		attempts.Add(1)
+		http.NotFound(writer, request)
+	}))
+	client := issueAuthorPermissionTestClient(t, server)
+
+	authorization, permission, err := currentAuthorization(
+		context.Background(),
+		client,
+		issueagentgithub.IssueFacts{
+			Number: 42, Author: "reporter", AuthorAssociation: "CONTRIBUTOR",
+		},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, authorization)
+	require.Equal(t, "read", permission)
+	require.Equal(t, int32(1), attempts.Load())
+}
+
+func TestCurrentAuthorizationStopsPermissionRecoveryOnCancellation(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -90,20 +128,9 @@ func TestCurrentAuthorizationStopsTrustedPermissionRecoveryOnCancellation(
 	) {
 		attempts.Add(1)
 		writer.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(writer).Encode(map[string]any{
-			"permission": "read",
-			"user":       map[string]string{"login": "reporter"},
-		}))
+		http.Error(writer, "transient failure", http.StatusInternalServerError)
 	}))
-	t.Cleanup(server.Close)
-	client, err := issueagentgithub.NewClient(
-		issueagentgithub.ClientConfig{
-			BaseURL: server.URL, Repository: "WuKongIM/WuKongIM",
-			Token: "token", MaxPages: 2, MaxBodyBytes: 1 << 20,
-		},
-		server.Client(),
-	)
-	require.NoError(t, err)
+	client := issueAuthorPermissionTestClient(t, server)
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 
@@ -119,4 +146,21 @@ func TestCurrentAuthorizationStopsTrustedPermissionRecoveryOnCancellation(
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Nil(t, authorization)
 	require.GreaterOrEqual(t, attempts.Load(), int32(2))
+}
+
+func issueAuthorPermissionTestClient(
+	t *testing.T,
+	server *httptest.Server,
+) *issueagentgithub.Client {
+	t.Helper()
+	t.Cleanup(server.Close)
+	client, err := issueagentgithub.NewClient(
+		issueagentgithub.ClientConfig{
+			BaseURL: server.URL, Repository: "WuKongIM/WuKongIM",
+			Token: "token", MaxPages: 2, MaxBodyBytes: 1 << 20,
+		},
+		server.Client(),
+	)
+	require.NoError(t, err)
+	return client
 }


### PR DESCRIPTION
## Outcome

Issue authors with a freshly resolved `write`, `maintain`, or `admin` repository permission now auto-start even when GitHub App visibility reports a lagging or reduced `author_association`.

## Root cause

The first signed snapshot for canary #748 proved that the Issue Agent App saw maintainer `tangtaoit` as `CONTRIBUTOR`, while an authenticated maintainer read showed `MEMBER`. The prior controller used that credential-sensitive association both to enable recovery and to gate automatic authorization, so the fresh permission result could not authorize the Issue.

## Change

- Make the freshly read repository permission the automatic authorization fact.
- Treat a definitive collaborator 404 as non-write access.
- Retry only ambiguous permission API failures inside the existing 3.1-second bound.
- Keep `author_association` as untrusted context, not authorization.

## Validation

- `GOWORK=off go test ./cmd/wkissueagent ./internal/access/issueagentcli ./internal/app ./internal/usecase/issueagent ./internal/infra/issueagentgithub ./internal/contracts/issueagent -count=1`
- `GOWORK=off go vet ./cmd/wkissueagent ./internal/access/issueagentcli ./internal/app ./internal/usecase/issueagent ./internal/infra/issueagentgithub ./internal/contracts/issueagent`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check`