### PR TITLE
perf(review-agent): add controller fast path

### DIFF
--- a/.github/actions/install-review-agent-tools/action.yml
+++ b/.github/actions/install-review-agent-tools/action.yml
@@ -8,6 +8,10 @@ inputs:
   control-sha:
     description: Exact protected control revision embedded in the artifact
     required: true
+  bundle-tools:
+    description: Space-separated exact binary inventory recorded by the artifact
+    required: false
+    default: wkreviewagent wkreviewcheck wkreviewcheckmcp
   tools:
     description: Space-separated allowlisted binaries required by this job
     required: true
@@ -15,13 +19,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ runner.temp }}/review-agent-tools
     - name: Verify and install exact protected binaries
       shell: bash
       env:
+        INPUT_BUNDLE_TOOLS: ${{ inputs.bundle-tools }}
         INPUT_CONTROL_SHA: ${{ inputs.control-sha }}
         INPUT_TOOLS: ${{ inputs.tools }}
       run: |
@@ -34,7 +39,25 @@ runs:
         test ! -L "$bundle/SHA256SUMS"
         test "$(cat "$bundle/control-sha")" = "$INPUT_CONTROL_SHA"
         mapfile -t manifest_files < <(awk '{print $2}' "$bundle/SHA256SUMS")
-        expected_files=(control-sha wkreviewagent wkreviewcheck wkreviewcheckmcp)
+        read -ra bundle_tools <<<"$INPUT_BUNDLE_TOOLS"
+        (( ${#bundle_tools[@]} >= 1 ))
+        expected_files=(control-sha)
+        declare -A bundled_tools=()
+        for tool in "${bundle_tools[@]}"; do
+          case "$tool" in
+            wkreviewagent|wkreviewcheck|wkreviewcheckmcp) ;;
+            *)
+              echo "unknown protected Review Agent bundle tool: $tool" >&2
+              exit 1
+              ;;
+          esac
+          if [[ -n "${bundled_tools[$tool]:-}" ]]; then
+            echo "duplicate protected Review Agent bundle tool: $tool" >&2
+            exit 1
+          fi
+          bundled_tools[$tool]=1
+          expected_files+=("$tool")
+        done
         test "${#manifest_files[@]}" -eq "${#expected_files[@]}"
         for index in "${!expected_files[@]}"; do
           test "${manifest_files[$index]}" = "${expected_files[$index]}"
@@ -51,6 +74,10 @@ runs:
               exit 1
               ;;
           esac
+          if [[ -z "${bundled_tools[$tool]:-}" ]]; then
+            echo "protected Review Agent tool is absent from bundle inventory: $tool" >&2
+            exit 1
+          fi
           test -f "$bundle/$tool"
           test ! -L "$bundle/$tool"
           install -m 0555 "$bundle/$tool" "$RUNNER_TEMP/$tool"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -67,6 +67,12 @@ binaries, and removes the downloaded bundle before continuing. Candidate code
 cannot build, replace, or upload this bundle, and no shared build cache crosses
 Worker runs.
 
+The Controller also compiles `wkreviewagent` only once per run. When a plan
+requires a state write or projection, credentialed jobs consume a run-scoped,
+control-SHA-bound manifest Artifact instead of rebuilding it. A true no-op
+uploads only its bounded plan; State Writer, Publisher, and Dispatcher jobs are
+skipped.
+
 The model can review and invoke only protected named checks. It cannot edit the
 PR, commit, push, merge, resolve threads, dismiss Reviews, or publish its own
 verdict. A trusted validator maps signed state to the sole required Check

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -193,7 +193,7 @@ jobs:
           ref: ${{ inputs.control_sha }}
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-recovery-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-recovery
@@ -284,7 +284,7 @@ jobs:
           ref: ${{ needs.recover.outputs.test_merge_sha }}
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-context-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-context
@@ -438,15 +438,15 @@ jobs:
           ref: ${{ needs.recover.outputs.test_merge_sha }}
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-context-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-context
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-recovery-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-recovery
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: inputs.operation == 'review'
         with:
           name: review-agent-baseline-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
@@ -649,25 +649,25 @@ jobs:
           artifact-name: review-agent-tools-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           control-sha: ${{ inputs.control_sha }}
           tools: wkreviewagent
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: review-agent-context-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-context
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-recovery-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-recovery
       - name: Download reviewer output
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-result-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-result
       - name: Download trusted baseline
         if: inputs.operation == 'review'
         continue-on-error: true
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-baseline-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-trusted-baseline
@@ -928,7 +928,7 @@ jobs:
           artifact-name: review-agent-tools-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           control-sha: ${{ inputs.control_sha }}
           tools: wkreviewagent
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-evidence-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-evidence
@@ -1056,11 +1056,11 @@ jobs:
           artifact-name: review-agent-tools-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           control-sha: ${{ inputs.control_sha }}
           tools: wkreviewagent
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-evidence-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-evidence
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-terminal-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-terminal
@@ -1108,7 +1108,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-terminal-${{ inputs.pull_request }}-${{ inputs.lease_run_id }}
           path: ${{ runner.temp }}/review-agent-terminal

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -54,6 +54,7 @@ jobs:
       scheduler_changed: ${{ steps.plan.outputs.scheduler_changed }}
       state_changed: ${{ steps.plan.outputs.state_changed }}
       state_head_sha: ${{ steps.plan.outputs.state_head_sha }}
+      tools_required: ${{ steps.plan.outputs.tools_required }}
     steps:
       - name: Verify Signal and extract hint
         id: signal
@@ -140,7 +141,7 @@ jobs:
           ref: ${{ steps.control.outputs.sha }}
           fetch-depth: 1
           persist-credentials: false
-      - name: Build protected Controller
+      - name: Build protected Controller once
         shell: bash
         run: GOWORK=off go build -trimpath -o "$RUNNER_TEMP/wkreviewagent" ./cmd/wkreviewagent
       - name: Reconcile from fresh facts
@@ -170,6 +171,16 @@ jobs:
             <"$RUNNER_TEMP/control-request.json" \
             >"$RUNNER_TEMP/control-plan.json"
           jq -e '.plan.action != null' "$RUNNER_TEMP/control-plan.json" >/dev/null
+          publish="$(jq -r '(.state_changed or
+            .plan.action == "repair_projection" or
+            .plan.action == "respond_status") and
+            (.next_state != null) and
+            (.next_state.phase != "awaiting_ready") and
+            (.next_state.phase != "closed")' \
+            "$RUNNER_TEMP/control-plan.json")"
+          tools_required="$(jq -r --argjson publish "$publish" \
+            '.state_changed or .scheduler_changed or $publish' \
+            "$RUNNER_TEMP/control-plan.json")"
           {
             echo "action=$(jq -r .plan.action "$RUNNER_TEMP/control-plan.json")"
             echo "cancel_run_id=$(jq -r .plan.cancel_run_id "$RUNNER_TEMP/control-plan.json")"
@@ -182,13 +193,34 @@ jobs:
             echo "scheduler_changed=$(jq -r .scheduler_changed "$RUNNER_TEMP/control-plan.json")"
             echo "state_changed=$(jq -r .state_changed "$RUNNER_TEMP/control-plan.json")"
             echo "state_head_sha=$(jq -r .state_head_sha "$RUNNER_TEMP/control-plan.json")"
-            echo "publish=$(jq -r '(.state_changed or
-              .plan.action == "repair_projection" or
-              .plan.action == "respond_status") and
-              (.next_state != null) and
-              (.next_state.phase != "awaiting_ready") and
-              (.next_state.phase != "closed")' "$RUNNER_TEMP/control-plan.json")"
+            echo "publish=$publish"
+            echo "tools_required=$tools_required"
           } >>"$GITHUB_OUTPUT"
