### PR TITLE
chore(agent): protect agent artifact contracts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 /.github/workflows/ @tangtaoit
 /.github/CODEOWNERS @tangtaoit
 
+/.agents/skills/ @tangtaoit
+/.agents/skill-tests.json @tangtaoit
+/scripts/skillcheck/ @tangtaoit
+
 /.github/review-agent/ @tangtaoit
 /.github/actions/install-review-agent-tools/ @tangtaoit
 /.github/workflows/review-agent-pr-signal.yml @tangtaoit

--- a/scripts/agent_artifact_ownership_test.go
+++ b/scripts/agent_artifact_ownership_test.go
@@ -1,0 +1,29 @@
+package scripts_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentArtifactContractsHaveCodeOwners(t *testing.T) {
+	raw := readFile(t, filepath.Join(repoRoot(t), ".github", "CODEOWNERS"))
+	ownersByPath := make(map[string][]string)
+	for _, line := range strings.Split(raw, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || strings.HasPrefix(fields[0], "#") {
+			continue
+		}
+		ownersByPath[fields[0]] = fields[1:]
+	}
+
+	for _, path := range []string{
+		"/.agents/skills/",
+		"/.agents/skill-tests.json",
+		"/scripts/skillcheck/",
+	} {
+		require.Equal(t, []string{"@tangtaoit"}, ownersByPath[path], path)
+	}
+}


### PR DESCRIPTION
## What changed

- assign `@tangtaoit` as the sole CODEOWNER for `/.agents/skills/`
- assign `@tangtaoit` as the sole CODEOWNER for `/.agents/skill-tests.json`
- assign `@tangtaoit` as the sole CODEOWNER for `/scripts/skillcheck/`
- add a default-tier static contract test that parses `.github/CODEOWNERS` and verifies those exact mappings

## Why

These paths define repository-local agent behavior and its deterministic validation contract. Explicit ownership makes review routing for changes to those control artifacts visible and enforceable without broadening ownership to unrelated `.agents` or `scripts` content.

This is intentionally separate from Draft PR #819, which introduces the Skill contract artifacts themselves.

## Impact

Changes to the three protected agent-artifact paths will request review from `@tangtaoit`. Runtime product behavior is unchanged.

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `git diff --check`
- two-axis Standards/Spec review: no findings
