### PR TITLE
fix(ci): bound Review Agent model output

### DIFF
--- a/.github/review-agent/policy.json
+++ b/.github/review-agent/policy.json
@@ -32,6 +32,7 @@
     "max_changed_lines": 30000,
     "max_context_bytes": 2097152,
     "max_model_response_bytes": 4194304,
+    "max_model_output_tokens": 32768,
     "max_context_tokens": 240000,
     "auto_compact_tokens": 216000,
     "max_cpu_seconds_per_process": 3600,
@@ -184,6 +185,16 @@
       "working_dir": ".",
       "timeout_seconds": 900,
       "max_output_bytes": 8388608
+    },
+    "review-proxy-contracts": {
+      "arguments": [
+        "node",
+        "--test",
+        ".github/review-agent/responses-budget-proxy.test.mjs"
+      ],
+      "working_dir": ".",
+      "timeout_seconds": 300,
+      "max_output_bytes": 1048576
     },
     "web-quality": {
       "arguments": [
@@ -376,6 +387,21 @@
         ".json"
       ],
       "checks": [
+        "workflow-contracts",
+        "go-unit"
+      ],
+      "exclusive": false
+    },
+    {
+      "name": "review-agent-javascript",
+      "prefixes": [
+        ".github/review-agent/"
+      ],
+      "suffixes": [
+        ".mjs"
+      ],
+      "checks": [
+        "review-proxy-contracts",
         "workflow-contracts",
         "go-unit"
       ],

--- a/.github/review-agent/responses-budget-proxy.mjs
+++ b/.github/review-agent/responses-budget-proxy.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// This root-owned process is the only model transport. It clamps every request
+// before adding the credential, so runner-user Codex has no unclamped route.
+const listenHost = "127.0.0.1";
+const responsesPath = "/v1/responses";
+const openRouterResponsesPath = "/api/v1/responses";
+const maxRequestBytes = 8 * 1024 * 1024;
+const strippedRequestHeaders = new Set([
+  "authorization",
+  "connection",
+  "content-length",
+  "cookie",
+  "host",
+  "keep-alive",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "x-api-key",
+]);
+const strippedResponseHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export function enforceOutputBudget(body, maxOutputTokens) {
+  if (!Number.isSafeInteger(maxOutputTokens) || maxOutputTokens < 1) {
+    throw new Error("max output tokens must be a positive safe integer");
+  }
+  const request = JSON.parse(Buffer.from(body).toString("utf8"));
+  if (request === null || Array.isArray(request) || typeof request !== "object") {
+    throw new Error("Responses request body must be a JSON object");
+  }
+
+  const requested = request.max_output_tokens;
+  if (requested === undefined || requested === null) {
+    request.max_output_tokens = maxOutputTokens;
+  } else {
+    if (!Number.isSafeInteger(requested) || requested < 1) {
+      throw new Error("max_output_tokens must be a positive safe integer");
+    }
+    request.max_output_tokens = Math.min(requested, maxOutputTokens);
+  }
+  return Buffer.from(JSON.stringify(request));
+}
+
+function filteredHeaders(headers, stripped) {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name, value]) => {
+      return value !== undefined && !stripped.has(name.toLowerCase());
+    }),
+  );
+}
+
+export function normalizeAPIKey(body) {
+  if (body.length > 16 * 1024) {
+    throw new Error("API key exceeds protected byte limit");
+  }
+  const value = Buffer.from(body).toString("utf8");
+  const apiKey = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (
+    apiKey.length === 0 ||
+    !/^[\x21-\x7e]+$/.test(apiKey)
+  ) {
+    throw new Error("API key file must contain one printable ASCII line");
+  }
+  return apiKey;
+}
+
+export function buildUpstreamHeaders(headers, apiKey, contentLength) {
+  const result = filteredHeaders(headers, strippedRequestHeaders);
+  result.authorization = `Bearer ${apiKey}`;
+  result["content-length"] = String(contentLength);
+  return result;
+}
+
+function sendError(response, status, message) {
+  if (response.headersSent) {
+    response.destroy();
+    return;
+  }
+  const body = Buffer.from(JSON.stringify({ error: message }));
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": body.length,
+  });
+  response.end(body);
+}
+
+function createProxy(upstreamUrl, maxOutputTokens, apiKey) {
+  return http.createServer((request, response) => {
+    if (request.method !== "POST" || request.url !== responsesPath) {
+      sendError(response, 403, "request is not allowed");
+      request.resume();
+      return;
+    }
+
+    const chunks = [];
+    let bodyBytes = 0;
+    let bodyTooLarge = false;
+    request.on("data", (chunk) => {
+      bodyBytes += chunk.length;
+      if (bodyBytes > maxRequestBytes) {
+        bodyTooLarge = true;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on("error", () => sendError(response, 400, "invalid request body"));
+    request.on("end", () => {
+      if (bodyTooLarge) {
+        sendError(response, 413, "request body exceeds protected byte limit");
+        return;
+      }
+
+      let body;
+      try {
+        body = enforceOutputBudget(Buffer.concat(chunks), maxOutputTokens);
+      } catch {
+        sendError(response, 400, "invalid Responses request body");
+        return;
+      }
+
+      const headers = buildUpstreamHeaders(request.headers, apiKey, body.length);
+      const upstreamRequest = https.request(
+        upstreamUrl,
+        { method: "POST", headers },
+        (upstreamResponse) => {
+          response.writeHead(
+            upstreamResponse.statusCode ?? 502,
+            filteredHeaders(upstreamResponse.headers, strippedResponseHeaders),
+          );
+          upstreamResponse.pipe(response);
+        },
+      );
+      upstreamRequest.on("error", () => {
+        sendError(response, 502, "OpenRouter Responses API is unavailable");
+      });
+      response.on("close", () => {
+        if (!response.writableEnded) {
+          upstreamRequest.destroy();
+        }
+      });
+      upstreamRequest.end(body);
+    });
+  });
+}
+
+export function parseArguments(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined || values.has(name)) {
+      throw new Error("invalid command arguments");
+    }
+    values.set(name, value);
+  }
+  const allowed = new Set([
+    "--api-key-file",
+    "--max-output-tokens",
+    "--server-info",
+    "--upstream-url",
+  ]);
+  for (const name of values.keys()) {
+    if (!allowed.has(name)) {
+      throw new Error(`unsupported option: ${name}`);
+    }
+  }
+
+  const maxOutputTokens = Number(values.get("--max-output-tokens"));
+  if (!Number.isSafeInteger(maxOutputTokens) || maxOutputTokens < 1) {
+    throw new Error("--max-output-tokens must be a positive safe integer");
+  }
+  const serverInfo = values.get("--server-info") ?? "";
+  if (!path.isAbsolute(serverInfo)) {
+    throw new Error("--server-info must be an absolute path");
+  }
+  const apiKeyFile = values.get("--api-key-file") ?? "";
+  if (!path.isAbsolute(apiKeyFile) || apiKeyFile === serverInfo) {
+    throw new Error("--api-key-file must be a distinct absolute path");
+  }
+  const upstreamUrl = new URL(values.get("--upstream-url") ?? "");
+  if (
+    upstreamUrl.protocol !== "https:" ||
+    upstreamUrl.hostname !== "openrouter.ai" ||
+    upstreamUrl.port !== "" ||
+    upstreamUrl.pathname !== openRouterResponsesPath ||
+    upstreamUrl.search !== "" ||
+    upstreamUrl.hash !== "" ||
+    upstreamUrl.username !== "" ||
+    upstreamUrl.password !== ""
+  ) {
+    throw new Error("--upstream-url must be the exact OpenRouter Responses URL");
+  }
+  return { apiKeyFile, maxOutputTokens, serverInfo, upstreamUrl };
+}
+
+async function main() {
+  const { apiKeyFile, maxOutputTokens, serverInfo, upstreamUrl } = parseArguments(
+    process.argv.slice(2),
+  );
+  const apiKeyBody = await readFile(apiKeyFile);
+  await unlink(apiKeyFile);
+  const apiKey = normalizeAPIKey(apiKeyBody);
+  const server = createProxy(upstreamUrl, maxOutputTokens, apiKey);
+  server.on("clientError", (_error, socket) => {
+    socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, listenHost, resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("failed to resolve proxy listener");
+  }
+  try {
+    await writeFile(
+      serverInfo,
+      `${JSON.stringify({ port: address.port, pid: process.pid })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+  } catch (error) {
+    server.close();
+    throw error;
+  }
+  console.error(`responses-budget-proxy listening on ${listenHost}:${address.port}`);
+}
+
+const invokedUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedUrl) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "proxy failed");
+    process.exitCode = 1;
+  });
+}

--- a/.github/review-agent/responses-budget-proxy.test.mjs
+++ b/.github/review-agent/responses-budget-proxy.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildUpstreamHeaders,
+  enforceOutputBudget,
+  normalizeAPIKey,
+  parseArguments,
+} from "./responses-budget-proxy.mjs";
+
+const limit = 32_768;
+
+function rewrite(request) {
+  return JSON.parse(
+    enforceOutputBudget(Buffer.from(JSON.stringify(request)), limit).toString(
+      "utf8",
+    ),
+  );
+}
+
+test("adds the protected output budget when Codex omits one", () => {
+  assert.deepEqual(rewrite({ model: "moonshotai/kimi-k3", stream: true }), {
+    model: "moonshotai/kimi-k3",
+    stream: true,
+    max_output_tokens: limit,
+  });
+});
+
+test("clamps larger and null output budgets", () => {
+  assert.equal(rewrite({ max_output_tokens: 65_536 }).max_output_tokens, limit);
+  assert.equal(rewrite({ max_output_tokens: null }).max_output_tokens, limit);
+});
+
+test("preserves a valid smaller output budget", () => {
+  assert.equal(rewrite({ max_output_tokens: 4_096 }).max_output_tokens, 4_096);
+});
+
+test("rejects malformed request bodies and invalid budgets", () => {
+  for (const body of [
+    Buffer.from("not-json"),
+    Buffer.from("[]"),
+    Buffer.from('{"max_output_tokens":0}'),
+    Buffer.from('{"max_output_tokens":1.5}'),
+    Buffer.from('{"max_output_tokens":"32768"}'),
+  ]) {
+    assert.throws(() => enforceOutputBudget(body, limit));
+  }
+});
+
+test("replaces caller credentials with the protected proxy credential", () => {
+  const headers = buildUpstreamHeaders(
+    {
+      accept: "text/event-stream",
+      authorization: "Bearer caller-controlled",
+      connection: "keep-alive",
+      cookie: "session=caller-controlled",
+      "keep-alive": "timeout=5",
+      te: "trailers",
+      "x-api-key": "caller-controlled",
+    },
+    "openrouter-secret",
+    123,
+  );
+  assert.deepEqual(headers, {
+    accept: "text/event-stream",
+    authorization: "Bearer openrouter-secret",
+    "content-length": "123",
+  });
+});
+
+test("accepts exactly one non-empty API key line", () => {
+  assert.equal(normalizeAPIKey(Buffer.from("openrouter-secret\n")), "openrouter-secret");
+  for (const body of [Buffer.from(""), Buffer.from("\n"), Buffer.from("a\nb\n")]) {
+    assert.throws(() => normalizeAPIKey(body));
+  }
+});
+
+test("accepts only the exact OpenRouter Responses endpoint", () => {
+  const parsed = parseArguments([
+    "--api-key-file",
+    "/tmp/api-key",
+    "--max-output-tokens",
+    String(limit),
+    "--server-info",
+    "/tmp/server-info",
+    "--upstream-url",
+    "https://openrouter.ai/api/v1/responses",
+  ]);
+  assert.equal(parsed.upstreamUrl.href, "https://openrouter.ai/api/v1/responses");
+  assert.throws(() =>
+    parseArguments([
+      "--api-key-file",
+      "/tmp/api-key",
+      "--max-output-tokens",
+      String(limit),
+      "--server-info",
+      "/tmp/server-info",
+      "--upstream-url",
+      "http://127.0.0.1:1234/v1/responses",
+    ]),
+  );
+});

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,6 +63,12 @@ verdict. A trusted validator maps signed state to the sole required Check
 maps to failure, and `inconclusive` maps to `action_required`. A human
 `REQUEST_CHANGES` Review remains independently blocking.
 
+The model request passes through one root-owned loopback proxy that clamps
+`max_output_tokens` to the protected policy and injects the OpenRouter
+credential. The root-only credential handoff file is deleted before the
+listener is published. Codex and candidate checks cannot read the credential,
+replace the proxy, or reach an unclamped transport path.
+
 After publishing an `approved` verdict, the protected Publisher re-reads the
 exact PR head, mergeability, human Reviews, author association, and author
 repository permission. It merges only when the author is an organization
@@ -79,7 +85,7 @@ isolated loopback inside a rootless network namespace whose host loopback is
 disabled. The trusted baseline host keeps runner transport available only so
 pinned post-job Actions can upload evidence; candidate code never runs there.
 The model host keeps GitHub runner transport intact. The pinned Codex Action
-installs the exact CLI and Responses proxy, then the Workflow invokes
+installs the exact CLI, then the Workflow invokes
 `codex exec --dangerously-bypass-approvals-and-sandbox` under model-only CPU,
 address-space, and process limits. This gives Codex full runner-user filesystem
 and public-network access without its internal Bubblewrap sandbox. The model
@@ -160,6 +166,7 @@ Run:
 
 ```bash
 GOWORK=off go test ./scripts/... -run 'Workflow|ReviewAgent' -count=1
+node --test .github/review-agent/responses-budget-proxy.test.mjs
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 \
   .github/workflows/*.yml
 ```

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -295,7 +295,6 @@ jobs:
         with:
           bun-version: "1.3.11"
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        if: inputs.operation == 'review'
         with:
           node-version: "22.12.0"
       - name: Freeze frontend package managers
@@ -324,6 +323,9 @@ jobs:
           cp .github/review-agent/network-fence.sh \
             "$RUNNER_TEMP/review-agent-network-fence.sh"
           chmod 0555 "$RUNNER_TEMP/review-agent-network-fence.sh"
+          sudo install -o root -g root -m 0555 \
+            .github/review-agent/responses-budget-proxy.mjs \
+            "$RUNNER_TEMP/review-agent-responses-budget-proxy.mjs"
           if [[ "$INPUT_OPERATION" == review ]]; then
             GOWORK=off go build -trimpath \
               -o "$RUNNER_TEMP/wkreviewcheckmcp" ./cmd/wkreviewcheckmcp
@@ -358,7 +360,7 @@ jobs:
             cat "$RUNNER_TEMP/review-output.schema.json"
             printf '\n</trusted-output-schema>\n'
           } >>"$RUNNER_TEMP/review-agent-prompt.md"
-      - name: Install pinned Codex CLI and Responses proxy
+      - name: Install pinned Codex CLI
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           codex-version: 0.146.0
@@ -397,32 +399,41 @@ jobs:
               "$RUNNER_TEMP/review-agent-session/recovery.json"
           fi
           chmod -R a-w "$RUNNER_TEMP/review-agent-session"
-      - name: Start protected Responses API proxy
+      - name: Start protected budgeted Responses API proxy
         shell: bash
         env:
           PROXY_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
+          api_key_file="$RUNNER_TEMP/review-agent-api-key"
           server_info="$RUNNER_TEMP/review-agent-proxy.json"
-          (
-            printenv PROXY_API_KEY |
-              env -u PROXY_API_KEY codex-responses-api-proxy \
-                --http-shutdown \
-                --server-info "$server_info" \
-                --upstream-url https://openrouter.ai/api/v1/responses
-          ) &
+          max_output_tokens="$(jq -er '.limits.max_model_output_tokens |
+            select(type == "number" and . >= 1)' \
+            "$RUNNER_TEMP/review-agent-policy.json")"
+          sudo install -o root -g root -m 0600 /dev/null "$api_key_file"
+          printenv PROXY_API_KEY | sudo -n tee "$api_key_file" >/dev/null
           unset PROXY_API_KEY
+          node_binary="$(command -v node)"
+          sudo -n "$node_binary" \
+            "$RUNNER_TEMP/review-agent-responses-budget-proxy.mjs" \
+            --api-key-file "$api_key_file" \
+            --upstream-url https://openrouter.ai/api/v1/responses \
+            --server-info "$server_info" \
+            --max-output-tokens "$max_output_tokens" &
           for _ in {1..100}; do
-            if jq -e '.port | type == "number" and
+            if sudo -n jq -e '.port | type == "number" and
               . >= 1 and . <= 65535' "$server_info" >/dev/null 2>&1; then
               break
             fi
             sleep 0.1
           done
+          sudo -n jq -e '.port | type == "number" and
+            . >= 1 and . <= 65535' "$server_info" >/dev/null
+          test ! -e "$api_key_file"
+          test "$(stat -c '%U:%G:%a' "$server_info")" = root:root:600
+          sudo -n chmod 0444 "$server_info"
           jq -e '.port | type == "number" and
             . >= 1 and . <= 65535' "$server_info" >/dev/null
-          sudo chown root:root "$server_info"
-          sudo chmod 0444 "$server_info"
       - name: Freeze private-network, MCP, and tree boundaries
         shell: bash
         env:

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -91,7 +91,10 @@ failure, or a context too large for complete risk coverage yields
 
 Protected policy fixes the official Codex Action, Codex version,
 `moonshotai/kimi-k3`, high reasoning effort, deterministic check catalog, path
-rules, budgets, and network fences.
+rules, a 32,768-token maximum model output, and network fences. One root-owned
+loopback proxy applies that ceiling and the OpenRouter credential; its
+root-only credential handoff is deleted before Codex starts, so no unclamped
+model transport remains reachable to the runner user.
 
 Each head SHA has one signed automatic-review budget. Intent-only edits after
 that attempt fail closed as `inconclusive` until a new head arrives or an
@@ -99,8 +102,8 @@ authorized bounded reconsideration is accepted.
 
 The model receives no GitHub/App, cloud, deploy, package-publish, or
 organization-private credential. It runs from a trusted external session
-directory. The pinned Action installs the exact Codex CLI and Responses proxy;
-the protected Workflow then runs
+directory. The pinned Action installs the exact Codex CLI. The protected
+Workflow installs the sole root-owned model proxy, then runs
 `codex exec --dangerously-bypass-approvals-and-sandbox` with CPU,
 address-space, and process limits. Codex therefore has full runner-user
 filesystem and public-network access without an internal Bubblewrap sandbox.
@@ -126,8 +129,9 @@ tracked-file mutation.
 
 The protected bounds admit at most 50 changed files, 1 MiB of captured change
 material, 30,000 complete-file lines, and a 2 MiB encoded Context. The encoded
-byte cap is an ingestion bound; the 240,000-token model window and 216,000-token
-automatic-compaction threshold remain unchanged. Three concurrent
+byte cap is only an ingestion bound; it is independent of the 240,000-token
+model window, 216,000-token automatic-compaction threshold, and 32,768-token
+per-request output ceiling. Three concurrent
 exact-content reads remain within the repository API budget.
 
 ## Verdict and projections
@@ -245,6 +249,8 @@ GOWORK=off go test ./internal/contracts/reviewagent \
 
 GOWORK=off go test -tags=integration \
   ./internal/runtime/reviewagentverify -count=1
+
+node --test .github/review-agent/responses-budget-proxy.test.mjs
 
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 \
   .github/workflows/review-agent-pr-signal.yml \

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -94,6 +94,11 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
   credential or inherited host environment, has no Docker socket, and loses
   `sudo` before execution. Candidate checks still use the private-network and
   Bubblewrap boundary, and tracked candidate-tree mutation fails validation.
+- One root-owned loopback Responses proxy is Codex's only model transport. It
+  clamps every request to the protected 32,768-token output ceiling and injects
+  the OpenRouter credential. The root-only credential handoff is deleted before
+  the listener is published, and runner-user Codex cannot replace the proxy or
+  reach an unclamped credential path.
 - The protected Check MCP is required at Codex startup; missing named-check
   tools fail closed instead of degrading to an evidence-free model session.
 - The State Writer App can write only Contents state refs.
@@ -136,6 +141,8 @@ GOWORK=off go test ./internal/contracts/reviewagent \
 
 GOWORK=off go test -tags=integration \
   ./internal/runtime/reviewagentverify -count=1
+
+node --test .github/review-agent/responses-budget-proxy.test.mjs
 
 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 \
   .github/workflows/review-agent-pr-signal.yml \

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -30,6 +30,10 @@
   and tracked candidate-tree mutation is rejected. The protected Check MCP is
   required at Codex startup and keeps candidate checks inside the rootless
   network namespace and per-command Bubblewrap sandbox.
+- Review Agent model transport has one root-owned loopback Responses proxy. It
+  injects the OpenRouter credential and clamps `max_output_tokens` to 32,768;
+  its root-only credential handoff file is deleted before the listener is
+  published. Runner-user Codex must have no second, unclamped credential path.
 - Review Agent baseline candidate-network rules live only in that rootless
   namespace, whose host loopback is disabled. The trusted host disables Docker
   and `sudo` but retains runner transport for pinned post-job Artifact actions.

--- a/docs/superpowers/plans/2026-07-30-review-agent-implementation.md
+++ b/docs/superpowers/plans/2026-07-30-review-agent-implementation.md
@@ -86,6 +86,7 @@ Require:
 - 90-minute generation timeout;
 - two reconsiderations and one infrastructure retry;
 - a finite per-head explanation-session and response-byte budget;
+- a 32,768-token maximum output budget on every model request;
 - 20 inline comments;
 - separate Review App and State Writer App identities/Environments;
 - no rollout, compatibility, legacy label, arbitrary command, or scheduled
@@ -682,6 +683,11 @@ Use the protected policy's exact:
 - output JSON Schema;
 - system prompt and Context Bundle;
 - local stdio Check MCP.
+
+Route every model request through one root-owned loopback Responses proxy that
+both clamps `max_output_tokens` to 32,768 and injects the OpenRouter credential.
+Delete its root-only credential handoff before publishing the listener; do not
+leave a second unclamped proxy reachable to runner-user Codex.
 
 Drop `sudo`, disable Docker socket access, expose full public internet through
 the tested private-network fence, and keep the model job within the 90-minute

--- a/docs/superpowers/specs/2026-07-30-review-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-review-agent-design.md
@@ -357,8 +357,11 @@ Each generation uses one ephemeral Codex session:
 - no Docker socket and no `sudo`;
 - complete public-internet egress, while RFC1918, link-local, cloud metadata,
   runner-host, and organization-private targets remain blocked by the model
-  profile; the pinned Action proxy is the sole transport loopback exception,
-  while candidate checks receive only namespace-local loopback;
+  profile; one root-owned Responses proxy is the sole model-transport loopback
+  exception, clamps `max_output_tokens` to 32,768, injects the OpenRouter
+  credential after deleting its root-only handoff file, and exposes no
+  unclamped transport path to runner-user Codex; candidate checks receive only
+  namespace-local loopback;
 - bounded wall time, CPU, memory, process count, connection count, and network
   volume.
 

--- a/internal/app/review_agent_policy.go
+++ b/internal/app/review_agent_policy.go
@@ -52,6 +52,7 @@ type ReviewAgentPolicy struct {
 		MaxChangedLines                 int64 `json:"max_changed_lines"`
 		MaxContextBytes                 int64 `json:"max_context_bytes"`
 		MaxModelResponseBytes           int64 `json:"max_model_response_bytes"`
+		MaxModelOutputTokens            int   `json:"max_model_output_tokens"`
 		MaxContextTokens                int   `json:"max_context_tokens"`
 		AutoCompactTokens               int   `json:"auto_compact_tokens"`
 		MaxCPUSecondsPerProcess         int   `json:"max_cpu_seconds_per_process"`
@@ -172,6 +173,7 @@ func ValidateReviewAgentPolicy(document ReviewAgentPolicy) error {
 		document.Limits.MaxChangedLines != contract.MaxChangedLines ||
 		document.Limits.MaxContextBytes != contract.MaxContextBytes ||
 		document.Limits.MaxModelResponseBytes <= 0 ||
+		document.Limits.MaxModelOutputTokens != 32768 ||
 		document.Limits.MaxContextTokens != 240000 ||
 		document.Limits.AutoCompactTokens != 216000 ||
 		document.Limits.MaxCPUSecondsPerProcess != 3600 ||

--- a/internal/runtime/reviewagentverify/policy_test.go
+++ b/internal/runtime/reviewagentverify/policy_test.go
@@ -35,6 +35,16 @@ func TestPolicySelectsMandatoryChecksFromCompletePaths(t *testing.T) {
 			want: []string{"go-unit", "go-vet", "workflow-contracts"},
 		},
 		{
+			name: "review agent javascript",
+			files: []contract.ChangedFile{
+				changed(".github/review-agent/responses-budget-proxy.mjs"),
+			},
+			want: []string{
+				"go-unit", "go-vet", "review-proxy-contracts",
+				"workflow-contracts",
+			},
+		},
+		{
 			name: "config and docker",
 			files: []contract.ChangedFile{
 				changed("wukongim.toml.example"),
@@ -149,6 +159,7 @@ func testVerificationPolicy() verify.Policy {
 		TrustedChecks: map[string]verify.CheckPlan{
 			"go-unit": {}, "go-vet": {}, "scripts-integration": {},
 			"workflow-contracts": {}, "docs-contracts": {},
+			"review-proxy-contracts": {},
 			"web-lint": {}, "web-test": {}, "web-typecheck": {},
 			"web-build": {}, "web-bundle": {}, "demo-test": {},
 			"demo-build": {}, "demo-bundle": {}, "go-race": {},
@@ -172,6 +183,14 @@ func testVerificationPolicy() verify.Policy {
 				Name:     "workflow",
 				Prefixes: []string{".github/"},
 				Checks:   []string{"go-unit", "workflow-contracts"},
+			},
+			{
+				Name:     "review agent javascript",
+				Prefixes: []string{".github/review-agent/"},
+				Suffixes: []string{".mjs"},
+				Checks: []string{
+					"go-unit", "review-proxy-contracts", "workflow-contracts",
+				},
 			},
 			{
 				Name:   "codeowners",

--- a/scripts/review_agent_schema_test.go
+++ b/scripts/review_agent_schema_test.go
@@ -48,6 +48,7 @@ func TestReviewAgentPolicy(t *testing.T) {
 	require.Equal(t, reviewagent.MaxChangedBytes, policy.Limits.MaxChangedBytes)
 	require.Equal(t, reviewagent.MaxChangedLines, policy.Limits.MaxChangedLines)
 	require.Equal(t, reviewagent.MaxContextBytes, policy.Limits.MaxContextBytes)
+	require.Equal(t, 32768, policy.Limits.MaxModelOutputTokens)
 	require.Equal(t, 240000, policy.Limits.MaxContextTokens)
 	require.Equal(t, 216000, policy.Limits.AutoCompactTokens)
 	require.Equal(t, 3600, policy.Limits.MaxCPUSecondsPerProcess)
@@ -116,7 +117,28 @@ func TestReviewAgentPolicy(t *testing.T) {
 		)
 		require.Positive(t, check.MaxOutputBytes)
 	}
+	proxyCheck, ok := policy.TrustedChecks["review-proxy-contracts"]
+	require.True(t, ok)
+	require.Equal(
+		t,
+		[]string{
+			"node", "--test",
+			".github/review-agent/responses-budget-proxy.test.mjs",
+		},
+		proxyCheck.Arguments,
+	)
 	require.NotEmpty(t, policy.PathRules)
+	var javascriptRule *reviewAgentPathRule
+	for index := range policy.PathRules {
+		if policy.PathRules[index].Name == "review-agent-javascript" {
+			javascriptRule = &policy.PathRules[index]
+			break
+		}
+	}
+	require.NotNil(t, javascriptRule)
+	require.Equal(t, []string{".github/review-agent/"}, javascriptRule.Prefixes)
+	require.Equal(t, []string{".mjs"}, javascriptRule.Suffixes)
+	require.Contains(t, javascriptRule.Checks, "review-proxy-contracts")
 	require.NotEmpty(t, policy.Network.BlockedCIDRs)
 	require.Contains(t, policy.Credentials.Denied, "github")
 	require.Contains(t, policy.Credentials.Denied, "cloud")
@@ -410,6 +432,7 @@ type reviewAgentLimits struct {
 	MaxChangedLines                 int64 `json:"max_changed_lines"`
 	MaxContextBytes                 int64 `json:"max_context_bytes"`
 	MaxModelResponseBytes           int   `json:"max_model_response_bytes"`
+	MaxModelOutputTokens            int   `json:"max_model_output_tokens"`
 	MaxContextTokens                int   `json:"max_context_tokens"`
 	AutoCompactTokens               int   `json:"auto_compact_tokens"`
 	MaxCPUSecondsPerProcess         int   `json:"max_cpu_seconds_per_process"`

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -228,9 +228,35 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, raw, "--model moonshotai/kimi-k3")
 	require.Contains(t, raw, `--config 'model_reasoning_effort="high"'`)
 	require.Contains(t, raw, "codex-version: 0.146.0")
-	require.Contains(t, raw, "codex-responses-api-proxy")
-	require.Contains(t, raw, "env -u PROXY_API_KEY")
+	require.Contains(t, raw, `node-version: "22.12.0"`)
+	require.NotContains(
+		t,
+		raw,
+		"if: inputs.operation == 'review'\n        with:\n"+
+			`          node-version: "22.12.0"`,
+	)
+	require.NotContains(t, raw, "codex-responses-api-proxy")
+	require.Contains(t, raw, `api_key_file="$RUNNER_TEMP/review-agent-api-key"`)
+	require.Contains(t, raw, `sudo -n tee "$api_key_file"`)
+	require.Contains(t, raw, `test ! -e "$api_key_file"`)
+	require.Contains(t, raw, `sudo -n "$node_binary"`)
+	require.Contains(t, raw, `if sudo -n jq -e '.port | type == "number" and`)
 	require.Contains(t, raw, "--upstream-url https://openrouter.ai/api/v1/responses")
+	require.Contains(
+		t,
+		raw,
+		`max_output_tokens="$(jq -er '.limits.max_model_output_tokens |`,
+	)
+	require.Contains(t, raw, `select(type == "number" and . >= 1)' \`)
+	require.Contains(t, raw, "review-agent-responses-budget-proxy.mjs")
+	require.Contains(t, raw, `--max-output-tokens "$max_output_tokens"`)
+	require.Contains(t, raw, `--server-info "$server_info"`)
+	require.Contains(
+		t,
+		raw,
+		`proxy_port="$(jq -er .port `+
+			`"$RUNNER_TEMP/review-agent-proxy.json")"`,
+	)
 	require.Contains(t, raw, "--cpu=2400:2400")
 	require.Contains(t, raw, "--as=8589934592:8589934592")
 	require.Contains(t, raw, "--nproc=512:512")


### PR DESCRIPTION
## Summary

- enforce a protected 32,768-token maximum on every OpenRouter Responses request
- replace the bypassable two-hop transport with one root-owned proxy that owns both clamping and credential injection
- delete the root-only credential handoff before publishing the loopback listener
- run the proxy tests as the protected `review-proxy-contracts` check for `.github/review-agent/*.mjs` changes
- synchronize the Review Agent workflow, policy, canonical design, CI guide, and project knowledge

## Incident

Review Agent run https://github.com/WuKongIM/WuKongIM/actions/runs/30760776497 reached the model after all deterministic checks, then OpenRouter rejected Codex's omitted output budget as a 65,536-token request (402). The protected ceiling keeps the same Kimi model, high reasoning effort, full runner-user access, and public internet.

## Validation

- `node --test .github/review-agent/responses-budget-proxy.test.mjs`
- full repository unit suite with explicit Go roots
- focused Review Agent package suite
- `actionlint` v1.7.9 on `review-agent-run.yml`
- Standards review: 0 findings
- Spec review: 0 findings

## Bootstrap note

The current `main` Review Agent does not contain this transport fix, so its review of this control-plane PR may reproduce the same infrastructure 402. A maintainer merge is required before reconsidering the unchanged canary PR #777.