+      - name: Package exact protected Controller tool
+        if: steps.plan.outputs.tools_required == 'true'
+        shell: bash
+        env:
+          CONTROL_SHA: ${{ steps.control.outputs.sha }}
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/review-agent-controller-tools"
+          mkdir -m 0700 "$bundle"
+          install -m 0555 "$RUNNER_TEMP/wkreviewagent" "$bundle/wkreviewagent"
+          printf '%s\n' "$CONTROL_SHA" >"$bundle/control-sha"
+          chmod 0444 "$bundle/control-sha"
+          (
+            cd "$bundle"
+            sha256sum control-sha wkreviewagent >SHA256SUMS
+          )
+          chmod 0444 "$bundle/SHA256SUMS"
+      - name: Upload exact protected Controller tool
+        if: steps.plan.outputs.tools_required == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: review-agent-controller-tools-${{ github.run_id }}
+          path: ${{ runner.temp }}/review-agent-controller-tools/
+          if-no-files-found: error
+          retention-days: 1
       - name: Upload bounded control plan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -202,7 +234,10 @@ jobs:
   state-writer:
     name: Append authoritative state
     needs: reconcile
-    if: needs.reconcile.result == 'success'
+    if: >-
+      needs.reconcile.result == 'success' &&
+      (needs.reconcile.outputs.state_changed == 'true' ||
+       needs.reconcile.outputs.scheduler_changed == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: review-agent-state-writer
@@ -228,13 +263,16 @@ jobs:
           ref: ${{ needs.reconcile.outputs.control_sha }}
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-control-${{ github.run_id }}
           path: ${{ runner.temp }}/review-agent-control
-      - name: Build protected State Writer
-        shell: bash
-        run: GOWORK=off go build -trimpath -o "$RUNNER_TEMP/wkreviewagent" ./cmd/wkreviewagent
+      - uses: ./.github/actions/install-review-agent-tools
+        with:
+          artifact-name: review-agent-controller-tools-${{ github.run_id }}
+          control-sha: ${{ needs.reconcile.outputs.control_sha }}
+          bundle-tools: wkreviewagent
+          tools: wkreviewagent
       - name: Append exact scheduler and PR state
         id: append
         shell: bash
@@ -348,8 +386,12 @@ jobs:
     needs: [reconcile, state-writer]
     if: >-
       always() && needs.reconcile.result == 'success' &&
-      needs.state-writer.result == 'success' &&
-      needs.state-writer.outputs.publish == 'true'
+      (needs.state-writer.result == 'success' ||
+       needs.state-writer.result == 'skipped') &&
+      ((needs.state-writer.result == 'success' &&
+        needs.state-writer.outputs.publish == 'true') ||
+       (needs.state-writer.result == 'skipped' &&
+        needs.reconcile.outputs.publish == 'true'))
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: review-agent-publisher
@@ -365,13 +407,24 @@ jobs:
           ref: ${{ needs.reconcile.outputs.control_sha }}
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - name: Download post-write authoritative plan
+        if: needs.state-writer.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: review-agent-authoritative-control-${{ github.run_id }}
           path: ${{ runner.temp }}/review-agent-control
-      - name: Build protected Review Publisher
-        shell: bash
-        run: GOWORK=off go build -trimpath -o "$RUNNER_TEMP/wkreviewagent" ./cmd/wkreviewagent
+      - name: Download unchanged authoritative plan
+        if: needs.state-writer.result == 'skipped'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: review-agent-control-${{ github.run_id }}
+          path: ${{ runner.temp }}/review-agent-control
+      - uses: ./.github/actions/install-review-agent-tools
+        with:
+          artifact-name: review-agent-controller-tools-${{ github.run_id }}
+          control-sha: ${{ needs.reconcile.outputs.control_sha }}
+          bundle-tools: wkreviewagent
+          tools: wkreviewagent
       - name: Publish status without candidate execution
         shell: bash
         env:
@@ -397,14 +450,20 @@ jobs:
     needs: [reconcile, state-writer, status-publisher]
     if: >-
       always() && needs.reconcile.result == 'success' &&
-      needs.state-writer.result == 'success' &&
+      (needs.state-writer.result == 'success' ||
+       needs.state-writer.result == 'skipped') &&
       (needs.status-publisher.result == 'success' ||
        needs.status-publisher.result == 'skipped') &&
-      (needs.state-writer.outputs.dispatch == 'true' ||
-       needs.state-writer.outputs.cancel_run_id != '0' ||
-       needs.state-writer.outputs.next_pull_request != '0')
+      ((needs.state-writer.result == 'success' &&
+        (needs.state-writer.outputs.dispatch == 'true' ||
+         needs.state-writer.outputs.cancel_run_id != '0' ||
+         needs.state-writer.outputs.next_pull_request != '0')) ||
+       (needs.state-writer.result == 'skipped' &&
+        (needs.reconcile.outputs.dispatch == 'true' ||
+         needs.reconcile.outputs.cancel_run_id != '0' ||
+         needs.reconcile.outputs.next_pull_request != '0')))
     concurrency:
-      group: review-agent-dispatch-${{ needs.state-writer.outputs.pull_request }}
+      group: review-agent-dispatch-${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.pull_request || needs.reconcile.outputs.pull_request }}
       cancel-in-progress: false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -415,14 +474,14 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          CANCEL_LEASE_RUN_ID: ${{ needs.state-writer.outputs.cancel_run_id }}
