### PR TITLE
test(bench): stabilize chat lifecycle timing tests

### DIFF
--- a/internal/bench/chatlifecycle/engine_benchmark_test.go
+++ b/internal/bench/chatlifecycle/engine_benchmark_test.go
@@ -2,7 +2,6 @@ package chatlifecycle
 
 import (
 	"context"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -80,19 +79,7 @@ func BenchmarkEngineAdvanceAutoAck2000(b *testing.B) {
 		if err != nil || processed != workPerIteration {
 			b.Fatalf("Advance = %d, %v", processed, err)
 		}
-		for spin := 0; ; spin++ {
-			snapshot, snapshotErr := fixture.engine.Snapshot()
-			if snapshotErr != nil {
-				b.Fatalf("Snapshot: %v", snapshotErr)
-			}
-			if snapshot.InflightCurrent == 0 {
-				break
-			}
-			if spin >= 10_000 {
-				b.Fatalf("auto-ACK completion did not settle: %+v", snapshot)
-			}
-			runtime.Gosched()
-		}
+		waitForEngineCompletions(b, fixture.engine, "benchmark auto-ACK")
 		b.StopTimer()
 		fixture.factory.mu.Lock()
 		fixture.factory.routesV = nil

--- a/internal/bench/chatlifecycle/engine_test.go
+++ b/internal/bench/chatlifecycle/engine_test.go
@@ -4383,20 +4383,7 @@ func TestEngineRotatingAndLongChannelsConsumePrimaryGrantsOnlyBeforeDeadline(t *
 		t.Fatalf("bootstrap Step: %v", err)
 	}
 	fixture.settleScheduledLogins(t, now, bootstrap)
-	settleCompletions := func(stage string) {
-		t.Helper()
-		var snapshot EngineSnapshot
-		var snapshotErr error
-		for range 10_000 {
-			snapshot, snapshotErr = fixture.engine.Snapshot()
-			if snapshotErr == nil && snapshot.InflightCurrent == 0 && snapshot.RetryQueueDepth == 0 {
-				return
-			}
-			runtime.Gosched()
-		}
-		t.Fatalf("%s completions did not settle: snapshot=%+v snapshot_err=%v", stage, snapshot, snapshotErr)
-	}
-	settleCompletions("bootstrap")
+	waitForEngineCompletions(t, fixture.engine, "bootstrap")
 	now = now.Add(30 * time.Second)
 	fixture.clock.Set(now)
 	for iteration := 0; iteration < 100; iteration++ {
@@ -4410,7 +4397,7 @@ func TestEngineRotatingAndLongChannelsConsumePrimaryGrantsOnlyBeforeDeadline(t *
 		if _, err := fixture.engine.Advance(now); err != nil {
 			t.Fatalf("drain activity Advance(%d): %v", iteration, err)
 		}
-		settleCompletions(fmt.Sprintf("drain activity %d", iteration))
+		waitForEngineCompletions(t, fixture.engine, fmt.Sprintf("drain activity %d", iteration))
 	}
 	beforeDeadline, err := fixture.engine.Snapshot()
 	if err != nil {
@@ -4430,7 +4417,7 @@ func TestEngineRotatingAndLongChannelsConsumePrimaryGrantsOnlyBeforeDeadline(t *
 	if _, err := fixture.engine.Advance(now); err != nil {
 		t.Fatalf("active Advance: %v", err)
 	}
-	settleCompletions("active")
+	waitForEngineCompletions(t, fixture.engine, "active")
 	if sent := fixture.factory.sentCount() - before; sent != 100 {
 		t.Fatalf("active first-attempt sends = %d, want 100", sent)
 	}
@@ -4718,17 +4705,28 @@ func TestEngineCompletionPressureCannotDeadlockBatchAdvance(t *testing.T) {
 	if processed, err := fixture.engine.Advance(now); err != nil || processed != 100 {
 		t.Fatalf("Advance = %d, %v", processed, err)
 	}
-	var snapshot EngineSnapshot
-	for range 10_000 {
-		snapshot, _ = fixture.engine.Snapshot()
-		if snapshot.InflightCurrent == 0 {
-			break
-		}
-		runtime.Gosched()
-	}
+	snapshot := waitForEngineCompletions(t, fixture.engine, "completion pressure")
 	if snapshot.InflightCurrent != 0 || snapshot.FutureCurrent != 0 || fixture.verifier.Snapshot().Acknowledged != 100 {
 		t.Fatalf("completion pressure snapshot = engine %+v verifier %+v", snapshot, fixture.verifier.Snapshot())
 	}
+}
+
+func waitForEngineCompletions(t testing.TB, engine *Engine, stage string) EngineSnapshot {
+	t.Helper()
+	var snapshot EngineSnapshot
+	for range 10_000 {
+		var err error
+		snapshot, err = engine.Snapshot()
+		if err != nil {
+			t.Fatalf("%s Snapshot: %v", stage, err)
+		}
+		if snapshot.InflightCurrent == 0 && snapshot.RetryQueueDepth == 0 {
+			return snapshot
+		}
+		runtime.Gosched()
+	}
+	t.Fatalf("%s completions did not settle: %+v", stage, snapshot)
+	return snapshot
 }
 
 func approveCurrentColdRevisit(t *testing.T, engine *Engine, identity string) (bool, error) {

--- a/internal/bench/chatlifecycle/engine_test.go
+++ b/internal/bench/chatlifecycle/engine_test.go
@@ -4383,6 +4383,20 @@ func TestEngineRotatingAndLongChannelsConsumePrimaryGrantsOnlyBeforeDeadline(t *
 		t.Fatalf("bootstrap Step: %v", err)
 	}
 	fixture.settleScheduledLogins(t, now, bootstrap)
+	settleCompletions := func(stage string) {
+		t.Helper()
+		var snapshot EngineSnapshot
+		var snapshotErr error
+		for range 10_000 {
+			snapshot, snapshotErr = fixture.engine.Snapshot()
+			if snapshotErr == nil && snapshot.InflightCurrent == 0 && snapshot.RetryQueueDepth == 0 {
+				return
+			}
+			runtime.Gosched()
+		}
+		t.Fatalf("%s completions did not settle: snapshot=%+v snapshot_err=%v", stage, snapshot, snapshotErr)
+	}
+	settleCompletions("bootstrap")
 	now = now.Add(30 * time.Second)
 	fixture.clock.Set(now)
 	for iteration := 0; iteration < 100; iteration++ {
@@ -4396,6 +4410,7 @@ func TestEngineRotatingAndLongChannelsConsumePrimaryGrantsOnlyBeforeDeadline(t *
 		if _, err := fixture.engine.Advance(now); err != nil {
 			t.Fatalf("drain activity Advance(%d): %v", iteration, err)
 		}
+		settleCompletions(fmt.Sprintf("drain activity %d", iteration))
 	}
 	beforeDeadline, err := fixture.engine.Snapshot()
 	if err != nil {
@@ -4415,6 +4430,7 @@ func TestEngineRotatingAndLongChannelsConsumePrimaryGrantsOnlyBeforeDeadline(t *
 	if _, err := fixture.engine.Advance(now); err != nil {
 		t.Fatalf("active Advance: %v", err)
 	}
+	settleCompletions("active")
 	if sent := fixture.factory.sentCount() - before; sent != 100 {
 		t.Fatalf("active first-attempt sends = %d, want 100", sent)
 	}

--- a/internal/bench/chatlifecycle/worker_server_test.go
+++ b/internal/bench/chatlifecycle/worker_server_test.go
@@ -72,7 +72,7 @@ func TestWorkerServerRequiresBearerAuthenticationOnEveryEndpoint(t *testing.T) {
 }
 
 func TestWorkerServerLifecycleCandidateLeaseIsBoundedFencedAndTransient(t *testing.T) {
-	now := time.Unix(2_000, 0)
+	now := time.Unix(2_000, 0).UTC()
 	candidate := lifecycleTestCandidates(t, now)[0]
 	generation := &fakeLifecycleLeaseGeneration{fakeWorkerGeneration: newFakeWorkerGeneration(), candidates: []LifecycleCandidate{candidate}}
 	server, fence := startWorkerServerForGeneration(t, generation, "lifecycle-lease")


### PR DESCRIPTION
## Summary

- normalize the lifecycle-candidate lease fixture to UTC before JSON round trips
- wait boundedly for asynchronous fake auto-ACK completions before advancing the engine test clock
- share the completion barrier across the lifecycle tests and benchmark

## Root cause

The worker test compared `time.Time` values after JSON serialization. The instants were equal, but the source fixture could retain a host-local `Location` pointer, making struct equality depend on the machine time zone.

The engine test advanced its fake clock while auto-ACK completions were still moving asynchronously through the fake reader and session drain chain. Under CPU contention this could temporarily fill inflight or retry capacity and fail with `engine_inflight_saturated` or `retry_queue_saturated`.

## Impact

Test-only change. Production engine behavior, capacity limits, fairness, and fail-closed semantics are unchanged.

## Validation

- related lifecycle tests: 100 repetitions under `TZ=UTC`
- worker lease test: 100 repetitions under `TZ=Asia/Shanghai`
- engine contention stress: 16 parallel processes × 100 repetitions
- `GOWORK=off go vet ./internal/bench/chatlifecycle`
- benchmark smoke: `BenchmarkEngineAdvanceAutoAck2000`, one iteration
- full unit suite: `GOWORK=off go test ./cmd/... ./internal/... ./pkg/... ./scripts/... ./docker/... -count=1`
- final Standards and Spec reviews: no findings
