### PR TITLE
refactor(app): cut over online delivery runtime

### DIFF
--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -45,10 +45,10 @@ New(Config)
      Prometheus metrics and the optional Top collector
   -> create metrics registry when Observability.MetricsEnabled=true and attach
      runtime observers for metrics/logging
-     (gateway runtime pressure, Slot scheduler/proposal/apply-gap/leader-election pressure and low-cardinality preferred-leader reconcile decisions/strict-wait latency, Controller Raft step queue/bounded outbound send queue/apply gap, Transport service RPC totals/latency and observed write-batch shape, Channel runtime append/replication/PullHint/PullBatch/leader-Pull/runtime pressure stages, message DB grouped commit pressure, and delivery fanout)
+     (gateway runtime pressure, Slot scheduler/proposal/apply-gap/leader-election pressure and low-cardinality preferred-leader reconcile decisions/strict-wait latency, Controller Raft step queue/bounded outbound send queue/apply gap, Transport service RPC totals/latency and observed write-batch shape, Channel runtime append/replication/PullHint/PullBatch/leader-Pull/runtime pressure stages, message DB grouped commit pressure, and online delivery)
      plus direct ants/v2 pool occupancy gauges for instrumented runtime pools
-     plus direct channelappend owner-push attempts on the same bounded delivery
-     push metric families used by runtime fanout, conversation list request latency/page-shape metrics, conversation
+     plus canonical Online Delivery local and remote owner-push attempts on the
+     bounded delivery push metric families, conversation list request latency/page-shape metrics, conversation
      authority admit/list/cache-pressure/handoff counters, conversation active
      cache gauges, dirty-mutation counters, persisted/cleared/requeued/superseded
      flush conservation counters, fair dirty-queue and bounded dirty-age-index
@@ -58,7 +58,7 @@ New(Config)
      counters, presence authority expiry cost/index gauges and bounded owner
      touch-flush route/chunk/target-group counters plus aggregate exact-target
      endpoint lookup path/outcome/retry metrics, recipient authority batch
-     calls/items/physical-targets/duration, recipient delivery worker
+     calls/items/physical-targets/duration, online delivery runtime
      queue/admission/process metrics plus configured worker capacity and current
      in-flight command gauges, and owner-local ACK batch bind/finish shape,
      rejection, rollback, and duration metrics,
@@ -147,7 +147,7 @@ New(Config)
        Messages, durable state reads, and read-cursor writes
   -> when the cluster exposes cluster Slot metadata subscriber APIs, create
      a delivery metadata adapter backed by real storage for bench setup,
-     channelappend subscriber scans, and optional delivery fanout
+     and channelappend subscriber scans
   -> when the cluster exposes presence routing:
        create owner boot ID, online.Registry, runtime/presence.Directory,
        infra/cluster.PresenceAuthorityClient, usecase/presence.App,
@@ -220,16 +220,16 @@ New(Config)
        adapter, owner-local online registry, optional presence lookup, and the
        channel metadata adapter as the system UID store
   -> when Delivery.Enabled=true:
-       create a cluster-backed delivery partitioner
-       create infra/delivery.LocalOwnerPusher for exact owner-local session,
-       packet, and pending-RECVACK adaptation
-       when route snapshots are available, an app subscriber planner, presence
-       resolver, cluster delivery pusher, and partition-leader fanout router
-       wrap the fanout runner with a bounded in-memory retry scheduler
-       create runtime/delivery Manager in bounded async mode around the runner
-       attach delivery observer for metrics and async error logging
-       create usecase/delivery.App backed by the manager
-       register delivery push and fanout RPC handlers when node RPC is available
+       create the canonical runtime/delivery Runtime with bounded plan
+       admission, exact-target presence resolution, owner grouping, narrow
+       retry, pending-RECVACK tracking, and plugin/webhook offline observers
+       supply infra/delivery.LocalSessionWriter for final exact owner-local
+       packet writes and the node RPC client for remote owner pushes
+       attach delivery observers for metrics, pressure, ACK state, and bounded
+       terminal error logging
+       expose gateway RECVACK/session-close feedback through the temporary
+       usecase/delivery facade; channelappend remains the sole plan producer
+       register only the owner-push RPC handler when node RPC is available
   -> when Plugin.Enable=true (default unless WK_PLUGIN_ENABLE=false is set):
        wire a node-local PDK-compatible plugin runtime with a Unix host RPC
        socket, the lifecycle plus /message/send, /channel/messages,
@@ -250,10 +250,10 @@ New(Config)
        positive toNodeId /plugin/httpForward calls through the cluster manager
        plugin RPC forwarder; wire Receive hook binding selection to
        cluster-authoritative UID plugin bindings when available; attach the
-       plugin hook metrics observer
-       when metrics are enabled, expose durable commit PersistAfter events to
-       channelappend, expose each durable offline recipient batch to
-       channelappend's recipient delivery worker for Receive hooks, and
+       plugin hook metrics observer when metrics are enabled; expose durable
+       commit PersistAfter events to
+       channelappend, expose each durable offline recipient batch from the
+       Online Delivery runtime to Receive hooks, and
        register the manager plugin RPC handler when node RPC is available so
        peer managers can inspect or mutate this node's plugin lifecycle state
        and invoke this node's local /plugin/route hook for forwarded plugin
@@ -261,8 +261,9 @@ New(Config)
   -> when Webhook config is enabled:
        create the node-local webhook runtime with bounded workqueue admission,
        finite retry, and an HTTP sender; wire webhook adapters into
-       channelappend's durable post-commit PersistAfter sink, the batch offline
-       recipient observer, and the presence online-status observer
+       channelappend's durable post-commit PersistAfter sink, the Online
+       Delivery runtime's batch offline-recipient observer, and the presence
+       online-status observer
        Plugin hooks and webhook sinks coexist on the same side-effect surfaces.
        Webhook failures are best-effort side effects and must not affect
        SENDACK, durable append, recipient delivery, or conversation active
@@ -272,9 +273,8 @@ New(Config)
        cluster ChannelAppender, node-scoped message IDs, subscriber source,
        cluster-backed idempotency lookup when the cluster exposes it,
        infra/cluster recipient authority resolver adapter, conversation active-batch admitter,
-       optional recipient delivery worker enqueuer, optional plugin/webhook
-       PersistAfter enqueuers, optional plugin/webhook offline-recipient
-       observers, append metrics observer, and shared append/post-commit worker
+       optional canonical Online Delivery plan enqueuer, optional plugin/webhook
+       PersistAfter enqueuers, append metrics observer, and shared append/post-commit worker
        pools
        create channelappend.Router for local authority admission and remote
        channel-authority forwarding
@@ -403,7 +403,7 @@ Start(ctx)
   -> plugin runtime Start(ctx): open the host RPC socket, scan local plugins, and start enabled processes
   -> plugin PersistAfter worker Start(ctx): accept durable commit side effects before channel append opens
   -> webhook runtime Start(ctx): accept post-commit webhook side effects before producers open
-  -> delivery worker group Start(ctx): retry scheduler, async manager, then recipient delivery worker
+  -> Online Delivery runtime Start(ctx): open bounded plan admission and workers
   -> channel append group Start(ctx): open local channel-authority writer admission
   -> api.Start()
   -> manager.Start()
@@ -439,7 +439,7 @@ Stop(ctx)
        and controller-task-audit dependencies running
        retain their started flags so a later Stop(newCtx) waits for the same
        channel append drain and then resumes this dependency shutdown sequence
-  -> delivery worker group Stop(ctx): recipient delivery worker drains before async manager and retry scheduler
+  -> Online Delivery runtime Stop(ctx): close admission and drain accepted plans
   -> webhook runtime Stop(ctx): stop accepting new webhook side effects after producers drain
   -> plugin PersistAfter worker Stop(ctx): stop accepting new side effects after channel append drains
   -> plugin runtime Stop(ctx): stop plugin processes and close the host RPC socket
@@ -502,9 +502,9 @@ post-commit PersistAfter, batch offline recipient observation, and online-status
 observation. Webhook queue admission, retries, and HTTP failures remain
 best-effort and do not change SENDACK, durable append, plugin hooks,
 conversation active admission, or owner delivery.
-The manager drains accepted fanout before the retry scheduler stops, so queued
-retries remain available while accepted manager work completes. Stale pending
-recvacks expire during owner-local push activity. The owner pusher admits at
+The Online Delivery runtime drains accepted plans before it stops. Retryable
+owner routes are narrowed and retried inside the plan's bounded execution
+window. Stale pending recvacks expire during owner-local push activity. The runtime admits at
 most one full pending-ack scan per second and never overlaps scans; ordinary
 pushes, binds, and Recvacks therefore do not pay an O(pending acks) sweep on
 every owner batch. The tracker uses second-resolution delivery timestamps, so

--- a/internal/app/FLOW_PRODUCT_RUNTIME.md
+++ b/internal/app/FLOW_PRODUCT_RUNTIME.md
@@ -1,9 +1,15 @@
 # internal/app Product Runtime Details
 
 This companion to `FLOW.md` records the detailed product-runtime composition
