### PR TITLE
docs: publish scenario tutorials

### DIFF
--- a/docs-site/FLOW.md
+++ b/docs-site/FLOW.md
@@ -92,6 +92,19 @@ content/docs/**/*.mdx
   delivery, while only command-style `NoPersist` enters transient delivery.
   Plugins remain node-local: Send is synchronous and fail-closed by default,
   while Receive and PersistAfter are bounded post-commit effects.
+- Phase 10 publishes the first scenario tutorials: direct chat and groups
+  through 100,000-member workloads. Direct chat uses the peer UID and
+  `channel_type=1`; the server owns canonical person-Channel derivation. Group
+  chat uses product-owned group IDs and `channel_type=2`; the product service
+  remains authoritative for group lifecycle and reconciles subscriber
+  metadata through bounded requests. Durable SEND success means Channel
+  quorum commit, not complete fanout, RECVACK, conversation projection, or a
+  business result. Current product HTTP routes remain a trusted service-side
+  boundary without general product authentication. Large-group guidance MUST
+  use bounded application batches and post-commit paged fanout, never one
+  100,000-member request or a context-free capacity promise. `ClearUnread`
+  advances to the newest server-visible message and MUST NOT be documented as
+  an exact client-supplied read-sequence update.
 
 ## Static delivery
 

--- a/docs-site/PHASE_10_SPEC.md
+++ b/docs-site/PHASE_10_SPEC.md
@@ -1,0 +1,80 @@
+# WuKongIM v3 Documentation — Phase 10 Specification
+
+## Goal
+
+Publish the first bilingual scenario tutorials: direct chat and groups through
+100,000-member workloads. Each tutorial must connect business-service
+responsibilities, trusted HTTP mutations, client connection behavior, durable
+message semantics, conversation state, and operational verification without
+inventing an SDK API or weakening current security boundaries.
+
+## Published routes
+
+- Tutorials landing page
+- Tutorials / Direct Chat
+- Tutorials / Groups & Large Groups
+
+Each route has matching Chinese and English MDX and is included in search,
+sitemap, LLM outputs, and per-page Markdown. Message Push and AI & IoT remain
+planned, visible, `noindex`, and excluded from those public indexes.
+
+## Source-of-truth boundaries
+
+- Product services own accounts, relationship and group lifecycles,
+  authorization, moderation, mobile push, and durable business workflows.
+  WuKongIM owns connection, Channel ordering, durable message logs, online
+  delivery, offline sync, and UID-owned conversation projections.
+- Current product HTTP routes have no general product-authentication
+  middleware. Tutorial `curl` commands are trusted development/service-side
+  examples and MUST NOT be presented as browser- or mobile-client calls.
+  Stored token metadata is not automatically validated by the default v3 Beta
+  Gateway composition.
+- A direct send uses the peer UID with `channel_type=1`; the server derives the
+  canonical person Channel. Applications MUST NOT construct or persist the
+  internal canonical Channel ID as their relationship identity.
+- A group uses a product-owned group ID with `channel_type=2`. The product
+  service creates the Channel metadata and reconciles ordinary subscribers.
+  Membership changes are durable Slot metadata and are distinct from the
+  Channel message log.
+- Durable sends retain a stable `client_msg_no`, reach quorum commit before a
+  successful SENDACK/HTTP success reason, and keep online delivery,
+  conversation projection, webhooks, and plugin effects outside that commit
+  boundary.
+- Conversation rows are UID-owned projections. Person Channel IDs are mapped
+  back to peer UIDs by compatible HTTP adapters. Unread state is per UID and
+  does not prove that every device received an online delivery. `ClearUnread`
+  advances through the newest server-visible message; its optional request
+  sequence is only a fallback when no newest message exists, not an exact
+  client-side read-progress marker.
+- Subscriber mutations are de-duplicated and internally chunked. Public
+  large-group workflows additionally submit bounded application batches and
+  reconcile checkpoints; they MUST NOT place a 100,000-member snapshot in one
+  request. Partial progress across multiple requests is expected and repaired
+  by the product-owned reconciler.
+- `channel.large_group_subscriber_threshold` defaults to 500. After ordinary
+  subscriber mutations, a count greater than the configured threshold marks
+  the Channel large. Post-commit fanout pages members and builds bounded
+  delivery plans; one durable message is not copied into 100,000 Channel logs.
+- A successful group SENDACK does not prove all members are online, delivered,
+  acknowledged, or projected into conversations. Capacity validation must
+  cover hot-Channel commit, member paging, Presence routing, owner queues,
+  Session writes, reconnect sync, CPU, memory, disk, network, and tail latency.
+
+## Validation
+
+- Navigation tests freeze the Tutorials landing page and first two published
+  children while leaving Message Push and AI & IoT planned.
+- Static-output validation confirms the three new routes appear in sitemap,
+  search, LLM outputs, and per-page Markdown.
+- Local validation runs `bun run verify`, focused Go tests for the compatible
+  API, message, channel, conversation, and channelappend contracts, and the
+  full repository unit suite.
+- Browser QA covers both tutorials in both locales at desktop and mobile
+  widths, including console output and horizontal overflow.
+
+## Excluded
+
+- New runtime behavior, SDK method signatures, API reference completeness,
+  production authentication implementation, or benchmark promises.
+- Message Push, AI streaming, IoT command tutorials, Kubernetes, legacy-site
+  migration, deployment, DNS, or production cutover.

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -21,7 +21,9 @@ materialization, 256 physical hash-slot routing into logical Slot Raft Groups,
 Channel quorum commit, bounded transport, the end-to-end send flow, and
 target-fenced online routing. Phase 9 completes the guide foundation with
 workload-qualified capabilities and use cases, precise cluster/message/Channel/
