### PR TITLE
refactor(agent): centralize review budgets

### DIFF
--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -121,10 +121,11 @@ rejects unrecorded claims, generation mismatches, incomplete coverage, failed
 mandatory checks, invalid findings, excessive output, and unexpected
 tracked-file mutation.
 
-The protected bounds admit at most 50 changed files, 128 KiB of captured
-change material, 10,000 changed lines, and a 384 KiB encoded Context. This
-conservatively enforces the 240,000-token model window and keeps three
-concurrent exact-content reads within the repository API budget.
+The protected bounds admit at most 50 changed files, 1 MiB of captured change
+material, 30,000 complete-file lines, and a 2 MiB encoded Context. The encoded
+byte cap is an ingestion bound; the 240,000-token model window and 216,000-token
+automatic-compaction threshold remain unchanged. Three concurrent
+exact-content reads remain within the repository API budget.
 
 ## Verdict and projections
 

--- a/internal/app/review_agent_policy.go
+++ b/internal/app/review_agent_policy.go
@@ -168,8 +168,8 @@ func ValidateReviewAgentPolicy(document ReviewAgentPolicy) error {
 		document.Interaction.MaxExplanationSessionsPerHead <= 0 ||
 		document.Interaction.MaxResponseBytesPerHead <= 0 ||
 		document.Limits.MaxChangedFiles != contract.MaxChangedFiles ||
-		document.Limits.MaxChangedBytes != 1048576 ||
-		document.Limits.MaxChangedLines != 30000 ||
+		document.Limits.MaxChangedBytes != contract.MaxChangedBytes ||
+		document.Limits.MaxChangedLines != contract.MaxChangedLines ||
 		document.Limits.MaxContextBytes != contract.MaxContextBytes ||
 		document.Limits.MaxModelResponseBytes <= 0 ||
 		document.Limits.MaxContextTokens != 240000 ||

--- a/internal/contracts/reviewagent/context.go
+++ b/internal/contracts/reviewagent/context.go
@@ -10,6 +10,12 @@ import (
 
 const (
 	MaxChangedFiles = 50
+	// MaxChangedBytes bounds the complete changed-file material captured for
+	// one Review generation.
+	MaxChangedBytes int64 = 1 << 20
+	// MaxChangedLines bounds the complete changed-file lines captured for one
+	// Review generation.
+	MaxChangedLines int64 = 30000
 	// MaxContextBytes bounds the canonical encoded Context Bundle.
 	MaxContextBytes int64 = 2 << 20
 

--- a/internal/infra/reviewagentgithub/reader.go
+++ b/internal/infra/reviewagentgithub/reader.go
@@ -531,8 +531,9 @@ func (client *Client) readPullInventory(
 
 func reviewInventoryLimits() verify.InventoryLimits {
 	return verify.InventoryLimits{
-		MaxFiles: contract.MaxChangedFiles, MaxTotalBytes: 1048576,
-		MaxLines: 30000,
+		MaxFiles:      contract.MaxChangedFiles,
+		MaxTotalBytes: contract.MaxChangedBytes,
+		MaxLines:      contract.MaxChangedLines,
 	}
 }
 

--- a/internal/infra/reviewagentgithub/reader_budget_test.go
+++ b/internal/infra/reviewagentgithub/reader_budget_test.go
@@ -12,7 +12,8 @@ func TestReviewInventoryLimits(t *testing.T) {
 
 	limits := reviewInventoryLimits()
 	if limits.MaxFiles != contract.MaxChangedFiles ||
-		limits.MaxTotalBytes != 1048576 || limits.MaxLines != 30000 {
+		limits.MaxTotalBytes != contract.MaxChangedBytes ||
+		limits.MaxLines != contract.MaxChangedLines {
 		t.Fatalf("review inventory limits = %+v", limits)
 	}
 }

--- a/scripts/review_agent_schema_test.go
+++ b/scripts/review_agent_schema_test.go
@@ -45,6 +45,8 @@ func TestReviewAgentPolicy(t *testing.T) {
 	require.Equal(t, reviewagent.MaxInlineComments, policy.Limits.MaxInlineComments)
 	require.Equal(t, reviewagent.MaxFindings, policy.Limits.MaxFindings)
 	require.Equal(t, reviewagent.MaxChangedFiles, policy.Limits.MaxChangedFiles)
+	require.Equal(t, reviewagent.MaxChangedBytes, policy.Limits.MaxChangedBytes)
+	require.Equal(t, reviewagent.MaxChangedLines, policy.Limits.MaxChangedLines)
 	require.Equal(t, reviewagent.MaxContextBytes, policy.Limits.MaxContextBytes)
 	require.Equal(t, 240000, policy.Limits.MaxContextTokens)
 	require.Equal(t, 216000, policy.Limits.AutoCompactTokens)
@@ -403,8 +405,8 @@ type reviewAgentInteraction struct {
 
 type reviewAgentLimits struct {
 	MaxChangedFiles                 int   `json:"max_changed_files"`
-	MaxChangedBytes                 int   `json:"max_changed_bytes"`
-	MaxChangedLines                 int   `json:"max_changed_lines"`
+	MaxChangedBytes                 int64 `json:"max_changed_bytes"`
+	MaxChangedLines                 int64 `json:"max_changed_lines"`
 	MaxContextBytes                 int64 `json:"max_context_bytes"`
 	MaxModelResponseBytes           int   `json:"max_model_response_bytes"`
 	MaxContextTokens                int   `json:"max_context_tokens"`


### PR DESCRIPTION
## Summary

- centralize the changed-file byte and line caps with the existing Review Agent context limits
- make policy validation, GitHub inventory reads, and schema contracts consume the shared limits
- document the active 1 MiB capture and 2 MiB encoded Context bounds

## Validation

- `GOWORK=off go test ./internal/contracts/reviewagent -count=1`
- `GOWORK=off go test ./internal/infra/reviewagentgithub -count=1`
- `GOWORK=off go test ./internal/app -count=1`
- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `GOWORK=off go vet ./internal/contracts/reviewagent ./internal/infra/reviewagentgithub ./internal/app ./scripts`
- `git diff --check origin/main...HEAD`