+          CANCEL_LEASE_RUN_ID: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.cancel_run_id || needs.reconcile.outputs.cancel_run_id }}
           CONTROL_SHA: ${{ needs.reconcile.outputs.control_sha }}
-          DISPATCH: ${{ needs.state-writer.outputs.dispatch }}
-          LEASE_RUN_ID: ${{ needs.state-writer.outputs.lease_run_id }}
-          INFRASTRUCTURE_ATTEMPT: ${{ needs.state-writer.outputs.infrastructure_attempt }}
-          NEXT_PR: ${{ needs.state-writer.outputs.next_pull_request }}
-          OPERATION: ${{ needs.state-writer.outputs.operation }}
-          PR_NUMBER: ${{ needs.state-writer.outputs.pull_request }}
+          DISPATCH: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.dispatch || needs.reconcile.outputs.dispatch }}
+          LEASE_RUN_ID: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.lease_run_id || needs.reconcile.outputs.lease_run_id }}
+          INFRASTRUCTURE_ATTEMPT: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.infrastructure_attempt || needs.reconcile.outputs.infrastructure_attempt }}
+          NEXT_PR: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.next_pull_request || needs.reconcile.outputs.next_pull_request }}
+          OPERATION: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.operation || needs.reconcile.outputs.operation }}
+          PR_NUMBER: ${{ needs.state-writer.result == 'success' && needs.state-writer.outputs.pull_request || needs.reconcile.outputs.pull_request }}
           WRITTEN_STATE_HEAD: ${{ needs.state-writer.outputs.state_head_sha }}
           EXISTING_STATE_HEAD: ${{ needs.reconcile.outputs.state_head_sha }}
         run: |

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -64,6 +64,13 @@ idempotency key at both initial and retry boundaries. Terminal work wakes the
 next signed queue entry. Partial state writes and dispatches are recoverable
 from signed checkpoints and leases.
 