-user/conversation concepts, and the current node-local plugin boundary.
+user/conversation concepts, and the current node-local plugin boundary. Phase
+10 publishes the first scenario tutorials: direct chat plus group chat through
+bounded 100,000-member membership and fanout workflows.
 
 ## Develop
 
@@ -63,4 +65,5 @@ scope, `PHASE_5_SPEC.md` defines the server-configuration scope, and
 `PHASE_6_SPEC.md` defines the server-operations scope. `PHASE_7_SPEC.md`
 defines troubleshooting and official-tool boundaries. `PHASE_8_SPEC.md`
 defines the current server-architecture boundaries. `PHASE_9_SPEC.md` defines
-the guide-foundation and plugin boundaries.
+the guide-foundation and plugin boundaries. `PHASE_10_SPEC.md` defines the
+direct-chat and group-tutorial boundaries.

--- a/docs-site/content/docs/guide/index.en.mdx
+++ b/docs-site/content/docs/guide/index.en.mdx
@@ -6,7 +6,7 @@ description: Learn WuKongIM and complete your first product integration.
 WuKongIM is a general-purpose messaging system for real-time communication at scale. This area follows the path users take to complete real tasks.
 
 <Callout type="info" title="Start here">
-  The product overview, core concepts, complete quick start, and business-integration path are published. Sidebar pages marked “Planned” remain excluded from search, sitemap, and LLM indexes.
+  The product overview, core concepts, complete quick start, business-integration path, and first scenario tutorials are published. Sidebar pages marked “Planned” remain excluded from search, sitemap, and LLM indexes.
 </Callout>
 
 ## Recommended paths
@@ -16,6 +16,7 @@ WuKongIM is a general-purpose messaging system for real-time communication at sc
   <Card title="Quick start" description="Start a single-node cluster and send the first message." href="/en/guide/quick-start" />
   <Card title="Core concepts" description="Learn the message, channel, user, device, and conversation vocabulary." href="/en/guide/core-concepts" />
   <Card title="Integration" description="Integrate WuKongIM with an existing product system." href="/en/guide/integration" />
+  <Card title="Tutorials" description="Complete end-to-end direct chat, group chat, and 100,000-member group designs." href="/en/guide/tutorials" />
 </Cards>
 
 New to WuKongIM? Begin with the [quick start](/en/guide/quick-start) to launch a cluster, check readiness, and verify your first two-way message.

--- a/docs-site/content/docs/guide/index.mdx
+++ b/docs-site/content/docs/guide/index.mdx
@@ -6,7 +6,7 @@ description: 从认识 WuKongIM 到完成第一个业务集成。
 WuKongIM 是面向大规模实时通信场景的通用消息系统。本区域按照用户完成任务的路径组织内容。
 
 <Callout type="info" title="从这里开始">
-  产品概览、核心概念、完整快速开始和业务集成路径已经发布。侧栏中标记为“规划中”的页面仍不会进入搜索、Sitemap 和 LLM 索引。
+  产品概览、核心概念、完整快速开始、业务集成和首批场景教程已经发布。侧栏中标记为“规划中”的页面仍不会进入搜索、Sitemap 和 LLM 索引。
 </Callout>
 
 ## 推荐路径
@@ -16,6 +16,7 @@ WuKongIM 是面向大规模实时通信场景的通用消息系统。本区域�
   <Card title="快速开始" description="启动单节点集群并发送第一条消息。" href="/zh/guide/quick-start" />
   <Card title="核心概念" description="建立消息、频道、用户、设备和会话术语。" href="/zh/guide/core-concepts" />
   <Card title="集成指南" description="把 WuKongIM 接入已有业务系统。" href="/zh/guide/integration" />
+  <Card title="场景教程" description="完成单聊、群聊和十万成员群的端到端设计。" href="/zh/guide/tutorials" />
 </Cards>
 
 第一次使用 WuKongIM？从[快速开始](/zh/guide/quick-start)出发，完成启动、就绪检查和第一次双向消息验证。

--- a/docs-site/content/docs/guide/quick-start/next-steps.en.mdx
+++ b/docs-site/content/docs/guide/quick-start/next-steps.en.mdx
@@ -10,6 +10,7 @@ If readiness succeeds, both test UIDs connect, and messages flow in both directi
 <Cards>
   <Card title="Core Concepts" description="Learn channel ordering, message commits, users, devices, conversations, nodes, and Slots." href="/en/guide/core-concepts" />
   <Card title="Integration" description="Divide product responsibilities and design authentication, messaging, and webhooks." href="/en/guide/integration" />
+  <Card title="Tutorials" description="Continue with direct chat, group chat, and 100,000-member group paths." href="/en/guide/tutorials" />
   <Card title="Deployment" description="Choose Docker or Linux, plan a multi-node cluster, and complete production checks." href="/en/server/deployment" />
   <Card title="Basic Configuration" description="Understand TOML, configuration search order, WK_ environment variables, and development credentials." href="/en/server/configuration" />
   <Card title="Choose an SDK" description="Plan client integration by platform and access method." href="/en/sdk" />

--- a/docs-site/content/docs/guide/quick-start/next-steps.mdx
+++ b/docs-site/content/docs/guide/quick-start/next-steps.mdx
@@ -10,6 +10,7 @@ description: 根据接入、配置、部署和运维目标选择后续阅读路�
 <Cards>
   <Card title="核心概念" description="理解频道顺序、消息提交、用户、设备、会话、节点和 Slot。" href="/zh/guide/core-concepts" />
   <Card title="集成指南" description="划分业务职责，设计认证、消息收发和 Webhook。" href="/zh/guide/integration" />
