### PR TITLE
test(agent): verify administrator-only review trigger

### DIFF
--- a/docs/agents/review-agent-manual-trigger-canary.md
+++ b/docs/agents/review-agent-manual-trigger-canary.md
@@ -1,0 +1,11 @@
+# Review Agent Manual-Trigger Canary
+
+This temporary documentation-only change verifies the production Review Agent
+control boundary after the administrator-command rollout.
+
+Expected behavior:
+
+- opening or updating this pull request does not start a Review Agent Worker;
+- an exact `@review-agent review` comment from a repository administrator
+  starts one review for the current head; and
+- the canary pull request is closed without merging after verification.


### PR DESCRIPTION
## Purpose

Production canary for the administrator-command Review Agent boundary merged in #781.

## Expected behavior

- opening and updating this ready PR must not start `Agent Tool - Review Pull Request`
- only a fresh administrator comment containing exactly `@review-agent review` may start one Worker for this head
- the PR will be closed without merging and the branch deleted after verification

## Local validation

- `GOWORK=off go test ./scripts/... -run 'ReviewAgent|Workflow' -count=1`
- `git diff --check`