### PR TITLE
refactor(app): isolate delivery wiring tests

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3083,33 +3083,6 @@ func TestValidateDeliveryConfigRejectsInvalidValues(t *testing.T) {
 	}
 }
 
-func TestNewWiresIndependentRecipientDeliveryWorkerConcurrency(t *testing.T) {
-	cluster := newFakePresenceCluster(1, nil)
-	app, err := newTestApp(t,
-		Config{
-			Cluster: clusterpkg.Config{NodeID: 1},
-			ChannelAppend: ChannelAppendConfig{
-				RecipientAuthorityDispatchConcurrency: 3,
-			},
-			Delivery: DeliveryConfig{
-				Enabled:                    true,
-				RecipientWorkerConcurrency: 7,
-			},
-		},
-		WithCluster(cluster),
-		WithGateway(&fakeGateway{calls: &[]string{}}),
-	)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-	if app.channelAppendDeliveryWorker == nil {
-		t.Fatal("channelappend recipient delivery worker was not wired")
-	}
-	if got := app.channelAppendDeliveryWorker.WorkerCapacity(); got != 7 {
-		t.Fatalf("recipient delivery worker capacity = %d, want 7", got)
-	}
-}
-
 func TestDefaultConversationConfigUsesRuntimeDefaults(t *testing.T) {
 	cfg := defaultConversationConfig(ConversationConfig{})
 
@@ -3326,65 +3299,6 @@ func TestStopSyncsLogger(t *testing.T) {
 	}
 	if got := logger.syncCallCount(); got != 1 {
 		t.Fatalf("Sync calls = %d, want 1", got)
-	}
-}
-
-func TestNewWiresDeliveryWhenEnabled(t *testing.T) {
-	cluster := newFakePresenceCluster(1, nil)
-	app, err := newTestApp(t,
-		Config{
-			Cluster:  clusterpkg.Config{NodeID: 1},
-			Delivery: DeliveryConfig{Enabled: true},
-		},
-		WithCluster(cluster),
-		WithGateway(&fakeGateway{calls: &[]string{}}),
-	)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-
-	if app.Delivery() == nil {
-		t.Fatal("delivery usecase was not wired")
-	}
-	if app.deliveryManager == nil {
-		t.Fatal("delivery manager was not wired")
-	}
-	if _, ok := cluster.registeredHandlers[accessnode.DeliveryPushRPCServiceID]; !ok {
-		t.Fatalf("delivery push rpc service was not registered")
-	}
-	if app.deliveryWorker == nil {
-		t.Fatal("delivery worker was not wired")
-	}
-	if app.channelAppendDeliveryWorker == nil {
-		t.Fatal("channelappend recipient delivery worker was not wired")
-	}
-	if app.deliveryManager == nil || app.deliveryManager.PendingAckCount() != 0 {
-		t.Fatal("delivery manager was not initialized for async runtime")
-	}
-	group, ok := app.deliveryWorker.(deliveryWorkerGroup)
-	if !ok {
-		t.Fatalf("delivery worker = %T, want deliveryWorkerGroup", app.deliveryWorker)
-	}
-	if len(group) != 3 {
-		t.Fatalf("delivery worker count = %d, want recipient worker, retry scheduler, and manager", len(group))
-	}
-	if group[0] != app.deliveryRetry {
-		t.Fatalf("delivery worker[0] = %T, want retry scheduler", group[0])
-	}
-	if group[1] != app.deliveryManager {
-		t.Fatalf("delivery worker[1] = %T, want manager", group[1])
-	}
-	if _, ok := group[2].(*channelappend.RecipientDeliveryWorker); !ok {
-		t.Fatalf("delivery worker[2] = %T, want recipient delivery worker", group[2])
-	}
-	if group[2] != app.channelAppendDeliveryWorker {
-		t.Fatalf("delivery worker[2] = %T, want app channelappend recipient delivery worker", group[2])
-	}
-	if app.deliveryRetry == nil {
-		t.Fatal("delivery retry scheduler was not wired")
-	}
-	if _, ok := cluster.registeredHandlers[accessnode.DeliveryFanoutRPCServiceID]; !ok {
-		t.Fatalf("delivery fanout rpc service was not registered")
 	}
 }
 
@@ -4576,20 +4490,6 @@ func TestDeliveryRuntimeAdapterScopesPersonChannelAcrossPartitions(t *testing.T)
 			t.Fatalf("unexpected scoped UID %q in %#v", uid, got)
 		}
 	}
