### PR TITLE
fix(agent): raise review inventory budget

### DIFF
--- a/.github/review-agent/policy.json
+++ b/.github/review-agent/policy.json
@@ -28,8 +28,8 @@
   },
   "limits": {
     "max_changed_files": 50,
-    "max_changed_bytes": 131072,
-    "max_changed_lines": 10000,
+    "max_changed_bytes": 1048576,
+    "max_changed_lines": 30000,
     "max_context_bytes": 393216,
     "max_model_response_bytes": 4194304,
     "max_context_tokens": 240000,

--- a/internal/app/review_agent_policy.go
+++ b/internal/app/review_agent_policy.go
@@ -173,8 +173,8 @@ func ValidateReviewAgentPolicy(document ReviewAgentPolicy) error {
 		document.Interaction.MaxExplanationSessionsPerHead <= 0 ||
 		document.Interaction.MaxResponseBytesPerHead <= 0 ||
 		document.Limits.MaxChangedFiles != contract.MaxChangedFiles ||
-		document.Limits.MaxChangedBytes != 131072 ||
-		document.Limits.MaxChangedLines != 10000 ||
+		document.Limits.MaxChangedBytes != 1048576 ||
+		document.Limits.MaxChangedLines != 30000 ||
 		document.Limits.MaxContextBytes != 393216 ||
 		document.Limits.MaxModelResponseBytes <= 0 ||
 		document.Limits.MaxContextTokens != 240000 ||

--- a/internal/infra/reviewagentgithub/reader.go
+++ b/internal/infra/reviewagentgithub/reader.go
@@ -425,6 +425,7 @@ func (client *Client) readPullMetadataInventory(
 	number int64,
 	pull pullResponse,
 ) (verify.Inventory, map[string]string, string, error) {
+	limits := reviewInventoryLimits()
 	inventory := verify.Inventory{
 		DeclaredFiles: pull.ChangedFiles,
 		TotalLines:    pull.Additions + pull.Deletions,
@@ -457,11 +458,8 @@ func (client *Client) readPullMetadataInventory(
 			commentPatches[file.Filename] = file.Patch
 		}
 	}
-	if inventory.TotalBytes > 131072 {
-		return inventory, commentPatches, "changed-byte budget exceeded", nil
-	}
-	if inventory.TotalLines > 10000 {
-		return inventory, commentPatches, "changed-line budget exceeded", nil
+	if reason := reviewInventoryBudgetFailure(inventory, limits); reason != "" {
+		return inventory, commentPatches, reason, nil
 	}
 	return inventory, commentPatches, "", nil
 }
@@ -530,15 +528,32 @@ func (client *Client) readPullInventory(
 	inventory, err := verify.BuildInventory(
 		pull.ChangedFiles,
 		rawFiles,
-		verify.InventoryLimits{
-			MaxFiles: contract.MaxChangedFiles, MaxTotalBytes: 131072,
-			MaxLines: 10000,
-		},
+		reviewInventoryLimits(),
 	)
 	if err != nil {
 		return inventoryFailure(err)
 	}
 	return inventory, "", nil
+}
+
+func reviewInventoryLimits() verify.InventoryLimits {
+	return verify.InventoryLimits{
+		MaxFiles: contract.MaxChangedFiles, MaxTotalBytes: 1048576,
+		MaxLines: 30000,
+	}
+}
+
+func reviewInventoryBudgetFailure(
+	inventory verify.Inventory,
+	limits verify.InventoryLimits,
+) string {
+	if inventory.TotalBytes > limits.MaxTotalBytes {
+		return "changed-byte budget exceeded"
+	}
+	if inventory.TotalLines > limits.MaxLines {
+		return "changed-line budget exceeded"
+	}
+	return ""
 }
 
 func inventoryFailure(err error) (verify.Inventory, string, error) {

--- a/internal/infra/reviewagentgithub/reader_budget_test.go
+++ b/internal/infra/reviewagentgithub/reader_budget_test.go
@@ -1,0 +1,40 @@
+package reviewagentgithub
+
+import (
+	"testing"
+
+	contract "github.com/WuKongIM/WuKongIM/internal/contracts/reviewagent"
+	verify "github.com/WuKongIM/WuKongIM/internal/runtime/reviewagentverify"
+)
+
+func TestReviewInventoryLimits(t *testing.T) {
+	t.Parallel()
+
+	limits := reviewInventoryLimits()
+	if limits.MaxFiles != contract.MaxChangedFiles ||
+		limits.MaxTotalBytes != 1048576 || limits.MaxLines != 30000 {
+		t.Fatalf("review inventory limits = %+v", limits)
+	}
+}
+
+func TestReviewInventoryBudgetFailure(t *testing.T) {
+	t.Parallel()
+
+	limits := reviewInventoryLimits()
+	if reason := reviewInventoryBudgetFailure(verify.Inventory{
+		TotalBytes: limits.MaxTotalBytes,
+		TotalLines: limits.MaxLines,
+	}, limits); reason != "" {
+		t.Fatalf("exact budget rejected: %s", reason)
+	}
+	if reason := reviewInventoryBudgetFailure(verify.Inventory{
+		TotalBytes: limits.MaxTotalBytes + 1,
+	}, limits); reason != "changed-byte budget exceeded" {
+		t.Fatalf("byte overflow reason = %q", reason)
+	}
+	if reason := reviewInventoryBudgetFailure(verify.Inventory{
+		TotalLines: limits.MaxLines + 1,
+	}, limits); reason != "changed-line budget exceeded" {
+		t.Fatalf("line overflow reason = %q", reason)
+	}
+}


### PR DESCRIPTION
## Summary

- raise the exact Review Agent inventory budget from 128 KiB / 10,000 complete-file lines to 1 MiB / 30,000 lines
- apply the same bound to the Controller metadata precheck and the worker's complete base/head inventory
- add exact-boundary coverage for the shared Reader limit

## Root cause

Review Agent policy and both GitHub Reader paths encoded the old inventory bound independently. PR #753 has only 1,932 ordinary diff additions, but exact review evidence captures complete before/after files: 861,899 bytes and 20,263 lines. The Controller or worker therefore rejected it before Codex could review it.

## Bootstrap boundary

This PR intentionally changes only the inventory bound. Its own exact before/after inventory is 120,073 bytes and 4,283 lines, so the currently deployed 128 KiB / 10,000-line Review Agent can still review it.

The encoded Context bound remains 384 KiB in this bootstrap. Immediately after merge, a second control PR will raise that bound to 2 MiB and update the numeric documentation and schema contract test together. Including those larger files here would make the current Review Agent reject its own bootstrap before review.

The model window, automatic compaction, concurrency, credentials, network fences, checks, and all other security limits are unchanged.

## Validation

- `GOWORK=off go test ./internal/app ./internal/infra/reviewagentgithub ./scripts -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `GOWORK=off go vet ./internal/app ./internal/infra/reviewagentgithub ./scripts`
- real PR #753 replay: 27 files, 861,899 bytes, 20,263 lines; complete inventory succeeds with the new bound
- two-axis local review: Standards 0 findings, Spec 0 findings
