### PR TITLE
docs: complete scenario tutorials

### DIFF
--- a/docs-site/FLOW.md
+++ b/docs-site/FLOW.md
@@ -105,6 +105,22 @@ content/docs/**/*.mdx
   100,000-member request or a context-free capacity promise. `ClearUnread`
   advances to the newest server-visible message and MUST NOT be documented as
   an exact client-supplied read-sequence update.
+- Phase 11 completes the scenario tutorials with Message Push and AI & IoT.
+  Push guidance MUST keep mobile-provider delivery in the product service:
+  `msg.offline` is a UID-level, durable-ordinary-message candidate emitted by
+  a bounded best-effort webhook, not a device-level or provider receipt.
+  Offline candidates are collected before sender-echo suppression, so product
+  policy MUST filter sender and service identities before provider work.
+  Stream guidance MUST anchor events to a successfully committed `setting=2`
+  base message, preserve stable event IDs, distinguish cache-only deltas from
+  terminal durable projection, and state that fine-grained event sync is not
+  public. IoT guidance MUST distinguish durable `SyncOnce` command recovery
+  from command-style transient `NoPersist`; recoverable commands MUST use a
+  stable source Channel with recipient `/message/cmd/bind` completed before
+  SEND because request-scoped recipients do not create discovery membership.
+  Group telemetry examples MUST provision the Channel and sender membership
+  before SEND; protocol ACK and sync cursors do not prove device-side business
+  execution.
 
 ## Static delivery
 

--- a/docs-site/PHASE_11_SPEC.md
+++ b/docs-site/PHASE_11_SPEC.md
@@ -1,0 +1,113 @@
+# WuKongIM v3 Documentation — Phase 11 Specification
+
+## Goal
+
+Complete the bilingual scenario-tutorial menu with Message Push and AI & IoT
+Communication. The tutorials must be runnable from the current trusted product
+HTTP surface while separating WuKongIM delivery and projection semantics from
+application-owned provider integration, AI execution, device policy, and
+business acknowledgements.
+
+## Published routes
+
+- Tutorials / Message Push
+- Tutorials / AI & IoT Communication
+
+Both routes have matching Chinese and English MDX and are included in search,
+sitemap, LLM outputs, and per-page Markdown. This phase leaves no planned child
+under the Tutorials group.
+
+## Message Push boundaries
+
+- WuKongIM does not call APNs, FCM, or another mobile-push provider. The product
+  service owns provider credentials, device-token lifecycle, notification
+  policy, collapse and quiet-hour rules, provider retries, and delivery
+  receipts.
+- `msg.offline` is emitted only for an ordinary durable message after presence
+  resolution finds a recipient UID with no online route. `SyncOnce`,
+  request-scoped subscriber sends, and transient `NoPersist` work do not
+  produce this offline-recipient effect.
+- `msg.offline` identifies UID candidates, not every offline device. A UID with
+  at least one online route is not an offline candidate, so per-device policy
+  requires application-owned device state and may also consume `msg.notify`.
+  Collection runs before sender-echo suppression, so a person-Channel candidate
+  list can include `from_uid`; the product filters sender and service identities
+  according to its notification policy.
+- Webhook delivery is node-local, bounded, in-memory, retry-limited,
+  best-effort, and not crash-replayed. Queue pressure or retry exhaustion may
+  drop an event without changing durable SEND success. The current sender adds
+  no signature or shared-secret header.
+- Receivers must support both plain `to_uids` and gzip/Base64
+  `compress_to_uids`. Provider work uses an application outbox and an
+  idempotency key such as `event + message_id + uid`.
+- A notification or system notice is an application payload and policy, not a
+  privileged message class. Trusted system-UID bypasses are optional and must
+  not replace product authorization.
+
+## AI streaming boundaries
+
+- The product service owns model invocation, prompt policy, tool execution,
+  cancellation, quotas, and safety. Product HTTP examples stay behind a trusted
+  boundary without general product authentication.
+- A stream starts from one durable base message with the legacy stream setting
+  bit (`setting=2`) and a stable `client_msg_no`. Event updates use the same
+  channel identity and `client_msg_no`, plus stable unique `event_id` values.
+- `/message/event` currently does not perform a routed base-message existence
+  check. The product service must wait for base SEND success and preserve the
+  exact anchor; `message_id` in an event request is response context, not that
+  missing validation.
+- `stream.open`, `stream.delta`, and `stream.snapshot` may remain only in the
+  bounded Slot-Leader cache and return `msg_event_seq=0`. A terminal
+  `stream.finish` flushes open lanes and the finish marker in one Slot proposal.
+  Leadership loss without cached lanes fails finish closed; callers replay the
+  complete stream state before retrying.
+- Event IDs are idempotency keys. Reusing an applied ID returns the original
+  result rather than applying a different payload.
+- Current public sync exposes compact event summaries through
+  `/channel/messagesync` with `event_summary_mode=full`; fine-grained
+  `/message/eventsync` is not registered, and `/message/event` does not itself
+  push every delta to connected client Sessions. Live token rendering therefore
+  needs an application-owned stream or an explicitly designed message path.
+
+## IoT boundaries
+
+- Every device has a stable product identity and credential policy. The default
+  Beta Gateway does not automatically validate stored `/user/token` metadata.
+- Durable telemetry uses ordinary Channel messages with stable
+  `client_msg_no`. A group telemetry example must first provision the Channel
+  and sender membership; high-rate samples are aggregated or sampled before
+  they create unbounded message, webhook, conversation, or storage load.
+- Recoverable server commands use `sync_once=1` on a stable source Channel.
+  Each recipient binds that source through `/message/cmd/bind` before the first
+  command; binding starts at the current CMD-log tail, so it does not backfill
+  older commands. The separate CMD log and UID-owned discovery directory stay
+  out of ordinary conversations and recover through `/message/sync` followed
+  by `/message/syncack`.
+- Request-scoped `subscribers` provide bounded immediate targeting but do not
+  create CMD discovery membership. They must not be presented as reconnect
+  recovery unless a compatible binding already exists.
+- Online-only commands require both `no_persist=1` and `sync_once=1`. Plain
+  non-command `NoPersist` is terminal success without realtime delivery.
+- SENDACK, online write, RECVACK, and `/message/syncack` are transport or cursor
+  signals, not proof that a device executed an operation. Command payloads carry
+  a product idempotency key, deadline, and desired state; the device reports a
+  separate durable business result.
+
+## Validation
+
+- Navigation tests publish the final two tutorial children and freeze the
+  complete Tutorials order.
+- Static-output validation includes both routes in sitemap, search, LLM, and
+  per-page Markdown outputs.
+- Local validation runs `bun run verify`, focused Go tests for webhook,
+  message-event, CMD-sync, message, channelappend, and compatible API behavior,
+  plus the repository unit suite.
+- Browser QA covers both tutorials in both locales at desktop and mobile widths,
+  including console output and horizontal overflow.
+
+## Excluded
+
+- Runtime, protocol, SDK, webhook-security, mobile-provider, model-provider, or
+  device-firmware changes.
+- Provider-specific APNs/FCM payload references, a public fine-grained message
+  event sync API, benchmark promises, deployment, DNS, or production cutover.

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -23,7 +23,9 @@ target-fenced online routing. Phase 9 completes the guide foundation with
 workload-qualified capabilities and use cases, precise cluster/message/Channel/
 user/conversation concepts, and the current node-local plugin boundary. Phase
 10 publishes the first scenario tutorials: direct chat plus group chat through
