### PR TITLE
docs: align Review Agent App description

### DIFF
--- a/docs/superpowers/runbooks/review-agent-bootstrap.md
+++ b/docs/superpowers/runbooks/review-agent-bootstrap.md
@@ -10,6 +10,10 @@ replacement pull request merges.
 
 Create a repository-scoped App with exactly:
 
+Use an App description that reflects its bounded authority, for example:
+`Policy-gated code review, verdict, and exact-head merge publisher for WuKongIM.`
+Do not describe the App as read-only after enabling Contents write.
+
 | Permission | Level |
 | --- | --- |
 | Metadata | Read |


### PR DESCRIPTION
Clarify that the GitHub App description must reflect its bounded exact-head merge authority after Contents write is enabled. This is also the post-rollout trusted-author auto-merge canary.\n\nValidation: GOWORK=off go test ./scripts -run ReviewAgent\|Workflow -count=1; git diff --check.