### PR TITLE
refactor(app): isolate delivery wiring

### DIFF
--- a/internal/app/delivery_wiring.go
+++ b/internal/app/delivery_wiring.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
+	clusterinfra "github.com/WuKongIM/WuKongIM/internal/infra/cluster"
+	deliveryinfra "github.com/WuKongIM/WuKongIM/internal/infra/delivery"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	deliveryusecase "github.com/WuKongIM/WuKongIM/internal/usecase/delivery"
+)
+
+func (a *App) wireDelivery() {
+	if a.cfg.Delivery.Enabled && a.delivery == nil {
+		localPusher := deliveryinfra.NewLocalOwnerPusher(deliveryinfra.LocalOwnerPusherOptions{
+			Online:        a.online,
+			PendingAckTTL: a.cfg.Delivery.PendingAckTTL,
+			Logger:        a.logger.Named("delivery.owner"),
+		})
+		a.localOwnerPusher = localPusher
+		deliveryObserver := a.deliveryObserver()
+		var push runtimedelivery.Pusher = localPusher
+		var fanoutRemote runtimedelivery.FanoutTaskForwarder
+		var localNodeID uint64
+		if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
+			localNodeID = presenceNode.NodeID()
+			nodeClient := accessnode.NewClient(presenceNode)
+			push = clusterinfra.NewDeliveryPusher(localNodeID, localPusher, nodeClient)
+			fanoutRemote = nodeClient
+		}
+		var partitioner runtimedelivery.Partitioner
+		if routes, ok := a.cluster.(clusterWriteReadyRuntime); ok {
+			partitioner = clusterinfra.NewDeliveryPartitioner(routes)
+		}
+		fanoutWorker := runtimedelivery.NewFanoutWorker(runtimedelivery.FanoutWorkerOptions{
+			Subscribers: appSubscriberPlanner{
+				channel: runtimedelivery.NewChannelSubscriberPlanner(runtimedelivery.ChannelSubscriberPlannerOptions{
+					Source: a.deliverySubscribers,
+				}),
+			},
+			Presence:      presenceResolverAdapter{presence: a.presence},
+			Push:          push,
+			PageSize:      a.cfg.Delivery.FanoutPageSize,
+			PushBatchSize: a.cfg.Delivery.PushBatchSize,
+			Observer:      deliveryObserver,
+		})
+		var fanoutRunner runtimedelivery.FanoutTaskRunner = fanoutWorker
+		if localNodeID != 0 {
+			fanoutRunner = runtimedelivery.NewFanoutTaskRouter(runtimedelivery.FanoutTaskRouterOptions{
+				LocalNodeID: localNodeID,
+				Local:       fanoutWorker,
+				Remote:      fanoutRemote,
+				Observer:    deliveryObserver,
+			})
+		}
+		var retryObserver runtimedelivery.RetryObserver
+		if observer, ok := deliveryObserver.(runtimedelivery.RetryObserver); ok {
+			retryObserver = observer
+		}
+		retryScheduler := runtimedelivery.NewRetryScheduler(runtimedelivery.RetrySchedulerOptions{
+			Runner:      fanoutRunner,
+			Capacity:    a.cfg.Delivery.EventQueueSize,
+			MaxAttempts: defaultDeliveryRetryMaxAttempts,
+			Backoff:     defaultDeliveryRetryBackoff,
+			Observer:    retryObserver,
+			Goroutines:  a.goroutines,
+		})
+		var managerObserver runtimedelivery.ManagerObserver
+		if observer, ok := deliveryObserver.(runtimedelivery.ManagerObserver); ok {
+			managerObserver = observer
+		}
+		var ackObserver runtimedelivery.AckObserver
+		if observer, ok := deliveryObserver.(runtimedelivery.AckObserver); ok {
+			ackObserver = observer
+		}
+		var ackBatchObserver runtimedelivery.AckBatchObserver
+		if a.metrics != nil {
+			ackBatchObserver = deliveryMetricsObserver{metrics: a.metrics}
+		}
+		manager := runtimedelivery.NewManager(runtimedelivery.ManagerOptions{
+			Planner:          runtimedelivery.NewPlanner(runtimedelivery.PlannerOptions{Partitioner: partitioner}),
+			Runner:           retryScheduler,
+			AsyncQueueSize:   a.cfg.Delivery.EventQueueSize,
+			AsyncWorkers:     1,
+			ManagerObserver:  managerObserver,
+			Goroutines:       a.goroutines,
+			AckObserver:      ackObserver,
+			AckBatchObserver: ackBatchObserver,
+			Acks: runtimedelivery.NewAckTracker(runtimedelivery.AckTrackerOptions{
+				MaxPendingPerSession: a.cfg.Delivery.PendingAckMaxPerSession,
+			}),
+		})
+		localPusher.SetAckManager(manager)
+		a.deliveryManager = manager
+		a.deliveryRetry = retryScheduler
+		a.delivery = deliveryusecase.New(deliveryusecase.Options{Runtime: deliveryRuntimeAdapter{manager: manager}})
+		if a.deliveryWorker == nil {
+			a.deliveryWorker = deliveryWorkerGroup{retryScheduler, manager}
+		}
+		if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
+			adapter := accessnode.New(accessnode.Options{Delivery: localPusher, DeliveryFanout: fanoutWorker, Logger: a.logger.Named("node")})
+			presenceNode.RegisterRPC(accessnode.DeliveryPushRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryPushRPC))
+			presenceNode.RegisterRPC(accessnode.DeliveryFanoutRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryFanoutRPC))
+		}
+	}
+}

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -26,7 +26,6 @@ import (
 	channelusecase "github.com/WuKongIM/WuKongIM/internal/usecase/channel"
 	cmdsyncusecase "github.com/WuKongIM/WuKongIM/internal/usecase/cmdsync"
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
-	deliveryusecase "github.com/WuKongIM/WuKongIM/internal/usecase/delivery"
 	managementusecase "github.com/WuKongIM/WuKongIM/internal/usecase/management"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/message"
 	observe "github.com/WuKongIM/WuKongIM/internal/usecase/opsobserve"
@@ -681,101 +680,6 @@ func (a *App) wireUsers() {
 				SystemUIDs:   systemUIDs,
 				Logger:       a.logger.Named("usecase.user"),
 			})
