### PR TITLE
feat(agent): add verifiable skill contracts

### DIFF
--- a/.agents/skill-tests.json
+++ b/.agents/skill-tests.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "chat-lifecycle-skill-contracts",
+      "skill": "wukongim-chat-lifecycle",
+      "arguments": [
+        "go",
+        "test",
+        "./scripts/...",
+        "-run",
+        "^TestChatLifecycleProjectSkillKeepsPaidAuthorityAndOperationsSeparate$",
+        "-count=1"
+      ],
+      "timeout_seconds": 20
+    },
+    {
+      "id": "cloud-analysis-skill-contracts",
+      "skill": "wukongim-cloud-analysis",
+      "arguments": [
+        "go",
+        "test",
+        "./scripts/...",
+        "-run",
+        "^TestCloudAnalysisSkill",
+        "-count=1"
+      ],
+      "timeout_seconds": 20
+    }
+  ]
+}

--- a/.github/review-agent/policy.json
+++ b/.github/review-agent/policy.json
@@ -173,6 +173,27 @@
       "timeout_seconds": 600,
       "max_output_bytes": 8388608
     },
+    "agent-artifact-contracts": {
+      "arguments": [
+        "go",
+        "run",
+        "./scripts/skillcheck"
+      ],
+      "working_dir": ".",
+      "timeout_seconds": 15,
+      "max_output_bytes": 1048576
+    },
+    "skill-focused-contracts": {
+      "arguments": [
+        "go",
+        "run",
+        "./scripts/skillcheck",
+        "--run-focused"
+      ],
+      "working_dir": ".",
+      "timeout_seconds": 45,
+      "max_output_bytes": 1048576
+    },
     "workflow-contracts": {
       "arguments": [
         "go",
@@ -389,6 +410,21 @@
       "checks": [
         "workflow-contracts",
         "go-unit"
+      ],
+      "exclusive": false
+    },
+    {
+      "name": "agent-skills",
+      "paths": [
+        ".agents/skill-tests.json"
+      ],
+      "prefixes": [
+        ".agents/skills/"
+      ],
+      "suffixes": [],
+      "checks": [
+        "agent-artifact-contracts",
+        "skill-focused-contracts"
       ],
       "exclusive": false
     },

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -91,6 +91,12 @@ verdict. A trusted validator maps signed state to the sole required Check
 maps to failure, and `inconclusive` maps to `action_required`. A human
 `REQUEST_CHANGES` Review remains independently blocking.
 
+Repository Skills use the protected `agent-artifact-contracts` and
+`skill-focused-contracts` checks. Their Review Agent command definitions live
+only in `.github/review-agent/policy.json`; focused Skill test commands live
+only in `.agents/skill-tests.json`. The structural check never discovers or
+executes files from a Skill's `scripts/` directory.
+
 The model request passes through one root-owned loopback proxy that clamps
 `max_output_tokens` to the protected policy and injects the OpenRouter
 credential. The root-only credential handoff file is deleted before the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,16 @@ app -> access/usecase/runtime/infra/pkg
   Its control code, Workflows, policy, schemas, prompts, and instruction files
   are protected from automated changes. Every Codex task freezes applicable
   `AGENTS.md` and `FLOW.md` digests from its exact source revision.
+- `.github/review-agent/policy.json` MUST remain the sole machine-executable
+  authority for Review Agent check arguments, limits, and path selection.
+  Instructions, Skills, prompts, and Workflows MUST reference named checks
+  instead of copying their commands.
+- `.agents/skill-tests.json` MUST remain the sole catalog of focused
+  repository-Skill tests. Only its explicitly registered, contract-validated
+  commands may run; automation MUST NOT discover and execute arbitrary files
+  from Skill directories.
+- Changes under `.agents/skills/` MUST pass the `agent-artifact-contracts` and
+  `skill-focused-contracts` named checks.
 
 ## GitHub Actions tools
 

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -59,6 +59,16 @@
   true no-op never enters the credentialed State Writer or Publisher and never
   dispatches; mutation and projection paths reuse the exact run-scoped,
   control-SHA-bound binary Artifact.
+- Repository Skill verification has two layers. `agent-artifact-contracts`
+  validates Skill metadata, local-reference containment, interface YAML,
+  fixtures, executable bits, the focused-test registry, and Review policy
+  routing without executing Skill scripts. `skill-focused-contracts` runs only
+  the allowlisted `go test ./scripts/... -run '^Test...' -count=1` commands in
+  `.agents/skill-tests.json`; every pattern must match a default-tier Go test,
+  and their declared timeouts total at most 40 seconds.
+  The paired static and focused named checks have a combined 60-second budget.
+  Review check commands and path selection remain authoritative only in
+  `.github/review-agent/policy.json`.
 - Backup has one Manager-owned plan in Controller state; it is configured only through Manager, supports Cron or `@every`, and has no TOML/environment compatibility path.
 - Saving backup repository configuration is a durable Controller operation and never proves connectivity. Only the exact saved plan revision that completes the repository and all-active-data-node probe is verified and eligible for backup admission. A nil verification record is legacy verified state until the effective repository changes.
 - Every run publishes one independent full 256-hash-slot archive to the shared file repository under `<data_dir>/backup-repository`, Alibaba OSS, Tencent COS, or a generic S3-compatible repository. `COMPLETE` makes an archive visible, `HOLD` exempts it from retention, and object-storage credentials are encrypted in Controller state while archive payloads are not encrypted.

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/bytebufferpool v1.0.0
+	github.com/yuin/goldmark v1.8.2
 	go.etcd.io/raft/v3 v3.6.0
 	go.uber.org/zap v1.27.0
 	go.yaml.in/yaml/v3 v3.0.4

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.30/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
@@ -480,6 +482,8 @@ golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
 golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/scripts/skillcheck/main.go
+++ b/scripts/skillcheck/main.go
@@ -1,0 +1,992 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	goast "go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+	"go.yaml.in/yaml/v3"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout io.Writer, stderr io.Writer) int {
+	return runWithExecutor(args, stdout, stderr, executeFocusedCommand)
+}
+
+type focusedCommandExecutor func(
+	context.Context,
+	string,
+	[]string,
+	io.Writer,
+	io.Writer,
+) error
+
+func runWithExecutor(
+	args []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	executor focusedCommandExecutor,
+) int {
+	flags := flag.NewFlagSet("skillcheck", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	runFocused := flags.Bool("run-focused", false, "run explicitly registered focused tests")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintf(stderr, "skillcheck: unexpected arguments: %v\n", flags.Args())
+		return 2
+	}
+
+	entries, err := os.ReadDir(filepath.Join(*root, ".agents", "skills"))
+	if err != nil {
+		fmt.Fprintf(stderr, ".agents/skills: %v\n", err)
+		return 1
+	}
+	skills := 0
+	var diagnostics []string
+	skillNames := make(map[string]string)
+	focusedTestRequired := make(map[string]struct{})
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skills++
+		skillRelative := filepath.Join(".agents", "skills", entry.Name(), "SKILL.md")
+		if _, err := os.Stat(filepath.Join(*root, skillRelative)); err != nil {
+			if os.IsNotExist(err) {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: required file is missing",
+					filepath.ToSlash(skillRelative),
+				))
+			} else {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: %v", filepath.ToSlash(skillRelative), err,
+				))
+			}
+			continue
+		}
+		metadata, err := readSkillMetadata(filepath.Join(*root, skillRelative))
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: %v", filepath.ToSlash(skillRelative), err,
+			))
+			continue
+		}
+		if earlier, exists := skillNames[metadata.Name]; exists {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: frontmatter name %q duplicates %s",
+				filepath.ToSlash(skillRelative), metadata.Name, earlier,
+			))
+		} else {
+			skillNames[metadata.Name] = filepath.ToSlash(skillRelative)
+		}
+		if len(metadata.Name) > 64 || !skillNamePattern.MatchString(metadata.Name) {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: frontmatter name must be 1-64 lowercase letters, digits, or single hyphen-separated words",
+				filepath.ToSlash(skillRelative),
+			))
+		}
+		if metadata.Name != entry.Name() {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: frontmatter name %q must match directory %q",
+				filepath.ToSlash(skillRelative), metadata.Name, entry.Name(),
+			))
+		}
+		if strings.TrimSpace(metadata.Description) == "" {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: frontmatter description must be non-empty",
+				filepath.ToSlash(skillRelative),
+			))
+		}
+		openAIRelative := filepath.Join(
+			".agents", "skills", entry.Name(), "agents", "openai.yaml",
+		)
+		if _, err := os.Stat(filepath.Join(*root, openAIRelative)); err != nil {
+			if os.IsNotExist(err) {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: required file is missing",
+					filepath.ToSlash(openAIRelative),
+				))
+			} else {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: %v", filepath.ToSlash(openAIRelative), err,
+				))
+			}
+			continue
+		}
+		openAI, err := readOpenAIInterface(filepath.Join(*root, openAIRelative))
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: %v", filepath.ToSlash(openAIRelative), err,
+			))
+			continue
+		}
+		for _, field := range []struct {
+			name  string
+			value string
+		}{
+			{name: "display_name", value: openAI.Interface.DisplayName},
+			{name: "short_description", value: openAI.Interface.ShortDescription},
+			{name: "default_prompt", value: openAI.Interface.DefaultPrompt},
+		} {
+			if strings.TrimSpace(field.value) == "" {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: interface.%s must be non-empty",
+					filepath.ToSlash(openAIRelative), field.name,
+				))
+			}
+		}
+		diagnostics = append(
+			diagnostics,
+			validateMarkdownReferences(
+				*root,
+				filepath.Join(".agents", "skills", entry.Name()),
+			)...,
+		)
+		diagnostics = append(
+			diagnostics,
+			validateStructuredFixtures(
+				*root,
+				filepath.Join(".agents", "skills", entry.Name()),
+			)...,
+		)
+		diagnostics = append(
+			diagnostics,
+			validateSkillFileModes(
+				*root,
+				filepath.Join(".agents", "skills", entry.Name()),
+			)...,
+		)
+		if skillNeedsFocusedTest(
+			filepath.Join(*root, ".agents", "skills", entry.Name()),
+		) {
+			focusedTestRequired[metadata.Name] = struct{}{}
+		}
+	}
+	registry, registryDiagnostics := readFocusedTestRegistry(
+		*root,
+		skillNames,
+		focusedTestRequired,
+	)
+	diagnostics = append(diagnostics, registryDiagnostics...)
+	diagnostics = append(diagnostics, validateReviewPolicyChecks(*root)...)
+	if len(diagnostics) != 0 {
+		sort.Strings(diagnostics)
+		for _, diagnostic := range diagnostics {
+			fmt.Fprintln(stderr, diagnostic)
+		}
+		return 1
+	}
+	if !*runFocused {
+		fmt.Fprintf(
+			stdout,
+			"skillcheck: %d %s valid\n",
+			skills,
+			pluralize(skills, "skill", "skills"),
+		)
+		return 0
+	}
+	tests := append([]focusedTest(nil), registry.Tests...)
+	sort.Slice(tests, func(left int, right int) bool {
+		return tests[left].ID < tests[right].ID
+	})
+	for _, test := range tests {
+		fmt.Fprintf(stdout, "skillcheck: running focused test %s (%s)\n", test.ID, test.Skill)
+		ctx, cancel := context.WithTimeout(
+			context.Background(), time.Duration(test.TimeoutSeconds)*time.Second,
+		)
+		err := executor(ctx, *root, test.Arguments, stdout, stderr)
+		cancel()
+		if err != nil {
+			fmt.Fprintf(stderr, ".agents/skill-tests.json: focused test %q failed: %v\n", test.ID, err)
+			return 1
+		}
+	}
+	fmt.Fprintf(
+		stdout,
+		"skillcheck: %d %s valid; %d focused %s passed\n",
+		skills,
+		pluralize(skills, "skill", "skills"),
+		len(tests),
+		pluralize(len(tests), "test", "tests"),
+	)
+	return 0
+}
+
+func pluralize(count int, singular string, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+func executeFocusedCommand(
+	ctx context.Context,
+	root string,
+	arguments []string,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	command := exec.CommandContext(ctx, arguments[0], arguments[1:]...)
+	command.Dir = root
+	command.Stdout = stdout
+	command.Stderr = stderr
+	command.Env = environmentWith(os.Environ(), "GOWORK", "off")
+	return command.Run()
+}
+
+func environmentWith(environment []string, name string, value string) []string {
+	prefix := name + "="
+	result := make([]string, 0, len(environment)+1)
+	for _, item := range environment {
+		if !strings.HasPrefix(item, prefix) {
+			result = append(result, item)
+		}
+	}
+	return append(result, prefix+value)
+}
+
+type skillMetadata struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+func readSkillMetadata(path string) (skillMetadata, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return skillMetadata{}, err
+	}
+	lines := strings.Split(string(raw), "\n")
+	if len(lines) < 3 || strings.TrimSuffix(lines[0], "\r") != "---" {
+		return skillMetadata{}, fmt.Errorf("must start with YAML frontmatter")
+	}
+	closing := -1
+	for index := 1; index < len(lines); index++ {
+		if strings.TrimSuffix(lines[index], "\r") == "---" {
+			closing = index
+			break
+		}
+	}
+	if closing < 0 {
+		return skillMetadata{}, fmt.Errorf("YAML frontmatter is not closed")
+	}
+	var metadata skillMetadata
+	if err := yaml.NewDecoder(bytes.NewBufferString(
+		strings.Join(lines[1:closing], "\n"),
+	)).Decode(&metadata); err != nil {
+		return skillMetadata{}, fmt.Errorf("decode YAML frontmatter: %w", err)
+	}
+	return metadata, nil
+}
+
+type openAIInterfaceDocument struct {
+	Interface struct {
+		DisplayName      string `yaml:"display_name"`
+		ShortDescription string `yaml:"short_description"`
+		DefaultPrompt    string `yaml:"default_prompt"`
+	} `yaml:"interface"`
+}
+
+func readOpenAIInterface(path string) (openAIInterfaceDocument, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return openAIInterfaceDocument{}, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	var document openAIInterfaceDocument
+	if err := decoder.Decode(&document); err != nil {
+		return openAIInterfaceDocument{}, fmt.Errorf("decode YAML: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return openAIInterfaceDocument{}, fmt.Errorf("must contain one YAML document")
+		}
+		return openAIInterfaceDocument{}, fmt.Errorf("decode trailing YAML: %w", err)
+	}
+	return document, nil
+}
+
+var (
+	skillNamePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+)
+
+func validateMarkdownReferences(repoRoot string, skillRelative string) []string {
+	skillRoot := filepath.Join(repoRoot, skillRelative)
+	var diagnostics []string
+	_ = filepath.WalkDir(skillRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			relative, _ := filepath.Rel(repoRoot, path)
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: %v", filepath.ToSlash(relative), walkErr,
+			))
+			return nil
+		}
+		if entry.IsDir() || strings.ToLower(filepath.Ext(path)) != ".md" {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			relative, _ := filepath.Rel(repoRoot, path)
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: %v", filepath.ToSlash(relative), err,
+			))
+			return nil
+		}
+		document := goldmark.DefaultParser().Parse(text.NewReader(raw))
+		_ = ast.Walk(document, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			var destination []byte
+			switch typed := node.(type) {
+			case *ast.Link:
+				destination = typed.Destination
+			case *ast.Image:
+				destination = typed.Destination
+			default:
+				return ast.WalkContinue, nil
+			}
+			target := string(destination)
+			parsed, err := url.Parse(target)
+			if err != nil || parsed.Scheme != "" || strings.HasPrefix(target, "#") {
+				return ast.WalkContinue, nil
+			}
+			if parsed.Path == "" {
+				return ast.WalkContinue, nil
+			}
+			relativeMarkdown, _ := filepath.Rel(repoRoot, path)
+			resolved := filepath.Clean(filepath.Join(
+				filepath.Dir(path), filepath.FromSlash(parsed.Path),
+			))
+			relativeToSkill, err := filepath.Rel(skillRoot, resolved)
+			if filepath.IsAbs(parsed.Path) || err != nil || relativeToSkill == ".." ||
+				strings.HasPrefix(relativeToSkill, ".."+string(filepath.Separator)) {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: local reference %q escapes the skill directory",
+					filepath.ToSlash(relativeMarkdown), target,
+				))
+				return ast.WalkContinue, nil
+			}
+			if _, err := os.Stat(resolved); err != nil {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: local reference %q does not exist",
+					filepath.ToSlash(relativeMarkdown), target,
+				))
+				return ast.WalkContinue, nil
+			}
+			canonicalSkillRoot, rootErr := filepath.EvalSymlinks(skillRoot)
+			canonicalResolved, resolvedErr := filepath.EvalSymlinks(resolved)
+			if rootErr == nil && resolvedErr == nil {
+				canonicalRelative, relErr := filepath.Rel(canonicalSkillRoot, canonicalResolved)
+				if relErr != nil || canonicalRelative == ".." ||
+					strings.HasPrefix(canonicalRelative, ".."+string(filepath.Separator)) {
+					diagnostics = append(diagnostics, fmt.Sprintf(
+						"%s: local reference %q escapes the skill directory through a symlink",
+						filepath.ToSlash(relativeMarkdown), target,
+					))
+				}
+			}
+			return ast.WalkContinue, nil
+		})
+		return nil
+	})
+	return diagnostics
+}
+
+func validateStructuredFixtures(repoRoot string, skillRelative string) []string {
+	skillRoot := filepath.Join(repoRoot, skillRelative)
+	var diagnostics []string
+	_ = filepath.WalkDir(skillRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		extension := strings.ToLower(filepath.Ext(path))
+		if walkErr != nil || entry.IsDir() ||
+			(extension != ".json" && extension != ".yaml" && extension != ".yml") {
+			return nil
+		}
+		relativeToSkill, err := filepath.Rel(skillRoot, path)
+		if err != nil || !strings.Contains(
+			string(filepath.Separator)+relativeToSkill,
+			string(filepath.Separator)+"fixtures"+string(filepath.Separator),
+		) {
+			return nil
+		}
+		relative, _ := filepath.Rel(repoRoot, path)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: %v", filepath.ToSlash(relative), err,
+			))
+			return nil
+		}
+		if extension == ".json" {
+			decoder := json.NewDecoder(bytes.NewReader(raw))
+			var value any
+			if err := decoder.Decode(&value); err != nil {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: invalid JSON: %v", filepath.ToSlash(relative), err,
+				))
+				return nil
+			}
+			if err := decoder.Decode(&value); err != io.EOF {
+				if err == nil {
+					diagnostics = append(diagnostics, fmt.Sprintf(
+						"%s: invalid JSON: multiple values",
+						filepath.ToSlash(relative),
+					))
+				} else {
+					diagnostics = append(diagnostics, fmt.Sprintf(
+						"%s: invalid JSON: %v", filepath.ToSlash(relative), err,
+					))
+				}
+			}
+			return nil
+		}
+		decoder := yaml.NewDecoder(bytes.NewReader(raw))
+		var value any
+		if err := decoder.Decode(&value); err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: invalid YAML: %v", filepath.ToSlash(relative), err,
+			))
+			return nil
+		}
+		if err := decoder.Decode(&value); err != io.EOF {
+			if err == nil {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: invalid YAML: multiple documents",
+					filepath.ToSlash(relative),
+				))
+			} else {
+				diagnostics = append(diagnostics, fmt.Sprintf(
+					"%s: invalid YAML: %v", filepath.ToSlash(relative), err,
+				))
+			}
+		}
+		return nil
+	})
+	return diagnostics
+}
+
+func validateSkillFileModes(repoRoot string, skillRelative string) []string {
+	skillRoot := filepath.Join(repoRoot, skillRelative)
+	var diagnostics []string
+	_ = filepath.WalkDir(skillRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return nil
+		}
+		relativeToSkill, err := filepath.Rel(skillRoot, path)
+		if err != nil {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		hasShebang, err := fileHasShebang(path)
+		if err != nil {
+			relative, _ := filepath.Rel(repoRoot, path)
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: %v", filepath.ToSlash(relative), err,
+			))
+			return nil
+		}
+		executable := info.Mode().Perm()&0o111 != 0
+		if executable && !hasShebang {
+			relative, _ := filepath.Rel(repoRoot, path)
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: files without a shebang must not be executable",
+				filepath.ToSlash(relative),
+			))
+			return nil
+		}
+		parts := strings.Split(filepath.ToSlash(relativeToSkill), "/")
+		inScripts := len(parts) >= 2 && parts[0] == "scripts"
+		if executable && !inScripts {
+			relative, _ := filepath.Rel(repoRoot, path)
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: files outside scripts/ must not be executable",
+				filepath.ToSlash(relative),
+			))
+			return nil
+		}
+		if inScripts && hasShebang && !executable {
+			relative, _ := filepath.Rel(repoRoot, path)
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: files under scripts/ must be executable",
+				filepath.ToSlash(relative),
+			))
+		}
+		return nil
+	})
+	return diagnostics
+}
+
+func fileHasShebang(path string) (bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+	var prefix [2]byte
+	read, err := io.ReadFull(file, prefix[:])
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return false, err
+	}
+	return read == len(prefix) && string(prefix[:]) == "#!", nil
+}
+
+func skillNeedsFocusedTest(skillRoot string) bool {
+	for _, directory := range []string{"references", "fixtures", "scripts"} {
+		info, err := os.Stat(filepath.Join(skillRoot, directory))
+		if err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+type focusedTestRegistry struct {
+	// SchemaVersion selects the strict registry contract understood by skillcheck.
+	SchemaVersion int `json:"schema_version"`
+	// Tests is the complete allowlist of focused commands skillcheck may execute.
+	Tests []focusedTest `json:"tests"`
+}
+
+type focusedTest struct {
+	// ID is the stable diagnostic identity of this focused contract.
+	ID string `json:"id"`
+	// Skill names the existing skill whose behavior the command verifies.
+	Skill string `json:"skill"`
+	// Arguments is an argv-only command constrained by parseFocusedTestCommand.
+	Arguments []string `json:"arguments"`
+	// TimeoutSeconds bounds this command within the registry's shared fast budget.
+	TimeoutSeconds int `json:"timeout_seconds"`
+}
+
+var focusedTestIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+const maxFocusedTestSeconds = 40
+
+func readFocusedTestRegistry(
+	repoRoot string,
+	skillNames map[string]string,
+	focusedTestRequired map[string]struct{},
+) (focusedTestRegistry, []string) {
+	const registryRelative = ".agents/skill-tests.json"
+	path := filepath.Join(repoRoot, filepath.FromSlash(registryRelative))
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return focusedTestRegistry{}, []string{
+				registryRelative + ": required file is missing",
+			}
+		}
+		return focusedTestRegistry{}, []string{
+			fmt.Sprintf("%s: %v", registryRelative, err),
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var registry focusedTestRegistry
+	if err := decoder.Decode(&registry); err != nil {
+		return focusedTestRegistry{}, []string{
+			fmt.Sprintf("%s: invalid registry JSON: %v", registryRelative, err),
+		}
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return focusedTestRegistry{}, []string{
+			registryRelative + ": invalid registry JSON: trailing value",
+		}
+	}
+
+	var diagnostics []string
+	if registry.SchemaVersion != 1 {
+		diagnostics = append(diagnostics,
+			registryRelative+": schema_version must equal 1",
+		)
+	}
+	seenIDs := make(map[string]struct{})
+	registeredSkills := make(map[string]struct{})
+	totalTimeoutSeconds := 0
+	for _, test := range registry.Tests {
+		totalTimeoutSeconds += test.TimeoutSeconds
+		if len(test.ID) > 64 || !focusedTestIDPattern.MatchString(test.ID) {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test id %q must be 1-64 lowercase letters, digits, or single hyphen-separated words",
+				registryRelative, test.ID,
+			))
+		}
+		if _, exists := seenIDs[test.ID]; exists {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test id %q is duplicated", registryRelative, test.ID,
+			))
+		}
+		seenIDs[test.ID] = struct{}{}
+		if _, exists := skillNames[test.Skill]; !exists {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test %q references unknown skill %q",
+				registryRelative, test.ID, test.Skill,
+			))
+		}
+		registeredSkills[test.Skill] = struct{}{}
+		if test.TimeoutSeconds < 1 || test.TimeoutSeconds > maxFocusedTestSeconds {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test %q timeout_seconds must be between 1 and %d",
+				registryRelative, test.ID, maxFocusedTestSeconds,
+			))
+		}
+		pattern, allowed := parseFocusedTestCommand(test.Arguments)
+		if !allowed {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test %q must be an explicit go test ./scripts/... -run '^Test...' -count=1 command",
+				registryRelative, test.ID,
+			))
+			continue
+		}
+		matched, err := matchesDefaultScriptsTest(repoRoot, pattern)
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test %q cannot inspect default scripts tests: %v",
+				registryRelative, test.ID, err,
+			))
+		} else if !matched {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: test %q -run pattern %q matches no default scripts test",
+				registryRelative, test.ID, pattern.String(),
+			))
+		}
+	}
+	if totalTimeoutSeconds > maxFocusedTestSeconds {
+		diagnostics = append(diagnostics, fmt.Sprintf(
+			"%s: total timeout_seconds must not exceed %d",
+			registryRelative, maxFocusedTestSeconds,
+		))
+	}
+	for skill := range focusedTestRequired {
+		if _, exists := registeredSkills[skill]; !exists {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: skill %q has references/, fixtures/, or scripts/ and must register a focused test",
+				registryRelative, skill,
+			))
+		}
+	}
+	return registry, diagnostics
+}
+
+func parseFocusedTestCommand(arguments []string) (*regexp.Regexp, bool) {
+	if len(arguments) != 6 || arguments[0] != "go" || arguments[1] != "test" ||
+		arguments[2] != "./scripts/..." || arguments[3] != "-run" ||
+		arguments[5] != "-count=1" || !strings.HasPrefix(arguments[4], "^Test") {
+		return nil, false
+	}
+	pattern, err := regexp.Compile(arguments[4])
+	return pattern, err == nil
+}
+
+func matchesDefaultScriptsTest(repoRoot string, pattern *regexp.Regexp) (bool, error) {
+	scriptsRoot := filepath.Join(repoRoot, "scripts")
+	matched := false
+	err := filepath.WalkDir(scriptsRoot, func(
+		path string,
+		entry fs.DirEntry,
+		walkErr error,
+	) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != scriptsRoot && (entry.Name() == "testdata" ||
+				entry.Name() == "vendor" || strings.HasPrefix(entry.Name(), ".") ||
+				strings.HasPrefix(entry.Name(), "_")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+		included, err := build.Default.MatchFile(filepath.Dir(path), entry.Name())
+		if err != nil {
+			return err
+		}
+		if !included {
+			return nil
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*goast.FuncDecl)
+			if !ok || !isDiscoverableGoTest(parsed, function) {
+				continue
+			}
+			if pattern.MatchString(function.Name.Name) {
+				matched = true
+				return fs.SkipAll
+			}
+		}
+		return nil
+	})
+	return matched, err
+}
+
+func isDiscoverableGoTest(file *goast.File, function *goast.FuncDecl) bool {
+	if function.Recv != nil || !isGoTestName(function.Name.Name) ||
+		function.Type.TypeParams != nil || function.Type.Params == nil ||
+		len(function.Type.Params.List) != 1 ||
+		function.Type.Params.NumFields() != 1 ||
+		function.Type.Results != nil && function.Type.Results.NumFields() != 0 {
+		return false
+	}
+	parameter, ok := function.Type.Params.List[0].Type.(*goast.StarExpr)
+	if !ok {
+		return false
+	}
+	aliases, dotImported := testingImportAliases(file)
+	switch typed := parameter.X.(type) {
+	case *goast.SelectorExpr:
+		qualifier, ok := typed.X.(*goast.Ident)
+		if !ok {
+			return false
+		}
+		_, imported := aliases[qualifier.Name]
+		return imported && typed.Sel.Name == "T"
+	case *goast.Ident:
+		return dotImported && typed.Name == "T"
+	default:
+		return false
+	}
+}
+
+func isGoTestName(name string) bool {
+	if !strings.HasPrefix(name, "Test") {
+		return false
+	}
+	if len(name) == len("Test") {
+		return true
+	}
+	for _, first := range name[len("Test"):] {
+		return !unicode.IsLower(first)
+	}
+	return false
+}
+
+func testingImportAliases(file *goast.File) (map[string]struct{}, bool) {
+	aliases := make(map[string]struct{})
+	dotImported := false
+	for _, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil || path != "testing" {
+			continue
+		}
+		if imported.Name == nil {
+			aliases["testing"] = struct{}{}
+			continue
+		}
+		switch imported.Name.Name {
+		case ".":
+			dotImported = true
+		case "_":
+		default:
+			aliases[imported.Name.Name] = struct{}{}
+		}
+	}
+	return aliases, dotImported
+}
+
+type reviewPolicySubset struct {
+	// TrustedChecks is the policy-owned executable catalog. This validator reads
+	// it but never reconstructs or overrides its commands.
+	TrustedChecks map[string]reviewPolicyCheck `json:"trusted_checks"`
+	// PathRules is the policy-owned mapping from changed paths to named checks.
+	PathRules []reviewPolicyPathRule `json:"path_rules"`
+}
+
+type reviewPolicyCheck struct {
+	// Arguments is the policy-owned argv executed without a shell.
+	Arguments []string `json:"arguments"`
+	// WorkingDir must keep repository-relative contract paths meaningful.
+	WorkingDir string `json:"working_dir"`
+	// TimeoutSeconds bounds this named check inside the combined fast-gate budget.
+	TimeoutSeconds int `json:"timeout_seconds"`
+	// MaxOutputBytes bounds evidence retained by the Review Agent.
+	MaxOutputBytes int `json:"max_output_bytes"`
+}
+
+type reviewPolicyPathRule struct {
+	// Name is diagnostic identity only; selection semantics come from policy.
+	Name string `json:"name"`
+	// Paths and Prefixes select changed repository artifacts.
+	Paths    []string `json:"paths"`
+	Prefixes []string `json:"prefixes"`
+	// Checks references entries in TrustedChecks.
+	Checks []string `json:"checks"`
+}
+
+type namedReviewPolicyCheck struct {
+	name  string
+	check reviewPolicyCheck
+}
+
+func validateReviewPolicyChecks(repoRoot string) []string {
+	const policyRelative = ".github/review-agent/policy.json"
+	policyDirectory := filepath.Join(repoRoot, ".github", "review-agent")
+	if _, err := os.Stat(policyDirectory); os.IsNotExist(err) {
+		return nil
+	}
+	raw, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(policyRelative)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{policyRelative + ": required file is missing"}
+		}
+		return []string{fmt.Sprintf("%s: %v", policyRelative, err)}
+	}
+	var policy reviewPolicySubset
+	if err := json.Unmarshal(raw, &policy); err != nil {
+		return []string{fmt.Sprintf("%s: invalid JSON: %v", policyRelative, err)}
+	}
+	var diagnostics []string
+	var skillRule *reviewPolicyPathRule
+	for _, rule := range policy.PathRules {
+		if slices.Contains(rule.Prefixes, ".agents/skills/") &&
+			slices.Contains(rule.Paths, ".agents/skill-tests.json") {
+			copied := rule
+			skillRule = &copied
+			break
+		}
+	}
+	if skillRule == nil {
+		return []string{
+			policyRelative + ": must route .agents/skills/ and .agents/skill-tests.json through paired static and --run-focused checks",
+		}
+	}
+
+	selected := make([]namedReviewPolicyCheck, 0, len(skillRule.Checks))
+	for _, name := range skillRule.Checks {
+		check, exists := policy.TrustedChecks[name]
+		if !exists {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: trusted check %q is missing", policyRelative, name,
+			))
+			continue
+		}
+		selected = append(selected, namedReviewPolicyCheck{name: name, check: check})
+	}
+	if len(diagnostics) != 0 {
+		return diagnostics
+	}
+
+	static, focused, paired := findSkillCheckPair(selected)
+	if !paired {
+		return []string{
+			policyRelative + ": must route .agents/skills/ and .agents/skill-tests.json through paired static and --run-focused checks",
+		}
+	}
+	// This validates the agreed public entrypoint as policy schema. The Review
+	// Agent still obtains the argv it executes exclusively from the policy.
+	staticArguments := []string{"go", "run", "./scripts/skillcheck"}
+	focusedArguments := append(
+		append([]string(nil), staticArguments...),
+		"--run-focused",
+	)
+	if !slices.Equal(static.check.Arguments, staticArguments) ||
+		!slices.Equal(focused.check.Arguments, focusedArguments) {
+		return []string{
+			policyRelative + ": skill checks must invoke go run ./scripts/skillcheck with only an optional --run-focused argument",
+		}
+	}
+	for _, selectedCheck := range []namedReviewPolicyCheck{static, focused} {
+		if selectedCheck.check.WorkingDir != "." {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: trusted check %q must run from repository root",
+				policyRelative, selectedCheck.name,
+			))
+		}
+		if selectedCheck.check.TimeoutSeconds < 1 {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: trusted check %q timeout_seconds must be positive",
+				policyRelative, selectedCheck.name,
+			))
+		}
+		if selectedCheck.check.MaxOutputBytes < 1 {
+			diagnostics = append(diagnostics, fmt.Sprintf(
+				"%s: trusted check %q max_output_bytes must be positive",
+				policyRelative, selectedCheck.name,
+			))
+		}
+	}
+	combinedTimeout := static.check.TimeoutSeconds + focused.check.TimeoutSeconds
+	if combinedTimeout > 60 {
+		diagnostics = append(diagnostics, fmt.Sprintf(
+			"%s: paired skill checks %q and %q declare %d seconds, exceeding the 60-second gate budget",
+			policyRelative,
+			static.name,
+			focused.name,
+			combinedTimeout,
+		))
+	}
+	return diagnostics
+}
+
+func findSkillCheckPair(
+	checks []namedReviewPolicyCheck,
+) (namedReviewPolicyCheck, namedReviewPolicyCheck, bool) {
+	for _, focused := range checks {
+		staticArguments, removed := withoutArgument(
+			focused.check.Arguments,
+			"--run-focused",
+		)
+		if !removed {
+			continue
+		}
+		for _, static := range checks {
+			if slices.Equal(static.check.Arguments, staticArguments) {
+				return static, focused, true
+			}
+		}
+	}
+	return namedReviewPolicyCheck{}, namedReviewPolicyCheck{}, false
+}
+
+func withoutArgument(arguments []string, removed string) ([]string, bool) {
+	for index, argument := range arguments {
+		if argument == removed {
+			result := make([]string, 0, len(arguments)-1)
+			result = append(result, arguments[:index]...)
+			result = append(result, arguments[index+1:]...)
+			return result, true
+		}
+	}
+	return nil, false
+}