-bounded 100,000-member membership and fanout workflows.
+bounded 100,000-member membership and fanout workflows. Phase 11 completes the
+scenario set with application-owned mobile push, recoverable AI stream
+projections, bounded device telemetry, and durable or online-only IoT commands.
 
 ## Develop
 
@@ -66,4 +68,5 @@ scope, `PHASE_5_SPEC.md` defines the server-configuration scope, and
 defines troubleshooting and official-tool boundaries. `PHASE_8_SPEC.md`
 defines the current server-architecture boundaries. `PHASE_9_SPEC.md` defines
 the guide-foundation and plugin boundaries. `PHASE_10_SPEC.md` defines the
-direct-chat and group-tutorial boundaries.
+direct-chat and group-tutorial boundaries. `PHASE_11_SPEC.md` defines the
+message-push and AI/IoT tutorial boundaries.

--- a/docs-site/content/docs/guide/tutorials/ai-and-iot.en.mdx
+++ b/docs-site/content/docs/guide/tutorials/ai-and-iot.en.mdx
@@ -1,0 +1,183 @@
+---
+title: AI & IoT Communication
+description: Combine AI stream projections, device telemetry, durable command sync, and business execution receipts.
+---
+
+This tutorial covers two scenarios that share one messaging foundation but have different success criteria: AI answers need recoverable stream state, while IoT needs bounded telemetry and idempotent device commands. The product always owns model invocation, device credentials, business policy, and execution outcomes.
+
+<Callout type="warn" title="HTTP examples belong behind a trusted service boundary">
+  Current product HTTP routes have no general product authentication, and the default Beta Gateway does not automatically validate every CONNECT against stored `/user/token` metadata. Browsers, mobile clients, and device firmware must not hold these server capabilities directly.
+</Callout>
+
+## AI: create a durable stream anchor
+
+The product service first enforces model authorization, quotas, content safety, and cancellation policy. After a user prompt, send one base answer with a stable `client_msg_no` and the legacy stream bit. `setting=2` marks a stream message:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"ai-assistant",
+    "channel_id":"alice",
+    "channel_type":1,
+    "client_msg_no":"ai-answer-req-42",
+    "setting":2,
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiYWlfYW5zd2VyIiwic3RhdHVzIjoic3RyZWFtaW5nIiwicmVxdWVzdF9pZCI6InJlcS00MiJ9"
+  }'
+```
+
+Wait for `reason=1` before appending events. It proves that the base message reached Channel quorum commit, not that model generation, client rendering, or the product task completed.
+
+`/message/event` does not currently perform a routed existence check for the base message; `message_id` in an event request is response context only. The product service must preserve the exact Channel identity and `client_msg_no`, and must not create an orphan event projection after a failed base send.
+
+## AI: append deltas and finish
+
+Open the default event lane:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"alice",
+    "channel_type":1,
+    "from_uid":"ai-assistant",
+    "client_msg_no":"ai-answer-req-42",
+    "event_id":"ai-answer-req-42-open",
+    "event_type":"stream.open",
+    "payload":{"kind":"text"}
+  }'
+```
+
+Give every generated chunk a new stable `event_id`. Retry an uncertain result with the same ID and identical payload:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"alice",
+    "channel_type":1,
+    "from_uid":"ai-assistant",
+    "client_msg_no":"ai-answer-req-42",
+    "event_id":"ai-answer-req-42-delta-0001",
+    "event_type":"stream.delta",
+    "payload":{"kind":"text","delta":"Hello"}
+  }'
+```
+
+Reusing an applied `event_id` returns its original result; it does not replace the event with a different payload. `stream.open`, `stream.delta`, and `stream.snapshot` may remain only in the bounded Slot-Leader cache, in which case `msg_event_seq` can be `0`.
+
+Commit the terminal state when generation ends:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"alice",
+    "channel_type":1,
+    "from_uid":"ai-assistant",
+    "client_msg_no":"ai-answer-req-42",
+    "event_id":"ai-answer-req-42-finish",
+    "event_type":"stream.finish",
+    "payload":{"end_reason":3}
+  }'
+```
+
+`stream.finish` places all still-open lanes and the reserved finish marker into one Slot proposal to create the terminal projection. If leadership changes and the new leader lacks cached evidence, finish fails closed. Replay the complete deltas or final snapshot before retrying finish instead of recording an incomplete answer as complete.
+
+## AI: sync the terminal projection
+
+A reconnecting client can request compact event metadata:
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/messagesync \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "login_uid":"alice",
+    "channel_id":"ai-assistant",
+    "channel_type":1,
+    "start_message_seq":0,
+    "limit":20,
+    "pull_mode":1,
+    "event_summary_mode":"full"
+  }'
+```
+
+The response can include `event_meta`, completion state, and the final snapshot. There is no current public `/message/eventsync`, and `/message/event` does not itself push every delta to connected client Sessions. A token-by-token UI therefore needs a product-owned stream or another explicitly designed message path with backpressure, ordering, and recovery; WuKongIM event projection supplies terminal and reconnect state.
+
+## IoT: send bounded telemetry
+
+Assign every device a stable UID and revocable credential policy. A group Channel must already exist, and the sending device must satisfy its membership policy. Create the product-owned telemetry Channel from a trusted service network:
+
+```bash
+curl -sS http://127.0.0.1:5001/channel \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"fleet-west",
+    "channel_type":2,
+    "reset":1,
+    "subscribers":["device-42","control-service"]
+  }'
+```
+
+`reset=1` replaces membership with the supplied list, so use it for first-time provisioning or product-owned desired-state reconciliation, not blindly against unknown existing members. This example authorizes both the device and control service. After it succeeds, the device can send an ordinary durable message:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"device-42",
+    "channel_id":"fleet-west",
+    "channel_type":2,
+    "client_msg_no":"device-42-telemetry-1785897600",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoidGVsZW1ldHJ5IiwidGVtcGVyYXR1cmVfYyI6MjEuNCwicmVwb3J0ZWRfYXQiOjE3ODU4OTc2MDB9"
+  }'
+```
+
+Do not write every high-frequency sample forever as a chat message. Aggregate by device and time window, sample, or emit only state changes. Bound per-device rate, payload size, Channel hotspots, webhook/plugin consumption, and offline recovery windows independently.
+
+## IoT: send a recoverable command
+
+A recoverable command should reuse a stable source Channel. Before sending the first target command, create durable CMD discovery for the device:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/cmd/bind \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "uid":"device-42",
+    "channel_id":"fleet-west",
+    "channel_type":2
+  }'
+```
+
+Binding starts at the sequence after the current CMD-log tail and does not backfill older commands, so it must happen before SEND. The trusted control service then sets `sync_once=1` on that same source Channel:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"control-service",
+    "channel_id":"fleet-west",
+    "channel_type":2,
+    "sync_once":1,
+    "client_msg_no":"device-command-op-42",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiZGV2aWNlX2NvbW1hbmQiLCJvcGVyYXRpb25faWQiOiJvcC00MiIsImFjdGlvbiI6InNldF9mYW4iLCJ2YWx1ZSI6MiwiZGVhZGxpbmUiOjE3ODU4OTc2NjB9"
+  }'
+```
+
+It enters the separate CMD log, and the binding creates a UID-owned CMD discovery directory rather than an ordinary conversation. After reconnecting, the device synchronizes the latest command generation:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/sync \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"device-42","limit":20}'
+```
+
+Call `/message/syncack` after processing that response. It advances the server-recorded latest CMD sync generation; the request `last_message_seq` is a required compatibility field, not proof of device execution. When the device permanently loses command access to this source Channel, call `/message/cmd/unbind` with the same binding request shape.
+
+Request-scoped `subscribers` can provide bounded immediate targeting, but they do not automatically create CMD discovery membership and cannot directly promise reconnect recovery. An online-only command must set both `no_persist=1` and `sync_once=1`. It has no durable sequence, offline sync, ordinary conversation, or `msg.offline`. A plain non-command `NoPersist` can return compatibility success without any realtime delivery.
+
+## Close the loop with a business result
+
+Every device command carries a product `operation_id`, deadline, desired state, and version. The device executes idempotently by `operation_id`, then sends a separate durable result message. SENDACK, RECV, RECVACK, and `/message/syncack` mean commit, online write, receive feedback, and cursor advance respectively; none proves that the fan reached the requested speed.
+
+Before launch, test model cancellation, duplicate deltas, leader movement, cache pressure, terminal replay, device power loss, expired commands, repeated execution, out-of-order business results, hot device groups, and control-service rate limits. Continue with [Messages](/en/guide/core-concepts/messages), [Webhooks](/en/guide/integration/webhooks), and [Messaging](/en/guide/integration/messaging).

--- a/docs-site/content/docs/guide/tutorials/ai-and-iot.mdx
+++ b/docs-site/content/docs/guide/tutorials/ai-and-iot.mdx
@@ -1,0 +1,183 @@
+---
+title: AI 与 IoT 通信
+description: 组合 AI 流式投影、设备遥测、持久命令同步和业务执行回执。
+---
+
+本教程展示两个共享同一消息底座、但成功条件不同的场景：AI 回答需要可恢复的流式状态，IoT 需要有界遥测和可幂等执行的设备命令。模型调用、设备凭据、业务策略和执行结果始终由业务系统拥有。
+
+<Callout type="warn" title="HTTP 示例只属于受信服务边界">
+  当前产品 HTTP 路由没有通用业务鉴权，默认 Beta Gateway 也不会自动使用已存 `/user/token` 元数据验证每个 CONNECT。浏览器、移动端和设备固件不能直接持有这些服务端能力。
+</Callout>
+
+## AI：创建持久流锚点
+
+业务服务先完成模型权限、配额、内容安全和取消策略。收到用户问题后，以稳定 `client_msg_no` 发送一条带 legacy stream bit 的基础回答消息；`setting=2` 表示流式消息：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"ai-assistant",
+    "channel_id":"alice",
+    "channel_type":1,
+    "client_msg_no":"ai-answer-req-42",
+    "setting":2,
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiYWlfYW5zd2VyIiwic3RhdHVzIjoic3RyZWFtaW5nIiwicmVxdWVzdF9pZCI6InJlcS00MiJ9"
+  }'
+```
+
+等待 `reason=1` 后再写事件。这证明基础消息已达到 Channel quorum commit，但不表示模型生成、客户端渲染或业务任务已完成。
+
+`/message/event` 当前不会路由查询并验证基础消息是否存在；事件请求中的 `message_id` 只是响应上下文。业务服务必须保持完全相同的 Channel 身份和 `client_msg_no`，不能在基础发送失败时孤立地创建事件投影。
+
+## AI：追加增量并完成
+
+先打开默认事件 lane：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"alice",
+    "channel_type":1,
+    "from_uid":"ai-assistant",
+    "client_msg_no":"ai-answer-req-42",
+    "event_id":"ai-answer-req-42-open",
+    "event_type":"stream.open",
+    "payload":{"kind":"text"}
+  }'
+```
+
+每个生成块使用新的稳定 `event_id`；结果不明确时，用同一个 ID 和相同 Payload 重试：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"alice",
+    "channel_type":1,
+    "from_uid":"ai-assistant",
+    "client_msg_no":"ai-answer-req-42",
+    "event_id":"ai-answer-req-42-delta-0001",
+    "event_type":"stream.delta",
+    "payload":{"kind":"text","delta":"Hello"}
+  }'
+```
+
+已应用的 `event_id` 再次出现时返回原结果，不会用新 Payload 重写它。`stream.open`、`stream.delta` 和 `stream.snapshot` 可能只保存在 Slot Leader 的有界缓存中，此时 `msg_event_seq` 可以是 `0`。
+
+生成结束后提交终态：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"alice",
+    "channel_type":1,
+    "from_uid":"ai-assistant",
+    "client_msg_no":"ai-answer-req-42",
+    "event_id":"ai-answer-req-42-finish",
+    "event_type":"stream.finish",
+    "payload":{"end_reason":3}
+  }'
+```
+
+`stream.finish` 把仍打开的 lane 和保留的 finish marker 作为一个 Slot proposal 形成终态投影。如果领导权变化后新 Leader 没有缓存证据，finish 会 fail-closed；业务服务必须重放完整增量或终态快照，再重试 finish，不能把缺失内容标记为完成。
+
+## AI：同步最终投影
+
+重连客户端可以请求紧凑事件摘要：
+
+```bash
+curl -sS http://127.0.0.1:5001/channel/messagesync \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "login_uid":"alice",
+    "channel_id":"ai-assistant",
+    "channel_type":1,
+    "start_message_seq":0,
+    "limit":20,
+    "pull_mode":1,
+    "event_summary_mode":"full"
+  }'
+```
+
+响应可包含 `event_meta`、完成状态和最终 snapshot。当前没有公开 `/message/eventsync`，而 `/message/event` 本身不会把每个 delta 推送到在线客户端 Session。需要逐 Token 实时 UI 时，使用业务自有流连接，或先明确设计另一条有背压、顺序和恢复语义的消息路径；WuKongIM 的事件投影用于终态与重连恢复。
+
+## IoT：发送有界遥测
+
+为每台设备分配稳定 UID 和可撤销凭据。群 Channel 必须先存在，而且发送设备必须满足成员策略；在受信服务网络中创建产品拥有的遥测 Channel：
+
+```bash
+curl -sS http://127.0.0.1:5001/channel \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel_id":"fleet-west",
+    "channel_type":2,
+    "reset":1,
+    "subscribers":["device-42","control-service"]
+  }'
+```
+
+`reset=1` 用给定列表替换成员，适合首次配置或业务侧期望状态对账；不要在未知现有成员时盲目使用。这里同时授权设备和控制服务，成功后设备可以发送普通持久消息：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"device-42",
+    "channel_id":"fleet-west",
+    "channel_type":2,
+    "client_msg_no":"device-42-telemetry-1785897600",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoidGVsZW1ldHJ5IiwidGVtcGVyYXR1cmVfYyI6MjEuNCwicmVwb3J0ZWRfYXQiOjE3ODU4OTc2MDB9"
+  }'
+```
+
+高频采样不要逐条无限写入聊天日志。按设备/时间窗聚合、采样或只发送状态变化，并分别限制单设备速率、Payload 大小、Channel 热点、Webhook/插件消费和离线恢复窗口。
+
+## IoT：发送可恢复命令
+
+可恢复命令应复用一个稳定的源 Channel。必须在第一条目标命令发送前，为设备建立持久 CMD 发现绑定：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/cmd/bind \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "uid":"device-42",
+    "channel_id":"fleet-west",
+    "channel_type":2
+  }'
+```
+
+绑定从当前 CMD 日志尾部的下一条 sequence 开始，不会补回更早的命令；因此必须先绑定再发送。随后，受信控制服务在同一源 Channel 上设置 `sync_once=1`：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"control-service",
+    "channel_id":"fleet-west",
+    "channel_type":2,
+    "sync_once":1,
+    "client_msg_no":"device-command-op-42",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiZGV2aWNlX2NvbW1hbmQiLCJvcGVyYXRpb25faWQiOiJvcC00MiIsImFjdGlvbiI6InNldF9mYW4iLCJ2YWx1ZSI6MiwiZGVhZGxpbmUiOjE3ODU4OTc2NjB9"
+  }'
+```
+
+它进入独立 CMD 日志，绑定创建 UID-owned CMD 发现目录，不污染普通会话。设备重连后同步最新命令 generation：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/sync \
+  -H 'Content-Type: application/json' \
+  -d '{"uid":"device-42","limit":20}'
+```
+
+处理完本次返回后调用 `/message/syncack`。该调用推进服务端记录的最新 CMD sync generation；请求 `last_message_seq` 是兼容必填字段，不是设备执行成功证明。设备永久失去该源 Channel 的命令权限时，用相同请求结构调用 `/message/cmd/unbind`。
+
+请求级 `subscribers` 可以做有界的即时目标投递，但不会自动创建 CMD 发现绑定，不能直接承诺重连恢复。在线瞬时命令必须同时设置 `no_persist=1` 和 `sync_once=1`；它没有持久 sequence、离线同步、普通会话或 `msg.offline`。普通非命令 `NoPersist` 即使返回兼容成功，也不会进行实时投递。
+
+## 用业务结果闭环
+
+每个设备命令携带产品级 `operation_id`、deadline、期望状态和版本。设备先按 `operation_id` 幂等执行，再发送一条独立持久结果消息。SENDACK、RECV、RECVACK 和 `/message/syncack` 分别代表提交、在线写入、接收反馈和游标推进，都不代表风扇已经设置为目标档位。
+
+上线前测试模型取消、重复 delta、Leader 切换、缓存压力、终态重放、设备断电、过期命令、重复执行、乱序业务结果、热点设备群和控制服务限流。继续阅读 [消息](/zh/guide/core-concepts/messages)、[Webhook](/zh/guide/integration/webhooks) 和 [消息收发](/zh/guide/integration/messaging)。

--- a/docs-site/content/docs/guide/tutorials/index.en.mdx
+++ b/docs-site/content/docs/guide/tutorials/index.en.mdx
@@ -12,6 +12,8 @@ Scenario tutorials begin with a product outcome and connect the product service,
 <Cards>
   <Card title="Direct Chat" description="Connect identity, person-Channel messaging, offline recovery, unread state, and multi-device verification." href="/en/guide/tutorials/direct-chat" />
   <Card title="Groups & Large Groups" description="Connect group membership, group messages, churn, and 100,000-member capacity boundaries." href="/en/guide/tutorials/large-groups" />
+  <Card title="Message Push" description="Build recoverable notifications with offline webhooks, a product outbox, and providers." href="/en/guide/tutorials/push" />
+  <Card title="AI & IoT Communication" description="Combine AI stream projections, telemetry, durable commands, and business receipts." href="/en/guide/tutorials/ai-and-iot" />
 </Cards>
 
 ## Choose a path
@@ -21,6 +23,9 @@ Scenario tutorials begin with a product outcome and connect the product service,
 | Two users exchange messages | [Direct Chat](/en/guide/tutorials/direct-chat) | Use the peer UID; the server derives the canonical person Channel |
 | Ordinary group chat | [Groups & Large Groups](/en/guide/tutorials/large-groups) | The product owns group lifecycle and membership; WuKongIM owns the message log |
 | A 100,000-member community or room | [Groups & Large Groups](/en/guide/tutorials/large-groups#scale-to-100000-members) | Batched reconciliation, paged post-commit fanout, and hotspot capacity testing |
+| Offline mobile notification | [Message Push](/en/guide/tutorials/push) | The webhook produces candidates; the product outbox and provider receipts own reliability |
+| Streaming AI answer | [AI & IoT Communication](/en/guide/tutorials/ai-and-iot#ai-create-a-durable-stream-anchor) | Commit the base first, persist terminal projection, and keep live token streaming product-owned |
+| Device telemetry and control | [AI & IoT Communication](/en/guide/tutorials/ai-and-iot#iot-send-bounded-telemetry) | A command-sync cursor is not proof of business execution |
 
 ## Shared success model
 
@@ -36,4 +41,4 @@ SDK SEND or trusted HTTP send
 
 Treat “message committed,” “one Session received online delivery,” “the user's unread projection changed,” and “the business action completed” as four different outcomes. Strong business consistency belongs in the product service with its database, idempotency keys, and compensation workflow.
 
-Message Push and AI/IoT tutorials remain planned. For now, continue with [Use Cases](/en/guide/product-overview/use-cases) and [Integration Architecture](/en/guide/integration/architecture).
+All four scenario tutorials are now published. Continue with [Use Cases](/en/guide/product-overview/use-cases), [Integration Architecture](/en/guide/integration/architecture), and [Messaging](/en/guide/integration/messaging) to turn these examples into your own product protocol and reliability targets.

--- a/docs-site/content/docs/guide/tutorials/index.mdx
+++ b/docs-site/content/docs/guide/tutorials/index.mdx
@@ -12,6 +12,8 @@ description: 把身份、Channel、消息、会话与规模约束组合成可落
 <Cards>
   <Card title="单聊" description="完成身份接入、个人 Channel 消息、离线恢复、会话未读与多设备验证。" href="/zh/guide/tutorials/direct-chat" />
   <Card title="群聊与超大群" description="完成群成员维护、群消息、成员变更与十万成员容量边界。" href="/zh/guide/tutorials/large-groups" />
+  <Card title="消息推送" description="用离线 Webhook、业务 Outbox 和推送厂商完成可恢复通知。" href="/zh/guide/tutorials/push" />
+  <Card title="AI 与 IoT 通信" description="组合 AI 流式投影、设备遥测、持久命令与业务回执。" href="/zh/guide/tutorials/ai-and-iot" />
 </Cards>
 
 ## 如何选择
@@ -21,6 +23,9 @@ description: 把身份、Channel、消息、会话与规模约束组合成可落
 | 两个用户互发消息 | [单聊](/zh/guide/tutorials/direct-chat) | 使用对端 UID，canonical person Channel 由服务端生成 |
 | 普通群聊 | [群聊与超大群](/zh/guide/tutorials/large-groups) | 业务系统维护群生命周期和成员，WuKongIM 维护消息日志 |
 | 十万成员社区或房间 | [群聊与超大群](/zh/guide/tutorials/large-groups#扩展到十万成员) | 成员分批协调、提交后分页 Fan-out、热点容量验证 |
+| 离线移动通知 | [消息推送](/zh/guide/tutorials/push) | Webhook 只产生候选，业务 Outbox 和厂商回执负责可靠性 |
+| AI 流式回答 | [AI 与 IoT 通信](/zh/guide/tutorials/ai-and-iot#ai创建持久流锚点) | 基础消息先提交，终态投影持久化，实时 Token 流由业务侧拥有 |
+| 设备遥测与控制 | [AI 与 IoT 通信](/zh/guide/tutorials/ai-and-iot#iot发送有界遥测) | 命令同步游标不等于设备业务执行成功 |
 
 ## 所有教程共用的成功模型
 
@@ -36,4 +41,4 @@ SDK SEND 或受信 HTTP send
 
 把“消息已提交”“某个 Session 已在线收到”“用户会话未读已更新”和“业务动作已完成”作为四种不同结果。需要强一致业务结果时，由业务服务使用自己的数据库、幂等键和补偿流程完成。
 
-消息推送以及 AI/IoT 教程仍在规划中。当前可以先阅读[适用场景](/zh/guide/product-overview/use-cases)和[集成架构](/zh/guide/integration/architecture)。
+四个场景教程现在都已发布。继续阅读[适用场景](/zh/guide/product-overview/use-cases)、[集成架构](/zh/guide/integration/architecture)和[消息收发](/zh/guide/integration/messaging)，把示例收敛为自己的业务协议与可靠性目标。

--- a/docs-site/content/docs/guide/tutorials/push.en.mdx
+++ b/docs-site/content/docs/guide/tutorials/push.en.mdx
@@ -1,0 +1,108 @@
+---
+title: Message Push
+description: Build recoverable mobile notifications with offline webhooks, a product outbox, and push providers.
+---
+
+This tutorial turns a committed message into a mobile notification. WuKongIM identifies UIDs with no online route and emits a bounded webhook; the product service owns device tokens, notification policy, APNs/FCM provider calls, retries, and receipts.
+
+<Callout type="warn" title="WuKongIM does not call push providers">
+  `msg.offline` is an offline-candidate signal, not an APNs, FCM, or provider delivery receipt. A SENDACK, webhook HTTP 200, or provider acceptance does not prove that the user saw a notification.
+</Callout>
+
+```text
+durable message -> Channel quorum commit -> SENDACK
+                           |
+                           +-> online Session delivery
+                           |
+                           +-> no UID route -> msg.offline webhook
+                                                -> product outbox
+                                                -> APNs / FCM / vendor
+```
+
+## 1. Prepare product-owned device data
+
+At minimum, the product service stores stable UID, device ID, platform, provider token, token version, authorization state, locale, quiet hours, and the latest invalidation reason. `/user/token` can maintain compatible device metadata, but there is no current public token-read API for a push worker, and the default Beta Gateway does not automatically validate CONNECT against this metadata.
+
+Production push therefore uses the product database as its source of truth and updates it during login, token refresh, logout, and provider invalidation callbacks. Never use a nickname or transient Session ID as the push identity.
+
+## 2. Enable the offline webhook
+
+Configure a protected product endpoint in `wukongim.toml`:
+
+```toml
+[webhook]
+http_addr = "https://events.example.com/wukongim"
+focus_events = ["msg.notify", "msg.offline"]
+queue_size = 1024
+workers = 16
+offline_uid_batch_size = 512
+request_timeout = "5s"
+retry_max_attempts = 3
+```
+
+The current sender sets only `Content-Type: application/json`; it adds no signature or shared-secret header. Establish trust with HTTPS, a private network or service mesh, mTLS or fixed egress identity, body-size limits, and rate limits. See [Webhooks](/en/guide/integration/webhooks) for the complete configuration and receiver contract.
+
+## 3. Send a recoverable notification message
+
+First provision a permissioned notification-service UID in the product. This example sends an ordinary durable message to Alice's person Channel. Its payload is an application message model, not a privileged server message type:
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"notification-service",
+    "channel_id":"alice",
+    "channel_type":1,
+    "client_msg_no":"order-42-shipped-v1",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoib3JkZXJfdXBkYXRlIiwidGl0bGUiOiJPcmRlciBzaGlwcGVkIiwiYm9keSI6IlRyYWNrIHBhY2thZ2UgaW4gdGhlIGFwcCIsIm9yZGVyX2lkIjoib3JkZXItNDIifQ=="
+  }'
+```
+
+`reason=1` means the message reached Channel quorum commit. Keep `client_msg_no` stable for safe retry after an uncertain result. Trusted system-UID bypass is optional and must not replace product authorization, rate limits, or notification preferences.
+
+## 4. Receive offline candidates
+
+If neither Alice nor `notification-service` has an online route when Presence is resolved, the product endpoint receives a result like this:
+
+```text
+POST /wukongim?event=msg.offline
+Content-Type: application/json
+```
+
+```json
+{
+  "header": {"no_persist": 0, "red_dot": 0, "sync_once": 0},
+  "message_id": 123456789,
+  "message_idstr": "123456789",
+  "client_msg_no": "order-42-shipped-v1",
+  "message_seq": 8,
+  "from_uid": "notification-service",
+  "channel_id": "<canonical-person-channel>",
+  "channel_type": 1,
+  "payload": "eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoib3JkZXJfdXBkYXRlIiwidGl0bGUiOiJPcmRlciBzaGlwcGVkIiwiYm9keSI6IlRyYWNrIHBhY2thZ2UgaW4gdGhlIGFwcCIsIm9yZGVyX2lkIjoib3JkZXItNDIifQ==",
+  "to_uids": ["notification-service", "alice"]
+}
+```
+
+Offline candidates are collected before sender-echo suppression, so a person Channel's `to_uids` can include `from_uid`; the notification service is absent from the list when it has an online route. For a person message, webhook `channel_id` is the server's canonical Channel identity; product relationships still use the two UIDs and must not persist this internal value as their primary key. The receiver must also support `compress: "gzip"` with Base64 `compress_to_uids`. `msg.offline` applies only to ordinary durable messages: `SyncOnce`, request-scoped `subscribers`, and transient `NoPersist` do not produce this effect.
+
+Offline classification is per UID, not per device. If Alice has even one online route, she is not in the offline UID list. A policy such as “push every disconnected device” must combine the product's device table with `msg.notify`, client receipts, and product-specific rules.
+
+## 5. Write an outbox before calling the provider
+
+The webhook receiver should quickly:
+
+1. Authenticate the network source and event allowlist, and bound the body size.
+2. Expand `to_uids` or decompress `compress_to_uids`, then filter `from_uid`, service identities, and unauthorized users according to product notification policy.
+3. For every eligible UID, persist an outbox row keyed by `msg.offline + message_id + uid`.
+4. Return HTTP 200 after the outbox commit.
+5. Resolve active provider tokens by UID and apply quiet-hour, collapse, locale, and privacy rules in the background.
+6. Call the provider, classify permanent token failures and retryable errors, and persist the outcome.
+
+Webhook queues are node-local memory. Queue saturation, process exit, cancellation, or exhausted retries can drop an event, and a crash does not replay it. Critical push work must be reconstructible from a product outbox, a product event, or durable message history instead of relying on ever-larger WuKongIM queues.
+
+## 6. Recover from the message log
+
+A provider payload carries only a safe display summary and product locator, not the complete sensitive message. When the user opens it, the client authenticates again and reads the committed message through SDK sync or `/channel/messagesync`; the provider notification is never the message source of truth.
+
+Before launch, test duplicate and missing webhooks, compressed UID lists, token rotation, partially online users, provider throttling, quiet hours, stale deep links, logout, and retracted content. Continue with [Webhooks](/en/guide/integration/webhooks) and [AI & IoT Communication](/en/guide/tutorials/ai-and-iot).