-}
-
-func waitAppDeliveryPendingAckCount(t *testing.T, app *App, want int, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var got int
-	for time.Now().Before(deadline) {
-		got = app.deliveryManager.PendingAckCount()
-		if got == want {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("pending ack count = %d, want %d", got, want)
 }
 
 func waitAppFanoutTasks(t *testing.T, runner *appRecordingFanoutRunner, want int, timeout time.Duration) []runtimedelivery.FanoutTask {

--- a/internal/app/delivery_wiring_test.go
+++ b/internal/app/delivery_wiring_test.go
@@ -1,0 +1,110 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
+	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
+)
+
+func TestNewWiresIndependentRecipientDeliveryWorkerConcurrency(t *testing.T) {
+	cluster := newFakePresenceCluster(1, nil)
+	app, err := newTestApp(t,
+		Config{
+			Cluster: clusterpkg.Config{NodeID: 1},
+			ChannelAppend: ChannelAppendConfig{
+				RecipientAuthorityDispatchConcurrency: 3,
+			},
+			Delivery: DeliveryConfig{
+				Enabled:                    true,
+				RecipientWorkerConcurrency: 7,
+			},
+		},
+		WithCluster(cluster),
+		WithGateway(&fakeGateway{calls: &[]string{}}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if app.channelAppendDeliveryWorker == nil {
+		t.Fatal("channelappend recipient delivery worker was not wired")
+	}
+	if got := app.channelAppendDeliveryWorker.WorkerCapacity(); got != 7 {
+		t.Fatalf("recipient delivery worker capacity = %d, want 7", got)
+	}
+}
+
+func TestNewWiresDeliveryWhenEnabled(t *testing.T) {
+	cluster := newFakePresenceCluster(1, nil)
+	app, err := newTestApp(t,
+		Config{
+			Cluster:  clusterpkg.Config{NodeID: 1},
+			Delivery: DeliveryConfig{Enabled: true},
+		},
+		WithCluster(cluster),
+		WithGateway(&fakeGateway{calls: &[]string{}}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if app.Delivery() == nil {
+		t.Fatal("delivery usecase was not wired")
+	}
+	if app.deliveryManager == nil {
+		t.Fatal("delivery manager was not wired")
+	}
+	if _, ok := cluster.registeredHandlers[accessnode.DeliveryPushRPCServiceID]; !ok {
+		t.Fatalf("delivery push rpc service was not registered")
+	}
+	if app.deliveryWorker == nil {
+		t.Fatal("delivery worker was not wired")
+	}
+	if app.channelAppendDeliveryWorker == nil {
+		t.Fatal("channelappend recipient delivery worker was not wired")
+	}
+	if app.deliveryManager == nil || app.deliveryManager.PendingAckCount() != 0 {
+		t.Fatal("delivery manager was not initialized for async runtime")
+	}
+	group, ok := app.deliveryWorker.(deliveryWorkerGroup)
+	if !ok {
+		t.Fatalf("delivery worker = %T, want deliveryWorkerGroup", app.deliveryWorker)
+	}
+	if len(group) != 3 {
+		t.Fatalf("delivery worker count = %d, want recipient worker, retry scheduler, and manager", len(group))
+	}
+	if group[0] != app.deliveryRetry {
+		t.Fatalf("delivery worker[0] = %T, want retry scheduler", group[0])
+	}
+	if group[1] != app.deliveryManager {
+		t.Fatalf("delivery worker[1] = %T, want manager", group[1])
+	}
+	if _, ok := group[2].(*channelappend.RecipientDeliveryWorker); !ok {
+		t.Fatalf("delivery worker[2] = %T, want recipient delivery worker", group[2])
+	}
+	if group[2] != app.channelAppendDeliveryWorker {
+		t.Fatalf("delivery worker[2] = %T, want app channelappend recipient delivery worker", group[2])
+	}
+	if app.deliveryRetry == nil {
+		t.Fatal("delivery retry scheduler was not wired")
+	}
+	if _, ok := cluster.registeredHandlers[accessnode.DeliveryFanoutRPCServiceID]; !ok {
+		t.Fatalf("delivery fanout rpc service was not registered")
+	}
+}
+
+func waitAppDeliveryPendingAckCount(t *testing.T, app *App, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var got int
+	for time.Now().Before(deadline) {
+		got = app.deliveryManager.PendingAckCount()
+		if got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("pending ack count = %d, want %d", got, want)
+}


### PR DESCRIPTION
## What changed

- move the delivery worker concurrency wiring test into `delivery_wiring_test.go`
- move the delivery-enabled composition test into the same focused test module
- move their pending-ACK wait helper alongside the delivery wiring tests

The test bodies and assertions are unchanged.

## Why

`internal/app/app_test.go` has grown to about 318 KB. Review Agent captures complete base and head file contents for every changed text file, so even a small delivery assertion update in that file consumes roughly 654 KB of the 1 MiB changed-file inventory budget. The online-delivery cutover PR consequently became inconclusive before model review.

This extraction improves test locality at the delivery wiring seam and lets subsequent delivery changes update a focused file without repeatedly ingesting the full application test aggregate.

## Impact

No production code or runtime behavior changes. The same package-level test interface and existing fakes are used.

## Validation

- focused delivery wiring tests
- full `GOWORK=off go test ./internal/app -count=1`
- focused race test
- `GOWORK=off go vet ./internal/app`
- `gofmt` and `git diff --check`
- estimated complete changed-file inventory: about 655 KB, below the 1 MiB Review Agent cap