+  <Card title="场景教程" description="继续实现单聊、群聊和十万成员群路径。" href="/zh/guide/tutorials" />
   <Card title="部署" description="选择 Docker 或 Linux，规划多节点集群并完成生产检查。" href="/zh/server/deployment" />
   <Card title="基础配置" description="理解 TOML、配置搜索顺序、WK_ 环境变量和开发凭据。" href="/zh/server/configuration" />
   <Card title="选择 SDK" description="从平台和接入方式出发规划客户端集成。" href="/zh/sdk" />

--- a/docs-site/content/docs/guide/tutorials/direct-chat.en.mdx
+++ b/docs-site/content/docs/guide/tutorials/direct-chat.en.mdx
@@ -1,0 +1,108 @@
+---
+title: Direct Chat
+description: Implement durable messages, online delivery, offline sync, unread state, and multi-device recovery between two users.
+---
+
+This tutorial uses `alice` and `bob`. The target outcome is that both endpoints connect with their own product identity, Alice publishes one durable message to Bob's person Channel, Bob can receive it online or recover it after reconnect, and Bob can manage unread state in a UID-owned conversation projection.
+
+## Before you start
+
+- Complete [Start a Single-node Cluster](/en/guide/quick-start/single-node-cluster) or prepare a test cluster.
+- Understand the current Beta limits in [Authentication](/en/guide/integration/authentication).
+- Run HTTP examples only locally or inside a protected product-service network.
+
+```text
+Alice product session                         Bob product session
+        |                                             |
+        +-> SDK CONNECT -> Gateway       Gateway <- CONNECT <-+
+        |                                             |
+        +-> SEND peer=bob, type=1                    |
+                    -> canonical person Channel      |
+                    -> quorum commit -> SENDACK       |
+                    -> Bob RECV / offline sync -------+
+```
+
+## 1. Establish product identities
+
+The product service owns account login, friendship, bans, and content policy. Choose stable UIDs for the two test users; do not substitute a nickname, connection ID, or device ID for the UID.
+
+A local compatibility environment can store device-token metadata:
+
+```bash
+curl -sS http://127.0.0.1:5001/user/token \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"alice","token":"alice-local-only","device_flag":0,"device_level":1}'
+```
+
+<Callout type="error" title="This does not prove production authentication">
+  The default v3 Beta Gateway does not automatically validate every CONNECT against stored tokens. Before production, install an explicit credential validator and prove that invalid, expired, and revoked tokens cannot connect.
+</Callout>
+
+Store separate metadata for Bob, then connect both clients with their own UID, device identity, and token. If no SDK integration exists yet, use the [embedded Chat Demo](/en/guide/quick-start/first-message) to validate two browser sessions first.
+
+## 2. Send a person message
+
+The client uses the **peer UID** as `channel_id` and sets `channel_type=1`. Do not construct or persist the internal canonical person Channel ID; the server normalizes it from sender and receiver UIDs.
+
+A trusted product service can send with the same semantics:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"alice",
+    "channel_id":"bob",
+    "channel_type":1,
+    "client_msg_no":"dm-alice-bob-0001",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoidGV4dCIsInRleHQiOiJoZWxsbyBCb2IifQ=="
+  }'
+```
+
+Retain a stable, unique `client_msg_no`. If the network outcome is unclear, retry the same logical send with the same number instead of creating a duplicate with a new number. HTTP `reason=1` means the durable send reached Channel quorum commit; it does not mean every Bob device received it.
+
+## 3. Verify online and offline results
+
+An online Bob should receive `RECV` and send `RECVACK` after processing it. Verify the durable log through the compatibility sync route; a person-Channel query still uses the peer UID:
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/messagesync \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "login_uid":"bob",
+    "channel_id":"alice",
+    "channel_type":1,
+    "start_message_seq":0,
+    "limit":20,
+    "pull_mode":1
+  }'
+```
+
+The response maps `channel_id` back to `alice`; `message_seq` is ordered only within this person Channel. Merge online delivery and reconnect sync by message ID, `client_msg_no`, and Channel sequence while tolerating duplicate arrival.
+
+## 4. Inspect conversation and unread state
+
+```bash
+curl -sS http://127.0.0.1:5001/conversation/list \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"bob","limit":20}'
+```
+
+Bob's item uses `channel_id=alice`. `unread` is Bob's UID-owned projection, not a global delivery count. After the user confirms the current conversation is read, call through the trusted boundary:
+
+```bash
+curl -sS http://127.0.0.1:5001/conversations/clearUnread \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"bob","channel_id":"alice","channel_type":1}'
+```
+
+`clearUnread` reads the newest server-visible message and advances Bob's read position through that sequence; the optional request `message_seq` is only a compatibility fallback when the server finds no latest message. This endpoint does not record an exact client-side last-read sequence, so concurrently arriving messages can also become read. Conversation projection failure does not roll back a message that already reached quorum commit.
+
+## 5. Test multi-device recovery
+
+1. Connect a second Bob Session with a different `device_id`.
+2. Define the product's primary/secondary-device conflict policy; one UID does not imply one connection.
+3. Disconnect one device, then publish another durable message.
+4. Reconnect and recover the missing sequence through SDK sync or `/channel/messagesync`.
+5. Verify that online delivery, offline recovery, and unread projection are not treated as one completion signal.
+
+Before launch, also test friendship removal, denylist policy, token revocation, disconnect retries, duplicate sends, direct-Channel distribution, and duplicate webhook consumption. Continue with [Groups & Large Groups](/en/guide/tutorials/large-groups) or [Messaging](/en/guide/integration/messaging).

