### PR TITLE
feat(agent): gate automatic merges by author authority

### DIFF
--- a/.github/review-agent/policy.json
+++ b/.github/review-agent/policy.json
@@ -53,6 +53,7 @@
       "login": "wukongim-review-agent[bot]",
       "permissions": {
         "checks": "write",
+        "contents": "write",
         "issues": "write",
         "metadata": "read",
         "pull_requests": "write"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,6 +39,8 @@ PR/Review/comment event
   -> exact context + deterministic checks + one ephemeral model session
   -> evidence validation + signed terminal state
   -> status comment + formal Review + Review Agent Verdict
+  -> exact-head auto-merge for a repository admin or organization member
+     | otherwise wait for a human merge
 ```
 
 The Signal is a hint, not authority. It has no token permission, Secret,
@@ -60,6 +62,13 @@ verdict. A trusted validator maps signed state to the sole required Check
 `Review Agent Verdict`. Only `approved` maps to success. `changes_required`
 maps to failure, and `inconclusive` maps to `action_required`. A human
 `REQUEST_CHANGES` Review remains independently blocking.
+
+After publishing an `approved` verdict, the protected Publisher re-reads the
+exact PR head, mergeability, human Reviews, author association, and author
+repository permission. It merges only when the author is an organization
+`MEMBER`/`OWNER` or currently has repository `admin` permission. Every other
+approved PR remains open and is marked as requiring a human merge. The merge
+request is fenced to the reviewed head SHA and still obeys repository rules.
 
 The signed lease bounds the complete generation to 90 minutes. Infrastructure
 failure is retried once inside that same generation and deadline; a late result

--- a/docs/agents/issue-agent.md
+++ b/docs/agents/issue-agent.md
@@ -172,8 +172,10 @@ Configure:
 
 The App installation is limited to this repository and the exact permissions
 validated by `internal/infra/issueagentgithub/app_token.go`. Branch protection
-must require the dedicated App-owned `Review Agent Verdict`; neither Agent can
-merge.
+must require the dedicated App-owned `Review Agent Verdict`. Issue Agent cannot
+merge. Review Agent may merge only an exact-head approved PR whose author is a
+repository administrator or organization member; Issue Agent Bot PRs otherwise
+wait for a human merge.
 
 Action or Codex upgrades require a reviewed policy/workflow change updating
 the full Action SHA, exact CLI version, contract tests, and this document.

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -1,7 +1,9 @@
 # GitHub Review Agent
 
 The Review Agent is a senior reviewer embedded in every ready pull request
-targeting `main`. It reviews and adjudicates; it never changes code or merges.
+targeting `main`. The model reviews and adjudicates without changing code or
+merging. After approval, the protected Publisher may merge only an exact-head
+pull request authored by a repository administrator or organization member.
 
 ## Lifecycle
 
@@ -15,6 +17,7 @@ PR event
   -> trusted evidence validator
   -> State Writer App
   -> Review Agent App projections
+  -> authorized exact-head merge or human merge
 ```
 
 The Signal uses `pull_request_target` only to ensure Fork events can wake the
@@ -155,8 +158,23 @@ Projection repair re-reads signed state and refuses duplicate same-generation
 Checks or stale heads.
 
 A human `REQUEST_CHANGES` Review remains independently blocking. Review Agent
-cannot dismiss it, resolve a thread, or substitute for repository merge
-authority.
+cannot dismiss it or resolve a thread.
+
+After the approved Review and successful Verdict exist, the Publisher re-reads
+the open, non-Draft PR and author authority. Automatic merge requires all of:
+
+- the current PR head, base, test-merge identity, and intent still match the
+  signed approved generation;
+- GitHub reports the PR as cleanly mergeable;
+- no current exact-head human `REQUEST_CHANGES` Review exists; and
+- the PR author is an organization `MEMBER`/`OWNER`, or currently has
+  repository `admin` permission.
+
+`write`, `maintain`, ordinary collaborator, contributor, Bot, unknown, and
+permission-read-failure cases are not auto-merge authority. Their approved PRs
+remain open with an explicit human-merge notice. The merge API receives the
+exact reviewed head SHA and the normal merge method; repository Rulesets remain
+authoritative.
 
 ## Commands
 

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -26,8 +26,11 @@ Only `approved` unlocks the automated gate. `changes_required`,
 infrastructure failure all keep it blocked. A human `REQUEST_CHANGES` Review
 remains independently blocking.
 
-The Agent never edits code, commits, pushes, rebases, merges, closes a pull
-request, dismisses a Review, or resolves a thread.
+The model never edits code, commits, pushes, rebases, merges, closes a pull
+request, dismisses a Review, or resolves a thread. After approval, the
+protected Publisher may merge only the exact reviewed head of a repository
+administrator or organization member; every other author requires a human
+merge.
 
 Draft pull requests do not call the model. A new commit or intent change
 invalidates the old generation. The repository runs at most three model
@@ -94,7 +97,9 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
 - The protected Check MCP is required at Codex startup; missing named-check
   tools fail closed instead of degrading to an evidence-free model session.
 - The State Writer App can write only Contents state refs.
-- The Review Agent App can write only Issues, Reviews, and Checks.
+- The Review Agent App can write Issues, Reviews, Checks, and the exact-head PR
+  merge endpoint. GitHub requires `contents:write` for that merge; the adapter
+  exposes no generic contents, branch, or commit write.
 - Publisher jobs do not check out or execute candidate code.
 - Durable PR and scheduler state use a verified latest-plus-predecessor rolling
   checkpoint; older App-authored commits remain append-only audit history.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -284,7 +284,10 @@
   review-only Review Agent. Its signed generation binds the exact head, base,
   test-merge commit, intent digest, trusted checks, and model result. Only the
   dedicated Review Agent App may project the required `Review Agent Verdict`
-  Check; the Agent never edits code or merges. There is no periodic PR scan.
+  Check. The model never edits code or merges; the protected Publisher may
+  merge only the exact approved head of a repository administrator or
+  organization member, while every other author requires a human merge. There
+  is no periodic PR scan.
 - The GitHub Issue Agent is a GitHub-Actions-only stateless system. Canonical App-authored, GitHub-signed commits on `agent-state/issue-<number>` are its sole durable authority; event payloads are wake-up hints. A full-SHA-pinned official Codex Action performs one complete ephemeral engineering task with public internet but no GitHub/App/cloud/deploy credentials or Docker socket. Filesystem capture ignores Codex Git metadata, a clean credential-free Verifier owns test evidence and risk, and only the protected Publisher may create an expected-head signed commit on `agent/issue-<number>`, one complete Draft PR, and the status/state projections. Humans remain the only merge authority; setup and boundaries live in `docs/agents/issue-agent.md`.
 - Official `cmd/wukongim` goroutines must launch through a fixed `pkg/goroutine` task or an audited registered pool; `scripts/managed_goroutines_test.go` rejects raw `go`, `.Go`, and unregistered ants pools in production roots.
 - `internal/gateway` now ships only the `gnet` transport; connection callbacks are serialized by actor shards and there is no `stdnet` fallback or per-connection writer goroutine.

--- a/docs/superpowers/plans/2026-07-30-review-agent-implementation.md
+++ b/docs/superpowers/plans/2026-07-30-review-agent-implementation.md
@@ -15,8 +15,10 @@ signed per-PR/scheduler state. A protected dispatched Workflow builds a bounded 
 Bundle, runs deterministic minimum checks, gives their evidence and a named
 Check MCP to one ephemeral Codex reviewer, validates the complete result, then
 uses separate State Writer and Review Publisher Apps to persist authority and
-project it into GitHub. No scheduled scanner, compatibility path, code-writing
-reviewer, or automatic merge exists.
+project it into GitHub. No scheduled scanner, compatibility path, or
+code-writing reviewer exists. The protected Publisher may automatically merge
+only an exact approved head authored by a repository administrator or
+organization member; every other PR requires a human merge.
 
 **Tech stack:** Go 1.25, GitHub Actions YAML, GitHub REST/GraphQL APIs,
 GitHub Apps, official Codex Action, JSON Schema, stdio MCP, repository Rulesets,
@@ -216,7 +218,9 @@ Pure plans must render:
 - Review summary metadata;
 - exact Check external identity and conclusion;
 - projection repair versus creation;
-- no merge, close, dismiss, resolve, branch, or commit effect.
+- exact-head automatic-merge eligibility for approved administrator/member
+  PRs, with every other approved author routed to human merge;
+- no close-without-merge, dismiss, resolve, branch, or commit effect.
 
 - [ ] **Step 6: Run the package GREEN and commit**
 
@@ -274,10 +278,15 @@ Review App token profile:
 
 ```text
 checks: write
+contents: write
 issues: write
 metadata: read
 pull_requests: write
 ```
+
+GitHub requires `contents:write` for the pull-request merge endpoint. The
+protected adapter must still expose no generic contents, branch, or commit
+write.
 
 State Writer App token profile:
 
@@ -303,8 +312,9 @@ Use stable hidden markers and Check `external_id` values. Before every write:
 
 The adapter may create/update the one status comment, submit one Review per
 generation, create bounded inline comments, and create/update the one Check
-Run. It exposes no merge, branch, commit, close, dismiss, or thread-resolution
-method.
+Run. It may merge only the freshly re-read exact approved head after the pure
+plan authorizes an administrator/member author. It exposes no generic contents,
+branch, commit, close, dismiss, or thread-resolution method.
 
 - [ ] **Step 5: Run adapter tests and commit**
 
@@ -508,8 +518,10 @@ Prove that:
 - candidate/model roles cannot reach publisher methods;
 - state and Review private keys are rejected outside their exact commands;
 - all GitHub writes require fresh generation fences;
-- no method can merge, close, dismiss, resolve, commit code, or write a
-  non-state ref.
+- only the protected Review Publisher can merge, and only the exact approved
+  administrator/member head;
+- no method can close without merging, dismiss, resolve, commit code, or write
+  a non-state ref.
 
 - [ ] **Step 4: Update FLOW and directory documentation**
 
@@ -648,8 +660,9 @@ The contract must prove:
 - failure paths still produce an authoritative `inconclusive` state when
   identity is recoverable;
 - successful Artifacts retain 7 days and non-success evidence 30 days;
-- the Workflow has no merge, push, branch, close, dismiss, or arbitrary
-  repository-dispatch operation.
+- the Workflow exposes only the protected Publisher's exact-head authorized
+  merge and no push, branch, close, dismiss, or arbitrary repository-dispatch
+  operation.
 
 - [ ] **Step 2: Build trusted preparation**
 
@@ -1036,7 +1049,8 @@ Require every negative mutation to fail:
 - accept an incomplete inventory;
 - publish from a stale generation;
 - let the State Writer target a non-state ref;
-- let the Review App create a commit or merge;
+- let the Review App create a commit, branch, generic contents write, or merge
+  any head/author outside the protected exact-head administrator/member rule;
 - accept a same-named Check from the wrong App;
 - approve with failed/missing evidence;
 - exceed reconsideration, retry, queue, or comment budgets.

--- a/docs/superpowers/runbooks/review-agent-bootstrap.md
+++ b/docs/superpowers/runbooks/review-agent-bootstrap.md
@@ -14,12 +14,15 @@ Create a repository-scoped App with exactly:
 | --- | --- |
 | Metadata | Read |
 | Checks | Read and write |
+| Contents | Read and write |
 | Issues | Read and write |
 | Pull requests | Read and write |
 
-Do not grant Contents, Actions administration, Administration, Workflows,
-Secrets, Deployments, Members, Packages, or organization-wide installation.
-Install it only on this repository.
+GitHub requires Contents write for the pull-request merge endpoint. Repository
+code requests it only for the protected Publisher token and exposes only an
+exact-head merge operation. Do not grant Actions administration,
+Administration, Workflows, Secrets, Deployments, Members, Packages, or
+organization-wide installation. Install it only on this repository.
 
 Create Environment `review-agent-publisher` with:
 
@@ -120,6 +123,9 @@ Run local contract tests and `actionlint`, then prove:
 - `approved`, `changes_required`, and `inconclusive`;
 - status, explain, reconsider, retry, and cancel authorization;
 - approved control-plane change without human Approval;
+- approved repository-admin/member PR merges only at the reviewed head;
+- approved external, write, maintain, Bot, and unknown-authority PRs remain
+  open for human merge;
 - strict up-to-date status-check enforcement after `main` advances;
 - all three Environments reject a job whose workflow ref is not protected
   `main`;

--- a/docs/superpowers/specs/2026-07-30-review-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-review-agent-design.md
@@ -13,8 +13,9 @@ but difficult for contributors to understand.
 WuKongIM instead needs a senior reviewer embedded in each pull request. That
 reviewer should understand the requested behavior and repository rules,
 inspect the complete change, run the mandatory and risk-selected checks,
-participate in review discussion, and publish one authoritative verdict. It
-must not modify the pull request or merge it.
+participate in review discussion, and publish one authoritative verdict. The
+model must not modify or merge the pull request. A protected Publisher may
+merge only an exact-head approved PR from an administrator or member.
 
 ## Goals
 
@@ -28,8 +29,8 @@ must not modify the pull request or merge it.
   Review Agent from the exact pull-request risk.
 - Bind every decision to the exact pull request, head SHA, base SHA,
   test-merge SHA, intent digest, and review generation.
-- Preserve human authority: the Review Agent decides technical eligibility,
-  but never modifies code or performs the merge.
+- Preserve human authority: the model never modifies code or performs a merge;
+  external-author PRs always require a human merge.
 - Keep candidate execution, model execution, durable state writes, and
   GitHub Review/Check writes in separate credential boundaries.
 - Fail closed on stale work, incomplete diffs, missing evidence, infrastructure
@@ -41,7 +42,8 @@ must not modify the pull request or merge it.
 
 - Editing, committing, pushing, rebasing, or otherwise repairing pull-request
   code.
-- Automatically merging any pull request.
+- Automatically merging PRs from contributors who are neither repository
+  administrators nor organization members.
 - Reviewing Draft pull requests or pull requests targeting unprotected
   branches.
 - Running a persistent webhook service, database, or scheduler outside GitHub
@@ -94,6 +96,7 @@ pull_request_target / Review / comment event
   -> Evidence Validator: real commands/results, coverage, workspace integrity
   -> Review State Writer App: append signed authoritative state
   -> Review Agent App: repair or publish status comment, Review, and Check
+  -> exact-head merge for authorized admin/member authors, otherwise human merge
   -> optional second state append recording exact projection identities
 ```
 
@@ -430,6 +433,12 @@ The dedicated Review Agent App publishes:
 - at most 20 inline comments per generation;
 - one generation-bound `Review Agent Verdict` Check Run.
 
+For an approved generation, the Publisher may additionally perform one normal
+merge fenced to the reviewed head SHA. It does so only after a fresh read proves
+the author is an organization `MEMBER`/`OWNER` or has repository `admin`
+permission, the PR is cleanly mergeable, and no human `REQUEST_CHANGES` Review
+remains. Every other approved PR stays open for a human merge.
+
 The status comment shows queue/review/evidence state, exact generation,
 head SHA, elapsed time, reconsideration budget, and trusted links. It is not a
 merge authority. Repeated findings are grouped under one representative inline
@@ -513,10 +522,11 @@ Two independent GitHub Apps are required.
 
 ### Review Agent App
 
-The Review Agent App may read metadata and pull-request facts and write only
-the Review, comments, and Check surfaces required for projections. It has no
-Contents permission, branch creation, commit, merge, Ruleset administration,
-Actions administration, or Secrets permission.
+The Review Agent App may read metadata and pull-request facts and write the
+Review, comments, Check, and exact-head merge surfaces. GitHub requires
+`contents:write` for the merge endpoint; the protected adapter exposes no
+generic contents, branch, or commit write. The App has no Ruleset, Actions
+administration, or Secrets permission.
 
 Its private key is available only in the protected Review Publisher
 Environment. The Publisher never checks out or executes candidate code.
@@ -693,7 +703,8 @@ prove the complete path.
 - `sudo` and Docker socket access are absent;
 - Publisher jobs never download or execute candidate trees;
 - State Writer is rejected from every non-`review-state/**` ref by Rulesets;
-- Review Agent App cannot create commits, branches, or merges;
+- Review Agent adapter cannot create commits or branches and can merge only an
+  exact approved head from an authorized administrator/member author;
 - malicious instructions in code, comments, tests, and network responses
   cannot change authority or policy.
 

--- a/internal/app/FLOW.md
+++ b/internal/app/FLOW.md
@@ -25,7 +25,8 @@ stay in infra packages.
 GitHub-Actions composition roots. They do not call `New`, join a WuKongIM
 cluster, or start product runtimes. Review Agent composition keeps fresh
 GitHub reads, deterministic lifecycle, credential-free verification, signed
-state writes, and Review/Check publication behind separate role boundaries.
+state writes, Review/Check publication, and the authorized exact-head
+administrator/member merge behind separate role boundaries.
 Terminal `collect_only` verification reads and validates the frozen ledger
 without constructing the command executor used by the earlier baseline job.
 It also owns strict loading and cross-layer validation of the protected Review

--- a/internal/app/review_agent_policy.go
+++ b/internal/app/review_agent_policy.go
@@ -197,7 +197,7 @@ func ValidateReviewAgentPolicy(document ReviewAgentPolicy) error {
 		return errors.New("Review Agent policy is invalid")
 	}
 	if !sameStringMap(document.Apps.Review.Permissions, map[string]string{
-		"checks": "write", "issues": "write",
+		"checks": "write", "contents": "write", "issues": "write",
 		"metadata": "read", "pull_requests": "write",
 	}) ||
 		!sameStringMap(

--- a/internal/infra/reviewagentgithub/FLOW.md
+++ b/internal/infra/reviewagentgithub/FLOW.md
@@ -24,6 +24,7 @@ Review Agent App token
   -> one mutable status comment
   -> one formal Review with bounded inline comments
   -> one Review Agent Verdict Check Run
+  -> one exact-head merge only after fresh admin/member authorization
 ```
 
 The bounded scheduler recovery never rewinds or rewrites the protected state
@@ -35,7 +36,9 @@ read-your-write lag only while GitHub still reports the exact expected parent.
 The committed head must become visible within the retry budget; any third head
 is real contention and fails immediately.
 
-The Review App adapter exposes no contents, branch, commit, merge, close,
-dismiss, resolve, Ruleset, Actions, or Secrets operation. The State Writer
-adapter accepts no caller-selected ref or path and exposes no Review, comment,
-Check, merge, or pull-request mutation.
+The Review App token includes GitHub's required `contents:write` permission for
+the pull-request merge endpoint, but the adapter exposes only an exact-head
+normal merge after the pure authorization plan succeeds. It exposes no generic
+contents, branch, commit, close, dismiss, resolve, Ruleset, Actions, or Secrets
+operation. The State Writer adapter accepts no caller-selected ref or path and
+exposes no Review, comment, Check, merge, or pull-request mutation.

--- a/internal/infra/reviewagentgithub/app_token.go
+++ b/internal/infra/reviewagentgithub/app_token.go
@@ -297,6 +297,7 @@ func permissionsForRole(role AppRole) (map[string]string, error) {
 	case AppRoleReviewPublisher:
 		return map[string]string{
 			"checks":        "write",
+			"contents":      "write",
 			"issues":        "write",
 			"metadata":      "read",
 			"pull_requests": "write",

--- a/internal/infra/reviewagentgithub/app_token_test.go
+++ b/internal/infra/reviewagentgithub/app_token_test.go
@@ -63,7 +63,8 @@ func TestAppTokenMinterUsesExactCompileTimeRoleProfiles(t *testing.T) {
 
 	for role, want := range map[github.AppRole]map[string]string{
 		github.AppRoleReviewPublisher: {
-			"checks": "write", "issues": "write", "metadata": "read",
+			"checks": "write", "contents": "write", "issues": "write",
+			"metadata":      "read",
 			"pull_requests": "write",
 		},
 		github.AppRoleStateWriter: {

--- a/internal/infra/reviewagentgithub/projection_client.go
+++ b/internal/infra/reviewagentgithub/projection_client.go
@@ -148,6 +148,46 @@ func (client *Client) CreateReview(
 	return response.ID, nil
 }
 
+// MergePullRequest merges one pull request only while its head still matches
+// the exact reviewed generation. Repository rules remain authoritative.
+func (client *Client) MergePullRequest(
+	ctx context.Context,
+	pullRequest int64,
+	headSHA string,
+) error {
+	if pullRequest <= 0 || !gitSHAPattern.MatchString(headSHA) {
+		return errors.New("pull-request merge request is invalid")
+	}
+	var response struct {
+		SHA     string `json:"sha"`
+		Merged  bool   `json:"merged"`
+		Message string `json:"message"`
+	}
+	if err := client.requestJSON(
+		ctx,
+		http.MethodPut,
+		fmt.Sprintf(
+			"/repos/%s/pulls/%d/merge",
+			client.repository,
+			pullRequest,
+		),
+		struct {
+			SHA         string `json:"sha"`
+			MergeMethod string `json:"merge_method"`
+		}{SHA: headSHA, MergeMethod: "merge"},
+		&response,
+		http.StatusOK,
+	); err != nil {
+		return err
+	}
+	if !response.Merged ||
+		!gitSHAPattern.MatchString(response.SHA) ||
+		response.Message == "" || len(response.Message) > 1024 {
+		return errors.New("pull-request merge response is invalid")
+	}
+	return nil
+}
+
 // CreateCheckRun creates the sole Review Agent Verdict for one generation.
 func (client *Client) CreateCheckRun(
 	ctx context.Context,

--- a/internal/infra/reviewagentgithub/projection_client_test.go
+++ b/internal/infra/reviewagentgithub/projection_client_test.go
@@ -1,0 +1,60 @@
+package reviewagentgithub_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	github "github.com/WuKongIM/WuKongIM/internal/infra/reviewagentgithub"
+)
+
+func TestClientMergesOnlyTheExactPullRequestHead(t *testing.T) {
+	t.Parallel()
+
+	headSHA := strings.Repeat("a", 40)
+	server := httptest.NewServer(http.HandlerFunc(func(
+		writer http.ResponseWriter,
+		request *http.Request,
+	) {
+		writer.Header().Set("Content-Type", "application/json")
+		require.Equal(t, http.MethodPut, request.Method)
+		require.Equal(
+			t,
+			"/repos/WuKongIM/WuKongIM/pulls/42/merge",
+			request.URL.Path,
+		)
+		var body struct {
+			SHA         string `json:"sha"`
+			MergeMethod string `json:"merge_method"`
+		}
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&body))
+		require.Equal(t, headSHA, body.SHA)
+		require.Equal(t, "merge", body.MergeMethod)
+		writeJSON(writer, map[string]any{
+			"sha":     strings.Repeat("b", 40),
+			"merged":  true,
+			"message": "Pull Request successfully merged",
+		})
+	}))
+	t.Cleanup(server.Close)
+	client, err := github.NewClient(
+		github.ClientConfig{
+			BaseURL: server.URL, GraphQLURL: server.URL + "/graphql",
+			Repository: "WuKongIM/WuKongIM", Token: "token",
+			MaxPages: 100, MaxBodyBytes: 16 << 20,
+		},
+		server.Client(),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, client.MergePullRequest(
+		context.Background(),
+		42,
+		headSHA,
+	))
+}

--- a/internal/infra/reviewagentgithub/projections.go
+++ b/internal/infra/reviewagentgithub/projections.go
@@ -20,6 +20,7 @@ type ReviewStateReader interface {
 // ReviewFactsReader exposes the fresh, complete PR snapshot.
 type ReviewFactsReader interface {
 	ReadPullRequestMetadata(context.Context, int64) (PullRequestSnapshot, error)
+	ActorPermission(context.Context, string) (Permission, error)
 }
 
 // InlineReviewComment is one bounded line-level finding projection.
@@ -29,8 +30,9 @@ type InlineReviewComment struct {
 	Body string
 }
 
-// ProjectionWriter is deliberately unable to merge, close, dismiss, resolve,
-// edit branches, or create commits.
+// ProjectionWriter owns the bounded Review projections and an exact-head pull
+// request merge. It cannot close without merging, dismiss, resolve, edit
+// branches, or create commits.
 type ProjectionWriter interface {
 	CreateIssueComment(context.Context, int64, string) (int64, error)
 	UpdateIssueComment(context.Context, int64, string) error
@@ -74,6 +76,7 @@ type ProjectionWriter interface {
 		string,
 		string,
 	) error
+	MergePullRequest(context.Context, int64, string) error
 }
 
 // ReviewPublisher owns the sole Check, Review, and status-comment projection.
@@ -194,24 +197,12 @@ func (publisher *ReviewPublisher) PublishDecision(
 			)
 		}
 	}
-	loaded, found, err := publisher.state.Load(
+	if err := publisher.validateSignedState(
 		ctx,
-		request.State.Generation.PullRequest,
-	)
-	if err != nil || !found ||
-		loaded.HeadSHA != request.ExpectedStateHead ||
-		contract.MustGenerationDigest(loaded.State.Generation) !=
-			contract.MustGenerationDigest(request.State.Generation) {
-		return ReviewPublication{}, errors.New(
-			"Review publication signed state is stale",
-		)
-	}
-	loadedDigest, loadedErr := contract.ReviewStateDigest(loaded.State)
-	requestDigest, requestErr := contract.ReviewStateDigest(request.State)
-	if loadedErr != nil || requestErr != nil || loadedDigest != requestDigest {
-		return ReviewPublication{}, errors.New(
-			"Review publication signed state content changed",
-		)
+		request.ExpectedStateHead,
+		request.State,
+	); err != nil {
+		return ReviewPublication{}, err
 	}
 	snapshot, err := publisher.facts.ReadPullRequestMetadata(
 		ctx,
@@ -236,14 +227,14 @@ func (publisher *ReviewPublisher) PublishDecision(
 		)
 	}
 	if request.Result == nil {
-		return publisher.publishLifecycle(ctx, snapshot, request.State)
+		return publisher.publishLifecycle(
+			ctx,
+			snapshot,
+			request.ExpectedStateHead,
+			request.State,
+		)
 	}
-	plan, err := usecase.PlanPublication(
-		request.State,
-		usecase.PublicationFacts{
-			HumanChangesRequested: snapshot.Facts.HumanChangesRequested,
-		},
-	)
+	plan, err := publisher.planPublication(ctx, snapshot, request.State)
 	if err != nil {
 		return ReviewPublication{}, err
 	}
@@ -299,6 +290,13 @@ func (publisher *ReviewPublisher) PublishDecision(
 		publication.ExplanationCommentID =
 			explanation.ExplanationCommentID
 	}
+	if err := publisher.mergeApprovedIfAuthorized(
+		ctx,
+		request.ExpectedStateHead,
+		request.State,
+	); err != nil {
+		return ReviewPublication{}, err
+	}
 	return publication, nil
 }
 
@@ -332,11 +330,23 @@ func (publisher *ReviewPublisher) publishExplanation(
 func (publisher *ReviewPublisher) publishLifecycle(
 	ctx context.Context,
 	snapshot PullRequestSnapshot,
+	expectedStateHead string,
 	state contract.ReviewState,
 ) (ReviewPublication, error) {
 	body, err := usecase.RenderStatus(state, time.Now().UTC())
 	if err != nil {
 		return ReviewPublication{}, err
+	}
+	var terminalPlan *usecase.PublicationPlan
+	if decisionPhaseForProjection(state.Phase) {
+		plan, planErr := publisher.planPublication(ctx, snapshot, state)
+		if planErr != nil {
+			return ReviewPublication{}, planErr
+		}
+		terminalPlan = &plan
+		if plan.HumanMergeRequired {
+			body += "\n\nThis pull request requires a human merge."
+		}
 	}
 	marker := fmt.Sprintf(
 		"<!-- review-agent-status:pr-%d -->",
@@ -382,16 +392,12 @@ func (publisher *ReviewPublisher) publishLifecycle(
 	case contract.PhaseApproved,
 		contract.PhaseChangesRequired,
 		contract.PhaseInconclusive:
-		plan, planErr := usecase.PlanPublication(
-			state,
-			usecase.PublicationFacts{
-				HumanChangesRequested: snapshot.Facts.HumanChangesRequested,
-			},
-		)
-		if planErr != nil {
-			return ReviewPublication{}, planErr
+		if terminalPlan == nil {
+			return ReviewPublication{}, errors.New(
+				"terminal Review publication plan is missing",
+			)
 		}
-		value := plan.Conclusion
+		value := terminalPlan.Conclusion
 		conclusion = &value
 	default:
 		value := usecase.CheckActionRequired
@@ -467,6 +473,13 @@ func (publisher *ReviewPublisher) publishLifecycle(
 		publication.ExplanationCommentID =
 			explanation.ExplanationCommentID
 	}
+	if err := publisher.mergeApprovedIfAuthorized(
+		ctx,
+		expectedStateHead,
+		state,
+	); err != nil {
+		return ReviewPublication{}, err
+	}
 	return publication, nil
 }
 
@@ -486,12 +499,7 @@ func (publisher *ReviewPublisher) ensureLifecycleReview(
 			return review.ID, nil
 		}
 	}
-	plan, err := usecase.PlanPublication(
-		state,
-		usecase.PublicationFacts{
-			HumanChangesRequested: snapshot.Facts.HumanChangesRequested,
-		},
-	)
+	plan, err := publisher.planPublication(ctx, snapshot, state)
 	if err != nil {
 		return 0, err
 	}
@@ -692,6 +700,9 @@ func (publisher *ReviewPublisher) ensureCheck(
 	if plan.HumanReviewStillBlocks {
 		summary += "\n\nA human REQUEST_CHANGES Review still blocks merging."
 	}
+	if plan.HumanMergeRequired {
+		summary += "\n\nThis pull request requires a human merge."
+	}
 	if len(matches) == 1 {
 		if err := publisher.writer.UpdateCheckRun(
 			ctx,
@@ -726,6 +737,94 @@ func samePublishedGeneration(
 		facts.IntentDigest == generation.IntentDigest
 }
 
+func (publisher *ReviewPublisher) planPublication(
+	ctx context.Context,
+	snapshot PullRequestSnapshot,
+	state contract.ReviewState,
+) (usecase.PublicationPlan, error) {
+	permission := usecase.PermissionNone
+	association := snapshot.Facts.AuthorAssociation
+	if state.Phase == contract.PhaseApproved &&
+		association != "MEMBER" && association != "OWNER" {
+		resolved, err := publisher.facts.ActorPermission(
+			ctx,
+			snapshot.Facts.AuthorLogin,
+		)
+		if err == nil {
+			permission = usecase.Permission(resolved)
+		}
+	}
+	return usecase.PlanPublication(
+		state,
+		usecase.PublicationFacts{
+			HumanChangesRequested: snapshot.Facts.HumanChangesRequested,
+			AuthorAssociation:     association,
+			AuthorPermission:      permission,
+			Mergeability:          snapshot.Facts.Mergeability,
+		},
+	)
+}
+
+func (publisher *ReviewPublisher) mergeApprovedIfAuthorized(
+	ctx context.Context,
+	expectedStateHead string,
+	state contract.ReviewState,
+) error {
+	if state.Phase != contract.PhaseApproved {
+		return nil
+	}
+	fresh, err := publisher.facts.ReadPullRequestMetadata(
+		ctx,
+		state.Generation.PullRequest,
+	)
+	if err != nil {
+		return err
+	}
+	plan, err := publisher.planPublication(ctx, fresh, state)
+	if err != nil {
+		return err
+	}
+	if !fresh.Facts.Open || fresh.Facts.Draft ||
+		!samePublishedGeneration(fresh.Facts, state.Generation) ||
+		!plan.AutomaticMerge {
+		return nil
+	}
+	if err := publisher.validateSignedState(
+		ctx,
+		expectedStateHead,
+		state,
+	); err != nil {
+		return err
+	}
+	return publisher.writer.MergePullRequest(
+		ctx,
+		state.Generation.PullRequest,
+		state.Generation.HeadSHA,
+	)
+}
+
+func (publisher *ReviewPublisher) validateSignedState(
+	ctx context.Context,
+	expectedStateHead string,
+	state contract.ReviewState,
+) error {
+	loaded, found, err := publisher.state.Load(
+		ctx,
+		state.Generation.PullRequest,
+	)
+	if err != nil || !found || loaded.HeadSHA != expectedStateHead ||
+		contract.MustGenerationDigest(loaded.State.Generation) !=
+			contract.MustGenerationDigest(state.Generation) {
+		return errors.New("Review publication signed state is stale")
+	}
+	loadedDigest, loadedErr := contract.ReviewStateDigest(loaded.State)
+	stateDigest, stateErr := contract.ReviewStateDigest(state)
+	if loadedErr != nil || stateErr != nil || loadedDigest != stateDigest {
+		return errors.New("Review publication signed state content changed")
+	}
+	return nil
+}
+
 func normalizedTestMergeSHA(value string) string {
 	if value == "" {
 		return strings.Repeat("0", 40)
@@ -753,13 +852,17 @@ func renderDecisionStatus(
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(
+	body = fmt.Sprintf(
 		"%s\n- decision: `%s`\n- check: `%s`\n\n%s",
 		body,
 		result.Decision,
 		plan.Conclusion,
 		result.Summary,
-	), nil
+	)
+	if plan.HumanMergeRequired {
+		body += "\n\nThis pull request requires a human merge."
+	}
+	return body, nil
 }
 
 func renderFinding(finding contract.Finding) string {

--- a/internal/infra/reviewagentgithub/projections_test.go
+++ b/internal/infra/reviewagentgithub/projections_test.go
@@ -2,6 +2,7 @@ package reviewagentgithub_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +171,319 @@ func TestPublisherRepairsPersistedExplanationFromLifecycleState(t *testing.T) {
 	})
 }
 
+func TestPublisherAutomaticallyMergesApprovedMemberPullRequest(t *testing.T) {
+	t.Parallel()
+
+	state, result := approvedStateAndResult(t)
+	stateHead := strings.Repeat("f", 40)
+	writer := &recordingProjectionWriter{}
+	publisher, err := github.NewReviewPublisher(
+		"WuKongIM/WuKongIM",
+		"wukongim-review-agent",
+		"wukongim-review-agent[bot]",
+		fixedReviewStateReader{head: stateHead, state: state},
+		fixedReviewFactsReader{snapshot: github.PullRequestSnapshot{
+			Facts: usecase.PullRequestFacts{
+				Repository:        state.Generation.Repository,
+				PullRequest:       state.Generation.PullRequest,
+				HeadSHA:           state.Generation.HeadSHA,
+				BaseSHA:           state.Generation.BaseSHA,
+				TestMergeSHA:      state.Generation.TestMergeSHA,
+				IntentDigest:      state.Generation.IntentDigest,
+				Open:              true,
+				Mergeability:      usecase.MergeabilityClean,
+				AuthorLogin:       "maintainer",
+				AuthorAssociation: "MEMBER",
+			},
+			Author: "maintainer",
+		}},
+		writer,
+	)
+	require.NoError(t, err)
+
+	_, err = publisher.PublishDecision(
+		context.Background(),
+		github.ReviewPublicationRequest{
+			ExpectedStateHead: stateHead,
+			State:             state,
+			Result:            &result,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, state.Generation.HeadSHA, writer.mergedHead)
+}
+
+func TestPublisherRefusesAutomaticMergeAfterSignedStateAdvances(t *testing.T) {
+	t.Parallel()
+
+	state, result := approvedStateAndResult(t)
+	stateHead := strings.Repeat("f", 40)
+	writer := &recordingProjectionWriter{}
+	stateReader := &advancingReviewStateReader{
+		firstHead: stateHead,
+		laterHead: strings.Repeat("9", 40),
+		state:     state,
+	}
+	publisher, err := github.NewReviewPublisher(
+		"WuKongIM/WuKongIM",
+		"wukongim-review-agent",
+		"wukongim-review-agent[bot]",
+		stateReader,
+		fixedReviewFactsReader{snapshot: github.PullRequestSnapshot{
+			Facts: usecase.PullRequestFacts{
+				Repository:        state.Generation.Repository,
+				PullRequest:       state.Generation.PullRequest,
+				HeadSHA:           state.Generation.HeadSHA,
+				BaseSHA:           state.Generation.BaseSHA,
+				TestMergeSHA:      state.Generation.TestMergeSHA,
+				IntentDigest:      state.Generation.IntentDigest,
+				Open:              true,
+				Mergeability:      usecase.MergeabilityClean,
+				AuthorLogin:       "maintainer",
+				AuthorAssociation: "MEMBER",
+			},
+			Author: "maintainer",
+		}},
+		writer,
+	)
+	require.NoError(t, err)
+
+	_, err = publisher.PublishDecision(
+		context.Background(),
+		github.ReviewPublicationRequest{
+			ExpectedStateHead: stateHead,
+			State:             state,
+			Result:            &result,
+		},
+	)
+	require.ErrorContains(t, err, "signed state is stale")
+	require.Empty(t, writer.mergedHead)
+}
+
+func TestPublisherRepairAutomaticallyMergesApprovedMemberPullRequest(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	state, _ := approvedStateAndResult(t)
+	stateHead := strings.Repeat("f", 40)
+	writer := &recordingProjectionWriter{}
+	publisher, err := github.NewReviewPublisher(
+		"WuKongIM/WuKongIM",
+		"wukongim-review-agent",
+		"wukongim-review-agent[bot]",
+		fixedReviewStateReader{head: stateHead, state: state},
+		fixedReviewFactsReader{snapshot: github.PullRequestSnapshot{
+			Facts: usecase.PullRequestFacts{
+				Repository:        state.Generation.Repository,
+				PullRequest:       state.Generation.PullRequest,
+				HeadSHA:           state.Generation.HeadSHA,
+				BaseSHA:           state.Generation.BaseSHA,
+				TestMergeSHA:      state.Generation.TestMergeSHA,
+				IntentDigest:      state.Generation.IntentDigest,
+				Open:              true,
+				Mergeability:      usecase.MergeabilityClean,
+				AuthorLogin:       "maintainer",
+				AuthorAssociation: "MEMBER",
+			},
+			Author: "maintainer",
+		}},
+		writer,
+	)
+	require.NoError(t, err)
+
+	_, err = publisher.PublishDecision(
+		context.Background(),
+		github.ReviewPublicationRequest{
+			ExpectedStateHead: stateHead,
+			State:             state,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, state.Generation.HeadSHA, writer.mergedHead)
+}
+
+func TestPublisherRepairLeavesApprovedExternalPullRequestForHumanMerge(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	state, _ := approvedStateAndResult(t)
+	stateHead := strings.Repeat("f", 40)
+	writer := &recordingProjectionWriter{}
+	publisher, err := github.NewReviewPublisher(
+		"WuKongIM/WuKongIM",
+		"wukongim-review-agent",
+		"wukongim-review-agent[bot]",
+		fixedReviewStateReader{head: stateHead, state: state},
+		fixedReviewFactsReader{
+			permission: github.PermissionRead,
+			snapshot: github.PullRequestSnapshot{
+				Facts: usecase.PullRequestFacts{
+					Repository:        state.Generation.Repository,
+					PullRequest:       state.Generation.PullRequest,
+					HeadSHA:           state.Generation.HeadSHA,
+					BaseSHA:           state.Generation.BaseSHA,
+					TestMergeSHA:      state.Generation.TestMergeSHA,
+					IntentDigest:      state.Generation.IntentDigest,
+					Open:              true,
+					Mergeability:      usecase.MergeabilityClean,
+					AuthorLogin:       "external",
+					AuthorAssociation: "CONTRIBUTOR",
+				},
+				Author: "external",
+			},
+		},
+		writer,
+	)
+	require.NoError(t, err)
+
+	_, err = publisher.PublishDecision(
+		context.Background(),
+		github.ReviewPublicationRequest{
+			ExpectedStateHead: stateHead,
+			State:             state,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, writer.mergedHead)
+	require.Condition(t, func() bool {
+		for _, body := range writer.issueCommentBodies {
+			if strings.Contains(
+				body,
+				"This pull request requires a human merge.",
+			) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestPublisherAutomaticallyMergesApprovedRepositoryAdminPullRequest(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	state, result := approvedStateAndResult(t)
+	stateHead := strings.Repeat("f", 40)
+	writer := &recordingProjectionWriter{}
+	publisher, err := github.NewReviewPublisher(
+		"WuKongIM/WuKongIM",
+		"wukongim-review-agent",
+		"wukongim-review-agent[bot]",
+		fixedReviewStateReader{head: stateHead, state: state},
+		fixedReviewFactsReader{
+			permission: github.PermissionAdmin,
+			snapshot: github.PullRequestSnapshot{
+				Facts: usecase.PullRequestFacts{
+					Repository:        state.Generation.Repository,
+					PullRequest:       state.Generation.PullRequest,
+					HeadSHA:           state.Generation.HeadSHA,
+					BaseSHA:           state.Generation.BaseSHA,
+					TestMergeSHA:      state.Generation.TestMergeSHA,
+					IntentDigest:      state.Generation.IntentDigest,
+					Open:              true,
+					Mergeability:      usecase.MergeabilityClean,
+					AuthorLogin:       "repository-admin",
+					AuthorAssociation: "COLLABORATOR",
+				},
+				Author: "repository-admin",
+			},
+		},
+		writer,
+	)
+	require.NoError(t, err)
+
+	_, err = publisher.PublishDecision(
+		context.Background(),
+		github.ReviewPublicationRequest{
+			ExpectedStateHead: stateHead,
+			State:             state,
+			Result:            &result,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, state.Generation.HeadSHA, writer.mergedHead)
+}
+
+func TestPublisherLeavesUntrustedApprovedPullRequestForHumanMerge(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		permission    github.Permission
+		permissionErr error
+	}{
+		{name: "external contributor", permission: github.PermissionRead},
+		{name: "write collaborator", permission: github.PermissionWrite},
+		{
+			name:          "permission lookup unavailable",
+			permissionErr: errors.New("permission unavailable"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			state, result := approvedStateAndResult(t)
+			stateHead := strings.Repeat("f", 40)
+			writer := &recordingProjectionWriter{}
+			publisher, err := github.NewReviewPublisher(
+				"WuKongIM/WuKongIM",
+				"wukongim-review-agent",
+				"wukongim-review-agent[bot]",
+				fixedReviewStateReader{head: stateHead, state: state},
+				fixedReviewFactsReader{
+					permission:    test.permission,
+					permissionErr: test.permissionErr,
+					snapshot: github.PullRequestSnapshot{
+						Facts: usecase.PullRequestFacts{
+							Repository:        state.Generation.Repository,
+							PullRequest:       state.Generation.PullRequest,
+							HeadSHA:           state.Generation.HeadSHA,
+							BaseSHA:           state.Generation.BaseSHA,
+							TestMergeSHA:      state.Generation.TestMergeSHA,
+							IntentDigest:      state.Generation.IntentDigest,
+							Open:              true,
+							Mergeability:      usecase.MergeabilityClean,
+							AuthorLogin:       "external",
+							AuthorAssociation: "CONTRIBUTOR",
+						},
+						Author: "external",
+					},
+				},
+				writer,
+			)
+			require.NoError(t, err)
+
+			_, err = publisher.PublishDecision(
+				context.Background(),
+				github.ReviewPublicationRequest{
+					ExpectedStateHead: stateHead,
+					State:             state,
+					Result:            &result,
+				},
+			)
+			require.NoError(t, err)
+			require.Empty(t, writer.mergedHead)
+			require.Equal(t, usecase.FormalReviewApprove, writer.review)
+			require.Condition(t, func() bool {
+				for _, body := range writer.issueCommentBodies {
+					if strings.Contains(
+						body,
+						"This pull request requires a human merge.",
+					) {
+						return true
+					}
+				}
+				return false
+			})
+		})
+	}
+}
+
 type fixedReviewStateReader struct {
 	head  string
 	state contract.ReviewState
@@ -185,8 +499,29 @@ func (reader fixedReviewStateReader) Load(
 	}, true, nil
 }
 
+type advancingReviewStateReader struct {
+	firstHead string
+	laterHead string
+	state     contract.ReviewState
+	reads     int
+}
+
+func (reader *advancingReviewStateReader) Load(
+	context.Context,
+	int64,
+) (github.LoadedReviewState, bool, error) {
+	reader.reads++
+	head := reader.firstHead
+	if reader.reads > 1 {
+		head = reader.laterHead
+	}
+	return github.LoadedReviewState{HeadSHA: head, State: reader.state}, true, nil
+}
+
 type fixedReviewFactsReader struct {
-	snapshot github.PullRequestSnapshot
+	snapshot      github.PullRequestSnapshot
+	permission    github.Permission
+	permissionErr error
 }
 
 func (reader fixedReviewFactsReader) ReadPullRequestMetadata(
@@ -196,12 +531,20 @@ func (reader fixedReviewFactsReader) ReadPullRequestMetadata(
 	return reader.snapshot, nil
 }
 
+func (reader fixedReviewFactsReader) ActorPermission(
+	context.Context,
+	string,
+) (github.Permission, error) {
+	return reader.permission, reader.permissionErr
+}
+
 type recordingProjectionWriter struct {
 	review             usecase.FormalReview
 	inline             []github.InlineReviewComment
 	checkStatus        string
 	checkConclusion    *usecase.CheckConclusion
 	issueCommentBodies []string
+	mergedHead         string
 }
 
 func (writer *recordingProjectionWriter) CreateIssueComment(
@@ -280,6 +623,15 @@ func (writer *recordingProjectionWriter) UpdateLifecycleCheckRun(
 	return nil
 }
 
+func (writer *recordingProjectionWriter) MergePullRequest(
+	_ context.Context,
+	_ int64,
+	headSHA string,
+) error {
+	writer.mergedHead = headSHA
+	return nil
+}
+
 func conflictState() contract.ReviewState {
 	return contract.ReviewState{
 		SchemaVersion: 1,
@@ -300,4 +652,30 @@ func conflictState() contract.ReviewState {
 		StartedAt:      time.Date(2026, 7, 30, 7, 55, 0, 0, time.UTC),
 		UpdatedAt:      time.Date(2026, 7, 30, 8, 0, 0, 0, time.UTC),
 	}
+}
+
+func approvedStateAndResult(
+	t *testing.T,
+) (contract.ReviewState, contract.ReviewResult) {
+	t.Helper()
+	state := conflictState()
+	result := contract.ReviewResult{
+		SchemaVersion:     1,
+		Generation:        state.Generation,
+		Decision:          contract.DecisionApproved,
+		Summary:           "The exact candidate is approved.",
+		InventoryComplete: true,
+		FileAssessments: []contract.FileAssessment{{
+			Path: "README.md", Risk: contract.FileRiskLow,
+			Summary: "The change is bounded.",
+		}},
+	}
+	resultDigest, err := contract.ReviewResultDigest(result)
+	require.NoError(t, err)
+	state.Phase = contract.PhaseApproved
+	state.DecisionSource = contract.DecisionSourceModel
+	state.Reason = "review approved"
+	state.EvidenceDigest = "sha256:" + strings.Repeat("1", 64)
+	state.ResultDigest = resultDigest
+	return state, result
 }

--- a/internal/usecase/reviewagent/FLOW.md
+++ b/internal/usecase/reviewagent/FLOW.md
@@ -19,6 +19,8 @@ exact comment + fresh actor permission
 validated durable decision + fresh publication facts
   -> PlanPublication
   -> status comment + formal Review + Review Agent Verdict
+  -> auto-merge eligibility only for clean approved admin/member PRs
+     without a human REQUEST_CHANGES Review
 ```
 
 Only adapters execute plans. A model result never chooses a GitHub Check

--- a/internal/usecase/reviewagent/publication.go
+++ b/internal/usecase/reviewagent/publication.go
@@ -28,9 +28,13 @@ const (
 // PublicationFacts are freshly re-read immediately before publication.
 type PublicationFacts struct {
 	HumanChangesRequested bool
+	AuthorAssociation     string
+	AuthorPermission      Permission
+	Mergeability          Mergeability
 }
 
-// PublicationPlan contains only the projections supported by the Review App.
+// PublicationPlan contains the projections and bounded merge decision
+// supported by the protected Review Publisher.
 type PublicationPlan struct {
 	CheckName              string
 	ExternalID             string
@@ -38,10 +42,12 @@ type PublicationPlan struct {
 	Review                 FormalReview
 	Conclusion             CheckConclusion
 	HumanReviewStillBlocks bool
+	AutomaticMerge         bool
+	HumanMergeRequired     bool
 }
 
-// PlanPublication maps validated durable state to GitHub projections. It does
-// not expose merge or branch effects.
+// PlanPublication maps validated durable state to GitHub projections and
+// automatic-merge eligibility. It performs no GitHub or branch effect.
 func PlanPublication(
 	state contract.ReviewState,
 	facts PublicationFacts,
@@ -63,6 +69,13 @@ func PlanPublication(
 	case contract.PhaseApproved:
 		plan.Review = FormalReviewApprove
 		plan.Conclusion = CheckSuccess
+		trustedAuthor := facts.AuthorAssociation == "MEMBER" ||
+			facts.AuthorAssociation == "OWNER" ||
+			facts.AuthorPermission == PermissionAdmin
+		plan.AutomaticMerge = !facts.HumanChangesRequested &&
+			facts.Mergeability == MergeabilityClean &&
+			trustedAuthor
+		plan.HumanMergeRequired = !trustedAuthor
 	case contract.PhaseChangesRequired:
 		plan.Review = FormalReviewRequestChanges
 		plan.Conclusion = CheckFailure

--- a/internal/usecase/reviewagent/publication_test.go
+++ b/internal/usecase/reviewagent/publication_test.go
@@ -69,6 +69,112 @@ func TestPlanPublicationDoesNotOverrideHumanChangesRequest(t *testing.T) {
 	require.True(t, plan.HumanReviewStillBlocks)
 }
 
+func TestPlanPublicationAllowsAutomaticMergeForApprovedMember(t *testing.T) {
+	t.Parallel()
+
+	state := testReviewingState()
+	state.Phase = contract.PhaseApproved
+	state.DecisionSource = contract.DecisionSourceModel
+	state.EvidenceDigest = digest("a")
+	state.ResultDigest = digest("b")
+	plan, err := reviewagent.PlanPublication(
+		state,
+		reviewagent.PublicationFacts{
+			AuthorAssociation: "MEMBER",
+			Mergeability:      reviewagent.MergeabilityClean,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, plan.AutomaticMerge)
+}
+
+func TestPlanPublicationAllowsAutomaticMergeForRepositoryAdmin(t *testing.T) {
+	t.Parallel()
+
+	state := testReviewingState()
+	state.Phase = contract.PhaseApproved
+	state.DecisionSource = contract.DecisionSourceModel
+	state.EvidenceDigest = digest("a")
+	state.ResultDigest = digest("b")
+	plan, err := reviewagent.PlanPublication(
+		state,
+		reviewagent.PublicationFacts{
+			AuthorAssociation: "COLLABORATOR",
+			AuthorPermission:  reviewagent.PermissionAdmin,
+			Mergeability:      reviewagent.MergeabilityClean,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, plan.AutomaticMerge)
+}
+
+func TestPlanPublicationRequiresTrustedAuthorAndSafeMergeState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		phase contract.Phase
+		facts reviewagent.PublicationFacts
+	}{
+		{
+			name:  "external contributor",
+			phase: contract.PhaseApproved,
+			facts: reviewagent.PublicationFacts{
+				AuthorAssociation: "CONTRIBUTOR",
+				AuthorPermission:  reviewagent.PermissionRead,
+				Mergeability:      reviewagent.MergeabilityClean,
+			},
+		},
+		{
+			name:  "write collaborator",
+			phase: contract.PhaseApproved,
+			facts: reviewagent.PublicationFacts{
+				AuthorAssociation: "COLLABORATOR",
+				AuthorPermission:  reviewagent.PermissionWrite,
+				Mergeability:      reviewagent.MergeabilityClean,
+			},
+		},
+		{
+			name:  "human changes requested",
+			phase: contract.PhaseApproved,
+			facts: reviewagent.PublicationFacts{
+				HumanChangesRequested: true,
+				AuthorAssociation:     "MEMBER",
+				Mergeability:          reviewagent.MergeabilityClean,
+			},
+		},
+		{
+			name:  "mergeability unresolved",
+			phase: contract.PhaseApproved,
+			facts: reviewagent.PublicationFacts{
+				AuthorAssociation: "MEMBER",
+				Mergeability:      reviewagent.MergeabilityUnknown,
+			},
+		},
+		{
+			name:  "changes required",
+			phase: contract.PhaseChangesRequired,
+			facts: reviewagent.PublicationFacts{
+				AuthorAssociation: "MEMBER",
+				Mergeability:      reviewagent.MergeabilityClean,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			state := testReviewingState()
+			state.Phase = test.phase
+			state.DecisionSource = contract.DecisionSourceModel
+			state.EvidenceDigest = digest("a")
+			state.ResultDigest = digest("b")
+			plan, err := reviewagent.PlanPublication(state, test.facts)
+			require.NoError(t, err)
+			require.False(t, plan.AutomaticMerge)
+		})
+	}
+}
+
 func TestPlanPublicationMapsDeterministicConflictWithoutArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/review_agent_schema_test.go
+++ b/scripts/review_agent_schema_test.go
@@ -75,6 +75,7 @@ func TestReviewAgentPolicy(t *testing.T) {
 		t,
 		map[string]string{
 			"checks":        "write",
+			"contents":      "write",
 			"issues":        "write",
 			"metadata":      "read",
 			"pull_requests": "write",


### PR DESCRIPTION
## Summary

- automatically merge an approved PR only when its author is a repository MEMBER or OWNER, or has freshly verified admin permission
- require human merge for external authors, ordinary collaborators, bots, unknown authority, and permission lookup failures
- fence every merge by the exact reviewed head, signed-state generation, clean mergeability, and absence of human requested changes
- keep the merge operation inside the protected Review Agent publisher and update policy, tests, runbooks, and architecture documentation

## Safety behavior

The Review Agent still publishes its formal review and success check for an approved external PR, but it leaves the PR open and states: This pull request requires a human merge.

The GitHub App token profile requires Repository contents: Read and write because the GitHub merge API requires Contents write. The adapter only exposes an exact-head merge operation.

## Validation

- focused Review Agent tests passed after rebasing onto the latest main
- targeted go vet passed
- git diff --check passed
- dual spec and repository-standards review: zero findings
- full unit suite passed except one unrelated pkg/cluster timing test under parallel load; the exact failing test then passed 10 consecutive reruns
- actionlint remains blocked by the pre-existing cloud-sim-provision workflow having 11 workflow_dispatch inputs while GitHub allows 10

## Rollout status

- WuKongIM Review Agent App declares Repository contents: Read and write
- the existing WuKongIM installation accepted the new permission
- live App permissions were verified through the GitHub API
- installed repository scope remains limited to WuKongIM/WuKongIM