### PR TITLE
fix(db): compare encoded catalog key bytes for channel cursor pagination

### DIFF
--- a/pkg/db/message/catalog.go
+++ b/pkg/db/message/catalog.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -35,8 +36,10 @@ func (db *MessageDB) listChannelsPage(ctx context.Context, after ChannelKey, lim
 	prefix := encodeCatalogPrefix()
 	span := keycodec.NewPrefixSpan(prefix)
 	start := span.Start
+	var afterKeyEncoded []byte
 	if after != "" {
-		start = encodeCatalogKey(after)
+		afterKeyEncoded = encodeCatalogKey(after)
+		start = afterKeyEncoded
 	}
 	iter, err := db.engine.NewIter(engine.Span{Start: start, End: span.End}, engine.IterOptions{})
 	if err != nil {
@@ -54,12 +57,24 @@ func (db *MessageDB) listChannelsPage(ctx context.Context, after ChannelKey, lim
 		if err := ctx.Err(); err != nil {
 			return nil, "", false, err
 		}
+		// afterKeyEncoded, when set, is exactly the Start bound above, so the
+		// iterator never yields a row that sorts before it in the engine's
+		// true (encoded) key order. The only row left to exclude here is the
+		// cursor row itself, an exact byte match. Do NOT compare decoded
+		// channel_key strings for this: encodeCatalogKey length-prefixes the
+		// channel_key (see keycodec.AppendString), so the engine's real
+		// iteration order groups rows by channel_key length before content —
+		// a different order than plain Go string "<=" whenever two
+		// channel_key values on the same page have different lengths.
+		// Comparing decoded strings here used to drop a channel at page
+		// boundaries whenever that ordering diverged (this backs production
+		// paths: channel retention GC and backup/restore channel paging).
+		if afterKeyEncoded != nil && bytes.Equal(iter.Key(), afterKeyEncoded) {
+			continue
+		}
 		key, ok := decodeCatalogKey(iter.Key())
 		if !ok {
 			return nil, "", false, fmt.Errorf("%w: corrupt catalog key", dberrors.ErrCorruptValue)
-		}
-		if after != "" && key <= after {
-			continue
 		}
 		value, err := iter.Value()
 		if err != nil {

--- a/pkg/db/message/catalog_integration_test.go
+++ b/pkg/db/message/catalog_integration_test.go
@@ -170,6 +170,46 @@ func TestMessageDBListChannelsPage(t *testing.T) {
 	}
 }
 
+// TestMessageDBListChannelsPageMixedLengthKeysDoesNotDropChannels reproduces
+// a real defect: encodeCatalogKey length-prefixes channel_key (2-byte
+// big-endian length, then raw bytes), so the engine's true row order groups
+// channel_key by length first, then content — e.g. the 1-byte key "9" sorts
+// before every 2-byte key regardless of content. A resume filter that
+// instead compares decoded channel_key strings with plain Go "<=" uses a
+// different, incompatible order: the 2-byte key "00" is lexicographically
+// less than "9" ('0' < '9'), so a naive "key <= after" filter wrongly
+// treated "00" (and "01") as already returned once the cursor passed "9",
+// silently dropping them from every later page.
+func TestMessageDBListChannelsPageMixedLengthKeysDoesNotDropChannels(t *testing.T) {
+	store := openTestMessageStore(t)
+	defer store.close(t)
+
+	for i, key := range []ChannelKey{"9", "00", "01"} {
+		log := mustAcquireChannel(t, store.db, key, ChannelID{ID: string(key), Type: 1})
+		if _, err := log.Append(context.Background(), testRecords(800+uint64(i), string(key)), AppendOptions{}); err != nil {
+			t.Fatalf("%s Append(): %v", key, err)
+		}
+	}
+
+	page, last, more, err := store.db.ListChannelsPage(context.Background(), "", 1)
+	if err != nil {
+		t.Fatalf("ListChannelsPage first: %v", err)
+	}
+	assertCatalogKeys(t, page, "9")
+	if last != "9" || !more {
+		t.Fatalf("first cursor = (%q, %v), want 9 true", last, more)
+	}
+
+	page, last, more, err = store.db.ListChannelsPage(context.Background(), last, 10)
+	if err != nil {
+		t.Fatalf("ListChannelsPage second: %v", err)
+	}
+	assertCatalogKeys(t, page, "00", "01")
+	if last != "01" || more {
+		t.Fatalf("second cursor = (%q, %v), want 01 false", last, more)
+	}
+}
+
 func assertCatalogKeys(t *testing.T, entries []ChannelCatalogEntry, keys ...ChannelKey) {
 	t.Helper()
 	if len(entries) != len(keys) {

--- a/pkg/db/message/inspect.go
+++ b/pkg/db/message/inspect.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -83,8 +84,10 @@ func inspectChannelCatalogPage(ctx context.Context, db *MessageDB, req InspectMe
 	prefix := encodeCatalogPrefix()
 	span := keycodec.NewPrefixSpan(prefix)
 	start := span.Start
+	var afterKeyEncoded []byte
 	if req.AfterChannelKey != "" {
-		start = encodeCatalogKey(ChannelKey(req.AfterChannelKey))
+		afterKeyEncoded = encodeCatalogKey(ChannelKey(req.AfterChannelKey))
+		start = afterKeyEncoded
 	}
 	iter, err := db.engine.NewIter(engine.Span{Start: start, End: span.End}, engine.IterOptions{})
 	if err != nil {
@@ -99,12 +102,23 @@ func inspectChannelCatalogPage(ctx context.Context, db *MessageDB, req InspectMe
 		if err := ctx.Err(); err != nil {
 			return nil, 0, false, err
 		}
-		key, entry, err := decodeCatalogIteratorEntry(iter)
+		// afterKeyEncoded, when set, is exactly the Start bound above, so the
+		// iterator never yields a row that sorts before it in the engine's
+		// true (encoded) key order. The only row left to exclude here is the
+		// cursor row itself, an exact byte match. Do NOT compare decoded
+		// channel_key strings for this: encodeCatalogKey length-prefixes the
+		// channel_key (see keycodec.AppendString), so the engine's real
+		// iteration order groups rows by channel_key length before content —
+		// a different order than plain Go string "<=" whenever two
+		// channel_key values on the same page have different lengths.
+		// Comparing decoded strings here used to drop a channel at page
+		// boundaries whenever that ordering diverged.
+		if afterKeyEncoded != nil && bytes.Equal(iter.Key(), afterKeyEncoded) {
+			continue
+		}
+		_, entry, err := decodeCatalogIteratorEntry(iter)
 		if err != nil {
 			return nil, 0, false, err
-		}
-		if req.AfterChannelKey != "" && string(key) <= req.AfterChannelKey {
-			continue
 		}
 		scannedRows++
 		entries = append(entries, entry)
@@ -123,7 +137,12 @@ func inspectChannelCatalogPoint(ctx context.Context, db *MessageDB, channelKey s
 	if err := ctx.Err(); err != nil {
 		return nil, 0, false, err
 	}
-	if afterChannelKey != "" && channelKey <= afterChannelKey {
+	// Compare encoded catalog keys, not the decoded strings: the catalog's
+	// true order groups rows by channel_key length before content (see the
+	// comment in inspectChannelCatalogPage), so a plain string "<=" here can
+	// disagree with that order whenever channelKey and afterChannelKey have
+	// different lengths.
+	if afterChannelKey != "" && bytes.Compare(encodeCatalogKey(ChannelKey(channelKey)), encodeCatalogKey(ChannelKey(afterChannelKey))) <= 0 {
 		return nil, 0, true, nil
 	}
 	value, ok, err := db.engine.Get(encodeCatalogKey(ChannelKey(channelKey)))

--- a/pkg/db/message/inspect_integration_test.go
+++ b/pkg/db/message/inspect_integration_test.go
@@ -105,6 +105,58 @@ func TestInspectChannelsCursorAndLimit(t *testing.T) {
 	}
 }
 
+// TestInspectChannelsMixedLengthKeysDoesNotDropChannels reproduces a real v3
+// defect: encodeCatalogKey length-prefixes channel_key (2-byte big-endian
+// length, then raw bytes), so the engine's true row order groups channel_key
+// by length first, then content — e.g. the 1-byte key "9" sorts before every
+// 2-byte key regardless of content. inspectChannelCatalogPage's resume
+// filter used to compare decoded channel_key strings with plain Go "<=",
+// which is a different, incompatible order: the 2-byte key "00" is
+// lexicographically less than "9" ('0' < '9'), so once the cursor passed
+// "9" that filter wrongly treated "00" (and "01") as already returned,
+// silently dropping them from every later page.
+func TestInspectChannelsMixedLengthKeysDoesNotDropChannels(t *testing.T) {
+	store := openTestMessageStore(t)
+	defer store.close(t)
+	ctx := context.Background()
+
+	for i, key := range []ChannelKey{"9", "00", "01"} {
+		log := mustAcquireChannel(t, store.db, key, ChannelID{ID: string(key), Type: 1})
+		if _, err := log.Append(ctx, testRecords(uint64(600+i), string(key)), AppendOptions{}); err != nil {
+			t.Fatalf("Append(%s): %v", key, err)
+		}
+	}
+
+	first, err := InspectChannels(ctx, store.db, InspectMessageRequest{Limit: 1})
+	if err != nil {
+		t.Fatalf("InspectChannels(first): %v", err)
+	}
+	if len(first.Rows) != 1 || first.Rows[0]["channel_key"] != "9" {
+		t.Fatalf("first rows = %+v, want [9]", first.Rows)
+	}
+	if first.Done || first.Next == nil || first.Next.AfterChannelKey != "9" {
+		t.Fatalf("first result = %+v, want bounded page with next after 9", first)
+	}
+
+	second, err := InspectChannels(ctx, store.db, InspectMessageRequest{
+		AfterChannelKey: first.Next.AfterChannelKey,
+		Limit:           10,
+	})
+	if err != nil {
+		t.Fatalf("InspectChannels(second): %v", err)
+	}
+	gotKeys := make([]any, 0, len(second.Rows))
+	for _, row := range second.Rows {
+		gotKeys = append(gotKeys, row["channel_key"])
+	}
+	if len(second.Rows) != 2 || gotKeys[0] != "00" || gotKeys[1] != "01" {
+		t.Fatalf("second rows = %+v, want [00 01]", second.Rows)
+	}
+	if !second.Done {
+		t.Fatalf("second Done = false, want true")
+	}
+}
+
 func TestInspectChannelsLimitDoesNotDecodeBeyondLookahead(t *testing.T) {
 	store := openTestMessageStore(t)
 	defer store.close(t)


### PR DESCRIPTION
## Bug

`inspectChannelCatalogPage`/`inspectChannelCatalogPoint` (`pkg/db/message/inspect.go`) and `listChannelsPage` (`pkg/db/message/catalog.go`, backing the public `ListChannelsPage`/`ListChannels` API) resume a channel-catalog page scan by comparing the *decoded* `channel_key` string against the cursor with plain Go `<=`.

`encodeCatalogKey` length-prefixes `channel_key` (2-byte big-endian length, then raw bytes; see `keycodec.AppendString`), so the engine's true iteration order groups rows by `channel_key` **length before content** — a different, incompatible order than plain string comparison whenever two `channel_key` values on the same page have different lengths. That's the normal case in this codebase: `ChannelKeyForID` produces `"<type>:<id>"`, and `id` is a free-form, variable-length string (a UID, a `"uid1@uid2"` pair, a system/cmd channel name, ...).

Concretely: once the iterator seeks past a cursor whose `channel_key` happens to be short (e.g. `"9"`), every later, longer `channel_key` that is lexicographically *smaller as a plain string* (e.g. `"00"`, since `'0' < '9'`) gets wrongly treated as "already returned" by the `key <= after` filter and is silently dropped from every subsequent page. No error, no crash — just missing rows.

Found while reconciling row counts in an external v2->v3 migration tool: a real migrated store reported `1900/1901` channels (and that channel's 6 messages) with a paginated `Limit`, and the correct `1901/1901` with a single-page scan. `pkg/db/meta`'s sibling `Shard.listChannelsPage` doesn't have this problem — it computes an exclusive `Start` bound directly from the encoded cursor key (`keycodec.PrefixEnd(...)`) and never compares decoded strings at all.

## Fix

Compare the raw encoded iterator key against the encoded cursor instead of decoding it back to a string. Since the iterator's `Start` bound is already set to the cursor's encoded key, the only row left to exclude is the cursor's own row (an exact byte match) — every later row the iterator yields already sorts strictly after it in the engine's real order, so no less-or-equal range check is needed at all.

## Tests

Adds two regression tests with mixed-length channel keys that fail against the old comparison and pass against this one:

- `TestInspectChannelsMixedLengthKeysDoesNotDropChannels`
- `TestMessageDBListChannelsPageMixedLengthKeysDoesNotDropChannels`

```
go test -tags=integration ./pkg/db/message/...
ok  	github.com/WuKongIM/WuKongIM/pkg/db/message
```

Full repo `go build ./...` and `go vet ./pkg/db/message/...` are clean.