### PR TITLE
refactor: add canonical channelappend delivery port

### DIFF
--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -1,5 +1,11 @@
 # internal/runtime/channelappend Flow
 
+During Online Delivery convergence, channelappend exposes a canonical
+plan-enqueue option beside the existing recipient worker port. A boundary
+adapter reuses the established exact-target grouping and batching path while
+explicitly labeling durable versus transient work; app wiring chooses only one
+delivery port at a time.
+
 ## Responsibility
 
 `internal/runtime/channelappend` owns local channel append-authority admission.

--- a/internal/runtime/channelappend/online_delivery_compat.go
+++ b/internal/runtime/channelappend/online_delivery_compat.go
@@ -1,0 +1,69 @@
+package channelappend
+
+import (
+	"context"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+)
+
+// OnlineDeliveryEnqueuer accepts canonical plans during the delivery-runtime migration.
+type OnlineDeliveryEnqueuer interface {
+	// EnqueueRecipientDeliveryPlan transfers one bounded plan to Online Delivery.
+	EnqueueRecipientDeliveryPlan(context.Context, onlinedelivery.RecipientDeliveryPlan) error
+}
+
+// onlineDeliveryCompatibilityEnqueuer keeps recipient selection and batching on
+// the established channelappend path while changing only the handoff contract.
+type onlineDeliveryCompatibilityEnqueuer struct {
+	// mode labels the canonical handoff without changing recipient selection.
+	mode onlinedelivery.Mode
+	// next is the converged Online Delivery admission boundary.
+	next OnlineDeliveryEnqueuer
+}
+
+func (e onlineDeliveryCompatibilityEnqueuer) EnqueueRecipientBatch(ctx context.Context, target RecipientAuthorityTarget, batch RecipientBatch) error {
+	return e.next.EnqueueRecipientDeliveryPlan(ctx, onlinedelivery.RecipientDeliveryPlan{
+		Mode:  e.mode,
+		Event: batch.Event,
+		Targets: []onlinedelivery.RecipientTargetBatch{{
+			Target:     target,
+			Recipients: batch.Recipients,
+		}},
+	})
+}
+
+func (e onlineDeliveryCompatibilityEnqueuer) EnqueueRecipientDeliveryPlan(ctx context.Context, plan RecipientDeliveryPlan) error {
+	targets := make([]onlinedelivery.RecipientTargetBatch, len(plan.Targets))
+	for i := range plan.Targets {
+		targets[i] = onlinedelivery.RecipientTargetBatch{
+			Target:     plan.Targets[i].Target,
+			Recipients: plan.Targets[i].Recipients,
+		}
+	}
+	return e.next.EnqueueRecipientDeliveryPlan(ctx, onlinedelivery.RecipientDeliveryPlan{
+		Mode:    e.mode,
+		Event:   plan.Event,
+		Targets: targets,
+	})
+}
+
+func deliveryEnqueuerFromOptions(opts Options) RecipientDeliveryEnqueuer {
+	if opts.OnlineDeliveryEnqueuer != nil {
+		return onlineDeliveryCompatibilityEnqueuer{
+			mode: onlinedelivery.ModeDurable,
+			next: opts.OnlineDeliveryEnqueuer,
+		}
+	}
+	return opts.RecipientDeliveryEnqueuer
+}
+
+// transientDeliveryEnqueuer changes only canonical adapters. Legacy delivery
+// retains its pre-convergence behavior because its contract has no mode field.
+func transientDeliveryEnqueuer(enqueuer RecipientDeliveryEnqueuer) RecipientDeliveryEnqueuer {
+	adapter, ok := enqueuer.(onlineDeliveryCompatibilityEnqueuer)
+	if !ok {
+		return enqueuer
+	}
+	adapter.mode = onlinedelivery.ModeTransient
+	return adapter
+}

