### PR TITLE
fix(agent): harden review recovery evidence

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -112,9 +112,11 @@ request is fenced to the reviewed head SHA and still obeys repository rules.
 Repository administrators retain GitHub's manual merge authority for every PR
 whether or not Review Agent was invoked or produced a verdict.
 
-The signed lease bounds the complete generation to 90 minutes. Infrastructure
-failure is retried once inside that same generation and deadline; a late result
-is forced to `inconclusive`. A merge conflict bypasses the model and publishes
+Each review infrastructure attempt has a signed 90-minute deadline.
+Infrastructure failure is retried once inside the same generation with a fresh
+signed attempt deadline, so the complete generation remains bounded to at most
+180 minutes. A result that is late for its active attempt is forced to
+`inconclusive`. A merge conflict bypasses the model and publishes
 `changes_required`. Candidate baseline commands run only after the shared
 network fence disables both Docker access and `sudo`. Candidate checks receive
 isolated loopback inside a rootless network namespace whose host loopback is

--- a/.github/workflows/review-agent-run.yml
+++ b/.github/workflows/review-agent-run.yml
@@ -832,15 +832,42 @@ jobs:
               infrastructure_completion
               exit 0
             fi
+            if [[ "$(jq -r .decision "$RUNNER_TEMP/validated-decision.json")" != \
+                  "$(jq -r .decision "$RUNNER_TEMP/effective-result.json")" ]]; then
+              infrastructure_completion
+              exit 0
+            fi
           fi
           if [[ "$(jq -r .decision "$RUNNER_TEMP/validated-decision.json")" != \
-                "$(jq -r .decision "$RUNNER_TEMP/effective-result.json")" ]] ||
-              ! jq -e '
-                (.evidence_digest | test("^sha256:[0-9a-f]{64}$")) and
-                (.result_digest | test("^sha256:[0-9a-f]{64}$"))
-              ' "$RUNNER_TEMP/validated-decision.json" >/dev/null; then
+                "$(jq -r .decision "$RUNNER_TEMP/effective-result.json")" ]]; then
+            if jq -e '.effective_result != null' \
+                "$RUNNER_TEMP/validated-decision.json" >/dev/null; then
+              jq .effective_result "$RUNNER_TEMP/validated-decision.json" \
+                >"$RUNNER_TEMP/effective-result.json"
+            else
+              synthesize
+            fi
+            if ! validate; then
+              infrastructure_completion
+              exit 0
+            fi
+            if [[ "$(jq -r .decision "$RUNNER_TEMP/validated-decision.json")" != \
+                  "$(jq -r .decision "$RUNNER_TEMP/effective-result.json")" ]]; then
+              infrastructure_completion
+              exit 0
+            fi
+          fi
+          if ! jq -e '
+            (.evidence_digest | test("^sha256:[0-9a-f]{64}$")) and
+            (.result_digest | test("^sha256:[0-9a-f]{64}$"))
+          ' "$RUNNER_TEMP/validated-decision.json" >/dev/null; then
             synthesize
             if ! validate; then
+              infrastructure_completion
+              exit 0
+            fi
+            if [[ "$(jq -r .decision "$RUNNER_TEMP/validated-decision.json")" != \
+                  "$(jq -r .decision "$RUNNER_TEMP/effective-result.json")" ]]; then
               infrastructure_completion
               exit 0
             fi

--- a/docs/agents/review-agent.md
+++ b/docs/agents/review-agent.md
@@ -230,11 +230,12 @@ waits for another administrator review command. Infrastructure failure retries
 once inside the protected budget, then becomes `inconclusive`. Code/check
 failures are not infrastructure retries. The next administrator review command
 creates the new generation.
-One generation has a 90-minute wall-time budget measured from its signed lease;
-the initial review, automatic retry, reconsideration worker, and explanation
-worker all honor their own signed lease deadline. Late review results can never
-approve and are recorded as `inconclusive`; late explanations are discarded
-without changing the verdict. A fresh merge conflict is adjudicated without a
+Each review infrastructure attempt has a 90-minute wall-time budget. The one
+automatic retry remains in the same generation but receives a fresh signed
+attempt deadline, bounding a generation to 180 minutes. Reconsideration and
+explanation workers honor their own signed lease deadlines. Late review results
+can never approve and are recorded as `inconclusive`; late explanations are
+discarded without changing the verdict. A fresh merge conflict is adjudicated without a
 model as `changes_required`, with a formal `REQUEST_CHANGES` Review and failed
 Verdict. A failed Controller state, projection, or dispatch effect is
 automatically reconciled once from fresh facts.

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -117,14 +117,16 @@ All repository-wide Go commands use `GOWORK=off` and explicit roots. Root
 - Durable PR and scheduler state use a verified latest-plus-predecessor rolling
   checkpoint; older App-authored commits remain append-only audit history.
 
-Each signed lease has one 90-minute wall-time budget, including its one
-automatic infrastructure retry. Reconsideration and explanation leases use the
-same rule. Late review results fail closed as `inconclusive`; late explanations
-cannot change the decision. Merge conflicts are deterministic
+Each review infrastructure attempt has one signed 90-minute wall-time budget.
+The single automatic retry remains in the same generation with a fresh signed
+attempt deadline, so a complete generation is bounded to 180 minutes.
+Reconsideration and explanation leases retain their own signed deadline. Late
+review results fail closed as `inconclusive`; late explanations cannot change
+the decision. Merge conflicts are deterministic
 `changes_required` decisions and do not consume a model session.
 Every named trusted check is capped at 30 minutes. The workflow reserves up to
 30 minutes for baseline checks, 40 minutes for the reviewer, and 20 minutes for
