### PR TITLE
fix(ci): honor reconsideration after control changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -116,6 +116,12 @@ from pull request, signed lease, and infrastructure attempt is the idempotency
 key at both Controller and retry-drain boundaries, so concurrent recovery
 cannot start the same attempt twice.
 
+Automatic-review and interaction budgets are signed per head SHA. An
+authorized reconsideration of the current head binds a new generation from
+fresh eligible facts even when the protected control revision, intent, base,
+or test-merge revision changed; it consumes reconsideration allowance instead
+of falling through to another automatic review.
+
 Missing Context, reviewer, or trusted-baseline artifacts are evidence of an
 infrastructure failure, not reasons to abort the state machine. The Evidence
 job records the bounded retry or terminal `inconclusive` completion so signed

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -98,7 +98,10 @@ model transport remains reachable to the runner user.
 
 Each head SHA has one signed automatic-review budget. Intent-only edits after
 that attempt fail closed as `inconclusive` until a new head arrives or an
-authorized bounded reconsideration is accepted.
+authorized bounded reconsideration is accepted. A reconsideration for the
+current head remains eligible after the protected control revision, intent,
+base, or test-merge revision changes; it binds a new generation from fresh
+eligible facts and consumes the signed per-head reconsideration budget.
 
 The model receives no GitHub/App, cloud, deploy, package-publish, or
 organization-private credential. It runs from a trusted external session

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -40,6 +40,11 @@
 - A Review Agent generation has one signed 90-minute deadline and at most one
   automatic infrastructure retry. Merge conflicts deterministically publish
   `changes_required`; late results are always `inconclusive`.
+- Review Agent interaction budgets are per head, not per control revision. An
+  authorized reconsideration for the current head binds fresh eligible
+  control, intent, base, and test-merge facts and consumes the existing signed
+  reconsideration allowance; it must not fall through to a second automatic
+  review when those generation facts changed.
 - Backup has one Manager-owned plan in Controller state; it is configured only through Manager, supports Cron or `@every`, and has no TOML/environment compatibility path.
 - Saving backup repository configuration is a durable Controller operation and never proves connectivity. Only the exact saved plan revision that completes the repository and all-active-data-node probe is verified and eligible for backup admission. A nil verification record is legacy verified state until the effective repository changes.
 - Every run publishes one independent full 256-hash-slot archive to the shared file repository under `<data_dir>/backup-repository`, Alibaba OSS, Tencent COS, or a generic S3-compatible repository. `COMPLETE` makes an archive visible, `HOLD` exempts it from retention, and object-storage credentials are encrypted in Controller state while archive payloads are not encrypted.

--- a/docs/superpowers/specs/2026-07-30-review-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-review-agent-design.md
@@ -491,7 +491,11 @@ withdraw a prior finding only by explaining why it no longer applies. New
 commits create new generations and do not consume reconsideration allowance.
 The automatic count is signed per-head state. Intent-only edits after the
 automatic attempt fail closed as `inconclusive` until a new head or an
-authorized reconsideration; they cannot create unbounded model sessions.
+authorized reconsideration; they cannot create unbounded model sessions. An
+authorized reconsideration for the current head remains valid when protected
+control, intent, base, or test-merge facts changed: the Controller must bind a
+new generation from fresh eligible facts and consume the existing head's
+reconsideration allowance rather than attempting a second automatic review.
 
 Runner, provider, dependency-download, or public-network infrastructure
 failure may retry once inside the same attempt before publishing