-and messaging flows. `FLOW.md` remains the package's canonical index and may
-temporarily duplicate this detail during the review-bounded extraction; once
-linked, this file owns the detailed product-runtime flow.
+and messaging flows. `FLOW.md` remains the package's canonical index; this file
+owns the linked product-runtime detail.
+
+During Online Delivery convergence, app wiring starts only
+`internal/runtime/delivery.Runtime`, injects it into channelappend through the
+canonical compatibility port, and registers only owner-push RPC. The old
+manager/retry/fanout implementations remain compiled for one cleanup step but
+are no longer constructed. Gateway feedback temporarily crosses the existing
+delivery-usecase facade, which performs only command-type conversion.
 
 Operations MCP has no independent process, listener, port, or config enable
 switch. `internal/app` creates and closes its local call-control audit writer,
@@ -66,9 +72,10 @@ current control snapshot.
 delivery disabled, committed message effects still run inside the channel
 authority writer so recent conversation state is updated, but no online
 delivery is submitted. With delivery enabled, gateway RECVACK and session close
-feedback flows to the delivery usecase, while channelappend post-commit effects
-enqueue bounded multi-target recipient delivery plans into the recipient
-delivery worker. Each plan retains every exact Slot authority fence. The app
+feedback flows through the temporary delivery usecase facade, while
+channelappend post-commit effects enqueue bounded multi-target recipient
+delivery plans into the canonical Online Delivery runtime. Each plan retains
+every exact Slot authority fence. The app
 presence adapter converts all plan groups in one call; the cluster adapter then
 batches local groups in the presence directory, acquiring one read lock per
 touched directory shard while preserving group-aligned partial errors, and
@@ -93,7 +100,7 @@ recipient-authority target fanout for legacy batch-only enqueuers. The
 production plan-capable worker admits exact-target groups together instead of
 using this target fanout.
 `Delivery.RecipientWorkerConcurrency` independently defaults to 100 and controls
-only the goroutines draining the bounded recipient delivery queue. The legacy
+only the goroutines draining the bounded Online Delivery plan queue. The legacy
 target fanout and production plan execution capacities therefore remain
 independent. The lookup-shard count controls writer map sharding; effect workers run only blocking effects and never write channel
 state concurrently with another advance for the same channel. The delivery
@@ -115,7 +122,7 @@ different shards or workers.
 The foreground SEND path waits only for channel-authority durable append;
 subscriber scan, recipient authority grouping, delivery enqueue, and the
 independent conversation active projection all run after SENDACK from the
-authority writer's best-effort post-commit pipeline. The recipient delivery worker later
+authority writer's best-effort post-commit pipeline. The Online Delivery runtime later
 drains accepted plans, resolves all exact-target groups through the batched
 presence seam, coalesces successful routes by owner across each whole plan,
 splits each owner group by `Delivery.PushBatchSize`, and pushes those bounded
@@ -131,15 +138,17 @@ performs only a short bounded fresh-route retry in the routed client. Delivery
 is enqueued first; active projection failures surface independently as the
 `conversation_active` post-commit phase and do not stop online delivery or later
 large-channel pages.
-Runtime fanout failures are counted with normalized delivery error classes.
-Retryable fanout failures enter a bounded in-memory retry scheduler with a small
-fixed attempt cap; retry queue overflow is surfaced as `queue_full`. The
-composition root supplies `infra/delivery.LocalOwnerPusher` to that runtime and
-installs the delivery Manager before workers start. Exact owner-local session
-revalidation, recipient-specific `RecvPacket` construction, item-aligned pending
+Runtime owner-push failures are counted with normalized delivery error classes.
+Retryable results are narrowed to their exact routes and retried within a small
+fixed attempt cap; terminal or exhausted results remain plan-local. The
+composition root supplies `infra/delivery.LocalSessionWriter` to the runtime
+and registers only the owner-push node RPC before workers start. Exact
+owner-local session revalidation and recipient-specific `RecvPacket`
+construction remain inside that adapter. The runtime owns item-aligned pending
 RECVACK bind/finish/rollback, duplicate reservation refresh, write-error
-classification, and activity-throttled expiry remain inside the adapter; see
-`internal/infra/delivery/FLOW.md` for that state machine. The same append observer records
+classification, and activity-throttled expiry; see
+`internal/infra/delivery/FLOW.md` and `internal/runtime/delivery/FLOW.md` for
+those state machines. The same append observer records
 per-message append success/error latency and classifies append failures with
 low-cardinality labels for benchmark triage, including typed Channel runtime/cluster
 errors and short append results.
@@ -162,28 +171,26 @@ through the shared `ConversationAuthorityClient`; its first attempt consumes
 the already-grouped aligned snapshot, while exceptional sender or recipient
 route items use the legacy active-admission compatibility path. Channelappend
 chooses normal versus CMD kind from the committed envelope, and active admission
-still runs when online delivery is disabled. When delivery is enabled, the app wires a bounded
-recipient delivery worker that drains those plans and runs the delivery-only
-channelappend recipient processor outside the authority writer. `/bench/v1/channels`,
+still runs when online delivery is disabled. When delivery is enabled, the app
+wires the bounded canonical Online Delivery runtime that drains those plans
+outside the authority writer. `/bench/v1/channels`,
 `/bench/v1/channels/subscribers`, and `/bench/v1/channels/subscribers/remove`
 write real channel metadata or add/remove subscriber rows through Slot proposals.
 The benchmark data writer uses bounded concurrency for independent
 channel/subscriber mutations while preserving subscriber mutation order within
 the same channel. Scoped UID delivery bypasses subscriber scan and
 flows through recipient authority grouping, presence resolution, and the local
-or RPC owner pusher after the recipient delivery worker accepts the plan.
+or RPC owner pusher after the Online Delivery runtime accepts the plan.
 The app maps the worker's serialized execution-pressure observation into
 Prometheus worker capacity and in-flight gauges. These metrics do not include
 UID, channel, slot, or per-target labels.
 