-evidence validation and signed-state publication within the same lease.
+evidence validation and signed-state publication within each review attempt.
 
 Pull-request changes to `AGENTS.md`, `FLOW.md`, policy, prompts, schemas,
 Workflows, CODEOWNERS, or Review Agent code cannot govern their own review.

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -42,9 +42,11 @@
 - Review Agent baseline candidate-network rules live only in that rootless
   namespace, whose host loopback is disabled. The trusted host disables Docker
   and `sudo` but retains runner transport for pinned post-job Artifact actions.
-- A Review Agent generation has one signed 90-minute deadline and at most one
-  automatic infrastructure retry. Merge conflicts deterministically publish
-  `changes_required`; late results are always `inconclusive`.
+- A Review Agent review infrastructure attempt has one signed 90-minute
+  deadline. The single automatic retry stays in the generation with a fresh
+  signed attempt deadline, bounding the generation to 180 minutes. Merge
+  conflicts deterministically publish `changes_required`; results late for the
+  active attempt are always `inconclusive`.
 - Review Agent interaction budgets are per head, not per control revision. An
   authorized reconsideration for the current head binds fresh eligible
   control, intent, base, and test-merge facts and consumes the existing signed

--- a/docs/superpowers/plans/2026-07-30-review-agent-implementation.md
+++ b/docs/superpowers/plans/2026-07-30-review-agent-implementation.md
@@ -83,7 +83,8 @@ Require:
 - `deepseek/deepseek-v4-flash` with `high` effort;
 - immutable Codex Action/CLI identifiers;
 - three active repository leases and one per PR;
-- 90-minute generation timeout;
+- 90-minute timeout per review infrastructure attempt and a 180-minute
+  generation cap;
 - two reconsiderations and one infrastructure retry;
 - a finite per-head explanation-session and response-byte budget;
 - a 32,768-token maximum output budget on every model request;
@@ -692,8 +693,8 @@ Delete its root-only credential handoff before publishing the listener; do not
 leave a second unclamped proxy reachable to runner-user Codex.
 
 Drop `sudo`, disable Docker socket access, expose full public internet through
-the tested private-network fence, and keep the model job within the 90-minute
-generation deadline.
+the tested private-network fence, and keep each model job within its signed
+90-minute review infrastructure attempt deadline.
 
 - [ ] **Step 3a: Add the bounded explanation mode**
 

--- a/docs/superpowers/specs/2026-07-30-review-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-review-agent-design.md
@@ -512,10 +512,10 @@ new generation from fresh eligible facts and consume the existing head's
 reconsideration allowance rather than starting an unrequested review.
 
 Runner, provider, dependency-download, or public-network infrastructure
-failure may retry once inside the same attempt before publishing
-`inconclusive`. Assertions, races, build failures, and code defects are not
-infrastructure retries. `changes_required` can change only after a new commit
-or explicit reconsideration.
+failure may retry once as a fresh signed infrastructure attempt inside the
+same generation before publishing `inconclusive`. Assertions, races, build
+failures, and code defects are not infrastructure retries. `changes_required`
+can change only after a new commit or explicit reconsideration.
 
 Human `REQUEST_CHANGES` remains blocking even when the Review Agent approves.
 The Agent cannot dismiss, resolve, or override a human Review.
@@ -593,7 +593,8 @@ Initial hard budgets are:
 - one active generation per pull request;
 - at most three active Review Agent sessions repository-wide;
 - at most one active first-time external-author session;
-- 90 minutes wall-clock per complete generation;
+- 90 minutes wall-clock per review infrastructure attempt and at most 180
+  minutes for a generation that consumes its single automatic retry;
 - one administrator-requested initial review per head;
 - at most two explicit reconsiderations per head;
 - one automatic infrastructure retry per signed review generation.

--- a/internal/infra/reviewagentgithub/FLOW.md
+++ b/internal/infra/reviewagentgithub/FLOW.md
@@ -27,6 +27,10 @@ Review Agent App token
   -> one exact-head merge only after fresh admin/member authorization
 ```
 
+An infrastructure-sourced terminal projection reports that no current findings
+were adjudicated. Findings retained in signed state for a later reconsideration
+are not republished as if the failed attempt had confirmed them.
+
 The bounded scheduler recovery never rewinds or rewrites the protected state
 ref. A strict successor may name that one legacy checkpoint; after the next
 successor, it leaves the two-checkpoint verification window.

--- a/internal/infra/reviewagentgithub/projections.go
+++ b/internal/infra/reviewagentgithub/projections.go
@@ -507,17 +507,22 @@ func (publisher *ReviewPublisher) ensureLifecycleReview(
 		string(state.Phase) + "` decision."
 	inline := make([]InlineReviewComment, 0, contract.MaxInlineComments)
 	validLines := rightSideReviewLines(snapshot.CommentPatches)