--- a/internal/runtime/reviewagentverify/policy_test.go
+++ b/internal/runtime/reviewagentverify/policy_test.go
@@ -160,7 +160,7 @@ func testVerificationPolicy() verify.Policy {
 			"go-unit": {}, "go-vet": {}, "scripts-integration": {},
 			"workflow-contracts": {}, "docs-contracts": {},
 			"review-proxy-contracts": {},
-			"web-lint": {}, "web-test": {}, "web-typecheck": {},
+			"web-lint":               {}, "web-test": {}, "web-typecheck": {},
 			"web-build": {}, "web-bundle": {}, "demo-test": {},
 			"demo-build": {}, "demo-bundle": {}, "go-race": {},
 			"go-integration": {}, "go-e2e": {}, "three-node-cluster": {},

--- a/internal/usecase/reviewagent/reconcile.go
+++ b/internal/usecase/reviewagent/reconcile.go
@@ -152,7 +152,14 @@ func ReconcilePullRequest(input ReconcileInput) (ReconcilePlan, error) {
 	if input.Signal.Kind == SignalCommand {
 		readOnlyStatus := input.Signal.Command != nil &&
 			input.Signal.Command.Kind == CommandStatus
-		if sameGeneration &&
+		// Reconsideration is budgeted per head. Fresh control, intent, or base
+		// facts create a new generation but must not hide an explicit command.
+		reconsiderCurrentHead := input.State != nil &&
+			input.Signal.Command != nil &&
+			input.Signal.Command.Kind == CommandReconsider &&
+			input.State.Generation.HeadSHA == input.Facts.HeadSHA &&
+			ineligibleReason(input.Facts, input.Policy) == ""
+		if (sameGeneration || reconsiderCurrentHead) &&
 			(readOnlyStatus || input.Facts.Open && !input.Facts.Draft) {
 			return reconcileCommand(input)
 		}

--- a/internal/usecase/reviewagent/reconcile_test.go
+++ b/internal/usecase/reviewagent/reconcile_test.go
@@ -978,6 +978,96 @@ func TestReconcilePullRequestSeparatesInteractionEffects(t *testing.T) {
 	require.Equal(t, decided.PriorFindings, reconsider.PriorFindings)
 }
 
+func TestReconcilePullRequestHonorsReconsiderForEligibleCurrentHead(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*reviewagent.PullRequestFacts){
+		"control revision changed": func(facts *reviewagent.PullRequestFacts) {
+			facts.StateParentSHA = strings.Repeat("f", 40)
+		},
+		"intent changed": func(facts *reviewagent.PullRequestFacts) {
+			facts.IntentDigest = digest("f")
+		},
+		"base and test merge changed": func(facts *reviewagent.PullRequestFacts) {
+			facts.BaseSHA = strings.Repeat("1", 40)
+			facts.TestMergeSHA = strings.Repeat("2", 40)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			state := testReviewingState()
+			state.Phase = contract.PhaseInconclusive
+			state.DecisionSource = contract.DecisionSourcePolicy
+			state.Reason = "automatic Review budget exhausted for current head"
+			state.Budget.AutomaticReviewsUsed = 1
+
+			facts := testFacts()
+			mutate(&facts)
+			plan, err := reviewagent.ReconcilePullRequest(reviewagent.ReconcileInput{
+				Facts:     facts,
+				State:     &state,
+				Scheduler: testScheduler(),
+				Signal: reviewagent.Signal{
+					Kind:  reviewagent.SignalCommand,
+					RunID: 706,
+					Command: &reviewagent.Command{
+						Kind:    reviewagent.CommandReconsider,
+						Payload: "The protected model transport is repaired.",
+					},
+				},
+				Policy: testPolicy(),
+				Now:    time.Date(2026, 8, 3, 2, 20, 0, 0, time.UTC),
+			})
+			require.NoError(t, err)
+			require.Equal(t, reviewagent.ActionReconsiderAndDispatch, plan.Action)
+			require.True(t, plan.Dispatch)
+			require.Equal(t, uint64(2), plan.Generation.Generation)
+			require.Equal(t, facts.HeadSHA, plan.Generation.HeadSHA)
+			require.Equal(t, facts.BaseSHA, plan.Generation.BaseSHA)
+			require.Equal(t, facts.TestMergeSHA, plan.Generation.TestMergeSHA)
+			require.Equal(t, facts.IntentDigest, plan.Generation.IntentDigest)
+			require.Equal(t, facts.StateParentSHA, plan.Generation.StateParentSHA)
+			require.Equal(t, uint32(1), plan.NextBudget.AutomaticReviewsUsed)
+			require.Equal(t, uint32(1), plan.NextBudget.ReconsiderationsUsed)
+		})
+	}
+}
+
+func TestReconcilePullRequestDoesNotReconsiderIneligibleCurrentHead(t *testing.T) {
+	t.Parallel()
+
+	state := testReviewingState()
+	state.Phase = contract.PhaseInconclusive
+	state.DecisionSource = contract.DecisionSourcePolicy
+	state.Reason = "automatic Review budget exhausted for current head"
+	state.Budget.AutomaticReviewsUsed = 1
+
+	facts := testFacts()
+	facts.StateParentSHA = strings.Repeat("f", 40)
+	facts.Mergeability = reviewagent.MergeabilityConflicting
+	facts.TestMergeSHA = ""
+	plan, err := reviewagent.ReconcilePullRequest(reviewagent.ReconcileInput{
+		Facts:     facts,
+		State:     &state,
+		Scheduler: testScheduler(),
+		Signal: reviewagent.Signal{
+			Kind:  reviewagent.SignalCommand,
+			RunID: 707,
+			Command: &reviewagent.Command{
+				Kind:    reviewagent.CommandReconsider,
+				Payload: "Please review the current head again.",
+			},
+		},
+		Policy: testPolicy(),
+		Now:    time.Date(2026, 8, 3, 2, 20, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.Equal(t, reviewagent.ActionRecordChangesRequired, plan.Action)
+	require.Equal(t, contract.PhaseChangesRequired, plan.DesiredPhase)
+	require.False(t, plan.Dispatch)
+	require.Equal(t, uint32(0), plan.NextBudget.ReconsiderationsUsed)
+}
+
 func TestReconcilePullRequestBoundsAndRecoversPendingExplanation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- honor an authorized reconsider command for the current head when protected control, intent, base, or test-merge facts changed
- bind the reconsideration to a new generation built from fresh eligible facts and consume the signed per-head reconsideration budget
- preserve fail-closed handling for merge conflicts and other ineligible current facts

## Production reproduction

After PR #778 updated the protected control revision, the accepted reconsider command on PR #777 was downgraded to an observed event. The Controller emitted record_inconclusive with automatic Review budget exhausted for current head even though reconsiderations remained 0/2.

## Validation

- regression test reproduced reconsider_and_dispatch versus record_inconclusive before the fix
- Review Agent package and composition suites pass
- full repository unit suite passes
- Review Agent Actionlint contracts pass
- Responses budget proxy tests pass (7/7)