### PR TITLE
refactor(delivery): remove retired app fanout seams

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -87,15 +87,14 @@ type App struct {
 	// opsMCPEndpoint serves stateless MCP on every configured Manager listener.
 	opsMCPEndpoint *accessops.Endpoint
 	// opsMCPCalls owns node-local rate budgets and rotated audit output.
-	opsMCPCalls                 *runtimeops.CallControl
-	gateway                     GatewayRuntime
-	handler                     *accessgateway.Handler
-	messages                    *message.App
-	apiMessages                 accessapi.MessageUsecase
-	channelAppends              *channelappend.Group
-	channelAppendRouter         *channelappend.Router
-	channelAppendDeliveryWorker *channelappend.RecipientDeliveryWorker
-	channelAppendMetadata       *clusterinfra.ChannelAppendMetadataCache
+	opsMCPCalls           *runtimeops.CallControl
+	gateway               GatewayRuntime
+	handler               *accessgateway.Handler
+	messages              *message.App
+	apiMessages           accessapi.MessageUsecase
+	channelAppends        *channelappend.Group
+	channelAppendRouter   *channelappend.Router
+	channelAppendMetadata *clusterinfra.ChannelAppendMetadataCache
 	// messageIDs owns the node-scoped allocator so activated restore fences can
 	// be installed before ordinary traffic starts.
 	messageIDs *nodeMessageIDs
@@ -123,11 +122,9 @@ type App struct {
 	users         *userusecase.App
 	delivery      *deliveryusecase.App
 	// onlineDelivery owns canonical recipient-plan processing and owner-local ACK state.
-	onlineDelivery   *runtimedelivery.Runtime
-	deliveryManager  *runtimedelivery.Manager
-	deliveryRetry    *runtimedelivery.RetryScheduler
-	deliveryWorker   WorkerRuntime
-	localOwnerPusher runtimedelivery.Pusher
+	onlineDelivery *runtimedelivery.Runtime
+	// deliveryWorker owns the canonical delivery runtime lifecycle.
+	deliveryWorker WorkerRuntime
 	// seedJoinLoop retries pre-membership JoinNode RPCs and gates entry startup until admission is observed.
 	seedJoinLoop                seedJoinRuntime
 	conversationRouteLifecycle  WorkerRuntime
@@ -135,7 +132,7 @@ type App struct {
 	conversationAuthority       *conversationAuthority
 	conversationAuthorityClient *clusterinfra.ConversationAuthorityClient
 	// deliverySubscribers scans durable non-person channel subscribers when provided.
-	deliverySubscribers     runtimedelivery.ChannelSubscriberSource
+	deliverySubscribers     channelappend.SubscriberSource
 	deliveryMeta            *deliveryMetaStore
 	presence                *presence.App
 	presenceAuthorityClient *clusterinfra.PresenceAuthorityClient
@@ -348,8 +345,8 @@ func WithOnlineRegistry(reg *online.Registry) Option {
 	return func(a *App) { a.online = reg }
 }
 
-// WithDeliverySubscriberSource overrides the durable subscriber source used by delivery fanout.
-func WithDeliverySubscriberSource(source runtimedelivery.ChannelSubscriberSource) Option {
+// WithDeliverySubscriberSource overrides the durable subscriber source used by channelappend.
+func WithDeliverySubscriberSource(source channelappend.SubscriberSource) Option {
 	return func(a *App) { a.deliverySubscribers = source }
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -24,11 +24,9 @@ import (
 	accessgateway "github.com/WuKongIM/WuKongIM/internal/access/gateway"
 	accessmanager "github.com/WuKongIM/WuKongIM/internal/access/manager"
 	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
-	"github.com/WuKongIM/WuKongIM/internal/contracts/messageevents"
 	clusterinfra "github.com/WuKongIM/WuKongIM/internal/infra/cluster"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/conversationactive"
-	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/online"
 	authoritypresence "github.com/WuKongIM/WuKongIM/internal/runtime/presence"
 	channelusecase "github.com/WuKongIM/WuKongIM/internal/usecase/channel"
@@ -3245,9 +3243,6 @@ func TestConfigureObservabilityWiresTopObserversWhenMetricsDisabled(t *testing.T
 	if clusterCfg.Transport.Observer == nil {
 		t.Fatal("transport top observer was not wired")
 	}
-	if app.deliveryObserver() == nil {
-		t.Fatal("delivery top observer was not wired")
-	}
 }
 
 func TestConfigureObservabilitySamplesResourcesForMetricsWithoutTopProvider(t *testing.T) {
@@ -4401,112 +4396,6 @@ func TestConversationAuthorityRouteLifecyclePeriodicReconcileRepairsDroppedAutho
 	})
 }
 
-func TestDeliveryWorkerGroupStopKeepsDependenciesRunningWhenDrainFails(t *testing.T) {
-	retry := &recordingWorkerRuntime{}
-	manager := &recordingWorkerRuntime{stopErr: context.DeadlineExceeded}
-	group := deliveryWorkerGroup{retry, manager}
-
-	err := group.Stop(context.Background())
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Stop() error = %v, want deadline exceeded", err)
-	}
-	if manager.stopCount != 1 {
-		t.Fatalf("manager stop count = %d, want 1", manager.stopCount)
-	}
-	if retry.stopCount != 0 {
-		t.Fatalf("retry stop count = %d, want dependency kept running", retry.stopCount)
-	}
-}
-
-func TestAppSubscriberPlannerReturnsPersonChannelUIDs(t *testing.T) {
-	channelID := runtimechannelid.EncodePersonChannel("u1", "u2")
-	page, err := appSubscriberPlanner{}.NextPartitionPage(context.Background(), runtimedelivery.FanoutTask{
-		Envelope: runtimedelivery.Envelope{ChannelID: channelID, ChannelType: frame.ChannelTypePerson},
-	}, "", 512)
-	if err != nil {
-		t.Fatalf("NextPartitionPage() error = %v", err)
-	}
-	if !page.Done {
-		t.Fatalf("Done = false, want true")
-	}
-	if len(page.UIDs) != 2 || page.UIDs[0] == page.UIDs[1] {
-		t.Fatalf("UIDs = %#v, want two distinct participants", page.UIDs)
-	}
-	want := map[string]bool{"u1": true, "u2": true}
-	for _, uid := range page.UIDs {
-		if !want[uid] {
-			t.Fatalf("unexpected UID %q in %#v", uid, page.UIDs)
-		}
-	}
-}
-
-func TestDeliveryRuntimeAdapterScopesPersonChannelAcrossPartitions(t *testing.T) {
-	runner := &appRecordingFanoutRunner{}
-	manager := runtimedelivery.NewManager(runtimedelivery.ManagerOptions{
-		Planner: runtimedelivery.NewPlanner(runtimedelivery.PlannerOptions{
-			Partitioner: appStaticDeliveryPartitioner{
-				partitions: []runtimedelivery.Partition{
-					{ID: 1, LeaderNodeID: 1},
-					{ID: 2, LeaderNodeID: 2},
-					{ID: 3, LeaderNodeID: 3},
-				},
-			},
-		}),
-		Runner: runner,
-	})
-	if err := manager.Start(context.Background()); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	defer func() {
-		stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		if err := manager.Stop(stopCtx); err != nil {
-			t.Fatalf("Stop() error = %v", err)
-		}
-	}()
-	channelID := runtimechannelid.EncodePersonChannel("u1", "u2")
-
-	err := deliveryRuntimeAdapter{manager: manager}.SubmitCommitted(context.Background(), messageevents.MessageCommitted{
-		MessageID:   1,
-		MessageSeq:  1,
-		ChannelID:   channelID,
-		ChannelType: frame.ChannelTypePerson,
-		FromUID:     "u1",
-	})
-	if err != nil {
-		t.Fatalf("SubmitCommitted() error = %v", err)
-	}
-	tasks := waitAppFanoutTasks(t, runner, 1, time.Second)
-	if len(tasks) != 1 {
-		t.Fatalf("fanout tasks = %d, want 1 scoped person task", len(tasks))
-	}
-	got := tasks[0].Envelope.MessageScopedUIDs
-	if len(got) != 2 {
-		t.Fatalf("MessageScopedUIDs = %#v, want two participants", got)
-	}
-	want := map[string]bool{"u1": true, "u2": true}
-	for _, uid := range got {
-		if !want[uid] {
-			t.Fatalf("unexpected scoped UID %q in %#v", uid, got)
-		}
-	}
-}
-
-func waitAppFanoutTasks(t *testing.T, runner *appRecordingFanoutRunner, want int, timeout time.Duration) []runtimedelivery.FanoutTask {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var tasks []runtimedelivery.FanoutTask
-	for time.Now().Before(deadline) {
-		tasks = runner.snapshot()
-		if len(tasks) == want {
-			return tasks
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("fanout tasks = %d, want %d", len(tasks), want)
-	return nil
-}
-
 func TestDeliveryEnabledPersonSendWritesRecvAndRecvackClearsPending(t *testing.T) {
 	cluster := newFakePresenceCluster(1, nil)
 	cluster.snapshot = readyFakeClusterSnapshot(1, 16)
@@ -4589,8 +4478,8 @@ func TestDeliveryEnabledGroupSendUsesSubscriberSource(t *testing.T) {
 		},
 	}
 	subscribers := &fakeDeliverySubscriberSource{
-		pages: []runtimedelivery.UIDPage{
-			{UIDs: []string{"u2"}, Done: true},
+		pages: []channelappend.SubscriberPage{
+			{Recipients: []channelappend.Recipient{{UID: "u2"}}, Done: true},
 		},
 	}
 	app, err := newTestApp(t,
@@ -4656,11 +4545,8 @@ func TestDeliveryEnabledGroupSendUsesSubscriberSource(t *testing.T) {
 		t.Fatalf("subscriber requests = %d, want 1", len(subscribers.requests))
 	}
 	req := subscribers.requests[0]
-	if req.ChannelID != "g1" || req.ChannelType != frame.ChannelTypeGroup || req.Limit != app.cfg.Delivery.FanoutPageSize {
+	if req.ChannelID.ID != "g1" || req.ChannelID.Type != frame.ChannelTypeGroup || req.Limit != app.cfg.Delivery.FanoutPageSize {
 		t.Fatalf("subscriber request = %#v, want group channel with configured page size", req)
-	}
-	if req.Partition != (runtimedelivery.Partition{}) {
-		t.Fatalf("subscriber partition = %#v, want recipient-authority unpartitioned scan", req.Partition)
 	}
 
 	if err := app.Handler().OnFrame(gateway.Context{Session: recipient, RequestContext: context.Background()}, &frame.RecvackPacket{
@@ -4672,7 +4558,7 @@ func TestDeliveryEnabledGroupSendUsesSubscriberSource(t *testing.T) {
 	waitAppDeliveryPendingAckCount(t, app, 0, time.Second)
 }
 
-func TestDeliveryMetaStoreWritesBenchDataAndFiltersSubscriberPages(t *testing.T) {
+func TestDeliveryMetaStoreWritesBenchDataAndPagesSubscribers(t *testing.T) {
 	const hashSlotCount = 16
 	slotThreeUID := testUIDForHashSlot(t, 3, hashSlotCount)
 	slotNineUID := testUIDForHashSlot(t, 9, hashSlotCount)
@@ -4720,76 +4606,64 @@ func TestDeliveryMetaStoreWritesBenchDataAndFiltersSubscriberPages(t *testing.T)
 		t.Fatalf("removed = %#v accepted=%d, want one subscriber at mutation version 3", node.removed, removedSubscribers)
 	}
 
-	page, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{
-		ChannelID:   "g1",
-		ChannelType: frame.ChannelTypeGroup,
-		Partition:   runtimedelivery.Partition{HashSlotStart: 3, HashSlotEnd: 3},
-		Limit:       10,
+	page, err := store.NextSubscriberPage(context.Background(), channelappend.SubscriberPageRequest{
+		ChannelID: channelappend.ChannelID{ID: "g1", Type: frame.ChannelTypeGroup},
+		Limit:     10,
 	})
 	if err != nil {
-		t.Fatalf("ListSubscribers() error = %v", err)
+		t.Fatalf("NextSubscriberPage() error = %v", err)
 	}
-	if len(page.UIDs) != 1 || page.UIDs[0] != slotThreeUID || !page.Done {
-		t.Fatalf("slot-filtered page = %#v, want only slot 3 uid", page)
+	if len(page.Recipients) != 2 || page.Recipients[0].UID != slotThreeUID || page.Recipients[1].UID != slotNineUID || !page.Done {
+		t.Fatalf("subscriber page = %#v, want both durable subscribers", page)
 	}
-	first, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{
-		ChannelID:   "g1",
-		ChannelType: frame.ChannelTypeGroup,
-		Partition:   runtimedelivery.Partition{HashSlotStart: 0, HashSlotEnd: hashSlotCount - 1},
-		Limit:       1,
+	first, err := store.NextSubscriberPage(context.Background(), channelappend.SubscriberPageRequest{
+		ChannelID: channelappend.ChannelID{ID: "g1", Type: frame.ChannelTypeGroup},
+		Limit:     1,
 	})
 	if err != nil {
-		t.Fatalf("ListSubscribers(first) error = %v", err)
+		t.Fatalf("NextSubscriberPage(first) error = %v", err)
 	}
-	if len(first.UIDs) != 1 || first.NextCursor == "" || first.Done {
+	if len(first.Recipients) != 1 || first.Cursor == "" || first.Done {
 		t.Fatalf("first page = %#v, want one uid and continuation", first)
 	}
-	second, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{
-		ChannelID:   "g1",
-		ChannelType: frame.ChannelTypeGroup,
-		Partition:   runtimedelivery.Partition{HashSlotStart: 0, HashSlotEnd: hashSlotCount - 1},
-		Cursor:      first.NextCursor,
-		Limit:       1,
+	second, err := store.NextSubscriberPage(context.Background(), channelappend.SubscriberPageRequest{
+		ChannelID: channelappend.ChannelID{ID: "g1", Type: frame.ChannelTypeGroup},
+		Cursor:    first.Cursor,
+		Limit:     1,
 	})
 	if err != nil {
-		t.Fatalf("ListSubscribers(second) error = %v", err)
+		t.Fatalf("NextSubscriberPage(second) error = %v", err)
 	}
-	if len(second.UIDs) != 1 || !second.Done {
+	if len(second.Recipients) != 1 || !second.Done {
 		t.Fatalf("second page = %#v, want final uid", second)
 	}
 }
 
-func TestDeliveryMetaStoreCachesSubscriberSnapshotAcrossPartitions(t *testing.T) {
-	const hashSlotCount = 16
-	slotThreeUID := testUIDForHashSlot(t, 3, hashSlotCount)
-	slotNineUID := testUIDForHashSlot(t, 9, hashSlotCount)
+func TestDeliveryMetaStoreCachesSubscriberSnapshotAcrossPages(t *testing.T) {
 	node := &recordingDeliveryMetaNode{
-		snapshot:    readyFakeClusterSnapshot(1, hashSlotCount),
-		subscribers: map[string][]string{"g1": []string{slotThreeUID, slotNineUID}},
+		snapshot:    readyFakeClusterSnapshot(1, 16),
+		subscribers: map[string][]string{"g1": {"u1", "u2"}},
 	}
 	store := newDeliveryMetaStore(node)
 
-	first, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{
-		ChannelID:   "g1",
-		ChannelType: frame.ChannelTypeGroup,
-		Partition:   runtimedelivery.Partition{HashSlotStart: 3, HashSlotEnd: 3},
-		Limit:       10,
+	first, err := store.NextSubscriberPage(context.Background(), channelappend.SubscriberPageRequest{
+		ChannelID: channelappend.ChannelID{ID: "g1", Type: frame.ChannelTypeGroup},
+		Limit:     1,
 	})
 	if err != nil {
-		t.Fatalf("ListSubscribers(first) error = %v", err)
+		t.Fatalf("NextSubscriberPage(first) error = %v", err)
 	}
-	second, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{
-		ChannelID:   "g1",
-		ChannelType: frame.ChannelTypeGroup,
-		Partition:   runtimedelivery.Partition{HashSlotStart: 9, HashSlotEnd: 9},
-		Limit:       10,
+	second, err := store.NextSubscriberPage(context.Background(), channelappend.SubscriberPageRequest{
+		ChannelID: channelappend.ChannelID{ID: "g1", Type: frame.ChannelTypeGroup},
+		Cursor:    first.Cursor,
+		Limit:     1,
 	})
 	if err != nil {
-		t.Fatalf("ListSubscribers(second) error = %v", err)
+		t.Fatalf("NextSubscriberPage(second) error = %v", err)
 	}
 
-	if len(first.UIDs) != 1 || first.UIDs[0] != slotThreeUID || len(second.UIDs) != 1 || second.UIDs[0] != slotNineUID {
-		t.Fatalf("partition pages first=%#v second=%#v, want cached slot-specific results", first, second)
+	if len(first.Recipients) != 1 || first.Recipients[0].UID != "u1" || len(second.Recipients) != 1 || second.Recipients[0].UID != "u2" {
+		t.Fatalf("pages first=%#v second=%#v, want cached subscriber order", first, second)
 	}
 	if node.listCalls != 1 {
 		t.Fatalf("subscriber list calls = %d, want one cached channel snapshot read", node.listCalls)
@@ -4802,8 +4676,9 @@ func TestDeliveryMetaStoreInvalidatesSubscriberCacheAfterMutation(t *testing.T) 
 		subscribers: map[string][]string{"g1": []string{"u1"}},
 	}
 	store := newDeliveryMetaStore(node)
-	if _, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{ChannelID: "g1", ChannelType: frame.ChannelTypeGroup, Limit: 10}); err != nil {
-		t.Fatalf("ListSubscribers(before) error = %v", err)
+	request := channelappend.SubscriberPageRequest{ChannelID: channelappend.ChannelID{ID: "g1", Type: frame.ChannelTypeGroup}, Limit: 10}
+	if _, err := store.NextSubscriberPage(context.Background(), request); err != nil {
+		t.Fatalf("NextSubscriberPage(before) error = %v", err)
 	}
 	if _, err := store.AddSubscribers(context.Background(), []accessapi.BenchSubscriberMutation{{
 		ChannelID:   "g1",
@@ -4815,11 +4690,11 @@ func TestDeliveryMetaStoreInvalidatesSubscriberCacheAfterMutation(t *testing.T) 
 	node.mu.Lock()
 	node.subscribers["g1"] = []string{"u1", "u2"}
 	node.mu.Unlock()
-	after, err := store.ListSubscribers(context.Background(), runtimedelivery.SubscriberPageRequest{ChannelID: "g1", ChannelType: frame.ChannelTypeGroup, Limit: 10})
+	after, err := store.NextSubscriberPage(context.Background(), request)
 	if err != nil {
-		t.Fatalf("ListSubscribers(after) error = %v", err)
+		t.Fatalf("NextSubscriberPage(after) error = %v", err)
 	}
-	if len(after.UIDs) != 2 || after.UIDs[1] != "u2" {
+	if len(after.Recipients) != 2 || after.Recipients[1].UID != "u2" {
 		t.Fatalf("after mutation page = %#v, want refreshed subscribers", after)
 	}
 	if node.listCalls != 2 {
@@ -8353,21 +8228,8 @@ type recordingSessionHandle struct {
 }
 
 type fakeDeliverySubscriberSource struct {
-	requests []runtimedelivery.SubscriberPageRequest
-	pages    []runtimedelivery.UIDPage
-}
-
-type appStaticDeliveryPartitioner struct {
-	partitions []runtimedelivery.Partition
-}
-
-func (p appStaticDeliveryPartitioner) Partitions(context.Context) ([]runtimedelivery.Partition, error) {
-	return append([]runtimedelivery.Partition(nil), p.partitions...), nil
-}
-
-type appRecordingFanoutRunner struct {
-	mu    sync.Mutex
-	tasks []runtimedelivery.FanoutTask
+	requests []channelappend.SubscriberPageRequest
+	pages    []channelappend.SubscriberPage
 }
 
 type recordingWorkerRuntime struct {
@@ -8403,23 +8265,10 @@ func (r *recordingWorkerRuntime) Stop(context.Context) error {
 	return r.stopErr
 }
 
-func (r *appRecordingFanoutRunner) RunTask(_ context.Context, task runtimedelivery.FanoutTask) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.tasks = append(r.tasks, task)
-	return nil
-}
-
-func (r *appRecordingFanoutRunner) snapshot() []runtimedelivery.FanoutTask {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return append([]runtimedelivery.FanoutTask(nil), r.tasks...)
-}
-
-func (s *fakeDeliverySubscriberSource) ListSubscribers(_ context.Context, req runtimedelivery.SubscriberPageRequest) (runtimedelivery.UIDPage, error) {
+func (s *fakeDeliverySubscriberSource) NextSubscriberPage(_ context.Context, req channelappend.SubscriberPageRequest) (channelappend.SubscriberPage, error) {
 	s.requests = append(s.requests, req)
 	if len(s.pages) == 0 {
-		return runtimedelivery.UIDPage{Done: true}, nil
+		return channelappend.SubscriberPage{Done: true}, nil
 	}
 	page := s.pages[0]
 	s.pages = s.pages[1:]

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -12,9 +12,6 @@ import (
 	conversationusecase "github.com/WuKongIM/WuKongIM/internal/usecase/conversation"
 	deliveryusecase "github.com/WuKongIM/WuKongIM/internal/usecase/delivery"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/message"
-	"github.com/WuKongIM/WuKongIM/internal/usecase/presence"
-	runtimechannelid "github.com/WuKongIM/WuKongIM/pkg/protocol/channelid"
-	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 	"github.com/WuKongIM/WuKongIM/pkg/wklog"
 )
 
@@ -23,65 +20,9 @@ const defaultDeliveryRetryBackoff = 10 * time.Millisecond
 
 var errOnlineDeliveryCommittedSubmitUnsupported = errors.New("internal/app: committed delivery submission requires a canonical recipient plan")
 
-type deliveryRuntimeAdapter struct {
-	// manager handles committed-message fanout and ack mutations.
-	manager *runtimedelivery.Manager
-}
-
 type onlineDeliveryUsecaseAdapter struct {
 	// runtime owns recipient feedback after channelappend produces canonical plans.
 	runtime *runtimedelivery.Runtime
-}
-
-type deliveryWorkerGroup []WorkerRuntime
-
-func appendDeliveryWorker(current WorkerRuntime, worker WorkerRuntime) WorkerRuntime {
-	if worker == nil {
-		return current
-	}
-	group, ok := current.(deliveryWorkerGroup)
-	if !ok {
-		if current == nil {
-			return deliveryWorkerGroup{worker}
-		}
-		group = deliveryWorkerGroup{current}
-	}
-	for _, existing := range group {
-		if existing == worker {
-			return group
-		}
-	}
-	return append(group, worker)
-}
-
-func (g deliveryWorkerGroup) Start(ctx context.Context) error {
-	for idx, worker := range g {
-		if worker == nil {
-			continue
-		}
-		if err := worker.Start(ctx); err != nil {
-			for i := idx - 1; i >= 0; i-- {
-				if g[i] != nil {
-					_ = g[i].Stop(ctx)
-				}
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-// Stop preserves reverse dependency order; earlier workers stay running if a later worker cannot drain.
-func (g deliveryWorkerGroup) Stop(ctx context.Context) error {
-	for i := len(g) - 1; i >= 0; i-- {
-		if g[i] == nil {
-			continue
-		}
-		if stopErr := g[i].Stop(ctx); stopErr != nil {
-			return stopErr
-		}
-	}
-	return nil
 }
 
 type deliveryMessageObserver struct {
@@ -314,51 +255,6 @@ func (a *App) recordDeliveryError(err error) {
 	}
 }
 
-func (a deliveryRuntimeAdapter) SubmitCommitted(ctx context.Context, event messageevents.MessageCommitted) error {
-	if a.manager == nil {
-		return nil
-	}
-	event = scopePersonDeliveryEvent(event)
-	return a.manager.SubmitCommitted(ctx, event)
-}
-
-// scopePersonDeliveryEvent narrows person-channel fanout to the two channel participants.
-func scopePersonDeliveryEvent(event messageevents.MessageCommitted) messageevents.MessageCommitted {
-	if event.ChannelType != frame.ChannelTypePerson || len(event.MessageScopedUIDs) > 0 {
-		return event
-	}
-	left, right, err := runtimechannelid.DecodePersonChannel(event.ChannelID)
-	if err != nil {
-		return event
-	}
-	if left != "" {
-		event.MessageScopedUIDs = append(event.MessageScopedUIDs, left)
-	}
-	if right != "" && right != left {
-		event.MessageScopedUIDs = append(event.MessageScopedUIDs, right)
-	}
-	return event
-}
-
-func (a deliveryRuntimeAdapter) Recvack(ctx context.Context, cmd deliveryusecase.RecvackCommand) error {
-	if a.manager == nil {
-		return nil
-	}
-	return a.manager.Recvack(ctx, runtimedelivery.Recvack{
-		UID:        cmd.UID,
-		SessionID:  cmd.SessionID,
-		MessageID:  cmd.MessageID,
-		MessageSeq: cmd.MessageSeq,
-	})
-}
-
-func (a deliveryRuntimeAdapter) SessionClosed(ctx context.Context, cmd deliveryusecase.SessionClosedCommand) error {
-	if a.manager == nil {
-		return nil
-	}
-	return a.manager.SessionClosed(ctx, runtimedelivery.SessionClosed{UID: cmd.UID, SessionID: cmd.SessionID})
-}
-
 // SubmitCommitted is retained only for the temporary delivery-usecase facade.
 // Channelappend is the sole production producer of canonical delivery plans.
 func (a onlineDeliveryUsecaseAdapter) SubmitCommitted(context.Context, messageevents.MessageCommitted) error {
@@ -379,70 +275,4 @@ func (a onlineDeliveryUsecaseAdapter) SessionClosed(ctx context.Context, cmd del
 		return nil
 	}
 	return a.runtime.SessionClosed(ctx, runtimedelivery.SessionClosed{UID: cmd.UID, SessionID: cmd.SessionID})
-}
-
-type appSubscriberPlanner struct {
-	// channel scans durable subscribers for non-person channel fanout.
-	channel runtimedelivery.SubscriberPlanner
-}
-
-func (p appSubscriberPlanner) NextPartitionPage(ctx context.Context, task runtimedelivery.FanoutTask, cursor string, limit int) (runtimedelivery.UIDPage, error) {
-	if task.Envelope.ChannelType != frame.ChannelTypePerson {
-		if p.channel == nil {
-			return runtimedelivery.UIDPage{Done: true}, nil
-		}
-		return p.channel.NextPartitionPage(ctx, task, cursor, limit)
-	}
-	if cursor != "" {
-		return runtimedelivery.UIDPage{Done: true}, nil
-	}
-	left, right, err := runtimechannelid.DecodePersonChannel(task.Envelope.ChannelID)
-	if err != nil {
-		return runtimedelivery.UIDPage{Done: true}, nil
-	}
-	uids := make([]string, 0, 2)
-	if left != "" {
-		uids = append(uids, left)
-	}
-	if right != "" && right != left {
-		uids = append(uids, right)
-	}
-	return runtimedelivery.UIDPage{UIDs: uids, Done: true}, nil
-}
-
-type noopSubscriberPlanner struct{}
-
-func (noopSubscriberPlanner) NextPartitionPage(context.Context, runtimedelivery.FanoutTask, string, int) (runtimedelivery.UIDPage, error) {
-	return runtimedelivery.UIDPage{Done: true}, nil
-}
-
-type presenceResolverAdapter struct {
-	// presence resolves authoritative routes for selected UIDs.
-	presence *presence.App
-}
-
-func (r presenceResolverAdapter) EndpointsByUIDs(ctx context.Context, uids []string) (map[string][]runtimedelivery.Route, error) {
-	out := make(map[string][]runtimedelivery.Route, len(uids))
-	if r.presence == nil {
-		return out, nil
-	}
-	routesByUID, err := r.presence.EndpointsByUIDs(ctx, uids)
-	if err != nil {
-		return nil, err
-	}
-	for uid, routes := range routesByUID {
-		for _, route := range routes {
-			out[uid] = append(out[uid], runtimedelivery.Route{
-				UID:         route.UID,
-				OwnerNodeID: route.OwnerNodeID,
-				OwnerBootID: route.OwnerBootID,
-				OwnerSeq:    route.OwnerSeq,
-				SessionID:   route.SessionID,
-				DeviceID:    route.DeviceID,
-				DeviceFlag:  route.DeviceFlag,
-				DeviceLevel: route.DeviceLevel,
-			})
-		}
-	}
-	return out, nil
 }

--- a/internal/app/delivery_meta.go
+++ b/internal/app/delivery_meta.go
@@ -7,9 +7,7 @@ import (
 	"sync/atomic"
 
 	accessapi "github.com/WuKongIM/WuKongIM/internal/access/api"
-	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
-	"github.com/WuKongIM/WuKongIM/pkg/cluster"
-	"github.com/WuKongIM/WuKongIM/pkg/cluster/routing"
+	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	metadb "github.com/WuKongIM/WuKongIM/pkg/db/meta"
 	goruntimeregistry "github.com/WuKongIM/WuKongIM/pkg/goroutine"
 )
@@ -19,7 +17,6 @@ const deliveryMetaSubscriberCacheMaxChannels = 4096
 const deliveryMetaSubscriberCacheLoadPageSize = 1024
 
 type deliveryMetaNode interface {
-	Snapshot() cluster.Snapshot
 	UpsertChannelMetadata(context.Context, metadb.Channel) error
 	AddChannelSubscribers(context.Context, string, int64, []string, uint64) error
 	RemoveChannelSubscribers(context.Context, string, int64, []string, uint64) error
@@ -30,7 +27,7 @@ type recipientSubscriberNode interface {
 	ListChannelSubscribersPage(context.Context, string, int64, string, int) ([]string, string, bool, error)
 }
 
-// deliveryMetaStore adapts cluster Slot metadata to bench setup and delivery fanout.
+// deliveryMetaStore adapts cluster Slot metadata to bench setup and channelappend subscriber scans.
 type deliveryMetaStore struct {
 	// node owns the real replicated Slot metadata store.
 	node    deliveryMetaNode
@@ -182,21 +179,20 @@ send:
 	return int(accepted.Load()), nil
 }
 
-func (s *deliveryMetaStore) ListSubscribers(ctx context.Context, req runtimedelivery.SubscriberPageRequest) (runtimedelivery.UIDPage, error) {
+func (s *deliveryMetaStore) NextSubscriberPage(ctx context.Context, req channelappend.SubscriberPageRequest) (channelappend.SubscriberPage, error) {
 	if s == nil || s.node == nil {
-		return runtimedelivery.UIDPage{Done: true}, nil
+		return channelappend.SubscriberPage{Done: true}, nil
 	}
 	limit := req.Limit
 	if limit <= 0 {
 		limit = 1
 	}
-	key := deliveryMetaSubscriberKey{channelID: req.ChannelID, channelType: req.ChannelType}
+	key := deliveryMetaSubscriberKey{channelID: req.ChannelID.ID, channelType: req.ChannelID.Type}
 	snapshot, err := s.subscriberSnapshot(ctx, key)
 	if err != nil {
-		return runtimedelivery.UIDPage{}, err
+		return channelappend.SubscriberPage{}, err
 	}
-	filtered := s.filterPartition(snapshot, req.Partition)
-	return subscriberPageFromSnapshot(filtered, req.Cursor, limit)
+	return subscriberPageFromSnapshot(snapshot, req.Cursor, limit)
 }
 
 func (s *deliveryMetaStore) subscriberSnapshot(ctx context.Context, key deliveryMetaSubscriberKey) ([]string, error) {
@@ -267,54 +263,37 @@ func (s *deliveryMetaStore) loadSubscriberSnapshot(ctx context.Context, key deli
 			return out, nil
 		}
 		if nextCursor == "" || nextCursor == cursor {
-			return nil, runtimedelivery.ErrInvalidSubscriberCursor
+			return nil, channelappend.ErrInvalidSubscriberCursor
 		}
 		cursor = nextCursor
 	}
 }
 
-func subscriberPageFromSnapshot(uids []string, cursor string, limit int) (runtimedelivery.UIDPage, error) {
+func subscriberPageFromSnapshot(uids []string, cursor string, limit int) (channelappend.SubscriberPage, error) {
 	start := 0
 	if cursor != "" {
 		offset, err := strconv.Atoi(cursor)
 		if err != nil || offset < 0 {
-			return runtimedelivery.UIDPage{}, runtimedelivery.ErrInvalidSubscriberCursor
+			return channelappend.SubscriberPage{}, channelappend.ErrInvalidSubscriberCursor
 		}
 		start = offset
 	}
 	if start >= len(uids) {
-		return runtimedelivery.UIDPage{Done: true}, nil
+		return channelappend.SubscriberPage{Done: true}, nil
 	}
 	end := start + limit
+	pageEnd := min(end, len(uids))
+	pageRecipients := make([]channelappend.Recipient, 0, pageEnd-start)
+	for _, uid := range uids[start:pageEnd] {
+		pageRecipients = append(pageRecipients, channelappend.Recipient{UID: uid})
+	}
 	if end >= len(uids) {
-		return runtimedelivery.UIDPage{UIDs: append([]string(nil), uids[start:]...), Done: true}, nil
+		return channelappend.SubscriberPage{Recipients: pageRecipients, Done: true}, nil
 	}
-	return runtimedelivery.UIDPage{
-		UIDs:       append([]string(nil), uids[start:end]...),
-		NextCursor: strconv.Itoa(end),
+	return channelappend.SubscriberPage{
+		Recipients: pageRecipients,
+		Cursor:     strconv.Itoa(end),
 	}, nil
-}
-
-func (s *deliveryMetaStore) filterPartition(uids []string, partition runtimedelivery.Partition) []string {
-	count := uint16(0)
-	if s != nil && s.node != nil {
-		count = s.node.Snapshot().HashSlotCount
-	}
-	if count == 0 || isDefaultDeliveryPartition(partition) {
-		return uids
-	}
-	filtered := make([]string, 0, len(uids))
-	for _, uid := range uids {
-		slot := routing.HashSlotForKey(uid, count)
-		if slot >= partition.HashSlotStart && slot <= partition.HashSlotEnd {
-			filtered = append(filtered, uid)
-		}
-	}
-	return filtered
-}
-
-func isDefaultDeliveryPartition(partition runtimedelivery.Partition) bool {
-	return partition.LeaderNodeID == 0 && partition.HashSlotStart == 0 && partition.HashSlotEnd == 0
 }
 
 func int64FromBool(value bool) int64 {

--- a/internal/app/delivery_wiring_test.go
+++ b/internal/app/delivery_wiring_test.go
@@ -9,9 +9,10 @@ import (
 	accessnode "github.com/WuKongIM/WuKongIM/internal/access/node"
 	"github.com/WuKongIM/WuKongIM/internal/contracts/messageevents"
 	clusterpkg "github.com/WuKongIM/WuKongIM/pkg/cluster"
+	clusternet "github.com/WuKongIM/WuKongIM/pkg/cluster/net"
 )
 
-func TestNewWiresIndependentRecipientDeliveryWorkerConcurrency(t *testing.T) {
+func TestNewWiresConfiguredOnlineDeliveryWorkerConcurrency(t *testing.T) {
 	cluster := newFakePresenceCluster(1, nil)
 	app, err := newTestApp(t,
 		Config{
@@ -67,19 +68,13 @@ func TestNewWiresDeliveryWhenEnabled(t *testing.T) {
 	if app.deliveryWorker == nil {
 		t.Fatal("delivery worker was not wired")
 	}
-	if app.channelAppendDeliveryWorker != nil {
-		t.Fatal("legacy channelappend recipient delivery worker was wired")
-	}
 	if app.onlineDelivery.PendingAckCount() != 0 {
 		t.Fatal("online delivery runtime was not initialized with empty ack state")
 	}
 	if app.deliveryWorker != app.onlineDelivery {
 		t.Fatalf("delivery worker = %T, want online delivery runtime", app.deliveryWorker)
 	}
-	if app.deliveryManager != nil || app.deliveryRetry != nil || app.localOwnerPusher != nil {
-		t.Fatal("legacy delivery runtime was wired")
-	}
-	if _, ok := cluster.registeredHandlers[accessnode.DeliveryFanoutRPCServiceID]; ok {
+	if _, ok := cluster.registeredHandlers[clusternet.RPCDeliveryFanout]; ok {
 		t.Fatalf("retired delivery fanout rpc service was registered")
 	}
 }

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -18,7 +18,6 @@ import (
 	obsdiagnostics "github.com/WuKongIM/WuKongIM/internal/observability/diagnostics"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/channelappend"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/conversationactive"
-	runtimedelivery "github.com/WuKongIM/WuKongIM/internal/runtime/delivery"
 	"github.com/WuKongIM/WuKongIM/internal/runtime/online"
 	runtimeops "github.com/WuKongIM/WuKongIM/internal/runtime/opsmcp"
 	authoritypresence "github.com/WuKongIM/WuKongIM/internal/runtime/presence"
@@ -713,9 +712,9 @@ func (a *App) wireChannelAppend(nodeID uint64) error {
 				opts.Idempotency = clusterinfra.NewChannelIdempotencyStore(idempotencyNode)
 			}
 			if a.deliveryMeta != nil {
-				opts.Subscribers = channelAppendDeliverySubscriberSource{source: a.deliveryMeta}
+				opts.Subscribers = a.deliveryMeta
 			} else if a.deliverySubscribers != nil {
-				opts.Subscribers = channelAppendDeliverySubscriberSource{source: a.deliverySubscribers}
+				opts.Subscribers = a.deliverySubscribers
 			} else if subscriberNode, ok := a.cluster.(recipientSubscriberNode); ok {
 				opts.Subscribers = channelAppendSubscriberSource{node: subscriberNode}
 			}
@@ -772,17 +771,6 @@ func (a *App) ensureChannelAppendMetadataCache() *clusterinfra.ChannelAppendMeta
 		a.channelAppendMetadata = clusterinfra.NewChannelAppendMetadataCache()
 	}
 	return a.channelAppendMetadata
-}
-
-func (a *App) channelAppendOwnerPusher(nodeID uint64, observer runtimedelivery.Observer) channelappend.OwnerPusher {
-	if a.localOwnerPusher == nil {
-		return nil
-	}
-	var pusher runtimedelivery.Pusher = a.localOwnerPusher
-	if rpcNode, ok := a.cluster.(accessnode.PresenceRPCNode); ok {
-		pusher = clusterinfra.NewDeliveryPusher(nodeID, a.localOwnerPusher, accessnode.NewClient(rpcNode))
-	}
-	return channelAppendOwnerPusher{next: pusher, observer: observer}
 }
 
 func (a *App) wireMessages() {

--- a/internal/usecase/delivery/FLOW.md
+++ b/internal/usecase/delivery/FLOW.md
@@ -2,15 +2,15 @@
 
 ## Responsibility
 
-`internal/usecase/delivery` owns the entry-agnostic online delivery
-orchestration boundary. It accepts committed-message events from message
-orchestration and forwards receive-ack and session-close feedback to the
-configured runtime port.
+`internal/usecase/delivery` is the temporary entry-agnostic gateway feedback
+facade for receive-ack and session-close commands.
 
 Production app composition now uses this package only as the temporary gateway
 feedback facade. Channelappend submits canonical recipient plans directly to
-`internal/contracts/onlinedelivery`; `SubmitCommitted` and its runtime port
-remain for legacy compatibility until the superseded fanout path is removed.
+`internal/contracts/onlinedelivery`. `SubmitCommitted` remains temporarily as
+an explicit compatibility rejection surface for callers compiled against the
+old usecase API; production composition returns the canonical-plan-required
+error and never converts the event into fanout work.
 
 The package must not import gateway frames, access adapters, app composition,
 or concrete cluster/runtime implementations. Runtime adapters are responsible
@@ -19,9 +19,9 @@ for bridging these usecase DTOs to concrete runtime DTOs.
 ## Flow
 
 ```text
-MessageCommitted
+MessageCommitted compatibility call
   -> App.SubmitCommitted
-  -> runtime.SubmitCommitted
+  -> production runtime adapter rejects: canonical recipient plan required
 
 RecvackCommand
   -> App.Recvack


### PR DESCRIPTION
## Summary

- remove the app composition fields and compatibility adapters for the already-retired delivery Manager/fanout path
- make channelappend consume the durable subscriber paging port directly instead of crossing the retired delivery subscriber seam
- keep the canonical bounded `internal/runtime/delivery.Runtime` as the sole composed Online Delivery runtime and preserve the old implementation temporarily for bounded follow-up deletion PRs
- clarify that legacy `SubmitCommitted` calls are rejected unless the caller supplies a canonical recipient plan

This is the next tracer slice after #780. It is intentionally limited to seven files so the Review Agent can capture complete before/after evidence within its protected 1 MiB changed-content budget. It must receive normal Review Agent approval and merge without an administrator bypass.

## Validation

- `GOWORK=off go test ./internal/app ./internal/usecase/delivery -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `GOWORK=off go vet ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/...`
- `git diff --check`
- Review Agent complete-change estimate: 831,774 bytes / 1,048,576-byte limit