--- a/docs-site/content/docs/guide/tutorials/push.mdx
+++ b/docs-site/content/docs/guide/tutorials/push.mdx
@@ -1,0 +1,108 @@
+---
+title: 消息推送
+description: 用离线 Webhook、业务 Outbox 和推送厂商完成可恢复的移动通知流程。
+---
+
+本教程把一条已提交消息转换为移动推送。WuKongIM 负责识别没有在线路由的 UID 并产生有界 Webhook；业务服务负责设备 Token、通知策略、APNs/FCM 等厂商调用、重试和回执。
+
+<Callout type="warn" title="WuKongIM 不直接发送厂商推送">
+  `msg.offline` 是离线候选信号，不是 APNs、FCM 或厂商送达回执。不要把 SENDACK、Webhook HTTP 200 或厂商受理当成用户已经看到通知。
+</Callout>
+
+```text
+durable message -> Channel quorum commit -> SENDACK
+                           |
+                           +-> online Session delivery
+                           |
+                           +-> no UID route -> msg.offline Webhook
+                                                -> product outbox
+                                                -> APNs / FCM / vendor
+```
+
+## 1. 准备业务侧设备数据
+
+业务服务至少保存：稳定 UID、设备 ID、平台、厂商 Token、Token 版本、授权状态、语言、静默时段和最近失效原因。`/user/token` 可以维护兼容设备元数据，但当前没有面向推送工作器的公开 Token 查询接口，默认 Beta Gateway 也不会自动使用这份元数据验证 CONNECT。
+
+因此，生产推送应以业务数据库为准，并在登录、Token 刷新、退出和厂商失效回执时更新状态。不要把昵称或临时 Session ID 当作推送身份。
+
+## 2. 启用离线 Webhook
+
+在 `wukongim.toml` 中配置受保护的业务端点：
+
+```toml
+[webhook]
+http_addr = "https://events.example.com/wukongim"
+focus_events = ["msg.notify", "msg.offline"]
+queue_size = 1024
+workers = 16
+offline_uid_batch_size = 512
+request_timeout = "5s"
+retry_max_attempts = 3
+```
+
+当前 Sender 只设置 `Content-Type: application/json`，没有签名或共享密钥 Header。使用 HTTPS、私网或服务网格、mTLS/固定出口身份、请求大小限制和速率限制建立可信边界。完整配置与接收建议见 [Webhook](/zh/guide/integration/webhooks)。
+
+## 3. 发送可恢复的通知消息
+
+先在业务系统中创建受权限约束的通知服务 UID。本例向 Alice 的个人 Channel 发送一条普通持久消息；Payload 是应用消息模型，不是服务端特权类型：
+
+```bash
+curl -sS http://127.0.0.1:5001/message/send \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from_uid":"notification-service",
+    "channel_id":"alice",
+    "channel_type":1,
+    "client_msg_no":"order-42-shipped-v1",
+    "payload":"eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoib3JkZXJfdXBkYXRlIiwidGl0bGUiOiJPcmRlciBzaGlwcGVkIiwiYm9keSI6IlRyYWNrIHBhY2thZ2UgaW4gdGhlIGFwcCIsIm9yZGVyX2lkIjoib3JkZXItNDIifQ=="
+  }'
+```
+
+`reason=1` 表示消息已达到 Channel quorum commit。保持 `client_msg_no` 稳定，以便不确定结果时安全重试。系统 UID 的权限绕过是可选受信能力，不应替代业务授权、频控和用户通知偏好。
+
+## 4. 接收离线候选
+
+如果 Alice 和 `notification-service` 在 Presence 解析时都没有在线路由，业务端点会收到类似结果：
+
+```text
+POST /wukongim?event=msg.offline
+Content-Type: application/json
+```
+
+```json
+{
+  "header": {"no_persist": 0, "red_dot": 0, "sync_once": 0},
+  "message_id": 123456789,
+  "message_idstr": "123456789",
+  "client_msg_no": "order-42-shipped-v1",
+  "message_seq": 8,
+  "from_uid": "notification-service",
+  "channel_id": "<canonical-person-channel>",
+  "channel_type": 1,
+  "payload": "eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoib3JkZXJfdXBkYXRlIiwidGl0bGUiOiJPcmRlciBzaGlwcGVkIiwiYm9keSI6IlRyYWNrIHBhY2thZ2UgaW4gdGhlIGFwcCIsIm9yZGVyX2lkIjoib3JkZXItNDIifQ==",
+  "to_uids": ["notification-service", "alice"]
+}
+```
+
+离线候选在发送者回显抑制之前收集，因此个人 Channel 的 `to_uids` 可能包含 `from_uid`；如果通知服务有在线路由，它就不会出现在列表中。Webhook 中的个人 `channel_id` 是服务端 canonical Channel 身份；业务关系仍使用双方 UID，不能把这个内部值保存为关系主键。接收端还必须支持 `compress: "gzip"` 与 Base64 `compress_to_uids`。`msg.offline` 只针对普通持久消息：`SyncOnce`、请求级 `subscribers` 和瞬态 `NoPersist` 不会产生这个效果。
+
+离线判断粒度是 UID，不是设备。只要 Alice 有一条在线路由，她就不会进入离线 UID 列表；需要“某台设备离线也推送”时，业务服务必须结合自己的设备表、`msg.notify`、客户端回执和产品策略计算目标。
+
+## 5. 先写 Outbox，再调用厂商
+
+Webhook 接收器应快速完成以下步骤：
+
+1. 验证网络来源和事件白名单，限制请求大小。
+2. 展开 `to_uids` 或解压 `compress_to_uids`，再按产品通知策略过滤 `from_uid`、服务身份和未授权用户。
+3. 对每个合格 UID，以 `msg.offline + message_id + uid` 为幂等键写入持久 Outbox。
+4. 提交成功后返回 HTTP 200。
+5. 后台按 UID 查询有效设备 Token，应用免打扰、折叠、语言与隐私规则。
+6. 调用推送厂商，分类永久 Token 失效和可重试错误，并保存结果。
+
+Webhook 队列是节点本地内存状态，满队列、进程退出、取消或重试耗尽都可能丢事件，也不会在崩溃后重放。关键推送应能从业务 Outbox、业务事件或持久消息历史补偿，而不是依赖扩大 WuKongIM 内存队列。
+
+## 6. 让客户端从消息日志恢复
+
+推送 Payload 只携带安全的展示摘要和业务定位键，不携带完整敏感消息。用户点击通知后，客户端重新认证并从 SDK 同步或 `/channel/messagesync` 读取已提交消息；它不能把厂商通知当作消息真相。
+
+上线前验证：重复 Webhook、Webhook 丢失、压缩 UID、Token 轮换、部分设备在线、厂商限流、静默时段、深链失效、用户退出和消息已撤销等路径。继续阅读 [Webhook](/zh/guide/integration/webhooks) 和 [AI 与 IoT 通信](/zh/guide/tutorials/ai-and-iot)。