-When the cluster runtime exposes route snapshots, delivery planning uses the
-cluster UID hash-slot table to create authority partitions. A fanout task
-router runs local partitions through the in-process fanout worker and forwards
-remote partitions through access/node Delivery Fanout RPC. The remote node then
-uses its own subscriber source and still pushes resolved online routes by
-owner node. Runtime fanout task, resolve, and push observations are translated
-by app-level metrics/logging adapters; retry enqueue, attempt, drop, and
-queue-depth observations use the same adapter. The delivery runtime itself stays
+Channelappend creates exact-target recipient plans from the cluster UID
+authority table. The Online Delivery runtime resolves each complete plan,
+coalesces routes by owner node, executes local owner pushes directly, and
+forwards remote owner pushes through access/node Delivery Push RPC. App-level
+adapters translate bounded plan admission, terminal, pressure, owner-push, and
+ACK observations into metrics and logs. The delivery runtime itself stays
 independent from Prometheus and concrete logging backends.
 
 The Channel runtime metrics observer also logs rare admitted-append cancellation

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -116,12 +116,14 @@ type App struct {
 	// webhookPresence adapts owner-local online status transitions into webhook events.
 	webhookPresence presence.OnlineStatusObserver
 	// plugins exposes v2 plugin lifecycle and hook usecases.
-	plugins          *pluginusecase.App
-	channels         *channelusecase.App
-	cmdSync          *cmdsyncusecase.App
-	conversations    *conversationusecase.App
-	users            *userusecase.App
-	delivery         *deliveryusecase.App
+	plugins       *pluginusecase.App
+	channels      *channelusecase.App
+	cmdSync       *cmdsyncusecase.App
+	conversations *conversationusecase.App
+	users         *userusecase.App
+	delivery      *deliveryusecase.App
+	// onlineDelivery owns canonical recipient-plan processing and owner-local ACK state.
+	onlineDelivery   *runtimedelivery.Runtime
 	deliveryManager  *runtimedelivery.Manager
 	deliveryRetry    *runtimedelivery.RetryScheduler
 	deliveryWorker   WorkerRuntime
@@ -266,10 +268,10 @@ func New(cfg Config, opts ...Option) (*App, error) {
 	app.wireNodeLifecycleRPC()
 	app.wireSeedJoinLoop()
 	app.wireUsers()
-	app.wireDelivery()
 	if err := app.wirePluginSubsystem(clusterCfg.NodeID); err != nil {
 		return nil, err
 	}
+	app.wireDelivery()
 	app.wireManagerPluginRPC()
 	if err := app.wireChannelAppend(clusterCfg.NodeID); err != nil {
 		return nil, err

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -21,9 +21,16 @@ import (
 const defaultDeliveryRetryMaxAttempts = 3
 const defaultDeliveryRetryBackoff = 10 * time.Millisecond
 
+var errOnlineDeliveryCommittedSubmitUnsupported = errors.New("internal/app: committed delivery submission requires a canonical recipient plan")
+
 type deliveryRuntimeAdapter struct {
 	// manager handles committed-message fanout and ack mutations.
 	manager *runtimedelivery.Manager
+}
+
+type onlineDeliveryUsecaseAdapter struct {
+	// runtime owns recipient feedback after channelappend produces canonical plans.
+	runtime *runtimedelivery.Runtime
 }
 
 type deliveryWorkerGroup []WorkerRuntime
@@ -350,6 +357,28 @@ func (a deliveryRuntimeAdapter) SessionClosed(ctx context.Context, cmd deliveryu
 		return nil
 	}
 	return a.manager.SessionClosed(ctx, runtimedelivery.SessionClosed{UID: cmd.UID, SessionID: cmd.SessionID})
+}
+
+// SubmitCommitted is retained only for the temporary delivery-usecase facade.
+// Channelappend is the sole production producer of canonical delivery plans.
+func (a onlineDeliveryUsecaseAdapter) SubmitCommitted(context.Context, messageevents.MessageCommitted) error {
+	return errOnlineDeliveryCommittedSubmitUnsupported
+}
+
+func (a onlineDeliveryUsecaseAdapter) Recvack(ctx context.Context, cmd deliveryusecase.RecvackCommand) error {
+	if a.runtime == nil {
+		return nil
+	}
+	return a.runtime.Recvack(ctx, runtimedelivery.Recvack{
+		UID: cmd.UID, SessionID: cmd.SessionID, MessageID: cmd.MessageID, MessageSeq: cmd.MessageSeq,
+	})
+}
+
+func (a onlineDeliveryUsecaseAdapter) SessionClosed(ctx context.Context, cmd deliveryusecase.SessionClosedCommand) error {
+	if a.runtime == nil {
+		return nil
+	}
+	return a.runtime.SessionClosed(ctx, runtimedelivery.SessionClosed{UID: cmd.UID, SessionID: cmd.SessionID})
 }
 
 type appSubscriberPlanner struct {

--- a/internal/app/delivery_wiring.go
+++ b/internal/app/delivery_wiring.go
@@ -9,96 +9,54 @@ import (
 )
 
 func (a *App) wireDelivery() {
-	if a.cfg.Delivery.Enabled && a.delivery == nil {
-		localPusher := deliveryinfra.NewLocalOwnerPusher(deliveryinfra.LocalOwnerPusherOptions{
-			Online:        a.online,
-			PendingAckTTL: a.cfg.Delivery.PendingAckTTL,
-			Logger:        a.logger.Named("delivery.owner"),
+	if !a.cfg.Delivery.Enabled || a.onlineDelivery != nil {
+		return
+	}
+	localNodeID := a.cfg.Cluster.NodeID
+	if localNodeID == 0 {
+		localNodeID = a.cfg.NodeID
+	}
+	var remote runtimedelivery.RemoteOwnerPusher
+	if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
+		localNodeID = presenceNode.NodeID()
+		remote = accessnode.NewClient(presenceNode)
+	}
+	_, offlineBatch := composeOfflineRecipientObservers(a.pluginReceive, a.webhookOffline)
+	var offlineObserver runtimedelivery.OfflineRecipientsObserver
+	if offlineBatch != nil {
+		offlineObserver = onlineDeliveryOfflineObserver{next: offlineBatch}
+	}
+	observer := a.onlineDeliveryObserver()
+	runtime := runtimedelivery.NewRuntime(runtimedelivery.RuntimeOptions{
+		LocalNodeID:               localNodeID,
+		Presence:                  deliveryinfra.NewPresenceResolver(a.presence),
+		RemoteOwnerPusher:         remote,
+		SessionWriter:             deliveryinfra.NewLocalSessionWriter(deliveryinfra.LocalSessionWriterOptions{Online: a.online, Logger: a.logger.Named("delivery.owner")}),
+		OfflineRecipientsObserver: offlineObserver,
+		QueueSize:                 a.cfg.Delivery.EventQueueSize,
+		Workers:                   a.cfg.Delivery.RecipientWorkerConcurrency,
+		MaxPlanRecipients:         a.cfg.Delivery.PushBatchSize,
+		OwnerPushBatchSize:        a.cfg.Delivery.PushBatchSize,
+		RetryMaxAttempts:          defaultDeliveryRetryMaxAttempts,
+		RetryInitialBackoff:       defaultDeliveryRetryBackoff,
+		RetryMaxBackoff:           defaultDeliveryRetryBackoff,
+		PendingAckTTL:             a.cfg.Delivery.PendingAckTTL,
+		Observer:                  observer,
+		AckObserver:               observer,
+		AckBatchObserver:          observer,
+		Goroutines:                a.goroutines,
+		Acks: runtimedelivery.NewAckTracker(runtimedelivery.AckTrackerOptions{
+			MaxPendingPerSession: a.cfg.Delivery.PendingAckMaxPerSession,
+		}),
+	})
+	a.onlineDelivery = runtime
+	a.delivery = deliveryusecase.New(deliveryusecase.Options{Runtime: onlineDeliveryUsecaseAdapter{runtime: runtime}})
+	a.deliveryWorker = runtime
+	if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
+		adapter := accessnode.New(accessnode.Options{
+			Delivery: accessnode.AdaptOnlineDeliveryOwnerPush(runtime),
+			Logger:   a.logger.Named("node"),
 		})
-		a.localOwnerPusher = localPusher
-		deliveryObserver := a.deliveryObserver()
-		var push runtimedelivery.Pusher = localPusher
-		var fanoutRemote runtimedelivery.FanoutTaskForwarder
-		var localNodeID uint64
-		if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
-			localNodeID = presenceNode.NodeID()
-			nodeClient := accessnode.NewClient(presenceNode)
-			push = clusterinfra.NewDeliveryPusher(localNodeID, localPusher, nodeClient)
-			fanoutRemote = nodeClient
-		}
-		var partitioner runtimedelivery.Partitioner
-		if routes, ok := a.cluster.(clusterWriteReadyRuntime); ok {
-			partitioner = clusterinfra.NewDeliveryPartitioner(routes)
-		}
-		fanoutWorker := runtimedelivery.NewFanoutWorker(runtimedelivery.FanoutWorkerOptions{
-			Subscribers: appSubscriberPlanner{
-				channel: runtimedelivery.NewChannelSubscriberPlanner(runtimedelivery.ChannelSubscriberPlannerOptions{
-					Source: a.deliverySubscribers,
-				}),
-			},
-			Presence:      presenceResolverAdapter{presence: a.presence},
-			Push:          push,
-			PageSize:      a.cfg.Delivery.FanoutPageSize,
-			PushBatchSize: a.cfg.Delivery.PushBatchSize,
-			Observer:      deliveryObserver,
-		})
-		var fanoutRunner runtimedelivery.FanoutTaskRunner = fanoutWorker
-		if localNodeID != 0 {
-			fanoutRunner = runtimedelivery.NewFanoutTaskRouter(runtimedelivery.FanoutTaskRouterOptions{
-				LocalNodeID: localNodeID,
-				Local:       fanoutWorker,
-				Remote:      fanoutRemote,
-				Observer:    deliveryObserver,
-			})
-		}
-		var retryObserver runtimedelivery.RetryObserver
-		if observer, ok := deliveryObserver.(runtimedelivery.RetryObserver); ok {
-			retryObserver = observer
-		}
-		retryScheduler := runtimedelivery.NewRetryScheduler(runtimedelivery.RetrySchedulerOptions{
-			Runner:      fanoutRunner,
-			Capacity:    a.cfg.Delivery.EventQueueSize,
-			MaxAttempts: defaultDeliveryRetryMaxAttempts,
-			Backoff:     defaultDeliveryRetryBackoff,
-			Observer:    retryObserver,
-			Goroutines:  a.goroutines,
-		})
-		var managerObserver runtimedelivery.ManagerObserver
-		if observer, ok := deliveryObserver.(runtimedelivery.ManagerObserver); ok {
-			managerObserver = observer
-		}
-		var ackObserver runtimedelivery.AckObserver
-		if observer, ok := deliveryObserver.(runtimedelivery.AckObserver); ok {
-			ackObserver = observer
-		}
-		var ackBatchObserver runtimedelivery.AckBatchObserver
-		if a.metrics != nil {
-			ackBatchObserver = deliveryMetricsObserver{metrics: a.metrics}
-		}
-		manager := runtimedelivery.NewManager(runtimedelivery.ManagerOptions{
-			Planner:          runtimedelivery.NewPlanner(runtimedelivery.PlannerOptions{Partitioner: partitioner}),
-			Runner:           retryScheduler,
-			AsyncQueueSize:   a.cfg.Delivery.EventQueueSize,
-			AsyncWorkers:     1,
-			ManagerObserver:  managerObserver,
-			Goroutines:       a.goroutines,
-			AckObserver:      ackObserver,
-			AckBatchObserver: ackBatchObserver,
-			Acks: runtimedelivery.NewAckTracker(runtimedelivery.AckTrackerOptions{
-				MaxPendingPerSession: a.cfg.Delivery.PendingAckMaxPerSession,
-			}),
-		})
-		localPusher.SetAckManager(manager)
-		a.deliveryManager = manager
-		a.deliveryRetry = retryScheduler
-		a.delivery = deliveryusecase.New(deliveryusecase.Options{Runtime: deliveryRuntimeAdapter{manager: manager}})
-		if a.deliveryWorker == nil {
-			a.deliveryWorker = deliveryWorkerGroup{retryScheduler, manager}
-		}
-		if presenceNode, ok := a.cluster.(clusterinfra.PresenceNode); ok {
-			adapter := accessnode.New(accessnode.Options{Delivery: localPusher, DeliveryFanout: fanoutWorker, Logger: a.logger.Named("node")})
-			presenceNode.RegisterRPC(accessnode.DeliveryPushRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryPushRPC))
-			presenceNode.RegisterRPC(accessnode.DeliveryFanoutRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryFanoutRPC))
-		}
+		presenceNode.RegisterRPC(accessnode.DeliveryPushRPCServiceID, nodeRPCHandlerFunc(adapter.HandleDeliveryPushRPC))
 	}
 }

--- a/internal/app/delivery_wiring_test.go
+++ b/internal/app/delivery_wiring_test.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
-	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
+	"github.com/WuKongIM/WuKongIM/internal/contracts/messageevents"
 	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
 )
 
@@ -28,11 +30,11 @@ func TestNewWiresIndependentRecipientDeliveryWorkerConcurrency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
-	if app.channelAppendDeliveryWorker == nil {
-		t.Fatal("channelappend recipient delivery worker was not wired")
+	if app.onlineDelivery == nil {
+		t.Fatal("online delivery runtime was not wired")
 	}
-	if got := app.channelAppendDeliveryWorker.WorkerCapacity(); got != 7 {
-		t.Fatalf("recipient delivery worker capacity = %d, want 7", got)
+	if got := app.onlineDelivery.WorkerCapacity(); got != 7 {
+		t.Fatalf("online delivery worker capacity = %d, want 7", got)
 	}
 }
 
@@ -53,8 +55,11 @@ func TestNewWiresDeliveryWhenEnabled(t *testing.T) {
 	if app.Delivery() == nil {
 		t.Fatal("delivery usecase was not wired")
 	}
-	if app.deliveryManager == nil {
-		t.Fatal("delivery manager was not wired")
+	if err := app.Delivery().SubmitCommitted(context.Background(), messageevents.MessageCommitted{}); !errors.Is(err, errOnlineDeliveryCommittedSubmitUnsupported) {
+		t.Fatalf("delivery compatibility SubmitCommitted() error = %v, want canonical-plan requirement", err)
+	}
+	if app.onlineDelivery == nil {
+		t.Fatal("online delivery runtime was not wired")
 	}
 	if _, ok := cluster.registeredHandlers[accessnode.DeliveryPushRPCServiceID]; !ok {
 		t.Fatalf("delivery push rpc service was not registered")
@@ -62,36 +67,20 @@ func TestNewWiresDeliveryWhenEnabled(t *testing.T) {
 	if app.deliveryWorker == nil {
 		t.Fatal("delivery worker was not wired")
 	}
-	if app.channelAppendDeliveryWorker == nil {
-		t.Fatal("channelappend recipient delivery worker was not wired")
+	if app.channelAppendDeliveryWorker != nil {
+		t.Fatal("legacy channelappend recipient delivery worker was wired")
 	}
-	if app.deliveryManager == nil || app.deliveryManager.PendingAckCount() != 0 {
-		t.Fatal("delivery manager was not initialized for async runtime")
+	if app.onlineDelivery.PendingAckCount() != 0 {
+		t.Fatal("online delivery runtime was not initialized with empty ack state")
 	}
-	group, ok := app.deliveryWorker.(deliveryWorkerGroup)
-	if !ok {
-		t.Fatalf("delivery worker = %T, want deliveryWorkerGroup", app.deliveryWorker)
+	if app.deliveryWorker != app.onlineDelivery {
+		t.Fatalf("delivery worker = %T, want online delivery runtime", app.deliveryWorker)
 	}
-	if len(group) != 3 {
-		t.Fatalf("delivery worker count = %d, want recipient worker, retry scheduler, and manager", len(group))
+	if app.deliveryManager != nil || app.deliveryRetry != nil || app.localOwnerPusher != nil {
+		t.Fatal("legacy delivery runtime was wired")
 	}
-	if group[0] != app.deliveryRetry {
-		t.Fatalf("delivery worker[0] = %T, want retry scheduler", group[0])
-	}
-	if group[1] != app.deliveryManager {
-		t.Fatalf("delivery worker[1] = %T, want manager", group[1])
-	}
-	if _, ok := group[2].(*channelappend.RecipientDeliveryWorker); !ok {
-		t.Fatalf("delivery worker[2] = %T, want recipient delivery worker", group[2])
-	}
-	if group[2] != app.channelAppendDeliveryWorker {
-		t.Fatalf("delivery worker[2] = %T, want app channelappend recipient delivery worker", group[2])
-	}
-	if app.deliveryRetry == nil {
-		t.Fatal("delivery retry scheduler was not wired")
-	}
-	if _, ok := cluster.registeredHandlers[accessnode.DeliveryFanoutRPCServiceID]; !ok {
-		t.Fatalf("delivery fanout rpc service was not registered")
+	if _, ok := cluster.registeredHandlers[accessnode.DeliveryFanoutRPCServiceID]; ok {
+		t.Fatalf("retired delivery fanout rpc service was registered")
 	}
 }
 
@@ -100,7 +89,9 @@ func waitAppDeliveryPendingAckCount(t *testing.T, app *App, want int, timeout ti
 	deadline := time.Now().Add(timeout)
 	var got int
 	for time.Now().Before(deadline) {
-		got = app.deliveryManager.PendingAckCount()
+		if app.onlineDelivery != nil {
+			got = app.onlineDelivery.PendingAckCount()
+		}
 		if got == want {
 			return
 		}

--- a/internal/app/online_delivery.go
+++ b/internal/app/online_delivery.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"context"
+
+	"github.com/WuKongIM/WuKongIM/internal/contracts/onlinedelivery"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	"github.com/WuKongIM/WuKongIM/pkg/wklog"
+)
+
+type onlineDeliveryObserver struct {
+	// app projects canonical runtime observations into product metrics and logs.
+	app *App
+}
+
+func (a *App) onlineDeliveryObserver() *onlineDeliveryObserver {
+	if a == nil {
+		return nil
+	}
+	if a.metrics == nil {
+		if _, ok := a.topProvider.(*topCollector); !ok && a.logger == nil {
+			return nil
+		}
+	}
+	return &onlineDeliveryObserver{app: a}
+}
+
+func (o *onlineDeliveryObserver) ObservePlanAdmission(event runtimedelivery.PlanAdmissionEvent) {
+	if o == nil || o.app == nil {
+		return
+	}
+	if o.app.metrics != nil {
+		o.app.metrics.Delivery.SetRecipientWorkerQueue(event.QueueDepth, event.QueueCapacity)
+		o.app.metrics.Delivery.ObserveRecipientWorkerAdmission(string(event.Result), event.Duration)
+	}
+	if collector, ok := o.app.topProvider.(*topCollector); ok {
+		collector.SetDeliveryRecipientQueue(int64(event.QueueDepth), int64(event.QueueCapacity))
+		if event.Result != runtimedelivery.ObservationResultAccepted && event.Result != runtimedelivery.ObservationResultOK {
+			collector.addCounter(topCounterDeliveryPushErr, 1)
+		}
+	}
+}
+
+func (o *onlineDeliveryObserver) ObservePlanTerminal(event runtimedelivery.PlanTerminalEvent) {
+	if o == nil || o.app == nil {
+		return
+	}
+	if o.app.metrics != nil {
+		o.app.metrics.Delivery.ObserveRecipientWorkerProcess(string(event.Result), event.Recipients, event.Duration)
+	}
+	if event.Result != runtimedelivery.ObservationResultOK {
+		o.observeError(event.Failure.Err)
+	}
+	if collector, ok := o.app.topProvider.(*topCollector); ok && event.Result != runtimedelivery.ObservationResultOK {
+		collector.addCounter(topCounterDeliveryPushErr, 1)
+	}
+	if event.Result != runtimedelivery.ObservationResultOK {
+		o.app.deliveryLogger().Warn("online delivery plan incomplete",
+			wklog.Event("internal.app.delivery.plan_incomplete"),
+			wklog.Result(string(event.Result)),
+			wklog.String("phase", string(event.Failure.Phase)),
+			wklog.String("mode", onlineDeliveryModeLabel(event.Mode)),
+			wklog.Int("recipients", event.Recipients),
+			wklog.UID(event.Failure.RecipientUID),
+			wklog.Uint64("ownerNodeID", event.Failure.OwnerNodeID),
+			wklog.Error(event.Failure.Err),
+		)
+	}
+}
+
+func (o *onlineDeliveryObserver) SetRuntimePressure(event runtimedelivery.RuntimePressureEvent) {
+	if o == nil || o.app == nil {
+		return
+	}
+	if o.app.metrics != nil {
+		o.app.metrics.Delivery.SetRecipientWorkerQueue(event.QueueDepth, event.QueueCapacity)
+		o.app.metrics.Delivery.SetRecipientWorkerPressure(event.Inflight, event.Workers)
+	}
+	if collector, ok := o.app.topProvider.(*topCollector); ok {
+		collector.SetDeliveryRecipientQueue(int64(event.QueueDepth), int64(event.QueueCapacity))
+	}
+}
+
+func (o *onlineDeliveryObserver) ObserveOwnerPush(event runtimedelivery.OwnerPushEvent) {
+	if o == nil || o.app == nil {
+		return
+	}
+	if o.app.metrics != nil {
+		o.app.metrics.Delivery.ObservePushRPC(deliveryNodeLabel(event.OwnerNodeID), string(event.Result), event.Duration, event.Routes)
+	}
+	o.observeError(event.Failure.Err)
+	if collector, ok := o.app.topProvider.(*topCollector); ok {
+		collector.ObserveDeliveryRoutes(event.Routes)
+		collector.ObserveDeliveryPush(string(event.Result), event.Accepted, event.Duration)
+		if event.Retryable > 0 || event.Dropped > 0 {
+			collector.addCounter(topCounterDeliveryPushErr, uint64(event.Retryable+event.Dropped))
+		}
+	}
+}
+
+func (o *onlineDeliveryObserver) observeError(err error) {
+	if o == nil || o.app == nil || o.app.metrics == nil {
+		return
+	}
+	class := runtimedelivery.DeliveryErrorClass(err)
+	if class == runtimedelivery.DeliveryErrorClassNone {
+		return
+	}
+	o.app.metrics.Delivery.ObserveError(class)
+}
+
+func (o *onlineDeliveryObserver) ObserveAck(event runtimedelivery.AckEvent) {
+	if o == nil || o.app == nil {
+		return
+	}
+	if o.app.metrics != nil {
+		o.app.metrics.Delivery.SetAckBindings(event.PendingCount)
+	}
+	if collector, ok := o.app.topProvider.(*topCollector); ok {
+		collector.SetDeliveryAckBindings(int64(event.PendingCount))
+	}
+}
+
+func (o *onlineDeliveryObserver) ObserveAckBatch(event runtimedelivery.AckBatchEvent) {
+	if o == nil || o.app == nil || o.app.metrics == nil {
+		return
+	}
+	o.app.metrics.Delivery.ObserveAckBatch(
+		event.Phase, event.Outcome, event.Items, event.Shards, event.Rejected, event.Rollback, event.Duration,
+	)
+}
+
+func onlineDeliveryModeLabel(mode onlinedelivery.Mode) string {
+	switch mode {
+	case onlinedelivery.ModeDurable:
+		return "durable"
+	case onlinedelivery.ModeTransient:
+		return "transient"
+	default:
+		return "invalid"
+	}
+}
+
+type onlineDeliveryOfflineObserver struct {
+	// next preserves plugin and webhook offline side effects for durable plans.
+	next channelappend.OfflineRecipientsObserver
+}
+
+func (o onlineDeliveryOfflineObserver) ObserveOfflineRecipients(ctx context.Context, event runtimedelivery.OfflineRecipientsEvent) {
+	if o.next == nil || !channelappend.OfflineRecipientObserverEligible(event.Event) {
+		return
+	}
+	o.next.ObserveOfflineRecipients(ctx, channelappend.OfflineRecipientsEvent{Event: event.Event, UIDs: event.UIDs})
+}

--- a/internal/app/online_delivery_test.go
+++ b/internal/app/online_delivery_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
+	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
+	obsmetrics "github.com/WuKongIM/WuKongIM/pkg/metrics"
+)
+
+func TestOnlineDeliveryOfflineObserverPreservesOrdinaryCommitEligibility(t *testing.T) {
+	tests := []struct {
+		name  string
+		event channelappend.CommittedEnvelope
+		want  int
+	}{
+		{name: "ordinary durable", event: channelappend.CommittedEnvelope{MessageSeq: 1}, want: 1},
+		{name: "transient", event: channelappend.CommittedEnvelope{}, want: 0},
+		{name: "sync once", event: channelappend.CommittedEnvelope{MessageSeq: 1, SyncOnce: true}, want: 0},
+		{name: "request scoped", event: channelappend.CommittedEnvelope{MessageSeq: 1, MessageScopedUIDs: []string{"u1"}}, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next := &recordingOnlineDeliveryOfflineObserver{}
+			observer := onlineDeliveryOfflineObserver{next: next}
+
+			observer.ObserveOfflineRecipients(context.Background(), runtimedelivery.OfflineRecipientsEvent{
+				Event: tt.event,
+				UIDs:  []string{"u1"},
+			})
+
+			if len(next.events) != tt.want {
+				t.Fatalf("offline observer calls = %d, want %d", len(next.events), tt.want)
+			}
+		})
+	}
+}
+
+func TestOnlineDeliveryObserverRecordsRemotePushAndNormalizedError(t *testing.T) {
+	reg := obsmetrics.New(1, "n1")
+	observer := onlineDeliveryObserver{app: &App{metrics: reg}}
+	observer.ObserveOwnerPush(runtimedelivery.OwnerPushEvent{
+		OwnerNodeID: 2,
+		Result:      runtimedelivery.ObservationResultError,
+		Routes:      3,
+		Retryable:   3,
+		Duration:    time.Millisecond,
+		Failure:     runtimedelivery.OwnerPushFailureSample{Err: errors.New("remote transport unavailable")},
+	})
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	pushes := requireAppMetricFamily(t, families, "wukongim_delivery_push_rpc_total")
+	if got := findAppMetricByLabels(t, pushes, map[string]string{"target_node": "2", "result": "error"}).GetCounter().GetValue(); got != 1 {
+		t.Fatalf("remote push attempts = %v, want 1", got)
+	}
+	routes := requireAppMetricFamily(t, families, "wukongim_delivery_push_rpc_routes_total")
+	if got := findAppMetricByLabels(t, routes, map[string]string{"target_node": "2", "result": "error"}).GetCounter().GetValue(); got != 3 {
+		t.Fatalf("remote push routes = %v, want 3", got)
+	}
+	errorsTotal := requireAppMetricFamily(t, families, "wukongim_delivery_errors_total")
+	if got := findAppMetricByLabels(t, errorsTotal, map[string]string{"class": runtimedelivery.DeliveryErrorClassError}).GetCounter().GetValue(); got != 1 {
+		t.Fatalf("normalized delivery errors = %v, want 1", got)
+	}
+}
+
+type recordingOnlineDeliveryOfflineObserver struct {
+	events []channelappend.OfflineRecipientsEvent
+}
+
+func (o *recordingOnlineDeliveryOfflineObserver) ObserveOfflineRecipients(_ context.Context, event channelappend.OfflineRecipientsEvent) {
+	o.events = append(o.events, event)
+}

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -39,6 +39,11 @@ type composedOfflineRecipientsObserver struct {
 	webhookBatch channelappend.OfflineRecipientsObserver
 }
 
+type singleOfflineRecipientsObserver struct {
+	// next receives one compatibility callback per UID in a canonical batch.
+	next channelappend.OfflineRecipientObserver
+}
+
 func (a *App) wireWebhook() error {
 	if !a.cfg.Webhook.Enabled || a.webhook != nil {
 		return nil
@@ -136,14 +141,26 @@ func composeOfflineRecipientObservers(
 	pluginSingle channelappend.OfflineRecipientObserver,
 	webhookBatch channelappend.OfflineRecipientsObserver,
 ) (channelappend.OfflineRecipientObserver, channelappend.OfflineRecipientsObserver) {
-	if pluginSingle == nil || webhookBatch == nil {
-		return pluginSingle, webhookBatch
+	if pluginSingle == nil {
+		return nil, webhookBatch
 	}
 	pluginBatch, _ := pluginSingle.(channelappend.OfflineRecipientsObserver)
+	if webhookBatch == nil {
+		if pluginBatch != nil {
+			return pluginSingle, pluginBatch
+		}
+		return pluginSingle, singleOfflineRecipientsObserver{next: pluginSingle}
+	}
 	return pluginSingle, composedOfflineRecipientsObserver{
 		pluginSingle: pluginSingle,
 		pluginBatch:  pluginBatch,
 		webhookBatch: webhookBatch,
+	}
+}
+
+func (o singleOfflineRecipientsObserver) ObserveOfflineRecipients(ctx context.Context, event channelappend.OfflineRecipientsEvent) {
+	for _, uid := range event.UIDs {
+		o.next.ObserveOfflineRecipient(ctx, channelappend.OfflineRecipientEvent{Event: event.Event, UID: uid})
 	}
 }
 

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -186,6 +186,33 @@ func TestComposeOfflineRecipientObserversUsesPluginBatchWhenAvailable(t *testing
 	require.Equal(t, [][]string{{"u1", "u2"}}, webhook.uidBatches)
 }
 
+func TestComposeOfflineRecipientObserversKeepsPluginWithoutWebhook(t *testing.T) {
+	plugin := &recordingOfflineRecipientObserverForWebhookTest{}
+	_, batch := composeOfflineRecipientObservers(plugin, nil)
+
+	require.NotNil(t, batch)
+	batch.ObserveOfflineRecipients(context.Background(), channelappend.OfflineRecipientsEvent{
+		Event: channelappend.CommittedEnvelope{MessageID: 101},
+		UIDs:  []string{"u1", "u2"},
+	})
+
+	require.Equal(t, []string{"u1", "u2"}, plugin.uids)
+}
+
+func TestComposeOfflineRecipientObserversKeepsPluginBatchWithoutWebhook(t *testing.T) {
+	plugin := &recordingBatchOfflineRecipientObserverForWebhookTest{}
+	_, batch := composeOfflineRecipientObservers(plugin, nil)
+
+	require.NotNil(t, batch)
+	batch.ObserveOfflineRecipients(context.Background(), channelappend.OfflineRecipientsEvent{
+		Event: channelappend.CommittedEnvelope{MessageID: 101},
+		UIDs:  []string{"u1", "u2"},
+	})
+
+	require.Empty(t, plugin.singleUIDs)
+	require.Equal(t, [][]string{{"u1", "u2"}}, plugin.uidBatches)
+}
+
 func TestWebhookNotifyEnqueuerMapsCommittedEnvelopeAndCopiesSlices(t *testing.T) {
 	runtime := &recordingWebhookRuntime{}
 	enqueuer := webhookNotifyEnqueuer{runtime: runtime}

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -14,7 +14,6 @@ import (
 	accessops "github.com/WuKongIM/WuKongIM/internal/access/opsmcp"
 	opscontract "github.com/WuKongIM/WuKongIM/internal/contracts/opsmcp"
 	clusterinfra "github.com/WuKongIM/WuKongIM/internal/infra/cluster"
-	deliveryinfra "github.com/WuKongIM/WuKongIM/internal/infra/delivery"
 	applog "github.com/WuKongIM/WuKongIM/internal/log"
 	obsdiagnostics "github.com/WuKongIM/WuKongIM/internal/observability/diagnostics"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
@@ -737,29 +736,7 @@ func (a *App) wireChannelAppend(nodeID uint64) error {
 				opts.Observer = observer
 			}
 			if a.cfg.Delivery.Enabled {
-				offlineSingle, offlineBatch := composeOfflineRecipientObservers(a.pluginReceive, a.webhookOffline)
-				deliveryObserver := a.deliveryObserver()
-				processor := channelappend.NewRecipientProcessor(channelappend.RecipientProcessorOptions{
-					PresenceResolver:            deliveryinfra.NewChannelAppendPresenceResolver(a.presence),
-					OwnerPusher:                 a.channelAppendOwnerPusher(nodeID, deliveryObserver),
-					OwnerPushBatchSize:          a.cfg.Delivery.PushBatchSize,
-					OfflineRecipientObserver:    offlineSingle,
-					OfflineRecipientsObserver:   offlineBatch,
-					DeliveryRetryMaxAttempts:    defaultDeliveryRetryMaxAttempts,
-					DeliveryRetryInitialBackoff: defaultDeliveryRetryBackoff,
-					DeliveryRetryMaxBackoff:     defaultDeliveryRetryBackoff,
-				})
-				if a.channelAppendDeliveryWorker == nil {
-					a.channelAppendDeliveryWorker = channelappend.NewRecipientDeliveryWorker(channelappend.RecipientDeliveryWorkerOptions{
-						Processor:  processor,
-						QueueSize:  a.cfg.Delivery.EventQueueSize,
-						Workers:    a.cfg.Delivery.RecipientWorkerConcurrency,
-						Observer:   observer,
-						Goroutines: a.goroutines,
-					})
-				}
-				opts.RecipientDeliveryEnqueuer = a.channelAppendDeliveryWorker
-				a.deliveryWorker = appendDeliveryWorker(a.deliveryWorker, a.channelAppendDeliveryWorker)
+				opts.OnlineDeliveryEnqueuer = a.onlineDelivery
 			}
 			group := channelappend.New(opts)
 			var remote clusterinfra.ChannelAppendRemoteForwarder

--- a/internal/infra/delivery/FLOW.md
+++ b/internal/infra/delivery/FLOW.md
@@ -4,9 +4,11 @@
 
 `internal/infra/delivery` adapts the entry-independent delivery runtime to the
 owner node's concrete online registry, gateway session, and WuKong protocol
-packet. It owns the owner-local push state machine: exact route revalidation,
-pending RECVACK reservation lifecycle, packet construction, session writes,
-and terminal-versus-retryable write classification. It also owns the narrow
+packet. Production composition uses `LocalSessionWriter`, which owns final
+exact-route revalidation, packet construction, session writes, and
+terminal-versus-retryable write classification. The canonical Online Delivery
+runtime owns pending RECVACK reservation and retry policy around that narrow
+port. This package also owns the narrow
 presence-usecase adapters used by both channelappend and canonical Online
 Delivery recipient routing, so the app composition root only constructs and
 injects the runtime ports.
@@ -15,7 +17,23 @@ The package does not resolve cluster ownership, page channel subscribers, or
 choose retry policy. Those decisions remain in `internal/runtime/delivery` and
 the cluster adapters composed by `internal/app`.
 
-## Owner-local Push Flow
+## Canonical Owner-local Session Write Flow
+
+```text
+runtime/delivery.PushOwner
+  -> reserve item-aligned pending RECVACK state inside runtime/delivery
+  -> LocalSessionWriter validates the exact active UID/session/owner identity
+  -> build the recipient-specific frame.RecvPacket
+  -> write through the owner-local gateway SessionHandle
+     -> success: runtime finishes that reservation and reports accepted
+     -> stale route/build/closed/overflow failure: runtime rolls back and reports dropped
+     -> transient write failure: runtime rolls back and reports retryable
+```
+
+## Legacy Compatibility Owner-local Push Flow
+
+The following `LocalOwnerPusher` path remains compiled for compatibility tests
+and cleanup only. Production app composition does not construct it.
 
 The multi-route path validates routes before reserving an item-aligned ACK
 batch, then revalidates each route after its final reservation. This keeps one
@@ -61,18 +79,21 @@ rollback preserves a previous committed reservation when a refresh attempt or
 its write fails.
 
 `LocalOwnerPusher.SetAckManager` exists only to close the construction cycle
-between the pusher, fanout worker, retry scheduler, and delivery manager. App
-composition must call it exactly once before any concurrent `Push` call.
+between the pusher, fanout worker, retry scheduler, and delivery manager.
+Compatibility constructors and tests must call it exactly once before any
+concurrent `Push` call; production app composition has no such cycle.
 
 The convergence path also provides `LocalSessionWriter`, which owns only final
 exact-session validation, packet construction, and physical writes. The new
-Online Delivery runtime retains pending-ACK ownership around that narrow port;
-the existing `LocalOwnerPusher` remains active until app wiring cuts over. A
+Online Delivery runtime retains pending-ACK ownership around that narrow port.
+App composition now constructs `LocalSessionWriter`; `LocalOwnerPusher` remains
+compiled only for compatibility tests and a later cleanup slice. A
 missing owner-local registry is an unavailable adapter, not a stale route, so
 the writer returns a retryable result instead of terminally dropping the route.
 
-Stale pending-ACK expiry is activity-driven and globally throttled per pusher;
-ordinary pushes do not scan the tracker on every call.
+In the compatibility pusher, stale pending-ACK expiry is activity-driven and
+globally throttled; ordinary pushes do not scan the tracker on every call. The
+canonical runtime owns the equivalent throttled expiry policy directly.
 
 ## Presence Adapters
 

--- a/internal/runtime/channelappend/FLOW.md
+++ b/internal/runtime/channelappend/FLOW.md
@@ -1,10 +1,10 @@
 # internal/runtime/channelappend Flow
 
-During Online Delivery convergence, channelappend exposes a canonical
-plan-enqueue option beside the existing recipient worker port. A boundary
-adapter reuses the established exact-target grouping and batching path while
-explicitly labeling durable versus transient work; app wiring chooses only one
-delivery port at a time.
+Channelappend exposes a canonical Online Delivery plan-enqueue option beside
+the legacy recipient worker port. A boundary adapter reuses the established
+exact-target grouping and batching path while explicitly labeling durable
+versus transient work. Production app wiring selects only the canonical port;
+the legacy port remains compiled for compatibility tests and cleanup.
 
 ## Responsibility
 
@@ -362,7 +362,7 @@ carries `SenderUID` from the committed event, channel identity, message
 sequence, activity timestamp, and the expanded recipient UIDs. Receiver entries
 leave `IsSender` unset; the active worker advances the sender read sequence
 from `SenderUID` semantics. Active admission still runs when online
-delivery enqueueing is disabled or no `RecipientDeliveryEnqueuer` is
+delivery enqueueing is disabled or no effective delivery enqueuer is
 configured. If active admission fails, the post-commit failure phase is
 `conversation_active`, while accepted delivery, later large-channel pages, and
 a successfully loaded non-large subscriber snapshot continue independently. A
@@ -388,7 +388,7 @@ compatibility path dispatches different targets concurrently up to
 `RecipientAuthorityDispatchConcurrency`, while batches for the same target stay
 sequential.
 
-The dedicated delivery worker drains accepted plans. A target-aware presence
+The canonical Online Delivery runtime drains accepted plans. A target-aware presence
 resolver receives all target groups from one plan together and returns aligned
 per-group results, so one failed group is observed without suppressing the
 other groups. A legacy presence resolver remains supported by resolving the
@@ -408,8 +408,9 @@ push failures map back only to the exact target groups that contributed those
 routes, while unrelated owners and targets continue. Owner-local concrete
 session writes remain outside `channelState`.
 
-`RecipientDeliveryWorker` owns the bounded async queue for those delivery
-plans. The buffered queue is the admission backpressure primitive; there is
+`RecipientDeliveryWorker` remains the legacy compatibility implementation for
+this processing model; production app wiring no longer constructs it. Its
+buffered queue is the admission backpressure primitive; there is
 no second slot semaphore. Admission is open only between `Start` and `Stop`;
 closed admission returns `ErrRecipientDeliveryWorkerClosed`, and a full queue
 waits for capacity until the caller context expires. `Stop` closes admission

--- a/internal/runtime/channelappend/delivery.go
+++ b/internal/runtime/channelappend/delivery.go
@@ -450,7 +450,7 @@ func shouldObserveOfflineRecipients(
 	batchObserver OfflineRecipientsObserver,
 	singleObserver OfflineRecipientObserver,
 ) bool {
-	return (batchObserver != nil || singleObserver != nil) && offlineRecipientObserverEligible(event)
+	return (batchObserver != nil || singleObserver != nil) && OfflineRecipientObserverEligible(event)
 }
 
 func observeOfflineRecipients(
@@ -461,7 +461,7 @@ func observeOfflineRecipients(
 	batchObserver OfflineRecipientsObserver,
 	singleObserver OfflineRecipientObserver,
 ) {
-	if (batchObserver == nil && singleObserver == nil) || !offlineRecipientObserverEligible(batch.Event) {
+	if (batchObserver == nil && singleObserver == nil) || !OfflineRecipientObserverEligible(batch.Event) {
 		return
 	}
 	offlineUIDs := offlineRecipientUIDs(uids, routes)
@@ -574,7 +574,9 @@ func notifyOfflineRecipientsSafely(
 	return nil
 }
 
-func offlineRecipientObserverEligible(event CommittedEnvelope) bool {
+// OfflineRecipientObserverEligible reports whether an ordinary durable commit
+// may emit plugin or webhook offline-recipient side effects.
+func OfflineRecipientObserverEligible(event CommittedEnvelope) bool {
 	return event.MessageSeq > 0 && !event.SyncOnce && len(event.MessageScopedUIDs) == 0
 }
 

--- a/internal/runtime/delivery/FLOW.md
+++ b/internal/runtime/delivery/FLOW.md
@@ -1,19 +1,28 @@
 # internal/runtime/delivery Flow
 
-`internal/runtime/delivery` owns online delivery fanout primitives and recipient-owner recvack state.
+`internal/runtime/delivery` owns canonical Online Delivery plan execution and
+recipient-owner RECVACK state.
 
-During the convergence migration, `Runtime` is the new target facade behind
-`internal/contracts/onlinedelivery`, while the existing `Manager`, planner,
-fanout, and retry types remain available to the current app wiring. Adding the
-new facade does not route production traffic through it; later migration steps
-move callers before removing the superseded types.
+`Runtime` is the production facade behind
+`internal/contracts/onlinedelivery`. App composition injects it into
+channelappend as the sole plan consumer and exposes its owner-push handler over
+node RPC. The existing `Manager`, planner, fanout, retry, and
+`LocalOwnerPusher`-oriented surfaces remain compiled only for compatibility
+tests and a later cleanup slice; app composition no longer constructs them.
 
 The package is independent from gateway, app, and concrete cluster runtimes. It only consumes small ports for subscriber paging, presence resolution, partition discovery, and pushing, so planner and fanout behavior can be unit tested and benchmarked in isolation.
 
 `AckTracker` keeps owner-local recvack state, enforces a per UID/session pending
 limit, and maintains an O(1) derived pending count so the recvack hot path never
-scans all shards for observability. `Manager`, `Planner`, and `FanoutWorker`
-form the runtime facade used by app adapters. `Manager` owns bounded async
+scans all shards for observability. `Runtime` owns bounded plan admission,
+target-aware presence resolution, owner coalescing, narrow route retry,
+owner-local ACK mutation, and graceful drain. Its observers describe plan
+admission and terminal state, execution pressure, owner pushes, and ACK state
+with bounded result and error-class labels; concrete metrics and logging remain
+app concerns.
+
+The legacy `Manager`, `Planner`, and `FanoutWorker` form the superseded
+committed-event fanout facade retained for compatibility. `Manager` owns bounded async
 admission through `pkg/workqueue.BoundedWorkerQueue` when fanout ports are
 configured. Runtime `Observer`, `ManagerObserver`, and `AckObserver` events
 describe fanout routing, UID route resolution, owner push attempts, manager
@@ -33,7 +42,33 @@ without wiring a subscriber store. `FanoutTaskRouter` can sit between
 `Manager` and `FanoutWorker` to run local authority partitions in-process and
 forward remote authority partitions through a small node RPC port.
 
-Committed-message fanout flow:
+Canonical Online Delivery flow:
+
+1. Channelappend submits a bounded durable or transient
+   `RecipientDeliveryPlan` through `Runtime.EnqueueRecipientDeliveryPlan`.
+2. `Runtime` validates the mode, exact-target groups, and total recipient bound,
+   then admits an owned plan to its bounded queue only while started.
+3. A worker resolves every exact-target group through one aligned presence
+   call. Valid groups continue when a sibling group fails.
+4. The runtime reports one de-duplicated offline-recipient batch per durable
+   plan, coalesces online routes by owner node, and splits each owner command by
+   the configured push bound.
+5. Different owner commands execute under bounded concurrency. Local commands
+   enter `PushOwner`; remote commands use `RemoteOwnerPusher`. Retryable results
+   are narrowed to their exact routes before the bounded retry loop. Every
+   local execution and remote transport attempt emits one bounded owner-push
+   observation with route shape, duration, outcome, and one failure sample.
+6. `PushOwner` validates owner identity and exact active sessions, reserves
+   pending ACK state, and calls `LocalSessionWriter` for final packet
+   construction and physical writes. Successful writes finish their
+   reservations; retryable or terminal failures roll back only their attempt.
+7. Gateway RECVACK and session-close feedback mutates the same `AckTracker`.
+   Activity-throttled expiry removes stale identities without scanning on every
+   push or feedback command.
+8. `Runtime.Stop` closes admission, waits for in-flight enqueue senders, and
+   drains every accepted plan within the caller's bounded wait.
+
+Legacy committed-message fanout flow:
 
 1. A committed message event enters `Manager.SubmitCommitted`.
 2. `Manager` converts the event into an independent `Envelope`.
@@ -85,7 +120,7 @@ Retry scheduler lifecycle:
 4. Background workers retry queued tasks after the configured backoff.
 5. `Stop` cancels waiting backoff, drains queued tasks, and exits when the queue is empty or the caller context expires.
 
-Recvack flow:
+Legacy compatibility recvack flow:
 
 1. Push accepted by recipient owner.
 2. Owner-local multi-route delivery validates exact active sessions first, then

--- a/internal/runtime/delivery/runtime.go
+++ b/internal/runtime/delivery/runtime.go
@@ -630,15 +630,25 @@ func (r *Runtime) routeOwnerPush(ctx context.Context, push onlinedelivery.OwnerP
 	if push.OwnerNodeID == r.localNodeID {
 		return r.pushOwnerLocal(ctx, push)
 	}
-	if r.remoteOwnerPusher == nil {
-		return onlinedelivery.OwnerPushResult{Retryable: append([]onlinedelivery.Route(nil), push.Routes...)}, nil
-	}
+	return r.pushOwnerRemote(ctx, push)
+}
+
+func (r *Runtime) pushOwnerRemote(ctx context.Context, push onlinedelivery.OwnerPush) (result onlinedelivery.OwnerPushResult, err error) {
+	started := time.Now()
+	var failure OwnerPushFailureSample
 	defer func() {
 		if recover() != nil {
 			result = onlinedelivery.OwnerPushResult{Retryable: append([]onlinedelivery.Route(nil), push.Routes...)}
 			err = ErrOwnerPushPanic
 		}
+		if err != nil && len(push.Routes) > 0 {
+			failure = OwnerPushFailureSample{Err: err, Route: push.Routes[0]}
+		}
+		r.observeOwnerPushResult(push, result, err, failure, started)
 	}()
+	if r.remoteOwnerPusher == nil {
+		return onlinedelivery.OwnerPushResult{Retryable: append([]onlinedelivery.Route(nil), push.Routes...)}, nil
+	}
 	return r.remoteOwnerPusher.PushOwner(ctx, push)
 }
 
@@ -681,24 +691,7 @@ func (r *Runtime) pushOwnerLocal(ctx context.Context, push onlinedelivery.OwnerP
 				failure = OwnerPushFailureSample{Err: err, Route: push.Routes[0]}
 			}
 		}
-		label := ObservationResultOK
-		if err != nil {
-			label = ObservationResultError
-		} else if len(result.Retryable) > 0 {
-			label = ObservationResultRetryable
-		} else if len(result.Dropped) > 0 {
-			label = ObservationResultDropped
-		}
-		r.observeOwnerPush(OwnerPushEvent{
-			OwnerNodeID: push.OwnerNodeID,
-			Result:      label,
-			Routes:      len(push.Routes),
-			Accepted:    len(result.Accepted),
-			Retryable:   len(result.Retryable),
-			Dropped:     len(result.Dropped),
-			Duration:    positiveRuntimeDuration(time.Since(started)),
-			Failure:     failure,
-		})
+		r.observeOwnerPushResult(push, result, err, failure, started)
 	}()
 	if r.localNodeID == 0 || push.OwnerNodeID == 0 || push.OwnerNodeID != r.localNodeID {
 		return onlinedelivery.OwnerPushResult{}, ErrOwnerPushNotLocal
@@ -784,6 +777,35 @@ func (r *Runtime) pushOwnerLocal(ctx context.Context, push onlinedelivery.OwnerP
 	recoveryPending = nil
 	recoveryTokens = nil
 	return result, nil
+}
+
+func (r *Runtime) observeOwnerPushResult(
+	push onlinedelivery.OwnerPush,
+	result onlinedelivery.OwnerPushResult,
+	err error,
+	failure OwnerPushFailureSample,
+	started time.Time,
+) {
+	label := ObservationResultOK
+	retryable := len(result.Retryable)
+	if err != nil {
+		label = ObservationResultError
+		retryable = len(push.Routes)
+	} else if retryable > 0 {
+		label = ObservationResultRetryable
+	} else if len(result.Dropped) > 0 {
+		label = ObservationResultDropped
+	}
+	r.observeOwnerPush(OwnerPushEvent{
+		OwnerNodeID: push.OwnerNodeID,
+		Result:      label,
+		Routes:      len(push.Routes),
+		Accepted:    len(result.Accepted),
+		Retryable:   retryable,
+		Dropped:     len(result.Dropped),
+		Duration:    positiveRuntimeDuration(time.Since(started)),
+		Failure:     failure,
+	})
 }
 
 func setOwnerPushFailure(sample *OwnerPushFailureSample, route onlinedelivery.Route, err error) {

--- a/internal/runtime/delivery/runtime_ports.go
+++ b/internal/runtime/delivery/runtime_ports.go
@@ -209,7 +209,7 @@ type OwnerPushEvent struct {
 	Retryable int
 	// Dropped is the number of terminally rejected exact routes.
 	Dropped int
-	// Duration is the owner-local execution latency.
+	// Duration is owner-local execution or remote transport latency.
 	Duration time.Duration
 	// Failure contains at most one exact-route diagnostic sample.
 	Failure OwnerPushFailureSample

--- a/internal/runtime/delivery/runtime_test.go
+++ b/internal/runtime/delivery/runtime_test.go
@@ -753,6 +753,38 @@ func TestRuntimeRetryExhaustionReportsBoundedTargetSample(t *testing.T) {
 	}
 }
 
+func TestRuntimeRemoteTransportFailureEmitsOwnerPushObservation(t *testing.T) {
+	transportErr := errors.New("remote transport unavailable")
+	observer := &recordingRuntimeObserver{}
+	runtime := NewRuntime(RuntimeOptions{
+		LocalNodeID: 1,
+		RemoteOwnerPusher: remoteOwnerPusherFunc(func(context.Context, onlinedelivery.OwnerPush) (onlinedelivery.OwnerPushResult, error) {
+			return onlinedelivery.OwnerPushResult{}, transportErr
+		}),
+		Observer: observer,
+	})
+	push := onlinedelivery.OwnerPush{
+		OwnerNodeID: 2,
+		Event:       runtimePlanForTest(30).Event,
+		Routes:      []onlinedelivery.Route{runtimeRouteForTest()},
+	}
+	push.Routes[0].OwnerNodeID = 2
+
+	_, err := runtime.routeOwnerPush(context.Background(), push)
+
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("routeOwnerPush() error = %v, want transport error", err)
+	}
+	events := observer.ownerPushEvents()
+	if len(events) != 1 {
+		t.Fatalf("owner push observations = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.OwnerNodeID != 2 || event.Result != ObservationResultError || event.Routes != 1 || event.Retryable != 1 || !errors.Is(event.Failure.Err, transportErr) {
+		t.Fatalf("owner push observation = %#v, want remote transport failure", event)
+	}
+}
+
 func TestRuntimeRetryExhaustionReportsTargetFromFailedOwnerBatch(t *testing.T) {
 	observer := &recordingRuntimeObserver{}
 	var pushes atomic.Int64
@@ -1266,13 +1298,19 @@ func (panickingRuntimeObserver) ObserveAck(AckEvent)             { panic("ack ob
 func (panickingRuntimeObserver) ObserveAckBatch(AckBatchEvent)   { panic("ack batch observer") }
 
 type recordingRuntimeObserver struct {
-	mu       sync.Mutex
-	terminal []PlanTerminalEvent
+	mu        sync.Mutex
+	terminal  []PlanTerminalEvent
+	ownerPush []OwnerPushEvent
 }
 
 func (*recordingRuntimeObserver) ObservePlanAdmission(PlanAdmissionEvent) {}
 func (*recordingRuntimeObserver) SetRuntimePressure(RuntimePressureEvent) {}
-func (*recordingRuntimeObserver) ObserveOwnerPush(OwnerPushEvent)         {}
+
+func (o *recordingRuntimeObserver) ObserveOwnerPush(event OwnerPushEvent) {
+	o.mu.Lock()
+	o.ownerPush = append(o.ownerPush, event)
+	o.mu.Unlock()
+}
 
 func (o *recordingRuntimeObserver) ObservePlanTerminal(event PlanTerminalEvent) {
 	o.mu.Lock()
@@ -1297,6 +1335,12 @@ func (o *recordingRuntimeObserver) lastTerminal() PlanTerminalEvent {
 		return PlanTerminalEvent{}
 	}
 	return o.terminal[len(o.terminal)-1]
+}
+
+func (o *recordingRuntimeObserver) ownerPushEvents() []OwnerPushEvent {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]OwnerPushEvent(nil), o.ownerPush...)
 }
 
 func (o *recordingRuntimeAckBatchObserver) ObserveAckBatch(event AckBatchEvent) {

--- a/internal/usecase/delivery/FLOW.md
+++ b/internal/usecase/delivery/FLOW.md
@@ -7,6 +7,11 @@ orchestration boundary. It accepts committed-message events from message
 orchestration and forwards receive-ack and session-close feedback to the
 configured runtime port.
 
+Production app composition now uses this package only as the temporary gateway
+feedback facade. Channelappend submits canonical recipient plans directly to
+`internal/contracts/onlinedelivery`; `SubmitCommitted` and its runtime port
+remain for legacy compatibility until the superseded fanout path is removed.
+
 The package must not import gateway frames, access adapters, app composition,
 or concrete cluster/runtime implementations. Runtime adapters are responsible
 for bridging these usecase DTOs to concrete runtime DTOs.


### PR DESCRIPTION
## What changed

- make `internal/runtime/delivery.Runtime` the canonical online-delivery runtime wired by `internal/app`
- inject the canonical runtime into channel append, owner push RPC, ACK, and session-close paths
- retain the legacy delivery facade only for compatibility entry points and reject unsupported committed-submit calls explicitly
- preserve offline plugin/webhook eligibility and batch behavior
- preserve local and remote delivery observability, including normalized error and push metrics
- update the affected FLOW documents to describe the canonical path and compatibility boundaries

## Why

The application composition root still constructed both the canonical online-delivery runtime and legacy delivery workers. This kept duplicate orchestration paths alive and made runtime ownership, retries, offline fallback, and observability harder to reason about.

## Impact

Online recipient planning, queueing, owner push, ACK handling, and retry scheduling now converge on one bounded runtime. Existing gateway and node entry contracts remain stable, while unsupported legacy committed submission fails explicitly instead of being silently ignored.

## Validation

- `GOWORK=off go test ./internal/app ./internal/runtime/delivery ./internal/runtime/channelappend ./internal/infra/delivery ./internal/access/node ./internal/usecase/delivery -count=1`
- focused `go test -race` across the affected packages
- focused `go vet` across the affected packages
- `GOWORK=off go test ./internal/... -count=1`
- `GOWORK=off go test -tags=e2e ./test/e2e/message/cross_node_delivery -count=1 -timeout 2m`
- `GOWORK=off go test -tags=e2e ./test/e2e/message/webhook -count=1 -timeout 2m -p=1`
- recipient-authority E2E suite
- `gofmt`, `git diff --check`, and patch-identity verification after rebasing onto `main`
- independent spec and repository-standards reviews: PASS, no P0-P3 findings
