### PR TITLE
refactor: add online delivery compatibility adapters

### DIFF
--- a/internal/access/node/FLOW.md
+++ b/internal/access/node/FLOW.md
@@ -82,6 +82,10 @@ committed message identifiers, sender echo-suppression fields, payload, red-dot
 flag, and request-scoped UIDs. Responses carry status plus accepted, retryable,
 and dropped route groups.
 
+During Online Delivery convergence, the adapter can also invoke the canonical
+`PushOwner` port and the client exposes the same port. Compatibility conversion
+preserves the exact `WKVD1`/`WKVd1` bytes while old and new runtimes coexist.
+
 ## Delivery Fanout RPC
 
 ```text

--- a/internal/access/node/delivery_online_compat.go
+++ b/internal/access/node/delivery_online_compat.go
@@ -1,0 +1,130 @@
+package node
+
+import (
+	"context"
+
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+)
+
+// OnlineDeliveryOwnerPush accepts canonical owner pushes while the stable wire
+// codec remains compatible with the legacy delivery DTOs.
+type OnlineDeliveryOwnerPush interface {
+	PushOwner(context.Context, onlinedelivery.OwnerPush) (onlinedelivery.OwnerPushResult, error)
+}
+
+type onlineDeliveryOwnerPushAdapter struct {
+	push OnlineDeliveryOwnerPush
+}
+
+// AdaptOnlineDeliveryOwnerPush exposes a canonical owner pusher through the
+// existing server-side legacy port while the version-one wire remains stable.
+func AdaptOnlineDeliveryOwnerPush(push OnlineDeliveryOwnerPush) DeliveryOwnerPush {
+	if push == nil {
+		return nil
+	}
+	return &onlineDeliveryOwnerPushAdapter{push: push}
+}
+
+func (a *onlineDeliveryOwnerPushAdapter) Push(
+	ctx context.Context,
+	cmd runtimedelivery.PushCommand,
+) (runtimedelivery.PushResult, error) {
+	result, err := a.push.PushOwner(ctx, onlineDeliveryPushFromLegacy(cmd))
+	return legacyDeliveryResultFromOnline(result), err
+}
+
+func onlineDeliveryPushFromLegacy(cmd runtimedelivery.PushCommand) onlinedelivery.OwnerPush {
+	return onlinedelivery.OwnerPush{
+		OwnerNodeID: cmd.OwnerNodeID,
+		Event:       onlineDeliveryEnvelopeFromLegacy(cmd.Envelope),
+		Routes:      onlineDeliveryRoutesFromLegacy(cmd.Routes),
+	}
+}
+
+func legacyDeliveryPushFromOnline(push onlinedelivery.OwnerPush) runtimedelivery.PushCommand {
+	return runtimedelivery.PushCommand{
+		OwnerNodeID: push.OwnerNodeID,
+		Envelope:    legacyDeliveryEnvelopeFromOnline(push.Event),
+		Routes:      legacyDeliveryRoutesFromOnline(push.Routes),
+	}
+}
+
+func onlineDeliveryEnvelopeFromLegacy(env runtimedelivery.Envelope) channelappendcontract.CommittedEnvelope {
+	return channelappendcontract.CommittedEnvelope{
+		MessageID:         env.MessageID,
+		MessageSeq:        env.MessageSeq,
+		ChannelID:         env.ChannelID,
+		ChannelType:       env.ChannelType,
+		FromUID:           env.FromUID,
+		SenderNodeID:      env.SenderNodeID,
+		SenderSessionID:   env.SenderSessionID,
+		ClientMsgNo:       env.ClientMsgNo,
+		RedDot:            env.RedDot,
+		Payload:           append([]byte(nil), env.Payload...),
+		MessageScopedUIDs: append([]string(nil), env.MessageScopedUIDs...),
+	}
+}
+
+func legacyDeliveryEnvelopeFromOnline(event channelappendcontract.CommittedEnvelope) runtimedelivery.Envelope {
+	return runtimedelivery.Envelope{
+		MessageID:         event.MessageID,
+		MessageSeq:        event.MessageSeq,
+		ChannelID:         event.ChannelID,
+		ChannelType:       event.ChannelType,
+		FromUID:           event.FromUID,
+		SenderNodeID:      event.SenderNodeID,
+		SenderSessionID:   event.SenderSessionID,
+		ClientMsgNo:       event.ClientMsgNo,
+		RedDot:            event.RedDot,
+		Payload:           append([]byte(nil), event.Payload...),
+		MessageScopedUIDs: append([]string(nil), event.MessageScopedUIDs...),
+	}
+}
+
+func onlineDeliveryRoutesFromLegacy(routes []runtimedelivery.Route) []onlinedelivery.Route {
+	if routes == nil {
+		return nil
+	}
+	out := make([]onlinedelivery.Route, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, onlinedelivery.Route{
+			UID: route.UID, OwnerNodeID: route.OwnerNodeID, OwnerBootID: route.OwnerBootID,
+			OwnerSeq: route.OwnerSeq, SessionID: route.SessionID, DeviceID: route.DeviceID,
+			DeviceFlag: route.DeviceFlag, DeviceLevel: route.DeviceLevel,
+		})
+	}
+	return out
+}
+
+func legacyDeliveryRoutesFromOnline(routes []onlinedelivery.Route) []runtimedelivery.Route {
+	if routes == nil {
+		return nil
+	}
+	out := make([]runtimedelivery.Route, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, runtimedelivery.Route{
+			UID: route.UID, OwnerNodeID: route.OwnerNodeID, OwnerBootID: route.OwnerBootID,
+			OwnerSeq: route.OwnerSeq, SessionID: route.SessionID, DeviceID: route.DeviceID,
+			DeviceFlag: route.DeviceFlag, DeviceLevel: route.DeviceLevel,
+		})
+	}
+	return out
+}
+
+func onlineDeliveryResultFromLegacy(result runtimedelivery.PushResult) onlinedelivery.OwnerPushResult {
+	return onlinedelivery.OwnerPushResult{
+		Accepted:  onlineDeliveryRoutesFromLegacy(result.Accepted),
+		Retryable: onlineDeliveryRoutesFromLegacy(result.Retryable),
+		Dropped:   onlineDeliveryRoutesFromLegacy(result.Dropped),
+	}
+}
+
+func legacyDeliveryResultFromOnline(result onlinedelivery.OwnerPushResult) runtimedelivery.PushResult {
+	return runtimedelivery.PushResult{
+		Accepted:  legacyDeliveryRoutesFromOnline(result.Accepted),
+		Retryable: legacyDeliveryRoutesFromOnline(result.Retryable),
+		Dropped:   legacyDeliveryRoutesFromOnline(result.Dropped),
+	}
+}

--- a/internal/access/node/delivery_rpc.go
+++ b/internal/access/node/delivery_rpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
 	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
 	clusternet "github.com/WuKongIM/WuKongIM/pkg/cluster/net"
 	"github.com/WuKongIM/WuKongIM/pkg/wklog"
@@ -102,6 +103,16 @@ func (c *Client) PushBatch(ctx context.Context, nodeID uint64, cmd runtimedelive
 	default:
 		return runtimedelivery.PushResult{}, fmt.Errorf("internal/access/node: unknown delivery rpc status %q", resp.Status)
 	}
+}
+
+// PushOwner forwards a canonical owner push through the stable version-one
+// delivery wire format.
+func (c *Client) PushOwner(ctx context.Context, cmd onlinedelivery.OwnerPush) (onlinedelivery.OwnerPushResult, error) {
+	result, err := c.PushBatch(ctx, cmd.OwnerNodeID, legacyDeliveryPushFromOnline(cmd))
+	if err != nil {
+		return onlinedelivery.OwnerPushResult{}, err
+	}
+	return onlineDeliveryResultFromLegacy(result), nil
 }
 
 // ForwardFanoutTask forwards one partition-scoped fanout task to nodeID.

--- a/internal/access/node/delivery_rpc_test.go
+++ b/internal/access/node/delivery_rpc_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
 	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
 )
 
@@ -56,6 +58,36 @@ func TestDeliveryRPCHandlerRejectsNilDelivery(t *testing.T) {
 	}
 }
 
+func TestDeliveryRPCHandlerAdaptsCanonicalOwnerPush(t *testing.T) {
+	cmd := testDeliveryPushCommand()
+	canonicalResult := onlinedelivery.OwnerPushResult{
+		Accepted: onlineDeliveryRoutesFromLegacy(cmd.Routes[:1]),
+	}
+	canonical := &fakeOnlineDeliveryOwnerPush{result: canonicalResult}
+	adapter := New(Options{Delivery: AdaptOnlineDeliveryOwnerPush(canonical)})
+	body, err := encodeDeliveryPushRequest(deliveryPushRequest{Command: cmd})
+	if err != nil {
+		t.Fatalf("encodeDeliveryPushRequest() error = %v", err)
+	}
+
+	respBody, err := adapter.HandleDeliveryPushRPC(context.Background(), body)
+	if err != nil {
+		t.Fatalf("HandleDeliveryPushRPC() error = %v", err)
+	}
+	resp, err := decodeDeliveryPushResponse(respBody)
+	if err != nil {
+		t.Fatalf("decodeDeliveryPushResponse() error = %v", err)
+	}
+	wantPush := onlineDeliveryPushFromLegacy(cmd)
+	if len(canonical.pushes) != 1 || !reflect.DeepEqual(canonical.pushes[0], wantPush) {
+		t.Fatalf("canonical pushes = %#v, want %#v", canonical.pushes, wantPush)
+	}
+	wantResult := legacyDeliveryResultFromOnline(canonicalResult)
+	if resp.Status != rpcStatusOK || !reflect.DeepEqual(resp.Result, wantResult) {
+		t.Fatalf("response = %#v, want status %q and result %#v", resp, rpcStatusOK, wantResult)
+	}
+}
+
 func TestDeliveryClientCallsExpectedServiceAndDecodesResult(t *testing.T) {
 	cmd := testDeliveryPushCommand()
 	result := runtimedelivery.PushResult{Accepted: []runtimedelivery.Route{cmd.Routes[0]}}
@@ -84,6 +116,45 @@ func TestDeliveryClientCallsExpectedServiceAndDecodesResult(t *testing.T) {
 	}
 }
 
+func TestDeliveryClientPushOwnerUsesStableLegacyWireFormat(t *testing.T) {
+	push := onlinedelivery.OwnerPush{
+		OwnerNodeID: 13,
+		Event: channelappendcontract.CommittedEnvelope{
+			MessageID: 1, MessageSeq: 2, ChannelID: "room", ChannelType: 2,
+			Payload: []byte("payload"), MessageScopedUIDs: []string{"u1"},
+		},
+		Routes: []onlinedelivery.Route{{
+			UID: "u1", OwnerNodeID: 13, OwnerBootID: 7, OwnerSeq: 8,
+			SessionID: 9, DeviceID: "d1", DeviceFlag: 1, DeviceLevel: 2,
+		}},
+	}
+	legacyResult := runtimedelivery.PushResult{
+		Retryable: legacyDeliveryRoutesFromOnline(push.Routes),
+	}
+	node := &fakeDeliveryRPCNode{
+		response: deliveryPushResponse{Status: rpcStatusOK, Result: legacyResult},
+	}
+
+	got, err := NewClient(node).PushOwner(context.Background(), push)
+	if err != nil {
+		t.Fatalf("PushOwner() error = %v", err)
+	}
+	if node.nodeID != push.OwnerNodeID || node.serviceID != DeliveryPushRPCServiceID {
+		t.Fatalf("RPC target = node %d service %d, want node %d service %d",
+			node.nodeID, node.serviceID, push.OwnerNodeID, DeliveryPushRPCServiceID)
+	}
+	req, err := decodeDeliveryPushRequest(node.payload)
+	if err != nil {
+		t.Fatalf("decodeDeliveryPushRequest(client payload) error = %v", err)
+	}
+	if want := legacyDeliveryPushFromOnline(push); !reflect.DeepEqual(req.Command, want) {
+		t.Fatalf("wire command = %#v, want %#v", req.Command, want)
+	}
+	if want := onlineDeliveryResultFromLegacy(legacyResult); !reflect.DeepEqual(got, want) {
+		t.Fatalf("PushOwner() = %#v, want %#v", got, want)
+	}
+}
+
 func TestDeliveryClientMapsRejectedStatusToError(t *testing.T) {
 	client := NewClient(&fakeDeliveryRPCNode{
 		response: deliveryPushResponse{Status: rpcStatusRejected},
@@ -104,6 +175,20 @@ func (f *fakeDeliveryOwnerPush) Push(_ context.Context, cmd runtimedelivery.Push
 	f.commands = append(f.commands, cmd)
 	if f.err != nil {
 		return runtimedelivery.PushResult{}, f.err
+	}
+	return f.result, nil
+}
+
+type fakeOnlineDeliveryOwnerPush struct {
+	result onlinedelivery.OwnerPushResult
+	err    error
+	pushes []onlinedelivery.OwnerPush
+}
+
+func (f *fakeOnlineDeliveryOwnerPush) PushOwner(_ context.Context, push onlinedelivery.OwnerPush) (onlinedelivery.OwnerPushResult, error) {
+	f.pushes = append(f.pushes, push.Clone())
+	if f.err != nil {
+		return onlinedelivery.OwnerPushResult{}, f.err
 	}
 	return f.result, nil
 }

--- a/internal/infra/delivery/FLOW.md
+++ b/internal/infra/delivery/FLOW.md
@@ -7,8 +7,9 @@ owner node's concrete online registry, gateway session, and WuKong protocol
 packet. It owns the owner-local push state machine: exact route revalidation,
 pending RECVACK reservation lifecycle, packet construction, session writes,
 and terminal-versus-retryable write classification. It also owns the narrow
-presence-usecase to channelappend route adapter used by recipient delivery, so
-the app composition root only constructs and injects the runtime port.
+presence-usecase adapters used by both channelappend and canonical Online
+Delivery recipient routing, so the app composition root only constructs and
+injects the runtime ports.
 
 The package does not resolve cluster ownership, page channel subscribers, or
 choose retry policy. Those decisions remain in `internal/runtime/delivery` and
@@ -63,12 +64,25 @@ its write fails.
 between the pusher, fanout worker, retry scheduler, and delivery manager. App
 composition must call it exactly once before any concurrent `Push` call.
 
+The convergence path also provides `LocalSessionWriter`, which owns only final
+exact-session validation, packet construction, and physical writes. The new
+Online Delivery runtime retains pending-ACK ownership around that narrow port;
+the existing `LocalOwnerPusher` remains active until app wiring cuts over. A
+missing owner-local registry is an unavailable adapter, not a stale route, so
+the writer returns a retryable result instead of terminally dropping the route.
+
 Stale pending-ACK expiry is activity-driven and globally throttled per pusher;
 ordinary pushes do not scan the tracker on every call.
 
-## Channelappend Presence Adapter
+## Presence Adapters
 
 `ChannelAppendPresenceResolver` converts the entry-agnostic presence usecase's
 flat and exact-target lookup results into channelappend delivery DTOs. Exact
 target group cardinality, result order, partial errors, and all physical
 hash-slot/logical Slot Raft Group fencing fields are preserved.
+
+`PresenceResolver` converts the same exact-target lookup into canonical Online
+Delivery results. It preserves one result per target in input order, copies all
+authority fencing fields and route metadata, and reports a missing presence
+dependency as an aligned availability error for every target instead of
+misclassifying recipients as offline.

--- a/internal/infra/delivery/local_session_writer.go
+++ b/internal/infra/delivery/local_session_writer.go
@@ -1,0 +1,173 @@
+package delivery
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/online"
+	gatewaysession "github.com/WuKongIM/WuKongIM/pkg/gateway/session"
+	gatewaytransport "github.com/WuKongIM/WuKongIM/pkg/gateway/transport"
+	runtimechannelid "github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
+	"github.com/WuKongIM/WuKongIM/pkg/wklog"
+)
+
+var errOnlineDeliveryMessageIDOverflow = errors.New("internal/infra/delivery: delivery message id overflows recv packet")
+
+// LocalSessionWriterOptions configures the narrow owner-local session adapter.
+type LocalSessionWriterOptions struct {
+	// Online resolves exact active owner-local sessions.
+	Online *online.Registry
+	// Now supplies packet timestamps.
+	Now func() time.Time
+	// Logger records bounded physical write failures.
+	Logger wklog.Logger
+}
+
+// LocalSessionWriter validates, builds, and writes one exact local route.
+// Pending-ACK state belongs to runtime/delivery and is deliberately absent.
+type LocalSessionWriter struct {
+	// online is the owner-local exact-session registry.
+	online *online.Registry
+	// now supplies protocol packet timestamps.
+	now func() time.Time
+	// logger records bounded packet-build and write diagnostics.
+	logger wklog.Logger
+}
+
+var _ runtimedelivery.LocalSessionWriter = (*LocalSessionWriter)(nil)
+
+// NewLocalSessionWriter creates the owner-local physical write adapter.
+func NewLocalSessionWriter(opts LocalSessionWriterOptions) *LocalSessionWriter {
+	return &LocalSessionWriter{online: opts.Online, now: opts.Now, logger: opts.Logger}
+}
+
+// WriteSession performs final exact-session validation and one physical write.
+func (w *LocalSessionWriter) WriteSession(ctx context.Context, write runtimedelivery.LocalSessionWrite) runtimedelivery.SessionWriteResult {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return runtimedelivery.SessionWriteResult{Disposition: runtimedelivery.SessionWriteRetryable, Err: err}
+		}
+	}
+	if w == nil || w.online == nil {
+		return runtimedelivery.SessionWriteResult{
+			Disposition: runtimedelivery.SessionWriteRetryable,
+			Err:         runtimedelivery.ErrSessionWriterUnavailable,
+		}
+	}
+	session, ok := exactLocalSession(w.online, write.Route)
+	if !ok {
+		return runtimedelivery.SessionWriteResult{Disposition: runtimedelivery.SessionWriteDropped}
+	}
+	packet, err := buildOnlineDeliveryRecvPacket(write.Event, write.Route.UID, int32(w.nowTime().Unix()))
+	if err != nil {
+		w.loggerOrNop().Warn("delivery recv packet build failed",
+			wklog.Event("internal.infra.delivery.recv_packet_build_failed"),
+			wklog.UID(write.Route.UID),
+			wklog.SessionID(write.Route.SessionID),
+			wklog.Uint64("messageID", write.Event.MessageID),
+			wklog.Error(err),
+		)
+		return runtimedelivery.SessionWriteResult{Disposition: runtimedelivery.SessionWriteDropped, Err: err}
+	}
+	if err := session.Session.WriteDelivery(packet); err != nil {
+		disposition := runtimedelivery.SessionWriteRetryable
+		if terminalOnlineDeliveryWriteError(err) {
+			disposition = runtimedelivery.SessionWriteDropped
+		}
+		w.loggerOrNop().Warn("delivery write failed",
+			wklog.Event("internal.infra.delivery.write_failed"),
+			wklog.UID(write.Route.UID),
+			wklog.SessionID(write.Route.SessionID),
+			wklog.Uint64("messageID", write.Event.MessageID),
+			wklog.Bool("terminal", disposition == runtimedelivery.SessionWriteDropped),
+			wklog.Error(err),
+		)
+		return runtimedelivery.SessionWriteResult{Disposition: disposition, Err: err}
+	}
+	return runtimedelivery.SessionWriteResult{Disposition: runtimedelivery.SessionWriteAccepted}
+}
+
+func exactLocalSession(registry *online.Registry, route onlinedelivery.Route) (online.LocalSession, bool) {
+	if registry == nil || route.UID == "" || route.SessionID == 0 || route.OwnerNodeID == 0 || route.OwnerBootID == 0 || route.OwnerSeq == 0 {
+		return online.LocalSession{}, false
+	}
+	session, ok := registry.LocalSession(route.SessionID)
+	if !ok || session.State != online.RouteStateActive || session.Session == nil {
+		return online.LocalSession{}, false
+	}
+	local := session.Route
+	if local.UID != route.UID ||
+		local.SessionID != route.SessionID ||
+		local.OwnerNodeID != route.OwnerNodeID ||
+		local.OwnerBootID != route.OwnerBootID ||
+		local.OwnerSeq != route.OwnerSeq ||
+		local.DeviceID != route.DeviceID ||
+		local.DeviceFlag != route.DeviceFlag ||
+		local.DeviceLevel != route.DeviceLevel {
+		return online.LocalSession{}, false
+	}
+	return session, true
+}
+
+func terminalOnlineDeliveryWriteError(err error) bool {
+	return errors.Is(err, gatewaysession.ErrSessionClosed) ||
+		errors.Is(err, gatewaytransport.ErrOutboundBytesExceeded)
+}
+
+func buildOnlineDeliveryRecvPacket(event channelappendcontract.CommittedEnvelope, uid string, timestamp int32) (*frame.RecvPacket, error) {
+	if event.MessageID > uint64(1<<63-1) {
+		return nil, errOnlineDeliveryMessageIDOverflow
+	}
+	channelID := event.ChannelID
+	if event.ChannelType == frame.ChannelTypePerson {
+		channelID = onlineDeliveryPersonChannelView(event, uid)
+	}
+	return &frame.RecvPacket{
+		Framer:      frame.Framer{RedDot: event.RedDot},
+		MessageID:   int64(event.MessageID),
+		MessageSeq:  event.MessageSeq,
+		ClientMsgNo: event.ClientMsgNo,
+		Timestamp:   timestamp,
+		ChannelID:   channelID,
+		ChannelType: event.ChannelType,
+		FromUID:     event.FromUID,
+		Payload:     event.Payload,
+	}, nil
+}
+
+func onlineDeliveryPersonChannelView(event channelappendcontract.CommittedEnvelope, recipientUID string) string {
+	if recipientUID == "" {
+		return event.ChannelID
+	}
+	left, right, err := runtimechannelid.DecodePersonChannel(event.ChannelID)
+	if err != nil {
+		return event.FromUID
+	}
+	switch recipientUID {
+	case left:
+		return right
+	case right:
+		return left
+	default:
+		return event.FromUID
+	}
+}
+
+func (w *LocalSessionWriter) nowTime() time.Time {
+	if w != nil && w.now != nil {
+		return w.now()
+	}
+	return time.Now()
+}
+
+func (w *LocalSessionWriter) loggerOrNop() wklog.Logger {
+	if w == nil || w.logger == nil {
+		return wklog.NewNop()
+	}
+	return w.logger
+}

--- a/internal/infra/delivery/local_session_writer_test.go
+++ b/internal/infra/delivery/local_session_writer_test.go
@@ -1,0 +1,157 @@
+package delivery
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/online"
+	gatewaysession "github.com/WuKongIM/WuKongIM/pkg/gateway/session"
+	gatewaytransport "github.com/WuKongIM/WuKongIM/pkg/gateway/transport"
+	runtimechannelid "github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
+	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
+)
+
+func TestLocalSessionWriterClassifiesExactSessionWritesWithoutAckState(t *testing.T) {
+	registry := online.NewRegistry(online.RegistryOptions{ShardCount: 1})
+	session := &localSessionWriterTestSession{}
+	route := registerLocalSessionWriterTestSession(t, registry, 1, "u1", 10, session)
+	writer := NewLocalSessionWriter(LocalSessionWriterOptions{Online: registry})
+	write := runtimedelivery.LocalSessionWrite{
+		Event: channelappendcontract.CommittedEnvelope{
+			MessageID: 1, MessageSeq: 2, ChannelID: "room", ChannelType: 2, Payload: []byte("payload"),
+		},
+		Route: route,
+	}
+
+	if result := writer.WriteSession(context.Background(), write); result.Disposition != runtimedelivery.SessionWriteAccepted {
+		t.Fatalf("accepted write result = %#v", result)
+	}
+	if session.writes.Load() != 1 {
+		t.Fatalf("session writes = %d, want 1", session.writes.Load())
+	}
+	packet := session.last.Load()
+	if packet == nil || packet.MessageID != 1 || packet.MessageSeq != 2 || string(packet.Payload) != "payload" {
+		t.Fatalf("written packet = %#v", packet)
+	}
+
+	stale := write
+	stale.Route.OwnerSeq++
+	if result := writer.WriteSession(context.Background(), stale); result.Disposition != runtimedelivery.SessionWriteDropped {
+		t.Fatalf("stale write result = %#v, want dropped", result)
+	}
+	if session.writes.Load() != 1 {
+		t.Fatalf("stale route reached physical session; writes = %d", session.writes.Load())
+	}
+
+	session.writeErr = errors.New("temporary")
+	if result := writer.WriteSession(context.Background(), write); result.Disposition != runtimedelivery.SessionWriteRetryable {
+		t.Fatalf("temporary write result = %#v, want retryable", result)
+	}
+}
+
+func TestLocalSessionWriterClassifiesMissingRegistryAsRetryable(t *testing.T) {
+	result := NewLocalSessionWriter(LocalSessionWriterOptions{}).WriteSession(
+		context.Background(),
+		runtimedelivery.LocalSessionWrite{},
+	)
+
+	if result.Disposition != runtimedelivery.SessionWriteRetryable ||
+		!errors.Is(result.Err, runtimedelivery.ErrSessionWriterUnavailable) {
+		t.Fatalf("missing registry result = %#v, want retryable unavailable", result)
+	}
+}
+
+func TestLocalSessionWriterClassifiesPacketBuildAndTerminalWriteFailures(t *testing.T) {
+	registry := online.NewRegistry(online.RegistryOptions{ShardCount: 1})
+	session := &localSessionWriterTestSession{}
+	route := registerLocalSessionWriterTestSession(t, registry, 1, "u1", 10, session)
+	writer := NewLocalSessionWriter(LocalSessionWriterOptions{Online: registry})
+	write := runtimedelivery.LocalSessionWrite{
+		Event: channelappendcontract.CommittedEnvelope{MessageID: uint64(1 << 63)},
+		Route: route,
+	}
+
+	result := writer.WriteSession(context.Background(), write)
+	if result.Disposition != runtimedelivery.SessionWriteDropped || !errors.Is(result.Err, errOnlineDeliveryMessageIDOverflow) {
+		t.Fatalf("overflow result = %#v, want terminal packet-build drop", result)
+	}
+	if session.writes.Load() != 0 {
+		t.Fatalf("overflow physical writes = %d, want 0", session.writes.Load())
+	}
+
+	write.Event.MessageID = 1
+	for _, terminalErr := range []error{gatewaysession.ErrSessionClosed, gatewaytransport.ErrOutboundBytesExceeded} {
+		session.writeErr = terminalErr
+		result = writer.WriteSession(context.Background(), write)
+		if result.Disposition != runtimedelivery.SessionWriteDropped || !errors.Is(result.Err, terminalErr) {
+			t.Fatalf("terminal error %v result = %#v, want dropped", terminalErr, result)
+		}
+	}
+}
+
+func TestBuildOnlineDeliveryRecvPacketUsesRecipientPersonView(t *testing.T) {
+	payload := []byte("shared")
+	event := channelappendcontract.CommittedEnvelope{
+		MessageID: 1, MessageSeq: 2, ClientMsgNo: "c1", ChannelType: frame.ChannelTypePerson,
+		ChannelID: runtimechannelid.EncodePersonChannel("u1", "u2"), FromUID: "u1", RedDot: true, Payload: payload,
+	}
+
+	packet, err := buildOnlineDeliveryRecvPacket(event, "u2", 123)
+	if err != nil {
+		t.Fatalf("buildOnlineDeliveryRecvPacket() error = %v", err)
+	}
+	if packet.ChannelID != "u1" || packet.Timestamp != 123 || packet.FromUID != "u1" || !packet.RedDot {
+		t.Fatalf("recipient packet = %#v", packet)
+	}
+	if &packet.Payload[0] != &payload[0] {
+		t.Fatal("packet construction cloned immutable payload before serialization")
+	}
+}
+
+type localSessionWriterTestSession struct {
+	writeErr error
+	writes   atomic.Int64
+	last     atomic.Pointer[frame.RecvPacket]
+}
+
+func (s *localSessionWriterTestSession) WriteDelivery(value any) error {
+	s.writes.Add(1)
+	if packet, ok := value.(*frame.RecvPacket); ok {
+		retained := *packet
+		retained.Payload = append([]byte(nil), packet.Payload...)
+		s.last.Store(&retained)
+	}
+	return s.writeErr
+}
+
+func (*localSessionWriterTestSession) CloseSession(string) error { return nil }
+
+func registerLocalSessionWriterTestSession(
+	t *testing.T,
+	registry *online.Registry,
+	ownerNodeID uint64,
+	uid string,
+	sessionID uint64,
+	session online.SessionHandle,
+) onlinedelivery.Route {
+	t.Helper()
+	route := online.OwnerRoute{
+		UID: uid, OwnerNodeID: ownerNodeID, OwnerBootID: 7,
+		OwnerSeq: sessionID + 100, SessionID: sessionID, ConnectedUnix: 100,
+	}
+	if err := registry.RegisterPending(online.LocalSession{Route: route, Session: session}); err != nil {
+		t.Fatalf("RegisterPending(%d) error = %v", sessionID, err)
+	}
+	if err := registry.MarkActive(sessionID); err != nil {
+		t.Fatalf("MarkActive(%d) error = %v", sessionID, err)
+	}
+	return onlinedelivery.Route{
+		UID: uid, OwnerNodeID: ownerNodeID, OwnerBootID: route.OwnerBootID,
+		OwnerSeq: route.OwnerSeq, SessionID: sessionID,
+	}
+}

--- a/internal/infra/delivery/online_presence.go
+++ b/internal/infra/delivery/online_presence.go
@@ -1,0 +1,78 @@
+package delivery
+
+import (
+	"context"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/authority"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	presenceusecase "github.com/WuKongIM/WuKongIM/internal/usecase/presence"
+)
+
+// PresenceResolver adapts exact-target presence lookups to Online Delivery.
+type PresenceResolver struct {
+	// presence performs entry-agnostic exact-target authority lookups.
+	presence *presenceusecase.App
+}
+
+var _ runtimedelivery.PlanPresenceResolver = (*PresenceResolver)(nil)
+
+// NewPresenceResolver creates the exact-target Online Delivery presence adapter.
+func NewPresenceResolver(presence *presenceusecase.App) *PresenceResolver {
+	return &PresenceResolver{presence: presence}
+}
+
+// EndpointsByTargets preserves input alignment and exact authority fences.
+func (r *PresenceResolver) EndpointsByTargets(ctx context.Context, batches []onlinedelivery.RecipientTargetBatch) []runtimedelivery.TargetPresenceResult {
+	results := make([]runtimedelivery.TargetPresenceResult, len(batches))
+	if len(batches) == 0 {
+		return results
+	}
+	if r == nil || r.presence == nil {
+		for i := range results {
+			results[i].Err = presenceusecase.ErrAuthorityUnavailable
+		}
+		return results
+	}
+	groups := make([]presenceusecase.EndpointLookupGroup, len(batches))
+	for i, batch := range batches {
+		groups[i].Target = presenceTargetFromOnlineDeliveryTarget(batch.Target)
+		groups[i].UIDs = make([]string, 0, len(batch.Recipients))
+		for _, recipient := range batch.Recipients {
+			groups[i].UIDs = append(groups[i].UIDs, recipient.UID)
+		}
+	}
+	resolved := r.presence.EndpointsByTargets(ctx, groups)
+	for i := range results {
+		if i >= len(resolved) {
+			results[i].Err = runtimedelivery.ErrPresenceResultMissing
+			continue
+		}
+		results[i].Err = resolved[i].Err
+		results[i].Routes = onlineDeliveryRoutesFromPresence(resolved[i].Routes)
+	}
+	return results
+}
+
+func onlineDeliveryRoutesFromPresence(routes []presenceusecase.Route) []onlinedelivery.Route {
+	if routes == nil {
+		return nil
+	}
+	out := make([]onlinedelivery.Route, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, onlinedelivery.Route{
+			UID: route.UID, OwnerNodeID: route.OwnerNodeID, OwnerBootID: route.OwnerBootID,
+			OwnerSeq: route.OwnerSeq, SessionID: route.SessionID, DeviceID: route.DeviceID,
+			DeviceFlag: route.DeviceFlag, DeviceLevel: route.DeviceLevel,
+		})
+	}
+	return out
+}
+
+func presenceTargetFromOnlineDeliveryTarget(target authority.Target) presenceusecase.RouteTarget {
+	return presenceusecase.RouteTarget{
+		HashSlot: target.HashSlot, SlotID: target.SlotID, LeaderNodeID: target.LeaderNodeID,
+		LeaderTerm: target.LeaderTerm, ConfigEpoch: target.ConfigEpoch,
+		RouteRevision: target.RouteRevision, AuthorityEpoch: target.AuthorityEpoch,
+	}
+}

--- a/internal/infra/delivery/online_presence_test.go
+++ b/internal/infra/delivery/online_presence_test.go
@@ -1,0 +1,76 @@
+package delivery
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/authority"
+	channelappendcontract "github.com/WuKongIM/WuKongIM/internal/contracts/channelappend"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	presenceusecase "github.com/WuKongIM/WuKongIM/internal/usecase/presence"
+)
+
+func TestPresenceResolverPreservesExactTargetsAndAlignedResults(t *testing.T) {
+	first := authority.Target{
+		HashSlot: 1, SlotID: 11, LeaderNodeID: 10, LeaderTerm: 101,
+		ConfigEpoch: 1001, RouteRevision: 100, AuthorityEpoch: 1000,
+	}
+	second := authority.Target{
+		HashSlot: 2, SlotID: 22, LeaderNodeID: 20, LeaderTerm: 202,
+		ConfigEpoch: 2002, RouteRevision: 200, AuthorityEpoch: 2000,
+	}
+	fake := &targetedPresenceAuthorityForChannelAppendTest{
+		results: []presenceusecase.EndpointLookupResult{{
+			Routes: []presenceusecase.Route{{
+				UID: "u1", OwnerNodeID: 3, OwnerBootID: 4, OwnerSeq: 5,
+				SessionID: 6, DeviceID: "d1", DeviceFlag: 1, DeviceLevel: 2,
+			}},
+		}},
+	}
+	resolver := NewPresenceResolver(presenceusecase.New(presenceusecase.Options{Authority: fake}))
+
+	got := resolver.EndpointsByTargets(context.Background(), []onlinedelivery.RecipientTargetBatch{
+		{Target: first, Recipients: []channelappendcontract.Recipient{{UID: "u1"}}},
+		{Target: second, Recipients: []channelappendcontract.Recipient{{UID: "u2"}}},
+	})
+
+	if len(got) != 2 || got[0].Err != nil || !errors.Is(got[1].Err, runtimedelivery.ErrPresenceResultMissing) {
+		t.Fatalf("target results = %#v, want first success and aligned missing second result", got)
+	}
+	wantRoutes := []onlinedelivery.Route{{
+		UID: "u1", OwnerNodeID: 3, OwnerBootID: 4, OwnerSeq: 5,
+		SessionID: 6, DeviceID: "d1", DeviceFlag: 1, DeviceLevel: 2,
+	}}
+	if !reflect.DeepEqual(got[0].Routes, wantRoutes) {
+		t.Fatalf("first routes = %#v, want %#v", got[0].Routes, wantRoutes)
+	}
+	wantGroups := []presenceusecase.EndpointLookupGroup{
+		{Target: presenceTargetFromOnlineDeliveryTarget(first), UIDs: []string{"u1"}},
+		{Target: presenceTargetFromOnlineDeliveryTarget(second), UIDs: []string{"u2"}},
+	}
+	if !reflect.DeepEqual(fake.groups, wantGroups) {
+		t.Fatalf("presence groups = %#v, want exact targets %#v", fake.groups, wantGroups)
+	}
+	if fake.legacyCalls != 0 {
+		t.Fatalf("legacy endpoint calls = %d, want 0", fake.legacyCalls)
+	}
+}
+
+func TestPresenceResolverReportsUnavailableDependencyPerTarget(t *testing.T) {
+	got := NewPresenceResolver(nil).EndpointsByTargets(context.Background(), []onlinedelivery.RecipientTargetBatch{
+		{Recipients: []channelappendcontract.Recipient{{UID: "u1"}}},
+		{Recipients: []channelappendcontract.Recipient{{UID: "u2"}}},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("target results = %d, want 2", len(got))
+	}
+	for i := range got {
+		if !errors.Is(got[i].Err, presenceusecase.ErrAuthorityUnavailable) {
+			t.Fatalf("target result %d error = %v, want ErrAuthorityUnavailable", i, got[i].Err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- adapt canonical Online Delivery owner pushes to the existing WKVD1/WKVd1 node RPC without changing wire bytes
- add exact-target presence and owner-local session-writer adapters for the new runtime while leaving production app wiring unchanged
- keep pending RECVACK reservation ownership inside internal/runtime/delivery
- fail closed when presence or the owner-local online registry is unavailable

## Review fixes

- return aligned ErrAuthorityUnavailable results instead of treating a missing presence dependency as offline recipients
- classify a missing online registry as retryable ErrSessionWriterUnavailable instead of a terminal stale-route drop
- document the canonical adapters and dependency-failure semantics in FLOW.md

## Validation

- Standards review: PASS on exact head fc5459e17a39eacd7afc96753a0f58517624ea9b
- Spec review: PASS on exact head fc5459e17a39eacd7afc96753a0f58517624ea9b
- GOWORK=off go test ./internal/... -count=1
- focused related-package unit tests and 100x regression repetition
- focused race tests for access/node, infra/delivery, runtime/delivery, runtime/online, and usecase/presence
- focused go vet and git diff --check