--- a/docs-site/content/docs/guide/tutorials/direct-chat.mdx
+++ b/docs-site/content/docs/guide/tutorials/direct-chat.mdx
@@ -1,0 +1,108 @@
+---
+title: 单聊
+description: 实现两个用户之间的持久消息、在线投递、离线同步、未读状态与多设备恢复。
+---
+
+本教程以 `alice` 和 `bob` 为例。最终结果是：两端通过自己的业务身份连接，Alice 向 Bob 的个人 Channel 发送一条持久消息，Bob 可以在线接收，也能在断线后从日志恢复，并在自己的会话投影中处理未读状态。
+
+## 开始前
+
+- 完成[启动单节点集群](/zh/guide/quick-start/single-node-cluster)或准备一个测试集群。
+- 理解[身份认证](/zh/guide/integration/authentication)的当前 Beta 限制。
+- HTTP 示例只能在本地或受保护的业务服务网络中执行。
+
+```text
+Alice product session                         Bob product session
+        |                                             |
+        +-> SDK CONNECT -> Gateway       Gateway <- CONNECT <-+
+        |                                             |
+        +-> SEND peer=bob, type=1                    |
+                    -> canonical person Channel      |
+                    -> quorum commit -> SENDACK       |
+                    -> Bob RECV / offline sync -------+
+```
+
+## 1. 建立业务身份
+
+业务服务应拥有账号登录、好友关系、封禁和内容策略。为两个测试用户选择稳定 UID；不要使用昵称、连接 ID 或设备 ID 代替 UID。
+
+本地兼容环境可以保存设备 Token 元数据：
+
+```bash
+curl -sS http://127.0.0.1:5001/user/token \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"alice","token":"alice-local-only","device_flag":0,"device_level":1}'
+```
+
+<Callout type="error" title="这不是生产鉴权证明">
+  默认 v3 Beta Gateway 不会自动使用已存 Token 验证每个 CONNECT。生产发布前必须接入显式凭据校验，并证明错误、过期或撤销 Token 无法连接。
+</Callout>
+
+为 Bob 保存独立凭据，然后让两个客户端分别使用自己的 UID、设备标识和 Token 建立连接。没有 SDK 集成时，可以先用[内嵌 Chat Demo](/zh/guide/quick-start/first-message)验证两个浏览器会话。
+
+## 2. 发送个人消息
+
+客户端发送时使用**对端 UID** 作为 `channel_id`，并设置 `channel_type=1`。不要拼接或存储内部 canonical person Channel ID；服务端会用发送方和接收方 UID 归一化。
+
+受信业务服务也可以用同一语义发送：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"alice",
+    "channel_id":"bob",
+    "channel_type":1,
+    "client_msg_no":"dm-alice-bob-0001",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoidGV4dCIsInRleHQiOiJoZWxsbyBCb2IifQ=="
+  }'
+```
+
+保留稳定且唯一的 `client_msg_no`。网络结果不明确时，用同一个编号重试同一次逻辑发送，不要换编号制造重复消息。HTTP 返回 `reason=1` 表示持久发送到达 Channel quorum commit；它不表示 Bob 的每台设备都已收到。
+
+## 3. 验证在线与离线结果
+
+在线 Bob 应收到 `RECV` 并在处理后发送 `RECVACK`。再用兼容同步接口验证持久日志；个人频道查询仍使用对端 UID：
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/messagesync \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "login_uid":"bob",
+    "channel_id":"alice",
+    "channel_type":1,
+    "start_message_seq":0,
+    "limit":20,
+    "pull_mode":1
+  }'
+```
+
+响应中的 `channel_id` 会映射回 `alice`，`message_seq` 只在这一个 person Channel 内有序。客户端应按消息 ID、`client_msg_no` 和 Channel sequence 合并在线投递与重连同步，允许重复到达。
+
+## 4. 检查会话和未读
+
+```bash
+curl -sS http://127.0.0.1:5001/conversation/list \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"bob","limit":20}'
+```
+
+Bob 的会话项使用 `channel_id=alice`。`unread` 是 Bob 的 UID-owned 投影视角，不是全局投递计数。用户确认当前会话已读后，由受信边界调用：
+
+```bash
+curl -sS http://127.0.0.1:5001/conversations/clearUnread \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"bob","channel_id":"alice","channel_type":1}'
+```
+
+`clearUnread` 会读取服务端最新可见消息，并把 Bob 的已读位置推进到该 sequence；请求里的可选 `message_seq` 仅在服务端找不到最新消息时作为兼容回退。它不是精确记录客户端最后阅读 sequence 的接口，因此并发新消息可能一起被标记为已读。会话投影更新失败不会回滚已经 quorum commit 的消息。
+
+## 5. 验证多设备与恢复
+
+1. 用不同 `device_id` 建立 Bob 的第二个 Session。
+2. 明确产品的主/从设备冲突策略，不把“同 UID”理解为“只有一条连接”。
+3. 断开其中一个设备，再发送一条新的持久消息。
+4. 重连后通过 SDK 同步或 `/channel/messagesync` 恢复缺失 sequence。
+5. 验证在线投递、离线恢复和会话未读不会被当成同一个完成信号。
+
+上线前还要测试好友解除、黑名单、Token 撤销、断线重试、重复发送、热点单聊分布和 Webhook 重复消费。继续阅读[群聊与超大群](/zh/guide/tutorials/large-groups)或[消息收发](/zh/guide/integration/messaging)。