-	for _, finding := range state.PriorFindings {
-		body += "\n\n---\n\n" + renderFinding(finding)
-		if finding.Kind == contract.FindingBlocking &&
-			finding.Path != "" &&
-			validLines[finding.Path][int(finding.LineStart)] &&
-			len(inline) < contract.MaxInlineComments {
-			inline = append(inline, InlineReviewComment{
-				Path: finding.Path,
-				Line: int(finding.LineStart),
-				Body: renderFinding(finding),
-			})
+	if state.DecisionSource == contract.DecisionSourceInfrastructure {
+		body += "\n\nNo current findings were adjudicated because the " +
+			"review infrastructure did not complete."
+	} else {
+		for _, finding := range state.PriorFindings {
+			body += "\n\n---\n\n" + renderFinding(finding)
+			if finding.Kind == contract.FindingBlocking &&
+				finding.Path != "" &&
+				validLines[finding.Path][int(finding.LineStart)] &&
+				len(inline) < contract.MaxInlineComments {
+				inline = append(inline, InlineReviewComment{
+					Path: finding.Path,
+					Line: int(finding.LineStart),
+					Body: renderFinding(finding),
+				})
+			}
 		}
 	}
 	if len(body) > 64<<10 {

--- a/internal/infra/reviewagentgithub/projections_test.go
+++ b/internal/infra/reviewagentgithub/projections_test.go
@@ -112,6 +112,63 @@ func TestPublisherUsesOnlyGitHubDiffLinesForInlineFindings(t *testing.T) {
 	require.Equal(t, 1, writer.inline[0].Line)
 }
 
+func TestPublisherDoesNotProjectCarriedFindingsAsCurrentInfrastructureEvidence(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	state := conflictState()
+	state.Phase = contract.PhaseInconclusive
+	state.DecisionSource = contract.DecisionSourceInfrastructure
+	state.Reason = "Review infrastructure retry budget exhausted"
+	state.PriorFindings = []contract.Finding{{
+		Kind:       contract.FindingBlocking,
+		Dimension:  contract.DimensionRegressionTests,
+		Title:      "Old generation contract failure",
+		Path:       "internal/app/a.go",
+		LineStart:  1,
+		LineEnd:    1,
+		Scenario:   "An earlier generation failed a contract check.",
+		Impact:     "That earlier candidate could not be approved.",
+		Evidence:   []string{"check:agent-artifact-contracts"},
+		Resolution: "Repair the earlier candidate.",
+	}}
+	stateHead := strings.Repeat("f", 40)
+	writer := &recordingProjectionWriter{}
+	publisher, err := github.NewReviewPublisher(
+		"WuKongIM/WuKongIM",
+		"wukongim-review-agent",
+		"wukongim-review-agent[bot]",
+		fixedReviewStateReader{head: stateHead, state: state},
+		fixedReviewFactsReader{snapshot: github.PullRequestSnapshot{
+			Facts: usecase.PullRequestFacts{
+				Repository:   state.Generation.Repository,
+				PullRequest:  state.Generation.PullRequest,
+				HeadSHA:      state.Generation.HeadSHA,
+				BaseSHA:      state.Generation.BaseSHA,
+				TestMergeSHA: state.Generation.TestMergeSHA,
+				IntentDigest: state.Generation.IntentDigest,
+				Open:         true,
+			},
+		}},
+		writer,
+	)
+	require.NoError(t, err)
+
+	_, err = publisher.PublishDecision(
+		context.Background(),
+		github.ReviewPublicationRequest{
+			ExpectedStateHead: stateHead,
+			State:             state,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, usecase.FormalReviewComment, writer.review)
+	require.Contains(t, writer.reviewBody, "signed `inconclusive` decision")
+	require.NotContains(t, writer.reviewBody, "Old generation contract failure")
+	require.Empty(t, writer.inline)
+}
+
 func TestPublisherRepairsPersistedExplanationFromLifecycleState(t *testing.T) {
 	t.Parallel()
 
@@ -540,6 +597,7 @@ func (reader fixedReviewFactsReader) ActorPermission(
 
 type recordingProjectionWriter struct {
 	review             usecase.FormalReview
+	reviewBody         string
 	inline             []github.InlineReviewComment
 	checkStatus        string
 	checkConclusion    *usecase.CheckConclusion
@@ -569,10 +627,11 @@ func (writer *recordingProjectionWriter) CreateReview(
 	_ int64,
 	_ string,
 	review usecase.FormalReview,
-	_ string,
+	body string,
 	inline []github.InlineReviewComment,
 ) (int64, error) {
 	writer.review = review
+	writer.reviewBody = body
 	writer.inline = append([]github.InlineReviewComment(nil), inline...)
 	return 12, nil
 }

--- a/internal/runtime/reviewagentverify/FLOW.md
+++ b/internal/runtime/reviewagentverify/FLOW.md
@@ -25,6 +25,11 @@ complete ReviewResult + trusted ReviewEvidence + immutable tree digest
   -> validated decision or fail-closed inconclusive
 ```
 
+The first ledger result for each mandatory check is the sealed baseline result.
+Model-requested reruns remain append-only evidence but cannot replace that
+mandatory baseline during final collection. Trusted downgrades bind a complete
+effective result and digest for publication.
+
 No caller may supply a command, working directory, environment override, URL,
 test pattern, ref, or repository path to the runner. Only protected catalog
 names cross the Check MCP boundary.

--- a/internal/runtime/reviewagentverify/runner.go
+++ b/internal/runtime/reviewagentverify/runner.go
@@ -116,8 +116,8 @@ func (runner *Runner) Result(
 	return contract.CheckEvidence{}, errors.New("trusted check has no result")
 }
 
-// CollectEvidence validates the ledger chain and returns the newest result for
-// every executed check, requiring the complete mandatory set.
+// CollectEvidence validates the ledger chain, preserves the first sealed
+// result for every mandatory check, and returns the newest optional result.
 func (runner *Runner) CollectEvidence(
 	generation contract.GenerationIdentity,
 	mandatory []string,
@@ -160,6 +160,15 @@ func CollectEvidence(
 	if err != nil {
 		return contract.ReviewEvidence{}, err
 	}
+	mandatoryNames := make(map[string]struct{}, len(mandatory))
+	for _, name := range mandatory {
+		if _, exists := policy.TrustedChecks[name]; !exists {
+			return contract.ReviewEvidence{}, errors.New(
+				"mandatory evidence names an unknown trusted check",
+			)
+		}
+		mandatoryNames[name] = struct{}{}
+	}
 	latest := make(map[string]contract.CheckEvidence)
 	for _, record := range records {
 		if _, protected := policy.TrustedChecks[record.Evidence.Name]; !protected {
@@ -167,14 +176,14 @@ func CollectEvidence(
 				"evidence ledger names an unknown trusted check",
 			)
 		}
+		if _, mandatoryCheck := mandatoryNames[record.Evidence.Name]; mandatoryCheck {
+			if _, sealed := latest[record.Evidence.Name]; sealed {
+				continue
+			}
+		}
 		latest[record.Evidence.Name] = record.Evidence
 	}
 	for _, name := range mandatory {
-		if _, exists := policy.TrustedChecks[name]; !exists {
-			return contract.ReviewEvidence{}, errors.New(
-				"mandatory evidence names an unknown trusted check",
-			)
-		}
 		if _, exists := latest[name]; !exists {
 			return contract.ReviewEvidence{}, errors.New(
 				"mandatory trusted check has no evidence",

--- a/internal/runtime/reviewagentverify/runner_test.go
+++ b/internal/runtime/reviewagentverify/runner_test.go
@@ -73,6 +73,54 @@ func TestRunnerResolvesOnlyProtectedNamedChecks(t *testing.T) {
 	require.Equal(t, "go-unit", records[0].Evidence.Name)
 }
 
+func TestCollectEvidencePreservesSealedMandatoryBaselineAcrossReruns(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ledger, err := verify.NewFileLedger(
+		filepath.Join(t.TempDir(), "ledger.jsonl"),
+		root,
+	)
+	require.NoError(t, err)
+	generation := testGeneration()
+	baseline := contract.CheckEvidence{
+		Name:          "go-unit",
+		CommandDigest: digest("1"),
+		Outcome:       contract.CheckOutcomeFailed,
+		ExitCode:      1,
+		DurationMS:    239_784,
+		StdoutDigest:  digest("2"),
+		StderrDigest:  digest("3"),
+		Stdout:        "pre-existing flaky test failed",
+	}
+	require.NoError(t, ledger.Append(generation, baseline))
+	require.NoError(t, ledger.Append(generation, contract.CheckEvidence{
+		Name:          "go-unit",
+		CommandDigest: digest("1"),
+		Outcome:       contract.CheckOutcomeError,
+		ExitCode:      0,
+		DurationMS:    1,
+		StdoutDigest:  digest("4"),
+		StderrDigest:  digest("5"),
+	}))
+
+	evidence, err := verify.CollectEvidence(
+		ledger,
+		verify.Policy{TrustedChecks: map[string]verify.CheckPlan{
+			"go-unit": {},
+		}},
+		func() time.Time {
+			return time.Date(2026, 8, 9, 14, 0, 0, 0, time.UTC)
+		},
+		generation,
+		[]string{"go-unit"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []contract.CheckEvidence{baseline}, evidence.Checks)
+}
+
 func TestFileLedgerMustRemainOutsideModelWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/reviewagentverify/validate.go
+++ b/internal/runtime/reviewagentverify/validate.go
@@ -14,6 +14,9 @@ type ValidatedDecision struct {
 	EvidenceDigest string             `json:"evidence_digest"`
 	ResultDigest   string             `json:"result_digest"`
 	Findings       []contract.Finding `json:"findings"`
+	// EffectiveResult is present when trusted evidence downgrades the advisory
+	// model decision and therefore requires a newly bound publication result.
+	EffectiveResult *contract.ReviewResult `json:"effective_result,omitempty"`
 }
 
 // ValidateFinalResult prevents advisory model output from outranking missing,
@@ -154,11 +157,37 @@ func ValidateFinalResult(
 		}
 		if result.Decision == contract.DecisionApproved &&
 			check.Outcome != contract.CheckOutcomePassed {
-			return inconclusive(
-				"mandatory trusted check did not pass",
-				evidenceDigest,
-				resultDigest,
+			const reason = "mandatory trusted check did not pass"
+			effective := result
+			effective.Decision = contract.DecisionInconclusive
+			effective.Summary = reason
+			effective.Findings = append(
+				[]contract.Finding(nil),
+				result.Findings...,
 			)
+			effective.Sources = make([]string, 0, len(evidence.Checks))
+			for _, trustedCheck := range evidence.Checks {
+				effective.Sources = append(
+					effective.Sources,
+					"check:"+trustedCheck.Name,
+				)
+			}
+			effective.UnresolvedUncertainty = reason
+			effectiveDigest, digestErr := contract.ReviewResultDigest(effective)
+			if digestErr != nil {
+				return ValidatedDecision{}, digestErr
+			}
+			return ValidatedDecision{
+				Decision:       contract.DecisionInconclusive,
+				Reason:         reason,
+				EvidenceDigest: evidenceDigest,
+				ResultDigest:   effectiveDigest,
+				Findings: append(
+					[]contract.Finding(nil),
+					result.Findings...,
+				),
+				EffectiveResult: &effective,
+			}, nil
 		}
 	}
 	for _, source := range result.Sources {

--- a/internal/runtime/reviewagentverify/validate_test.go
+++ b/internal/runtime/reviewagentverify/validate_test.go
@@ -143,6 +143,99 @@ func TestValidateFinalResultOverridesChangesRequiredOnCheckError(t *testing.T) {
 	require.Contains(t, validated.Reason, "infrastructure")
 }
 
+func TestValidateFinalResultDowngradesFailedMandatoryWithoutRestoringWithdrawnFindings(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	prior := contract.Finding{
+		Kind:       contract.FindingBlocking,
+		Dimension:  contract.DimensionRegressionTests,
+		Title:      "Missing contract anchor",
+		Path:       "internal/runtime/delivery/queue.go",
+		LineStart:  1,
+		LineEnd:    1,
+		Scenario:   "The old candidate omitted a required contract anchor.",
+		Impact:     "The structural contract check failed.",
+		Evidence:   []string{"check:agent-artifact-contracts"},
+		Resolution: "Restore the required anchor.",
+	}
+	priorDigest, err := contract.FindingDigest(prior)
+	require.NoError(t, err)
+	context := validReviewContext()
+	context.PriorFindings = []contract.PriorFindingContext{{
+		Digest:  priorDigest,
+		Finding: prior,
+	}}
+	evidence := validReviewEvidence()
+	evidence.Checks[0].Outcome = contract.CheckOutcomeFailed
+	evidence.Checks[0].ExitCode = 1
+	advisory := contract.Finding{
+		Kind:       contract.FindingAdvisory,
+		Dimension:  contract.DimensionRegressionTests,
+		Title:      "Pre-existing flaky unit test",
+		Path:       "internal/runtime/delivery/queue.go",
+		LineStart:  1,
+		LineEnd:    1,
+		Scenario:   "The unit test also fails on the base revision.",
+		Impact:     "The mandatory check remains non-passing.",
+		Evidence:   []string{"check:go-unit"},
+		Resolution: "Stabilize the pre-existing test separately.",
+	}
+	result := validApprovedResult()
+	result.Findings = []contract.Finding{advisory}
+	result.PriorFindingDispositions = []contract.PriorFindingDisposition{{
+		FindingDigest: priorDigest,
+		Status:        "withdrawn",
+		Reason:        "The current structural contract check passes.",
+	}}
+	result.Sources = []string{"check:go-unit -> failed on head and base"}
+
+	validated, err := verify.ValidateFinalResult(
+		context,
+		evidence,
+		result,
+		digest("f"),
+		digest("f"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, contract.DecisionInconclusive, validated.Decision)
+	require.Contains(t, validated.Reason, "did not pass")
+	require.Equal(t, []contract.Finding{advisory}, validated.Findings)
+	require.NotNil(t, validated.EffectiveResult)
+	require.Equal(
+		t,
+		contract.DecisionInconclusive,
+		validated.EffectiveResult.Decision,
+	)
+	require.Equal(
+		t,
+		[]contract.Finding{advisory},
+		validated.EffectiveResult.Findings,
+	)
+	require.Equal(
+		t,
+		[]string{"check:go-unit"},
+		validated.EffectiveResult.Sources,
+	)
+	effectiveDigest, err := contract.ReviewResultDigest(
+		*validated.EffectiveResult,
+	)
+	require.NoError(t, err)
+	require.Equal(t, effectiveDigest, validated.ResultDigest)
+	revalidated, err := verify.ValidateFinalResult(
+		context,
+		evidence,
+		*validated.EffectiveResult,
+		digest("f"),
+		digest("f"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, contract.DecisionInconclusive, revalidated.Decision)
+	require.Equal(t, []contract.Finding{advisory}, revalidated.Findings)
+	require.Equal(t, effectiveDigest, revalidated.ResultDigest)
+}
+
 func TestValidateFinalResultNeverApprovesBinaryChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/reviewagent/FLOW.md
+++ b/internal/usecase/reviewagent/FLOW.md
@@ -28,5 +28,14 @@ validated durable decision + fresh publication facts
      without a human REQUEST_CHANGES Review
 ```
 
+Each review infrastructure attempt receives one signed 90-minute deadline. The
+single automatic retry remains in the same generation but receives a fresh
+attempt deadline, so it cannot inherit a budget shorter than the protected
+baseline/reviewer/publication reservation. A retry waiting in the scheduler
+has no active attempt deadline; the fresh deadline starts only when its lease
+is reacquired. The signed generation `StartedAt` derives the 180-minute cap;
+if that cap cannot contain a complete fresh attempt, reconciliation fails
+closed instead of dispatching a shortened or unbounded retry.
+
 Only adapters execute plans. A model result never chooses a GitHub Check
 conclusion directly.

--- a/internal/usecase/reviewagent/reconcile.go
+++ b/internal/usecase/reviewagent/reconcile.go
@@ -472,11 +472,13 @@ func ReconcilePullRequest(input ReconcileInput) (ReconcilePlan, error) {
 	superseding := input.State != nil && !sameGeneration
 	reuseEvidence := ""
 	priorFindings := []contract.Finding(nil)
-	if superseding {
+	if input.State != nil {
 		priorFindings = append(
 			priorFindings,
 			input.State.PriorFindings...,
 		)
+	}
+	if superseding {
 		if exactCodeCoordinates(input.State.Generation, input.Facts) {
 			reuseEvidence = input.State.EvidenceDigest
 		}
@@ -511,6 +513,29 @@ func ReconcilePullRequest(input ReconcileInput) (ReconcilePlan, error) {
 			generation,
 			lease.AcquiredAt,
 		)
+		queuedRetry := sameGeneration &&
+			input.State.Phase == contract.PhaseQueued &&
+			input.State.Budget.InfrastructureRetriesUsed > 0
+		if queuedRetry {
+			var withinGenerationCap bool
+			deadline, withinGenerationCap = freshAttemptDeadline(
+				input,
+				generation,
+				lease.AcquiredAt,
+				true,
+			)
+			if !withinGenerationCap {
+				return expireRecoveredLease(
+					input,
+					scheduler,
+					generation,
+					*lease,
+					cancelRunID,
+					priorFindings,
+					nextBudget,
+				)
+			}
+		}
 		if !input.Now.Before(deadline) {
 			return expireRecoveredLease(
 				input,
@@ -611,17 +636,35 @@ func ReconcilePullRequest(input ReconcileInput) (ReconcilePlan, error) {
 	if err != nil {
 		return ReconcilePlan{}, err
 	}
+	queuedRetry := sameGeneration &&
+		input.State.Phase == contract.PhaseQueued &&
+		input.State.Budget.InfrastructureRetriesUsed > 0
+	deadline, withinGenerationCap := freshAttemptDeadline(
+		input,
+		generation,
+		lease.AcquiredAt,
+		queuedRetry,
+	)
+	if !withinGenerationCap {
+		return expireRecoveredLease(
+			input,
+			scheduler,
+			generation,
+			*lease,
+			cancelRunID,
+			priorFindings,
+			nextBudget,
+		)
+	}
 	return ReconcilePlan{
-		Action:        action,
-		Reason:        "Review Agent lease acquired",
-		Generation:    generation,
-		DesiredPhase:  contract.PhaseReviewing,
-		NextScheduler: scheduler,
-		Dispatch:      true,
-		LeaseRunID:    lease.RunID,
-		DeadlineAt: lease.AcquiredAt.Add(
-			input.Policy.MaxGenerationDuration,
-		),
+		Action:              action,
+		Reason:              "Review Agent lease acquired",
+		Generation:          generation,
+		DesiredPhase:        contract.PhaseReviewing,
+		NextScheduler:       scheduler,
+		Dispatch:            true,
+		LeaseRunID:          lease.RunID,
+		DeadlineAt:          deadline,
 		CancelRunID:         cancelRunID,
 		ReuseEvidenceDigest: reuseEvidence,
 		NextBudget:          nextBudget,
@@ -1038,6 +1081,19 @@ func reconcileCompletion(input ReconcileInput) (ReconcilePlan, error) {
 			input.Policy.MaxInfrastructureRetries {
 			budget := input.State.Budget
 			budget.InfrastructureRetriesUsed++
+			deadline, withinGenerationCap := freshAttemptDeadline(
+				input,
+				completion.Generation,
+				input.Now,
+				true,
+			)
+			if !withinGenerationCap {
+				return completeInfrastructureFailure(
+					input,
+					*completion,
+					"Review generation exceeded its wall-time limit",
+				)
+			}
 			return ReconcilePlan{
 				Action:        ActionRetryAndDispatch,
 				Reason:        "automatic infrastructure retry",
@@ -1046,12 +1102,8 @@ func reconcileCompletion(input ReconcileInput) (ReconcilePlan, error) {
 				NextScheduler: input.Scheduler,
 				Dispatch:      true,
 				LeaseRunID:    lease.RunID,
-				DeadlineAt: generationDeadline(
-					input,
-					completion.Generation,
-					lease.AcquiredAt,
-				),
-				NextBudget: budget,
+				DeadlineAt:    deadline,
+				NextBudget:    budget,
 				PriorFindings: append(
 					[]contract.Finding(nil),
 					input.State.PriorFindings...,
@@ -1386,12 +1438,12 @@ func completeFailedExplanation(
 }
 
 func recoverReleasedWorker(input ReconcileInput) (ReconcilePlan, error) {
-	deadline := generationDeadline(
+	previousDeadline := generationDeadline(
 		input,
 		input.State.Generation,
 		input.Now,
 	)
-	if !input.Now.Before(deadline) {
+	if !input.Now.Before(previousDeadline) {
 		return ReconcilePlan{
 			Action:         ActionComplete,
 			Reason:         "Review generation exceeded its wall-time limit",
@@ -1498,6 +1550,23 @@ func recoverReleasedWorker(input ReconcileInput) (ReconcilePlan, error) {
 	if err != nil {
 		return ReconcilePlan{}, err
 	}
+	deadline, withinGenerationCap := freshAttemptDeadline(
+		input,
+		input.State.Generation,
+		lease.AcquiredAt,
+		true,
+	)
+	if !withinGenerationCap {
+		return expireRecoveredLease(
+			input,
+			acquired,
+			input.State.Generation,
+			*lease,
+			0,
+			input.State.PriorFindings,
+			budget,
+		)
+	}
 	return ReconcilePlan{
 		Action:        ActionRetryAndDispatch,
 		Reason:        "recover released failed worker",
@@ -1527,6 +1596,27 @@ func generationDeadline(
 		return input.State.SessionDeadlineAt
 	}
 	return fallback.Add(input.Policy.MaxGenerationDuration)
+}
+
+// freshAttemptDeadline grants a complete attempt while keeping a retried
+// generation within the cap derived from its signed start time.
+func freshAttemptDeadline(
+	input ReconcileInput,
+	generation contract.GenerationIdentity,
+	acquiredAt time.Time,
+	retry bool,
+) (time.Time, bool) {
+	deadline := acquiredAt.Add(input.Policy.MaxGenerationDuration)
+	if !retry || input.State == nil ||
+		contract.MustGenerationDigest(input.State.Generation) !=
+			contract.MustGenerationDigest(generation) {
+		return deadline, true
+	}
+	generationCap := input.State.StartedAt.Add(
+		time.Duration(input.Policy.MaxInfrastructureRetries+1) *
+			input.Policy.MaxGenerationDuration,
+	)
+	return deadline, !deadline.After(generationCap)
 }
 
 func expireRecoveredLease(

--- a/internal/usecase/reviewagent/reconcile_test.go
+++ b/internal/usecase/reviewagent/reconcile_test.go
@@ -621,8 +621,20 @@ func TestReconcilePullRequestRetriesInfrastructureFailureOnce(
 	require.True(t, plan.Dispatch)
 	require.Equal(t, int64(421), plan.LeaseRunID)
 	require.Equal(t, uint32(1), plan.NextBudget.InfrastructureRetriesUsed)
+	require.Equal(
+		t,
+		time.Date(2026, 7, 30, 5, 30, 0, 0, time.UTC),
+		plan.DeadlineAt,
+	)
 	require.Empty(t, plan.EvidenceDigest)
 	require.Empty(t, plan.ResultDigest)
+	next, err := reviewagent.BuildNextState(
+		&state,
+		plan,
+		time.Date(2026, 7, 30, 4, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.Equal(t, plan.DeadlineAt, next.SessionDeadlineAt)
 }
 
 func TestReconcilePullRequestFailsClosedAfterInfrastructureRetry(t *testing.T) {
@@ -716,7 +728,9 @@ func TestReconcilePullRequestRecoversSchedulerReleaseBeforeTerminalState(
 ) {
 	t.Parallel()
 
+	now := time.Date(2026, 7, 30, 4, 0, 0, 0, time.UTC)
 	state := testReviewingState()
+	state.SessionDeadlineAt = now.Add(time.Minute)
 	state.PriorFindings = []contract.Finding{testFinding()}
 	plan, err := reviewagent.ReconcilePullRequest(reviewagent.ReconcileInput{
 		Facts: testFacts(), State: &state, Scheduler: testScheduler(),
@@ -724,14 +738,120 @@ func TestReconcilePullRequestRecoversSchedulerReleaseBeforeTerminalState(
 			Kind: reviewagent.SignalWorkerFailure, RunID: 433,
 		},
 		Policy: testPolicy(),
-		Now:    time.Date(2026, 7, 30, 4, 0, 0, 0, time.UTC),
+		Now:    now,
 	})
 	require.NoError(t, err)
 	require.Equal(t, reviewagent.ActionRetryAndDispatch, plan.Action)
 	require.True(t, plan.Dispatch)
+	require.Equal(t, now.Add(90*time.Minute), plan.DeadlineAt)
 	require.Equal(t, uint32(1), plan.NextBudget.InfrastructureRetriesUsed)
 	require.Equal(t, state.PriorFindings, plan.PriorFindings)
 	require.Len(t, plan.NextScheduler.Active, 1)
+}
+
+func TestReconcilePullRequestQueuesReleasedWorkerWithoutOldAttemptDeadline(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 4, 0, 0, 0, time.UTC)
+	state := testReviewingState()
+	state.SessionDeadlineAt = now.Add(time.Minute)
+	scheduler := testScheduler()
+	for index := 0; index < testPolicy().Scheduler.MaxActive; index++ {
+		scheduler.Active = append(scheduler.Active, reviewagent.Lease{
+			Generation: generationForPR(int64(100 + index)),
+			RunID:      int64(500 + index),
+			AcquiredAt: now.Add(-time.Minute),
+		})
+	}
+	plan, err := reviewagent.ReconcilePullRequest(reviewagent.ReconcileInput{
+		Facts: testFacts(), State: &state, Scheduler: scheduler,
+		Signal: reviewagent.Signal{
+			Kind: reviewagent.SignalWorkerFailure, RunID: 437,
+		},
+		Policy: testPolicy(), Now: now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, reviewagent.ActionRetryAndEnqueue, plan.Action)
+	require.False(t, plan.Dispatch)
+
+	queued, err := reviewagent.BuildNextState(&state, plan, now)
+	require.NoError(t, err)
+	require.True(t, queued.SessionDeadlineAt.IsZero())
+
+	available := plan.NextScheduler
+	available.Active = nil
+	later := now.Add(10 * time.Minute)
+	resumed, err := reviewagent.ReconcilePullRequest(
+		reviewagent.ReconcileInput{
+			Facts: testFacts(), State: &queued, Scheduler: available,
+			Signal: reviewagent.Signal{
+				Kind: reviewagent.SignalManual, RunID: 438,
+			},
+			Policy: testPolicy(), Now: later,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, reviewagent.ActionAcquireAndDispatch, resumed.Action)
+	require.Equal(t, later.Add(90*time.Minute), resumed.DeadlineAt)
+}
+
+func TestReconcilePullRequestRejectsQueuedRetryWithoutFullBoundedAttempt(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 30, 4, 0, 0, 0, time.UTC)
+	state := testReviewingState()
+	state.SessionDeadlineAt = now.Add(time.Minute)
+	state.PriorFindings = []contract.Finding{testFinding()}
+	scheduler := testScheduler()
+	for index := 0; index < testPolicy().Scheduler.MaxActive; index++ {
+		scheduler.Active = append(scheduler.Active, reviewagent.Lease{
+			Generation: generationForPR(int64(200 + index)),
+			RunID:      int64(600 + index),
+			AcquiredAt: now.Add(-time.Minute),
+		})
+	}
+	plan, err := reviewagent.ReconcilePullRequest(reviewagent.ReconcileInput{
+		Facts: testFacts(), State: &state, Scheduler: scheduler,
+		Signal: reviewagent.Signal{
+			Kind: reviewagent.SignalWorkerFailure, RunID: 439,
+		},
+		Policy: testPolicy(), Now: now,
+	})
+	require.NoError(t, err)
+	require.Equal(t, reviewagent.ActionRetryAndEnqueue, plan.Action)
+	queued, err := reviewagent.BuildNextState(&state, plan, now)
+	require.NoError(t, err)
+
+	available := plan.NextScheduler
+	available.Active = nil
+	later := now.Add(time.Hour)
+	acquired, lease, err := reviewagent.AcquireNext(
+		available,
+		440,
+		later,
+		testPolicy().Scheduler,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	rejected, err := reviewagent.ReconcilePullRequest(
+		reviewagent.ReconcileInput{
+			Facts: testFacts(), State: &queued, Scheduler: acquired,
+			Signal: reviewagent.Signal{
+				Kind: reviewagent.SignalManual, RunID: 440,
+			},
+			Policy: testPolicy(), Now: later,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, reviewagent.ActionRecordInconclusive, rejected.Action)
+	require.Equal(t, contract.PhaseInconclusive, rejected.DesiredPhase)
+	require.False(t, rejected.Dispatch)
+	require.Empty(t, rejected.NextScheduler.Active)
+	require.Equal(t, state.PriorFindings, rejected.PriorFindings)
 }
 
 func TestReconcilePullRequestExpiresPersistedWorkerRetry(t *testing.T) {

--- a/internal/usecase/reviewagent/state.go
+++ b/internal/usecase/reviewagent/state.go
@@ -95,7 +95,8 @@ func BuildNextState(
 		if contract.MustGenerationDigest(next.Generation) ==
 			contract.MustGenerationDigest(previous.Generation) {
 			next.StartedAt = previous.StartedAt
-			if next.SessionDeadlineAt.IsZero() {
+			if next.SessionDeadlineAt.IsZero() &&
+				plan.Action != ActionRetryAndEnqueue {
 				next.SessionDeadlineAt = previous.SessionDeadlineAt
 			}
 		}

--- a/scripts/review_agent_workflows_test.go
+++ b/scripts/review_agent_workflows_test.go
@@ -395,6 +395,20 @@ func TestReviewAgentRunWorkflowMaintainsRoleIsolation(t *testing.T) {
 	require.Contains(t, raw, "terminal-request.json")
 	require.Contains(t, raw, "prior_finding_dispositions")
 	require.Equal(t, 2, strings.Count(raw, "(.prior_findings // [])[]"))
+	require.Contains(t, raw, `'.effective_result != null'`)
+	require.Contains(
+		t,
+		raw,
+		`.effective_result "$RUNNER_TEMP/validated-decision.json"`,
+	)
+	require.Equal(
+		t,
+		4,
+		strings.Count(
+			raw,
+			`"$(jq -r .decision "$RUNNER_TEMP/validated-decision.json")" !=`,
+		),
+	)
 	require.Contains(t, raw, "gh workflow run review-agent-run.yml")
 	require.Contains(t, raw, `-f "infrastructure_attempt=$attempt"`)
 	require.Contains(t, raw, "review-agent-trusted-baseline")


### PR DESCRIPTION
## What changed

- Preserve the first sealed mandatory-check result when later model-phase ledger entries reuse the same check name.
- Convert an advisory `approved` result with a failed mandatory check into a trusted, digest-bound `inconclusive` result while preserving current findings and prior-finding withdrawals.
- Give the single infrastructure retry a fresh signed 90-minute attempt deadline, while deriving and enforcing the 180-minute generation cap from signed state.
- Prevent infrastructure recovery reviews from presenting carried historical findings as current adjudicated findings.
- Fail closed when any validation or revalidation decision differs from the effective result, and update the applicable FLOW and Review Agent documentation.

## Why

Generation 5 of the live Review Agent canary exposed a recovery chain where a later same-name ledger record overwrote the sealed baseline, the automatic retry inherited only the residue of the first attempt deadline, and terminal infrastructure recovery could re-publish findings that the current model run had withdrawn.

## Impact

A pre-existing mandatory-check failure now produces a stable, evidence-backed `inconclusive` result instead of an infrastructure retry. Genuine infrastructure retries receive a complete attempt budget without making the generation unbounded. Historical findings remain in signed state for reconsideration but are not shown as current infrastructure evidence.

## Validation

- `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- `GOWORK=off go test -tags=integration ./internal/runtime/reviewagentverify -count=1`
- `node --test .github/review-agent/responses-budget-proxy.test.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/review-agent-pr-signal.yml .github/workflows/review-agent.yml .github/workflows/review-agent-run.yml`
- Generation 5 artifact replay through the final validator path
- Standards and Spec review against `origin/main`: no remaining findings

This PR is intentionally draft. Review Agent has not been invoked.