+Each Controller run compiles its protected `wkreviewagent` binary once. A
+state-writing or projection path passes that exact binary through a
+control-SHA-bound, SHA-256-verified run Artifact. When reconciliation proves
+that state, scheduler, projection, cancellation, and dispatch are all
+unchanged, the credentialed State Writer and Publisher plus the Dispatcher are
+not started.
+
 ## Review inputs
 
 The trusted Context Builder includes:

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -60,6 +60,12 @@ is limited to one.
 Ordinary comments, including Review Agent's own status comment, are observed
 no-ops.
 
+Controller no-ops stop after the fresh-fact plan is recorded. They do not enter
+the credentialed State Writer or Publisher Environments and do not start the
+Dispatcher. Non-no-op Controller jobs reuse one exact-control,
+manifest-verified binary built by reconciliation rather than compiling it once
+per authority boundary.
+
 ## Trusted checks
 
 `.github/review-agent/policy.json` maps complete path inventory to mandatory

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -55,6 +55,10 @@
   Artifact. Consumers install a role-specific allowlist and never share a
   cross-run build cache. Root `README.md` and `README_CN.md` join `docs/` and
   `docs-site/` on the exclusive `docs-contracts` path.
+- Review Agent Controller runs also compile their protected binary once. A
+  true no-op never enters the credentialed State Writer or Publisher and never
+  dispatches; mutation and projection paths reuse the exact run-scoped,
+  control-SHA-bound binary Artifact.
 - Backup has one Manager-owned plan in Controller state; it is configured only through Manager, supports Cron or `@every`, and has no TOML/environment compatibility path.
 - Saving backup repository configuration is a durable Controller operation and never proves connectivity. Only the exact saved plan revision that completes the repository and all-active-data-node probe is verified and eligible for backup admission. A nil verification record is legacy verified state until the effective repository changes.
 - Every run publishes one independent full 256-hash-slot archive to the shared file repository under `<data_dir>/backup-repository`, Alibaba OSS, Tencent COS, or a generic S3-compatible repository. `COMPLETE` makes an archive visible, `HOLD` exempts it from retention, and object-storage credentials are encrypted in Controller state while archive payloads are not encrypted.

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -133,7 +133,9 @@ func TestReviewAgentControllerWorkflowSeparatesAuthority(t *testing.T) {
 	require.Contains(
 		t,
 		dispatch,
-		"group: review-agent-dispatch-${{ needs.state-writer.outputs.pull_request }}",
+		"group: review-agent-dispatch-${{ needs.state-writer.result == 'success' && "+
+			"needs.state-writer.outputs.pull_request || "+
+			"needs.reconcile.outputs.pull_request }}",
 	)
 	require.Contains(t, dispatch, "cancel-in-progress: false")
 	require.Contains(t, dispatch, "gh workflow run review-agent-run.yml")
@@ -163,6 +165,44 @@ func TestReviewAgentControllerWorkflowSeparatesAuthority(t *testing.T) {
 	require.Contains(t, recovery, "recovery_attempt=$((attempt + 1))")
 	require.NotContains(t, recovery, "actions/checkout")
 	require.NotContains(t, recovery, "APP_PRIVATE_KEY")
+}
+
+func TestReviewAgentControllerWorkflowHasNoOpFastPath(t *testing.T) {
+	raw := readIssueAgentFile(t, ".github/workflows/review-agent.yml")
+	reconcile := issueAgentJobText(t, raw, "reconcile")
+	writer := issueAgentJobText(t, raw, "state-writer")
+	publisher := issueAgentJobText(t, raw, "status-publisher")
+	dispatch := issueAgentJobText(t, raw, "dispatch")
+
+	require.Equal(
+		t,
+		1,
+		strings.Count(raw, "GOWORK=off go build"),
+		"the protected Controller binary must be built once per run",
+	)
+	require.Contains(t, reconcile, "review-agent-controller-tools-${{ github.run_id }}")
+	require.Contains(t, reconcile, "steps.plan.outputs.tools_required == 'true'")
+	for _, consumer := range []string{writer, publisher} {
+		require.NotContains(t, consumer, "go build")
+		require.Contains(
+			t,
+			consumer,
+			"uses: ./.github/actions/install-review-agent-tools",
+		)
+		require.Contains(t, consumer, "bundle-tools: wkreviewagent")
+		require.Contains(t, consumer, "tools: wkreviewagent")
+	}
+	require.Contains(
+		t,
+		writer,
+		"needs.reconcile.outputs.state_changed == 'true' ||\n"+
+			"       needs.reconcile.outputs.scheduler_changed == 'true'",
+		"a true no-op must not enter the credentialed State Writer job",
+	)
+	require.Contains(t, publisher, "needs.state-writer.result == 'skipped'")
+	require.Contains(t, publisher, "needs.reconcile.outputs.publish == 'true'")
+	require.Contains(t, dispatch, "needs.state-writer.result == 'skipped'")
+	require.Contains(t, dispatch, "needs.reconcile.outputs.dispatch == 'true'")
 }
 
 func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
@@ -219,12 +259,15 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(
 		t,
 		installer,
-		"actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53",
+		"actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
 	)
 	for _, required := range []string{
 		"sha256sum --check SHA256SUMS",
 		`test "$(cat "$bundle/control-sha")" = "$INPUT_CONTROL_SHA"`,
-		"expected_files=(control-sha wkreviewagent wkreviewcheck wkreviewcheckmcp)",
+		`INPUT_BUNDLE_TOOLS: ${{ inputs.bundle-tools }}`,
+		"expected_files=(control-sha)",
+		`if [[ -n "${bundled_tools[$tool]:-}" ]]`,
+		"protected Review Agent tool is absent from bundle inventory",
 		`test ! -L "$bundle/SHA256SUMS"`,
 		"wkreviewagent|wkreviewcheck|wkreviewcheckmcp",
 		`rm -rf "$bundle"`,


### PR DESCRIPTION
## Summary

- stop true no-op Controller runs before the credentialed State Writer, Publisher, and Dispatcher jobs
- build the protected Controller binary once and distribute a control-SHA-bound, SHA-256-verified run artifact to credentialed consumers
- upgrade Review Agent artifact downloads to the pinned official download-artifact v8.0.1 Node 24 release
- document and lock the fast path with a deterministic workflow contract

## Root cause

Production canary #785 showed that a no-op still entered State Writer and that Controller, State Writer, and Publisher each rebuilt the same protected binary. This made an unchanged event take about 3m36s and delayed an authorized Worker by about 6m13s before model work began.

Shared Go build caches are deliberately not introduced: candidate checks run under the main workflow scope, so cache writeback could let candidate-derived compilation state cross into later trusted runs.

## Validation

- GOWORK=off go test ./scripts/... -count=1
- GOWORK=off go test ./scripts -run ^TestReviewAgentControllerWorkflowHasNoOpFastPath$ -count=3
- actionlint v1.7.9 on all Review Agent workflows
- node --test .github/review-agent/responses-budget-proxy.test.mjs
- YAML parse and git diff --check