--- a/docs-site/content/docs/guide/tutorials/index.en.mdx
+++ b/docs-site/content/docs/guide/tutorials/index.en.mdx
@@ -1,0 +1,39 @@
+---
+title: Tutorials
+description: Combine identity, Channels, messages, conversations, and scale boundaries into deployable product flows.
+---
+
+Scenario tutorials begin with a product outcome and connect the product service, client SDK, and WuKongIM cluster into one end-to-end path. They are not exhaustive API references; they establish responsibilities, ordering, success criteria, and compensation boundaries.
+
+<Callout type="warn" title="Establish a trusted boundary first">
+  HTTP commands in these tutorials are for local development or a trusted product service. Current product HTTP routes have no general product-authentication middleware. Browsers and mobile clients must not hold these management capabilities directly.
+</Callout>
+
+<Cards>
+  <Card title="Direct Chat" description="Connect identity, person-Channel messaging, offline recovery, unread state, and multi-device verification." href="/en/guide/tutorials/direct-chat" />
+  <Card title="Groups & Large Groups" description="Connect group membership, group messages, churn, and 100,000-member capacity boundaries." href="/en/guide/tutorials/large-groups" />
+</Cards>
+
+## Choose a path
+
+| Goal | Start here | Most important boundary |
+| --- | --- | --- |
+| Two users exchange messages | [Direct Chat](/en/guide/tutorials/direct-chat) | Use the peer UID; the server derives the canonical person Channel |
+| Ordinary group chat | [Groups & Large Groups](/en/guide/tutorials/large-groups) | The product owns group lifecycle and membership; WuKongIM owns the message log |
+| A 100,000-member community or room | [Groups & Large Groups](/en/guide/tutorials/large-groups#scale-to-100000-members) | Batched reconciliation, paged post-commit fanout, and hotspot capacity testing |
+
+## Shared success model
+
+```text
+product authorization / membership state
+        |
+        v
+SDK SEND or trusted HTTP send
+        -> Channel quorum commit -> SENDACK / reason=1
+        -> online delivery / conversation projection / webhook / plugin
+        -> reconnect sync from the durable log
+```
+
+Treat “message committed,” “one Session received online delivery,” “the user's unread projection changed,” and “the business action completed” as four different outcomes. Strong business consistency belongs in the product service with its database, idempotency keys, and compensation workflow.
+
+Message Push and AI/IoT tutorials remain planned. For now, continue with [Use Cases](/en/guide/product-overview/use-cases) and [Integration Architecture](/en/guide/integration/architecture).

--- a/docs-site/content/docs/guide/tutorials/index.mdx
+++ b/docs-site/content/docs/guide/tutorials/index.mdx
@@ -1,0 +1,39 @@
+---
+title: 场景教程
+description: 把身份、Channel、消息、会话与规模约束组合成可落地的业务流程。
+---
+
+场景教程从业务目标出发，把业务服务、客户端 SDK 与 WuKongIM 集群串成端到端路径。它们不是 API 字段全集，而是帮助你确定职责、顺序、成功条件和故障补偿。
+
+<Callout type="warn" title="先建立受信边界">
+  教程中的 HTTP 命令只应由本地开发环境或受信业务服务调用。当前产品 HTTP 路由没有通用业务鉴权中间件，浏览器和移动端不能直接持有这些管理能力。
+</Callout>
+
+<Cards>
+  <Card title="单聊" description="完成身份接入、个人 Channel 消息、离线恢复、会话未读与多设备验证。" href="/zh/guide/tutorials/direct-chat" />
+  <Card title="群聊与超大群" description="完成群成员维护、群消息、成员变更与十万成员容量边界。" href="/zh/guide/tutorials/large-groups" />
+</Cards>
+
+## 如何选择
+
+| 目标 | 从这里开始 | 最重要的边界 |
+| --- | --- | --- |
+| 两个用户互发消息 | [单聊](/zh/guide/tutorials/direct-chat) | 使用对端 UID，canonical person Channel 由服务端生成 |
+| 普通群聊 | [群聊与超大群](/zh/guide/tutorials/large-groups) | 业务系统维护群生命周期和成员，WuKongIM 维护消息日志 |
+| 十万成员社区或房间 | [群聊与超大群](/zh/guide/tutorials/large-groups#扩展到十万成员) | 成员分批协调、提交后分页 Fan-out、热点容量验证 |
+
+## 所有教程共用的成功模型
+
+```text
+业务授权 / 成员状态
+        |
+        v
+SDK SEND 或受信 HTTP send
+        -> Channel quorum commit -> SENDACK / reason=1
+        -> 在线投递 / 会话投影 / Webhook / 插件
+        -> 重连后按持久日志同步
+```
+
+把“消息已提交”“某个 Session 已在线收到”“用户会话未读已更新”和“业务动作已完成”作为四种不同结果。需要强一致业务结果时，由业务服务使用自己的数据库、幂等键和补偿流程完成。
+
+消息推送以及 AI/IoT 教程仍在规划中。当前可以先阅读[适用场景](/zh/guide/product-overview/use-cases)和[集成架构](/zh/guide/integration/architecture)。

--- a/docs-site/content/docs/guide/tutorials/large-groups.en.mdx
+++ b/docs-site/content/docs/guide/tutorials/large-groups.en.mdx
@@ -1,0 +1,110 @@
+---
+title: Groups & Large Groups
+description: Implement a group Channel, membership reconciliation, group messages, churn, and 100,000-member workload boundaries.
+---
+
+This tutorial creates an ordinary group first, then scales the same model to 100,000 members. The product system always owns group profiles, roles, invitation approval, moderation, content governance, and the membership database. WuKongIM stores authoritative Channel metadata, membership projections, and the ordered message log.
+
+## 1. Create a group Channel
+
+Choose a stable, non-recycled product group ID such as `team-42`. Create the Channel from a trusted service network and verify it with a small initial member set:
+
+```bash
+curl -sS http://127.0.0.1:5001/channel \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"team-42",
+    "channel_type":2,
+    "reset":1,
+    "subscribers":["alice","bob","carol"]
+  }'
+```
+
+The compatible success response is `{"status":200}`. `channel_type=2` identifies a group Channel. This subscriber list does not replace the product membership database; it is the cluster-authoritative projection used for messaging permission, synchronization, and delivery.
+
+<Callout type="warn" title="Membership routes are a trusted control plane">
+  Current product HTTP routes have no general product authentication. End users should call your product API first; the product service validates roles and approval policy before mutating WuKongIM membership.
+</Callout>
+
+## 2. Reconcile membership changes
+
+Add members:
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/subscriber_add \
+  -H 'Content-Type: application/json' \
+  -d '{"channel_id":"team-42","channel_type":2,"subscribers":["dave","erin"]}'
+```
+
+Use `/channel/subscriber_remove` with the same request shape to remove members. Ordinary membership mutations are de-duplicated, written under a monotonic mutation version, and projected into UID-owned membership metadata. The product service should still retain its desired membership version, audit log, and compensation jobs.
+
+## 3. Send and verify a group message
+
+The sender must satisfy current group permission and membership policy. A client SDK uses `channel_id=team-42` and `channel_type=2`; a trusted server-side example is:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"alice",
+    "channel_id":"team-42",
+    "channel_type":2,
+    "client_msg_no":"team-42-0001",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoidGV4dCIsInRleHQiOiJoZWxsbyB0ZWFtIn0="
+  }'
+```
+
+`reason=1` means this Channel message reached quorum commit. It does not mean every member was online, every online Session write succeeded, or every user's conversation projection is already current.
+
+Bob can sync the group log:
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/messagesync \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "login_uid":"bob",
+    "channel_id":"team-42",
+    "channel_type":2,
+    "start_message_seq":0,
+    "limit":20,
+    "pull_mode":1
+  }'
+```
+
+`message_seq` defines one order inside the group. Member online delivery, RECVACK, unread state, and reconnect recovery remain separate observations.
+
+## 4. Verify the leave boundary
+
+The product service commits its membership decision, calls the trusted subscriber-removal route, and records a retryable task. Removal affects later permission and delivery plans, but it does not delete the existing Channel log or automatically define product database, client-cache, and historical-conversation policy.
+
+Decide which historical sequence a former member may view, whether local records are removed, and where a returning member resumes. Those product rules cannot be inferred solely from “the subscriber row is gone.”
+
+## Scale to 100,000 members
+
+Do not place 100,000 UIDs into one `/channel` or `subscriber_add` JSON request. Use a product-owned coordinator:
+
+```text
+business membership snapshot/version
+  -> read next bounded UID batch
+  -> POST subscriber_add or subscriber_remove
+  -> persist checkpoint and result
+  -> retry/reconcile until desired == observed
+```
+
+- Use bounded application batches of hundreds to roughly one thousand UIDs, then tune from request bytes, latency, and error rate. Do not treat an internal chunk default as a permanent public API maximum.
+- Each request is still chunked and de-duplicated internally, but multiple HTTP requests are not one global transaction. Preserve successful progress and repair the desired/observed difference after failure.
+- `channel.large_group_subscriber_threshold` defaults to `500`; after an ordinary membership mutation, a count **greater than** the threshold refreshes the large-group marker. After changing the threshold, use controlled membership reconciliation and verification for existing Channels.
+- Large-group post-commit fanout pages members, groups them by Presence Authority, and creates bounded delivery plans. It does not write 100,000 copies into 100,000 Channel logs.
+- SENDACK guarantees Channel quorum commit and does not wait for complete fanout. If the product needs “everyone processed it,” build a separate business acknowledgement and aggregation flow.
+
+## Capacity validation
+
+Before launch, measure separately:
+
+1. hot-Channel append, quorum commit, and P99;
+2. member paging, Presence Authority resolution, and post-commit handoff queues;
+3. owner push, Session writes, disconnect ratio, and reconnect sync;
+4. membership mutation throughput, partial-failure repair, and mutation-version progress;
+5. CPU, memory, disk, network, queue depth, rejection, and end-to-end tail latency.
+
+Do not infer 100,000-member capacity from average QPS alone. Continue with [Channel Concepts](/en/guide/core-concepts/channels), [Cluster Configuration](/en/server/configuration/cluster), and [Benchmark Tooling](/en/server/tools/wkbench).

--- a/docs-site/content/docs/guide/tutorials/large-groups.mdx
+++ b/docs-site/content/docs/guide/tutorials/large-groups.mdx
@@ -1,0 +1,110 @@
+---
+title: 群聊与超大群
+description: 实现群 Channel、成员协调、群消息、成员变更，以及十万成员负载边界。
+---
+
+本教程先创建一个普通群，再把同一模型扩展到十万成员。业务系统始终拥有群资料、成员角色、邀请审批、禁言、内容治理和成员数据库；WuKongIM 保存 Channel 权威元数据、成员投影与有序消息日志。
+
+## 1. 创建群 Channel
+
+选择稳定且不可复用的业务群 ID，例如 `team-42`。在受信服务网络中创建 Channel，并用一个小的初始成员集完成验证：
+
+```bash
+curl -sS http://127.0.0.1:5001/channel \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"team-42",
+    "channel_type":2,
+    "reset":1,
+    "subscribers":["alice","bob","carol"]
+  }'
+```
+
+成功兼容响应是 `{"status":200}`。`channel_type=2` 表示群组 Channel。不要用这个成员列表替代业务群数据库；它是消息权限、同步与投递需要的集群权威投影。
+
+<Callout type="warn" title="成员接口是受信控制面">
+  当前产品 HTTP 路由没有通用业务鉴权。终端用户应先调用你的业务 API，由业务服务验证群角色和审批规则，再执行 WuKongIM 成员变更。
+</Callout>
+
+## 2. 协调成员变化
+
+新增成员：
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/subscriber_add \
+  -H 'Content-Type: application/json' \
+  -d '{"channel_id":"team-42","channel_type":2,"subscribers":["dave","erin"]}'
+```
+
+移除成员使用 `/channel/subscriber_remove` 和相同请求结构。普通成员变更会去重、写入单调 mutation version，并更新 UID-owned membership projection。业务服务仍应保存自己的期望成员版本、操作审计和补偿任务。
+
+## 3. 发送并验证群消息
+
+发送者必须满足当前群权限与成员策略。客户端 SDK 使用 `channel_id=team-42`、`channel_type=2`；受信服务端示例：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"alice",
+    "channel_id":"team-42",
+    "channel_type":2,
+    "client_msg_no":"team-42-0001",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoidGV4dCIsInRleHQiOiJoZWxsbyB0ZWFtIn0="
+  }'
+```
+
+`reason=1` 表示这个 Channel 的消息已达到 quorum commit。它不表示所有成员都在线、所有在线 Session 都写入成功，或者每位用户的会话投影已经刷新。
+
+Bob 可以同步群日志：
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/messagesync \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "login_uid":"bob",
+    "channel_id":"team-42",
+    "channel_type":2,
+    "start_message_seq":0,
+    "limit":20,
+    "pull_mode":1
+  }'
+```
+
+群内 `message_seq` 定义唯一顺序。成员的在线投递、RECVACK、未读数和重连恢复仍是不同观测。
+
+## 4. 验证离群边界
+
+业务系统先提交自己的成员状态，再通过受信调用移除订阅者，并记录可重试任务。成员移除决定之后的发送权限和投递计划，但不会删除既有 Channel 日志，也不会自动清理业务数据库、客户端缓存或历史会话展示策略。
+
+明确产品策略：离群用户能看到哪个历史 sequence、是否删除本地记录、再次入群从哪里同步。这些产品规则不能从“成员行已经删除”自动推导。
+
+## 扩展到十万成员
+
+不要把十万 UID 放入一次 `/channel` 或 `subscriber_add` JSON 请求。推荐使用业务侧协调器：
+
+```text
+business membership snapshot/version
+  -> read next bounded UID batch
+  -> POST subscriber_add or subscriber_remove
+  -> persist checkpoint and result
+  -> retry/reconcile until desired == observed
+```
+
+- 使用几百到约一千 UID 的有界应用批次，并按实际请求大小、延迟和错误率调节；不要把内部 chunk 默认值当作永久 API 上限。
+- 每个请求内部仍会分块和去重，但跨多个 HTTP 请求不是一个全局事务。失败时保留已成功进度，再通过期望/实际差异修复。
+- `channel.large_group_subscriber_threshold` 默认是 `500`；普通成员变更后，成员数**大于**阈值会刷新 large-group 标记。改变阈值后，要通过受控成员协调和验证确认现有 Channel 状态。
+- 大群提交后 Fan-out 分页读取成员、按 Presence Authority 分组并创建有界投递计划；它不会为十万成员写十万份 Channel 持久日志。
+- SENDACK 保证 Channel quorum commit，不等待完整 Fan-out。需要业务“全部处理”语义时，另建业务回执与聚合流程。
+
+## 容量验证
+
+上线前至少分别测量：
+
+1. 热点 Channel append、quorum commit 与 P99；
+2. 成员分页、Presence authority 解析和 post-commit handoff 队列；
+3. owner push、Session 写入、断线比例与重连同步；
+4. 成员变更吞吐、部分失败恢复和 mutation version 推进；
+5. CPU、内存、磁盘、网络、队列深度、拒绝和端到端尾延迟。
+
+不要只用平均 QPS 推导十万成员容量。继续阅读[Channel 核心概念](/zh/guide/core-concepts/channels)、[集群配置](/zh/server/configuration/cluster)和[性能测试工具](/zh/server/tools/wkbench)。