--- a/scripts/skillcheck/main_test.go
+++ b/scripts/skillcheck/main_test.go
@@ -1,0 +1,706 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunAcceptsMinimalSkill(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+
+# Example
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use $example for this repository task."
+`)
+
+	result := runSkillcheck(root)
+	if result.code != 0 {
+		t.Fatalf("run() code = %d, want 0; stderr = %q", result.code, result.stderr)
+	}
+	if result.stdout != "skillcheck: 1 skill valid\n" {
+		t.Fatalf("stdout = %q", result.stdout)
+	}
+	if result.stderr != "" {
+		t.Fatalf("stderr = %q, want empty", result.stderr)
+	}
+}
+
+func TestRunAcceptsRepositoryContracts(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+
+	result := runSkillcheck(root)
+	if result.code != 0 {
+		t.Fatalf("run() code = %d, want 0; stderr = %q", result.code, result.stderr)
+	}
+	if !strings.HasSuffix(result.stdout, " skills valid\n") {
+		t.Fatalf("stdout = %q, want a plural valid-skill summary", result.stdout)
+	}
+}
+
+func TestRunRejectsSkillNameThatDoesNotMatchDirectory(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: another-skill
+description: Exercise one deterministic repository task.
+---
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use $example for this repository task."
+`)
+
+	want := ".agents/skills/example/SKILL.md: frontmatter name \"another-skill\" must match directory \"example\"\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsMissingSkillDescription(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: ""
+---
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use $example for this repository task."
+`)
+
+	want := ".agents/skills/example/SKILL.md: frontmatter description must be non-empty\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsIncompleteOpenAIInterface(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+`)
+
+	want := ".agents/skills/example/agents/openai.yaml: interface.default_prompt must be non-empty\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsMissingMarkdownReference(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+
+Read [the contract](references/missing.md).
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use $example for this repository task."
+`)
+
+	want := ".agents/skills/example/SKILL.md: local reference \"references/missing.md\" does not exist\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsMarkdownReferenceThroughEscapingSymlink(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+
+Read [the contract](references/outside.md).
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use $example for this repository task."
+`)
+	writeTestFile(t, root, "outside.md", "outside the skill\n")
+	link := filepath.Join(root, ".agents", "skills", "example", "references", "outside.md")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "outside.md"), link); err != nil {
+		t.Fatal(err)
+	}
+	writeExampleFocusedTest(t, root)
+
+	want := ".agents/skills/example/SKILL.md: local reference \"references/outside.md\" escapes the skill directory through a symlink\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunParsesReferenceLinksAndIgnoresCodeFences(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+
+Read [the contract][rules].
+
+~~~text
+[example only](../../../ignored.md)
+~~~
+
+[rules]: ../../../outside.md
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use this repository skill."
+`)
+	writeTestFile(t, root, "outside.md", "outside the skill\n")
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "example-contracts",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", "^TestExample", "-count=1"],
+      "timeout_seconds": 20
+    }
+  ]
+}
+`)
+
+	want := ".agents/skills/example/SKILL.md: local reference \"../../../outside.md\" escapes the skill directory\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsInvalidJSONFixture(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skills/example/fixtures/broken.json", `{"schema":`)
+	writeExampleFocusedTest(t, root)
+
+	want := ".agents/skills/example/fixtures/broken.json: invalid JSON: unexpected EOF\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsInvalidYAMLFixture(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skills/example/fixtures/broken.yaml", "schema: [\n")
+	writeExampleFocusedTest(t, root)
+
+	result := runSkillcheck(root)
+	if result.code != 1 {
+		t.Fatalf("run() code = %d, want 1", result.code)
+	}
+	wantPrefix := ".agents/skills/example/fixtures/broken.yaml: invalid YAML:"
+	if !strings.HasPrefix(result.stderr, wantPrefix) {
+		t.Fatalf("stderr = %q, want prefix %q", result.stderr, wantPrefix)
+	}
+}
+
+func TestRunRejectsNonExecutableSkillScript(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skills/example/scripts/check.sh", "#!/bin/sh\nexit 0\n")
+	writeExampleFocusedTest(t, root)
+
+	want := ".agents/skills/example/scripts/check.sh: files under scripts/ must be executable\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsExecutableSkillDataFile(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	path := filepath.Join(root, ".agents", "skills", "example", "SKILL.md")
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	want := ".agents/skills/example/SKILL.md: files without a shebang must not be executable\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsExecutableFixtureEvenWithShebang(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	fixture := ".agents/skills/example/fixtures/data.yaml"
+	writeTestFile(t, root, fixture, "#!/usr/bin/env yaml\nkey: value\n")
+	if err := os.Chmod(filepath.Join(root, filepath.FromSlash(fixture)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExampleFocusedTest(t, root)
+
+	want := ".agents/skills/example/fixtures/data.yaml: files outside scripts/ must not be executable\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunAllowsNonExecutableDocumentationUnderScripts(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skills/example/scripts/README.md", "# Helper scripts\n")
+	writeExampleFocusedTest(t, root)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := run([]string{"--root", root}, &stdout, &stderr); code != 0 {
+		t.Fatalf("run() code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+}
+
+func TestRunRejectsDuplicateSkillNames(t *testing.T) {
+	root := newTestRepo(t)
+	for _, directory := range []string{"alpha", "beta"} {
+		writeTestFile(t, root, ".agents/skills/"+directory+"/SKILL.md", `---
+name: shared
+description: Exercise one deterministic repository task.
+---
+`)
+		writeTestFile(t, root, ".agents/skills/"+directory+"/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use this repository skill."
+`)
+	}
+
+	result := runSkillcheck(root)
+	if result.code != 1 {
+		t.Fatalf("run() code = %d, want 1", result.code)
+	}
+	want := ".agents/skills/beta/SKILL.md: frontmatter name \"shared\" duplicates .agents/skills/alpha/SKILL.md"
+	if !strings.Contains(result.stderr, want) {
+		t.Fatalf("stderr = %q, want it to contain %q", result.stderr, want)
+	}
+}
+
+func TestRunRejectsInvalidSkillName(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/Example/SKILL.md", `---
+name: Example
+description: Exercise one deterministic repository task.
+---
+`)
+	writeTestFile(t, root, ".agents/skills/Example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use this repository skill."
+`)
+
+	want := ".agents/skills/Example/SKILL.md: frontmatter name must be 1-64 lowercase letters, digits, or single hyphen-separated words\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunReportsMissingOpenAIInterfaceOnce(t *testing.T) {
+	root := newTestRepo(t)
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+`)
+
+	want := ".agents/skills/example/agents/openai.yaml: required file is missing\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsFocusedTestOutsideCommandAllowlist(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "unsafe",
+      "skill": "example",
+      "arguments": ["sh", "-c", "./scripts/discovered.sh"],
+      "timeout_seconds": 30
+    }
+  ]
+}
+`)
+
+	want := ".agents/skill-tests.json: test \"unsafe\" must be an explicit go test ./scripts/... -run '^Test...' -count=1 command\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsComplexSkillWithoutFocusedTest(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skills/example/references/contract.md", "# Contract\n")
+
+	want := ".agents/skill-tests.json: skill \"example\" has references/, fixtures/, or scripts/ and must register a focused test\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunFocusedExecutesOnlyRegisteredTest(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "example-contracts",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", "^TestExample", "-count=1"],
+      "timeout_seconds": 30
+    }
+  ]
+}
+`)
+
+	var executed [][]string
+	executor := func(
+		_ context.Context,
+		gotRoot string,
+		arguments []string,
+		_ io.Writer,
+		_ io.Writer,
+	) error {
+		if gotRoot != root {
+			t.Fatalf("executor root = %q, want %q", gotRoot, root)
+		}
+		executed = append(executed, append([]string(nil), arguments...))
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runWithExecutor(
+		[]string{"--root", root, "--run-focused"},
+		&stdout,
+		&stderr,
+		executor,
+	); code != 0 {
+		t.Fatalf("runWithExecutor() code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+	if len(executed) != 1 {
+		t.Fatalf("executed %d commands, want 1", len(executed))
+	}
+	wantArguments := []string{"go", "test", "./scripts/...", "-run", "^TestExample", "-count=1"}
+	if got := strings.Join(executed[0], "\x00"); got != strings.Join(wantArguments, "\x00") {
+		t.Fatalf("arguments = %q, want %q", executed[0], wantArguments)
+	}
+	wantOutput := "skillcheck: running focused test example-contracts (example)\n" +
+		"skillcheck: 1 skill valid; 1 focused test passed\n"
+	if got := stdout.String(); got != wantOutput {
+		t.Fatalf("stdout = %q, want %q", got, wantOutput)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsReviewPolicyWithoutFocusedSkillCheck(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".github/review-agent/policy.json", `{
+  "trusted_checks": {
+    "agent-artifact-contracts": {
+      "arguments": ["go", "run", "./scripts/skillcheck"],
+      "working_dir": ".",
+      "timeout_seconds": 60,
+      "max_output_bytes": 1048576
+    }
+  },
+  "path_rules": [
+    {
+      "name": "agent-skills",
+      "paths": [".agents/skill-tests.json"],
+      "prefixes": [".agents/skills/"],
+      "checks": ["agent-artifact-contracts", "skill-focused-contracts"]
+    }
+  ]
+}
+`)
+
+	want := ".github/review-agent/policy.json: trusted check \"skill-focused-contracts\" is missing\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsReviewPolicyWithoutSkillPathRouting(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".github/review-agent/policy.json", `{
+  "trusted_checks": {
+    "agent-artifact-contracts": {
+      "arguments": ["go", "run", "./scripts/skillcheck"],
+      "working_dir": ".",
+      "timeout_seconds": 60,
+      "max_output_bytes": 1048576
+    },
+    "skill-focused-contracts": {
+      "arguments": ["go", "run", "./scripts/skillcheck", "--run-focused"],
+      "working_dir": ".",
+      "timeout_seconds": 60,
+      "max_output_bytes": 1048576
+    }
+  },
+  "path_rules": []
+}
+`)
+
+	want := ".github/review-agent/policy.json: must route .agents/skills/ and .agents/skill-tests.json through paired static and --run-focused checks\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsReviewPolicyBeyondCombinedGateBudget(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".github/review-agent/policy.json", `{
+  "trusted_checks": {
+    "agent-artifact-contracts": {
+      "arguments": ["go", "run", "./scripts/skillcheck"],
+      "working_dir": ".",
+      "timeout_seconds": 20,
+      "max_output_bytes": 1048576
+    },
+    "skill-focused-contracts": {
+      "arguments": ["go", "run", "./scripts/skillcheck", "--run-focused"],
+      "working_dir": ".",
+      "timeout_seconds": 41,
+      "max_output_bytes": 1048576
+    }
+  },
+  "path_rules": [
+    {
+      "name": "agent-skills",
+      "paths": [".agents/skill-tests.json"],
+      "prefixes": [".agents/skills/"],
+      "checks": ["agent-artifact-contracts", "skill-focused-contracts"]
+    }
+  ]
+}
+`)
+
+	want := ".github/review-agent/policy.json: paired skill checks \"agent-artifact-contracts\" and \"skill-focused-contracts\" declare 61 seconds, exceeding the 60-second gate budget\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsFocusedTestsBeyondFastGateBudget(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "example-one",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", "^TestExampleOne", "-count=1"],
+      "timeout_seconds": 25
+    },
+    {
+      "id": "example-two",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", "^TestExampleTwo", "-count=1"],
+      "timeout_seconds": 20
+    }
+  ]
+}
+`)
+
+	want := ".agents/skill-tests.json: total timeout_seconds must not exceed 40\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsFocusedTestWithNoMatchingGoTest(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "missing-contracts",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", "^TestMissing$", "-count=1"],
+      "timeout_seconds": 20
+    }
+  ]
+}
+`)
+
+	want := ".agents/skill-tests.json: test \"missing-contracts\" -run pattern \"^TestMissing$\" matches no default scripts test\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func TestRunRejectsNonDiscoverableFocusedTestFunction(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		function string
+		pattern  string
+	}{
+		{
+			name:     "lowercase suffix",
+			function: "func Testexample(t *testing.T) {}",
+			pattern:  "^Testexample$",
+		},
+		{
+			name:     "wrong parameter type",
+			function: "func TestWrongSignature(value *testing.B) {}",
+			pattern:  "^TestWrongSignature$",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := newTestRepo(t)
+			writeMinimalSkill(t, root)
+			writeTestFile(t, root, "scripts/example_test.go", "package scripts\n\nimport \"testing\"\n\n"+test.function+"\n")
+			writeTestFile(t, root, ".agents/skill-tests.json", fmt.Sprintf(`{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "non-discoverable",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", %q, "-count=1"],
+      "timeout_seconds": 20
+    }
+  ]
+}
+`, test.pattern))
+
+			want := fmt.Sprintf(
+				".agents/skill-tests.json: test \"non-discoverable\" -run pattern %q matches no default scripts test\n",
+				test.pattern,
+			)
+			requireSkillcheckError(t, root, want)
+		})
+	}
+}
+
+func TestRunRejectsReviewPolicyThatReplacesSkillcheckCommand(t *testing.T) {
+	root := newTestRepo(t)
+	writeMinimalSkill(t, root)
+	writeTestFile(t, root, ".github/review-agent/policy.json", `{
+  "trusted_checks": {
+    "agent-artifact-contracts": {
+      "arguments": ["go", "run", "./scripts/othercheck"],
+      "working_dir": ".",
+      "timeout_seconds": 15,
+      "max_output_bytes": 1048576
+    },
+    "skill-focused-contracts": {
+      "arguments": ["go", "run", "./scripts/othercheck", "--run-focused"],
+      "working_dir": ".",
+      "timeout_seconds": 45,
+      "max_output_bytes": 1048576
+    }
+  },
+  "path_rules": [
+    {
+      "name": "agent-skills",
+      "paths": [".agents/skill-tests.json"],
+      "prefixes": [".agents/skills/"],
+      "checks": ["agent-artifact-contracts", "skill-focused-contracts"]
+    }
+  ]
+}
+`)
+
+	want := ".github/review-agent/policy.json: skill checks must invoke go run ./scripts/skillcheck with only an optional --run-focused argument\n"
+	requireSkillcheckError(t, root, want)
+}
+
+func writeTestFile(t *testing.T, root string, relative string, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMinimalSkill(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, root, ".agents/skills/example/SKILL.md", `---
+name: example
+description: Exercise one deterministic repository task.
+---
+`)
+	writeTestFile(t, root, ".agents/skills/example/agents/openai.yaml", `interface:
+  display_name: "Example"
+  short_description: "Exercise one repository task"
+  default_prompt: "Use this repository skill."
+`)
+}
+
+type skillcheckResult struct {
+	code   int
+	stdout string
+	stderr string
+}
+
+func runSkillcheck(root string) skillcheckResult {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{"--root", root}, &stdout, &stderr)
+	return skillcheckResult{
+		code:   code,
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+	}
+}
+
+func requireSkillcheckError(t *testing.T, root string, want string) {
+	t.Helper()
+	result := runSkillcheck(root)
+	if result.code != 1 {
+		t.Fatalf("run() code = %d, want 1", result.code)
+	}
+	if result.stderr != want {
+		t.Fatalf("stderr = %q, want %q", result.stderr, want)
+	}
+	if result.stdout != "" {
+		t.Fatalf("stdout = %q, want empty", result.stdout)
+	}
+}
+
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeTestFile(t, root, "scripts/example_test.go", `package scripts
+
+import "testing"
+
+func TestExample(t *testing.T) {}
+func TestExampleOne(t *testing.T) {}
+func TestExampleTwo(t *testing.T) {}
+`)
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": []
+}
+`)
+	return root
+}
+
+func writeExampleFocusedTest(t *testing.T, root string) {
+	t.Helper()
+	writeTestFile(t, root, ".agents/skill-tests.json", `{
+  "schema_version": 1,
+  "tests": [
+    {
+      "id": "example-contracts",
+      "skill": "example",
+      "arguments": ["go", "test", "./scripts/...", "-run", "^TestExample", "-count=1"],
+      "timeout_seconds": 20
+    }
+  ]
+}
+`)
+}


### PR DESCRIPTION
## What changed

- add `go run ./scripts/skillcheck` for deterministic repository Skill validation
- add the policy-owned focused-test registry at `.agents/skill-tests.json`
- route Skill changes through paired static and focused Review Agent checks
- document the authority boundary and fast-gate budgets

## Why

Repository Skills are executable agent interfaces, but their metadata, references, fixtures, file modes, focused tests, and Review Agent routing previously lacked one machine-verifiable contract. This made silent drift possible.

## Impact

Skill changes now fail closed when contracts drift. Focused execution remains an explicit argv allowlist and does not discover or execute arbitrary files from Skill directories. The focused registry has a 40-second declared budget; the paired Review Agent checks have a combined 60-second budget.

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go vet ./scripts/skillcheck`
- `GOWORK=off go run ./scripts/skillcheck`
- `GOWORK=off go run ./scripts/skillcheck --run-focused`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `go mod tidy -diff`
- `git diff --check`

Final Standards and Spec reviews reported no remaining findings.