### PR TITLE
test(agent): exercise failed mandatory-check recovery

### DIFF
--- a/internal/runtime/reviewagentverify/canary_failure_test.go
+++ b/internal/runtime/reviewagentverify/canary_failure_test.go
@@ -1,0 +1,9 @@
+package reviewagentverify_test
+
+import "testing"
+
+// TestReviewAgentRecoveryCanary intentionally fails so the live Review Agent
+// must preserve failed mandatory evidence and refuse approval or auto-merge.
+func TestReviewAgentRecoveryCanary(t *testing.T) {
+	t.Fatal("intentional Review Agent recovery canary failure")
+}


### PR DESCRIPTION
## Canary purpose

This is an intentionally failing, temporary Review Agent canary. It adds one test whose only purpose is to make the trusted mandatory `go-unit` baseline fail deterministically.

Do not merge this pull request.

## Expected Review Agent behavior

- preserve the first sealed `go-unit` failure even if the model requests a same-name rerun
- publish a model-backed `changes_required` verdict for the intentional candidate failure
- do not classify the failed check as infrastructure failure
- do not dispatch an infrastructure retry
- do not auto-merge

## Local validation

- the targeted canary test failed with the exact intentional message
- `GOWORK=off go vet ./internal/runtime/reviewagentverify` passed
- `gofmt -d` and `git diff --check` passed

After terminal evidence is captured, this PR will be closed without merging.