--- a/docs-site/lib/navigation.test.ts
+++ b/docs-site/lib/navigation.test.ts
@@ -111,7 +111,7 @@ describe('documentation navigation contract', () => {
     expect(integration?.children.find((page) => page.slug === 'plugins')?.status).toBe('published');
   });
 
-  test('publishes the first scenario tutorial tranche', () => {
+  test('publishes the complete scenario tutorial set', () => {
     const guide = domains.find((domain) => domain.key === 'guide');
     const tutorials = guide?.groups.find((group) => group.slug === 'tutorials');
 
@@ -119,8 +119,8 @@ describe('documentation navigation contract', () => {
     expect(tutorials?.children.map((page) => [page.slug, page.status])).toEqual([
       ['direct-chat', 'published'],
       ['large-groups', 'published'],
-      ['push', 'planned'],
-      ['ai-and-iot', 'planned'],
+      ['push', 'published'],
+      ['ai-and-iot', 'published'],
     ]);
   });
 
@@ -168,6 +168,8 @@ describe('documentation navigation contract', () => {
         `/${locale}/guide/tutorials`,
         `/${locale}/guide/tutorials/direct-chat`,
         `/${locale}/guide/tutorials/large-groups`,
+        `/${locale}/guide/tutorials/push`,
+        `/${locale}/guide/tutorials/ai-and-iot`,
         `/${locale}/server`,
         `/${locale}/server/deployment`,
         `/${locale}/server/deployment/choosing`,
@@ -330,10 +332,10 @@ describe('documentation navigation contract', () => {
     expect(isPublishedContentPath('guide/tutorials/direct-chat.en.mdx')).toBe(true);
     expect(isPublishedContentPath('guide/tutorials/large-groups.mdx')).toBe(true);
     expect(isPublishedContentPath('guide/tutorials/large-groups.en.mdx')).toBe(true);
-    expect(isPublishedContentPath('guide/tutorials/push.mdx')).toBe(false);
-    expect(isPublishedContentPath('guide/tutorials/push.en.mdx')).toBe(false);
-    expect(isPublishedContentPath('guide/tutorials/ai-and-iot.mdx')).toBe(false);
-    expect(isPublishedContentPath('guide/tutorials/ai-and-iot.en.mdx')).toBe(false);
+    expect(isPublishedContentPath('guide/tutorials/push.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/push.en.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/ai-and-iot.mdx')).toBe(true);
+    expect(isPublishedContentPath('guide/tutorials/ai-and-iot.en.mdx')).toBe(true);
     expect(isPublishedContentPath('unknown/index.mdx')).toBe(false);
   });
 });

--- a/docs-site/lib/navigation.ts
+++ b/docs-site/lib/navigation.ts
@@ -383,14 +383,14 @@ export const domains: DocumentationDomain[] = [
             '实现群成员维护和群消息，并说明十万级成员约束。',
             'Implements group membership and messaging with constraints for 100,000-member groups.',
           ),
-          plannedPage(
+          publishedPage(
             'push',
             '消息推送',
             'Message Push',
             '实现通知、系统消息、离线设备处理和失败恢复。',
             'Implements notifications, system messages, offline-device handling, and recovery.',
           ),
-          plannedPage(
+          publishedPage(
             'ai-and-iot',
             'AI 与 IoT 通信',
             'AI & IoT Communication',

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -396,6 +396,19 @@
   client-side read progress. A 100,000-member workflow uses checkpointed
   application batches and post-commit paged fanout rather than one full-member
   request.
+- Phase 11 public scenario tutorials keep mobile push provider integration,
+  AI execution, and device business outcomes application-owned. `msg.offline`
+  is a UID-level candidate emitted only for ordinary durable messages through a
+  bounded best-effort webhook; it is neither per-device state nor a provider
+  receipt. Candidate collection precedes sender-echo suppression, so product
+  push policy filters sender and service identities. Message events anchor to a committed `setting=2` base message;
+  active deltas may be cache-only until terminal projection, and no public
+  fine-grained event sync exists. Recoverable `SyncOnce` commands use a stable
+  source Channel and require recipient CMD binding before SEND; request-scoped
+  recipients do not create discovery membership. `NoPersist + SyncOnce` is
+  online-only. Group telemetry requires an existing Channel and sender
+  membership; neither protocol ACKs nor sync cursors prove that a device
+  executed the business operation.
 - Public deployment guidance treats the root Compose stack as development-only
   and builds artifacts from reviewed source without promising an official image
   registry or tag. Traffic admission uses `/readyz`, not process-level


### PR DESCRIPTION
## Summary

- publish bilingual Message Push tutorials with offline-webhook, application outbox, provider, and recovery boundaries
- publish bilingual AI and IoT tutorials covering durable stream projection, bounded telemetry, explicit CMD discovery binding, reconnect sync, and business receipts
- publish both routes through the shared navigation registry and tutorial indexes
- record Phase 11 contracts in the docs-site flow, specification, README, and project knowledge

## Why

This completes the public scenario-tutorial menu while keeping WuKongIM commit, delivery, webhook, stream-projection, and CMD-sync semantics separate from application-owned provider, model, device-policy, and business-result responsibilities.

## Validation

- `bun run verify` (11 tests, 284 assertions, 427 static pages, output contract)
- focused Go tests for webhook, message, CMD sync, channelappend, API, cluster adapter, and channel identity packages
- desktop and mobile browser QA for both locales with no horizontal overflow or console warnings/errors
- two-axis Standards and Spec review: no findings
