### PR TITLE
ci: run nightly 1000 QPS qualification directly

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,7 +18,7 @@ authorization and the applicable budget.
 | `chat-lifecycle-formal.yml` | `Safety Automation - Start Fresh Formal Chat Lifecycle` | Consumes an authenticated released rehearsal transition and starts a fresh 96-hour formal Lease |
 | `chat-lifecycle-formal-finalize.yml` | `Safety Automation - Finalize Formal Chat Lifecycle Runs` | Collects the same-Lease Soak/capacity/recovery result before Release and zero-inventory proof |
 | `chat-lifecycle-stop.yml` | `Agent Tool - Stop Chat Lifecycle Request` | Seals one request-level stop marker and requests coordinated cancellation plus bounded operator-stop finalization |
-| `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused PR benchmarks, runs a sealed three-node correctness/drain smoke, and runs the nightly reviewed staircase plus ten-minute 1,000 SEND/s qualification |
+| `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused PR benchmarks, runs a sealed three-node correctness/drain smoke, and runs one fresh nightly ten-minute 1,000 SEND/s qualification directly without the diagnostic rate staircase |
 | `review-agent-pr-signal.yml` | `Safety Automation - Review Agent PR Signal` | Emits a credential-free lifecycle or exact-command wake-up hint |
 | `review-agent.yml` | `Safety Automation - Review Agent Controller` | Re-reads GitHub facts and signed state, then plans one lifecycle transition |
 | `review-agent-run.yml` | `Agent Tool - Review Pull Request` | Runs one exact review or explanation generation |

--- a/.github/workflows/three-node-chat-lifecycle-regression.yml
+++ b/.github/workflows/three-node-chat-lifecycle-regression.yml
@@ -122,12 +122,12 @@ jobs:
           retention-days: 7
 
   nightly-qualification:
-    name: Nightly reviewed three-node qualification
+    name: Nightly direct 1000 QPS qualification
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 45
     env:
       GOWORK: "off"
     steps:
@@ -156,7 +156,7 @@ jobs:
             "$MINIMUM_FREE_PERCENT" "$observed_free_percent" \
             >"$evidence_root/filesystem-gate.txt"
           (( observed_free_percent >= MINIMUM_FREE_PERCENT ))
-      - name: Run reviewed staircase and ten-minute qualification
+      - name: Run direct ten-minute 1000 QPS qualification
         shell: bash
         run: |
           set -euo pipefail
@@ -165,10 +165,15 @@ jobs:
           printf '::add-mask::%s\n' "$api_token" "$worker_token"
           export WK_BENCH_API_TOKEN="$api_token"
           export WK_BENCH_WORKER_TOKEN="$worker_token"
-          scripts/run-wukongim-three-node-chat-lifecycle-local-baseline.sh \
+          scripts/run-wukongim-three-node-chat-lifecycle-shakeout.sh \
             --run-dir "$EVIDENCE_ROOT/artifacts" \
             --base-port 15000 \
             --ready-timeout 180 \
+            --send-rate 1000 \
+            --measure-seconds 600 \
+            --warmup-seconds 60 \
+            --drain-timeout 90 \
+            --hot-sendack-p99-ms 400 \
             2>&1 | tee "$EVIDENCE_ROOT/driver.log"
       - name: Reject tracked-tree mutation
         if: always()

--- a/scripts/three_node_chat_lifecycle_workflow_test.go
+++ b/scripts/three_node_chat_lifecycle_workflow_test.go
@@ -77,15 +77,24 @@ func TestThreeNodeChatLifecycleRegressionSeparatesPRSmokeFromNightlyQualificatio
 	require.True(t, ok)
 	require.Contains(t, nightly.If, "github.event_name == 'schedule'")
 	require.Contains(t, nightly.If, "github.ref == 'refs/heads/main'")
-	require.LessOrEqual(t, nightly.TimeoutMinutes, 90)
+	require.LessOrEqual(t, nightly.TimeoutMinutes, 45)
 	nightlyRun := workflowRunCommands(nightly.Steps)
 	require.Contains(t, nightlyRun, "MINIMUM_FREE_PERCENT=15")
-	require.Contains(t, nightlyRun, "run-wukongim-three-node-chat-lifecycle-local-baseline.sh")
-	require.NotContains(t, nightlyRun, "--hot-sendack-p99-ms")
+	for _, required := range []string{
+		"run-wukongim-three-node-chat-lifecycle-shakeout.sh",
+		"--send-rate 1000",
+		"--measure-seconds 600",
+		"--warmup-seconds 60",
+		"--drain-timeout 90",
+		"--hot-sendack-p99-ms 400",
+	} {
+		require.Contains(t, nightlyRun, required)
+	}
+	require.NotContains(t, nightlyRun, "run-wukongim-three-node-chat-lifecycle-local-baseline.sh")
 	require.NotContains(t, nightlyRun, "--no-start")
 	require.NotContains(t, nightlyRun, "--no-worker")
 	assertInitializesEvidenceRootFromRunnerTemp(t, nightly.Steps)
-	assertRejectsTrackedTreeMutationAfter(t, nightly.Steps, "Run reviewed staircase and ten-minute qualification")
+	assertRejectsTrackedTreeMutationAfter(t, nightly.Steps, "Run direct ten-minute 1000 QPS qualification")
 	assertRegressionArtifactStep(t, nightly.Steps, 14)
 }
 


### PR DESCRIPTION
## Summary
- run the nightly three-node qualification directly at 1,000 SEND/s for ten measured minutes
- keep the strict 400 ms hot SENDACK p99 threshold and full typed evidence/drain checks
- remove the diagnostic 250/500/750/1000 staircase from the nightly path and tighten the job timeout to 45 minutes
- keep the PR benchmark and correctness smoke unchanged

## Evidence
- the first merged nightly run spent 22m53s reaching a 750 QPS latency failure, so the 1,000 QPS target never started
- `GOWORK=off go test ./scripts -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/*.yml`
- `git diff --check`