### PR TITLE
fix(agent): raise review context budget

### DIFF
--- a/.github/review-agent/policy.json
+++ b/.github/review-agent/policy.json
@@ -30,7 +30,7 @@
     "max_changed_files": 50,
     "max_changed_bytes": 1048576,
     "max_changed_lines": 30000,
-    "max_context_bytes": 393216,
+    "max_context_bytes": 2097152,
     "max_model_response_bytes": 4194304,
     "max_context_tokens": 240000,
     "auto_compact_tokens": 216000,

--- a/internal/app/review_agent_policy.go
+++ b/internal/app/review_agent_policy.go
@@ -175,7 +175,7 @@ func ValidateReviewAgentPolicy(document ReviewAgentPolicy) error {
 		document.Limits.MaxChangedFiles != contract.MaxChangedFiles ||
 		document.Limits.MaxChangedBytes != 1048576 ||
 		document.Limits.MaxChangedLines != 30000 ||
-		document.Limits.MaxContextBytes != 393216 ||
+		document.Limits.MaxContextBytes != contract.MaxContextBytes ||
 		document.Limits.MaxModelResponseBytes <= 0 ||
 		document.Limits.MaxContextTokens != 240000 ||
 		document.Limits.AutoCompactTokens != 216000 ||

--- a/internal/contracts/reviewagent/context.go
+++ b/internal/contracts/reviewagent/context.go
@@ -9,7 +9,10 @@ import (
 )
 
 const (
-	MaxChangedFiles    = 50
+	MaxChangedFiles = 50
+	// MaxContextBytes bounds the canonical encoded Context Bundle.
+	MaxContextBytes int64 = 2 << 20
+
 	MaxInstructions    = 128
 	MaxMandatoryChecks = 128
 	MaxLinkedIssues    = 128

--- a/scripts/review_agent_schema_test.go
+++ b/scripts/review_agent_schema_test.go
@@ -45,7 +45,7 @@ func TestReviewAgentPolicy(t *testing.T) {
 	require.Equal(t, reviewagent.MaxInlineComments, policy.Limits.MaxInlineComments)
 	require.Equal(t, reviewagent.MaxFindings, policy.Limits.MaxFindings)
 	require.Equal(t, reviewagent.MaxChangedFiles, policy.Limits.MaxChangedFiles)
-	require.Equal(t, 393216, policy.Limits.MaxContextBytes)
+	require.Equal(t, reviewagent.MaxContextBytes, policy.Limits.MaxContextBytes)
 	require.Equal(t, 240000, policy.Limits.MaxContextTokens)
 	require.Equal(t, 216000, policy.Limits.AutoCompactTokens)
 	require.Equal(t, 3600, policy.Limits.MaxCPUSecondsPerProcess)
@@ -410,7 +410,7 @@ type reviewAgentLimits struct {
 	MaxChangedFiles                 int   `json:"max_changed_files"`
 	MaxChangedBytes                 int   `json:"max_changed_bytes"`
 	MaxChangedLines                 int   `json:"max_changed_lines"`
-	MaxContextBytes                 int   `json:"max_context_bytes"`
+	MaxContextBytes                 int64 `json:"max_context_bytes"`
 	MaxModelResponseBytes           int   `json:"max_model_response_bytes"`
 	MaxContextTokens                int   `json:"max_context_tokens"`
 	AutoCompactTokens               int   `json:"auto_compact_tokens"`


### PR DESCRIPTION
## What changed

- raise the Review Agent Context Bundle limit from 384 KiB to 2 MiB
- define the 2 MiB bound once in the review-agent contract
- make policy validation and schema tests consume the shared contract constant

## Why

PR #755 raised the complete changed-file inventory bound to 1 MiB / 30,000 lines. The old 384 KiB Context cap would still reject valid inventories before Kimi/Codex could review them. This is the second bootstrap stage: it changes only the Context bound after the inventory-bound stage was merged.

The model window remains 240k tokens and auto-compaction remains 216k. Credential, network, concurrency, and immutable-tree fences are unchanged.

## Validation

- `GOWORK=off go test ./internal/app ./internal/contracts/reviewagent ./scripts -count=1`
- `GOWORK=off go vet ./internal/app ./internal/contracts/reviewagent ./scripts`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check origin/main...HEAD`

Control-plane changes require independent approval from `@WuKongIM/review-agent-owners`.