--- a/docs-site/lib/navigation.test.ts
+++ b/docs-site/lib/navigation.test.ts
@@ -111,6 +111,19 @@ describe('documentation navigation contract', () => {
     expect(integration?.children.find((page) => page.slug === 'plugins')?.status).toBe('published');
   });
 
+  test('publishes the first scenario tutorial tranche', () => {
+    const guide = domains.find((domain) => domain.key === 'guide');
+    const tutorials = guide?.groups.find((group) => group.slug === 'tutorials');
+
+    expect(tutorials?.status).toBe('published');
+    expect(tutorials?.children.map((page) => [page.slug, page.status])).toEqual([
+      ['direct-chat', 'published'],
+      ['large-groups', 'published'],
+      ['push', 'planned'],
+      ['ai-and-iot', 'planned'],
+    ]);
+  });
+
   test('gives every bilingual menu item a unique canonical route', () => {
     for (const locale of locales) {
       const entries = getAllNavigationEntries(locale);
@@ -152,6 +165,9 @@ describe('documentation navigation contract', () => {
         `/${locale}/guide/integration/messaging`,
         `/${locale}/guide/integration/webhooks`,
         `/${locale}/guide/integration/plugins`,
+        `/${locale}/guide/tutorials`,
+        `/${locale}/guide/tutorials/direct-chat`,
+        `/${locale}/guide/tutorials/large-groups`,
         `/${locale}/server`,
         `/${locale}/server/deployment`,
         `/${locale}/server/deployment/choosing`,
@@ -308,8 +324,16 @@ describe('documentation navigation contract', () => {
     expect(isPublishedContentPath('server/architecture/message-flow.en.mdx')).toBe(true);
     expect(isPublishedContentPath('server/architecture/user-routing.mdx')).toBe(true);
     expect(isPublishedContentPath('server/architecture/user-routing.en.mdx')).toBe(true);
-    expect(isPublishedContentPath('guide/tutorials/direct-chat.mdx')).toBe(false);
-    expect(isPublishedContentPath('guide/tutorials/direct-chat.en.mdx')).toBe(false);
+    expect(isPublishedContentPath('guide/tutorials/index.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/index.en.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/direct-chat.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/direct-chat.en.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/large-groups.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/large-groups.en.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/push.mdx')).toBe(false);
+    expect(isPublishedContentPath('guide/tutorials/push.en.mdx')).toBe(false);
+    expect(isPublishedContentPath('guide/tutorials/ai-and-iot.mdx')).toBe(false);
+    expect(isPublishedContentPath('guide/tutorials/ai-and-iot.en.mdx')).toBe(false);
     expect(isPublishedContentPath('unknown/index.mdx')).toBe(false);
   });
 });

--- a/docs-site/lib/navigation.ts
+++ b/docs-site/lib/navigation.ts
@@ -362,21 +362,21 @@ export const domains: DocumentationDomain[] = [
           ),
         ],
       ),
-      plannedGroup(
+      publishedGroup(
         'tutorials',
         '场景教程',
         'Tutorials',
         '提供面向典型业务场景的端到端方案。',
         'Provides end-to-end solutions for representative product scenarios.',
         [
-          plannedPage(
+          publishedPage(
             'direct-chat',
             '单聊',
             'Direct Chat',
             '实现用户、单聊频道、消息、未读数和多设备同步。',
             'Implements users, direct channels, messages, unread counts, and multi-device sync.',
           ),
-          plannedPage(
+          publishedPage(
             'large-groups',
             '群聊与超大群',
             'Groups & Large Groups',

--- a/docs-site/scripts/check-static-output.ts
+++ b/docs-site/scripts/check-static-output.ts
@@ -1,4 +1,9 @@
-import { domains, getIndexedNavigationEntries, locales } from '../lib/navigation';
+import {
+  domains,
+  getAllNavigationEntries,
+  getIndexedNavigationEntries,
+  locales,
+} from '../lib/navigation';
 
 const out = new URL('../out/', import.meta.url);
 
@@ -19,9 +24,11 @@ for (const locale of locales) {
   }
 }
 
-const plannedRoutes = locales.flatMap((locale) => [
-  `/${locale}/server/deployment/kubernetes`,
-]);
+const plannedRoutes = locales.flatMap((locale) =>
+  getAllNavigationEntries(locale)
+    .filter((entry) => entry.status === 'planned')
+    .map((entry) => entry.url),
+);
 for (const route of plannedRoutes) {
   const planned = await text(`${route.slice(1)}/index.html`);
   if (!planned.includes('<meta name="robots" content="noindex, follow"/>')) {
@@ -56,7 +63,8 @@ for (const route of plannedRoutes) {
   }
 }
 
-const llms = `${await text('llms.txt')}\n${await text('llms-full.txt')}`;
+const llmsIndex = await text('llms.txt');
+const llms = `${llmsIndex}\n${await text('llms-full.txt')}`;
 for (const locale of locales) {
   for (const entry of getIndexedNavigationEntries(locale)) {
     if (!llms.includes(entry.url)) {
@@ -66,8 +74,8 @@ for (const locale of locales) {
   }
 }
 for (const route of plannedRoutes) {
-  if (llms.includes(route)) {
-    throw new Error(`planned page must not appear in LLM outputs: ${route}`);
+  if (llmsIndex.includes(route)) {
+    throw new Error(`planned page must not appear in llms.txt: ${route}`);
   }
   if (await exists(`llms.mdx${route}/content.md`)) {
     throw new Error(`planned page has per-page Markdown output: ${route}`);

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -326,6 +326,19 @@
   Send hooks are synchronous and fail closed by default, while Receive and
   PersistAfter are post-commit effects; Slot-owned UID bindings do not prove a
   compatible plugin is running on every node.
+- Phase 10 public scenario tutorials treat direct and group chat as product
+  workflows over the same cluster semantics. Direct chat supplies the peer UID
+  with `channel_type=1` and leaves canonical person-Channel derivation to the
+  server. Group chat uses a product-owned group ID with `channel_type=2`; the
+  product service owns the membership source of truth and reconciles
+  subscribers through bounded requests. Current product HTTP routes remain a
+  trusted service-side boundary. Durable SEND success proves Channel quorum
+  commit, not complete fanout, RECVACK, conversation projection, or a business
+  result. `ClearUnread` advances through the newest server-visible Channel
+  message; its optional request sequence is only a fallback, not exact
+  client-side read progress. A 100,000-member workflow uses checkpointed
+  application batches and post-commit paged fanout rather than one full-member
+  request.
 - Public deployment guidance treats the root Compose stack as development-only
   and builds artifacts from reviewed source without promising an official image
   registry or tag. Traffic admission uses `/readyz`, not process-level


### PR DESCRIPTION
## Summary

- publish the bilingual Tutorials landing page
- add Direct Chat and Groups & Large Groups scenario tutorials
- expose published tutorial routes through navigation, search, sitemap, LLM, and Markdown outputs
- keep Message Push and AI/IoT tutorials planned and noindex
- document trusted HTTP boundaries, quorum-commit semantics, conversation projections, and bounded 100,000-member workflows
- generalize static-output checks for all planned navigation entries

## Why

Phase 10 turns the guide foundations into task-oriented workflows while preserving the current runtime, authentication, and scaling boundaries.

## Validation

- `bun run verify`
- `GOWORK=off go test ./internal/access/api/... ./internal/usecase/message/... ./internal/usecase/channel/... ./internal/usecase/user/... ./internal/usecase/conversation/... ./internal/runtime/channelappend/... ./pkg/protocol/channelid/... -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- desktop and mobile browser QA for both tutorials in both locales
- two-axis Standards and Spec review