--- a/internal/runtime/channelappend/online_delivery_compat_test.go
+++ b/internal/runtime/channelappend/online_delivery_compat_test.go
@@ -1,0 +1,58 @@
+package channelappend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+)
+
+func TestOnlineDeliveryCompatibilityPortCarriesExplicitMode(t *testing.T) {
+	enqueuer := &recordingOnlineDeliveryEnqueuerForTest{}
+	legacy := &recordingRecipientDeliveryEnqueuerForRecipientTest{}
+	ports := commitPortsFromOptions(Options{
+		RecipientAuthorityResolver: staticRecipientAuthorityResolverForRecipientTest{nodeID: 1},
+		RecipientDeliveryEnqueuer:  legacy,
+		OnlineDeliveryEnqueuer:     enqueuer,
+		RecipientBatchSize:         16,
+	})
+	target := AuthorityTarget{ChannelID: ChannelID{ID: "room", Type: 2}, Large: true}
+	_, err := dispatchCommittedRecipientsForTarget(
+		context.Background(), target,
+		CommittedEnvelope{MessageID: 7, MessageScopedUIDs: []string{"u1"}},
+		subscriberCache{}, ports,
+	)
+	if err != nil {
+		t.Fatalf("durable dispatch error = %v", err)
+	}
+	completion := (realtimeEffect{target: target}).runItem(context.Background(), preparedSend{
+		Command: SendCommand{
+			MessageID: 8, ChannelID: "room", ChannelType: 2,
+			MessageScopedUIDs: []string{"u1"}, NoPersist: true,
+		},
+	}, ports)
+	if completion.result.Err != nil {
+		t.Fatalf("transient dispatch error = %v", completion.result.Err)
+	}
+	if len(enqueuer.plans) != 2 || enqueuer.plans[0].Mode != onlinedelivery.ModeDurable || enqueuer.plans[1].Mode != onlinedelivery.ModeTransient {
+		t.Fatalf("plans = %#v, want durable then transient", enqueuer.plans)
+	}
+	wantTarget := recipientAuthorityTargetForTest(1, 1, 1)
+	for _, plan := range enqueuer.plans {
+		if len(plan.Targets) != 1 || plan.Targets[0].Target != wantTarget || len(plan.Targets[0].Recipients) != 1 || plan.Targets[0].Recipients[0].UID != "u1" {
+			t.Fatalf("plan targets = %#v, want exact target with u1", plan.Targets)
+		}
+	}
+	if got := legacy.callCount(); got != 0 {
+		t.Fatalf("legacy enqueue calls = %d, want canonical precedence", got)
+	}
+}
+
+type recordingOnlineDeliveryEnqueuerForTest struct {
+	plans []onlinedelivery.RecipientDeliveryPlan
+}
+
+func (e *recordingOnlineDeliveryEnqueuerForTest) EnqueueRecipientDeliveryPlan(_ context.Context, plan onlinedelivery.RecipientDeliveryPlan) error {
+	e.plans = append(e.plans, plan.Clone())
+	return nil
+}

--- a/internal/runtime/channelappend/options.go
+++ b/internal/runtime/channelappend/options.go
@@ -455,6 +455,8 @@ type Options struct {
 	RecipientAuthorityResolver RecipientAuthorityResolver
 	// RecipientDeliveryEnqueuer queues selected recipients for asynchronous delivery processing.
 	RecipientDeliveryEnqueuer RecipientDeliveryEnqueuer
+	// OnlineDeliveryEnqueuer queues canonical plans when the converged runtime is wired.
+	OnlineDeliveryEnqueuer OnlineDeliveryEnqueuer
 	// PersistAfterEnqueuer queues durable committed messages for plugin PersistAfter side effects.
 	PersistAfterEnqueuer PersistAfterEnqueuer
 	// ConversationActiveAdmitter admits active conversation batches after recipient expansion.
@@ -564,7 +566,7 @@ func commitPortsFromOptions(opts Options) commitPorts {
 		subscribers:                  opts.Subscribers,
 		activeAdmitter:               opts.ConversationActiveAdmitter,
 		recipientAuthorityResolver:   opts.RecipientAuthorityResolver,
-		deliveryEnqueuer:             opts.RecipientDeliveryEnqueuer,
+		deliveryEnqueuer:             deliveryEnqueuerFromOptions(opts),
 		persistAfter:                 opts.PersistAfterEnqueuer,
 		subscriberPageSize:           opts.SubscriberScanPageSize,
 		recipientBatchSize:           opts.RecipientBatchSize,

--- a/internal/runtime/channelappend/realtime.go
+++ b/internal/runtime/channelappend/realtime.go
@@ -46,6 +46,7 @@ func (e realtimeEffect) runItem(runtimeCtx context.Context, item preparedSend, p
 	defer cancel()
 	realtimePorts := ports
 	realtimePorts.activeAdmitter = nil
+	realtimePorts.deliveryEnqueuer = transientDeliveryEnqueuer(ports.deliveryEnqueuer)
 	event := committedEnvelopeForRealtime(item)
 	if _, err := dispatchCommittedRecipientsForTarget(ctx, e.target, event, subscriberCache{}, realtimePorts); err != nil {
 		return realtimeItemCompletion{item: item, result: SendBatchItemResult{Err: err}}


### PR DESCRIPTION
## Summary

- expose a canonical Online Delivery plan enqueuer option at the channelappend boundary
- adapt it onto the established exact-target grouping and batching path while preserving the legacy fallback
- label durable commits and NoPersist realtime handoffs with explicit delivery modes

Production app wiring is intentionally unchanged in this slice.

## Validation

- GOWORK=off go test ./internal/runtime/channelappend -count=1
- GOWORK=off go test -race ./internal/runtime/channelappend -count=1
- GOWORK=off go vet ./internal/runtime/channelappend
- GOWORK=off go test ./internal/... -count=1
- focused compatibility test repeated 100 times
- independent Spec and Standards reviews: PASS