-		}
-	}
-}
-
-func (a *App) wireDelivery() {
-	if a.cfg.Delivery.Enabled && a.delivery == nil {
-		localPusher := deliveryinfra.NewLocalOwnerPusher(deliveryinfra.LocalOwnerPusherOptions{
-			Online:        a.online,
-			PendingAckTTL: a.cfg.Delivery.PendingAckTTL,
-			Logger:        a.logger.Named("delivery.owner"),
-		})
-		a.localOwnerPusher = localPusher
-		deliveryObserver := a.deliveryObserver()
-		var push runtimedelivery.Pusher = localPusher
-		var fanoutRemote runtimedelivery.FanoutTaskForwarder
-		var localNodeID uint64
-		if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
-			localNodeID = presenceNode.NodeID()
-			nodeClient := accessnode.NewClient(presenceNode)
-			push = clusterinfra.NewDeliveryPusher(localNodeID, localPusher, nodeClient)
-			fanoutRemote = nodeClient
-		}
-		var partitioner runtimedelivery.Partitioner
-		if routes, ok := a.cluster.(clusterWriteReadyRuntime); ok {
-			partitioner = clusterinfra.NewDeliveryPartitioner(routes)
-		}
-		fanoutWorker := runtimedelivery.NewFanoutWorker(runtimedelivery.FanoutWorkerOptions{
-			Subscribers: appSubscriberPlanner{
-				channel: runtimedelivery.NewChannelSubscriberPlanner(runtimedelivery.ChannelSubscriberPlannerOptions{
-					Source: a.deliverySubscribers,
-				}),
-			},
-			Presence:      presenceResolverAdapter{presence: a.presence},
-			Push:          push,
-			PageSize:      a.cfg.Delivery.FanoutPageSize,
-			PushBatchSize: a.cfg.Delivery.PushBatchSize,
-			Observer:      deliveryObserver,
-		})
-		var fanoutRunner runtimedelivery.FanoutTaskRunner = fanoutWorker
-		if localNodeID != 0 {
-			fanoutRunner = runtimedelivery.NewFanoutTaskRouter(runtimedelivery.FanoutTaskRouterOptions{
-				LocalNodeID: localNodeID,
-				Local:       fanoutWorker,
-				Remote:      fanoutRemote,
-				Observer:    deliveryObserver,
-			})
-		}
-		var retryObserver runtimedelivery.RetryObserver
-		if observer, ok := deliveryObserver.(runtimedelivery.RetryObserver); ok {
-			retryObserver = observer
-		}
-		retryScheduler := runtimedelivery.NewRetryScheduler(runtimedelivery.RetrySchedulerOptions{
-			Runner:      fanoutRunner,
-			Capacity:    a.cfg.Delivery.EventQueueSize,
-			MaxAttempts: defaultDeliveryRetryMaxAttempts,
-			Backoff:     defaultDeliveryRetryBackoff,
-			Observer:    retryObserver,
-			Goroutines:  a.goroutines,
-		})
-		var managerObserver runtimedelivery.ManagerObserver
-		if observer, ok := deliveryObserver.(runtimedelivery.ManagerObserver); ok {
-			managerObserver = observer
-		}
-		var ackObserver runtimedelivery.AckObserver
-		if observer, ok := deliveryObserver.(runtimedelivery.AckObserver); ok {
-			ackObserver = observer
-		}
-		var ackBatchObserver runtimedelivery.AckBatchObserver
-		if a.metrics != nil {
-			ackBatchObserver = deliveryMetricsObserver{metrics: a.metrics}
-		}
-		manager := runtimedelivery.NewManager(runtimedelivery.ManagerOptions{
-			Planner:          runtimedelivery.NewPlanner(runtimedelivery.PlannerOptions{Partitioner: partitioner}),
-			Runner:           retryScheduler,
-			AsyncQueueSize:   a.cfg.Delivery.EventQueueSize,
-			AsyncWorkers:     1,
-			ManagerObserver:  managerObserver,
-			Goroutines:       a.goroutines,
-			AckObserver:      ackObserver,
-			AckBatchObserver: ackBatchObserver,
-			Acks: runtimedelivery.NewAckTracker(runtimedelivery.AckTrackerOptions{
-				MaxPendingPerSession: a.cfg.Delivery.PendingAckMaxPerSession,
-			}),
-		})
-		localPusher.SetAckManager(manager)
-		a.deliveryManager = manager
-		a.deliveryRetry = retryScheduler
-		a.delivery = deliveryusecase.New(deliveryusecase.Options{Runtime: deliveryRuntimeAdapter{manager: manager}})
-		if a.deliveryWorker == nil {
-			a.deliveryWorker = deliveryWorkerGroup{retryScheduler, manager}
-		}
-		if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
-			adapter := accessnode.New(accessnode.Options{Delivery: localPusher, DeliveryFanout: fanoutWorker, Logger: a.logger.Named("node")})
-			presenceNode.RegisterRPC(accessnode.DeliveryPushRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryPushRPC))
-			presenceNode.RegisterRPC(accessnode.DeliveryFanoutRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryFanoutRPC))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- move `App.wireDelivery` from the broad composition file into `delivery_wiring.go`
- keep the function body and construction order byte-for-byte unchanged
- establish a focused composition seam for the Online Delivery cutover

## Validation

- moved function body matches the base implementation byte-for-byte
- `GOWORK=off go test ./internal/app -count=1`
- `GOWORK=off go test -race ./internal/app -count=1`
- `GOWORK=off go vet ./internal/app`
- `git diff --check origin/main...HEAD`
- independent Spec and Standards reviews: PASS
- exact complete change: 110,754 bytes