### PR TITLE
ci: run nightly three-node regression at 500 QPS

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,7 +18,7 @@ authorization and the applicable budget.
 | `chat-lifecycle-formal.yml` | `Safety Automation - Start Fresh Formal Chat Lifecycle` | Consumes an authenticated released rehearsal transition and starts a fresh 96-hour formal Lease |
 | `chat-lifecycle-formal-finalize.yml` | `Safety Automation - Finalize Formal Chat Lifecycle Runs` | Collects the same-Lease Soak/capacity/recovery result before Release and zero-inventory proof |
 | `chat-lifecycle-stop.yml` | `Agent Tool - Stop Chat Lifecycle Request` | Seals one request-level stop marker and requests coordinated cancellation plus bounded operator-stop finalization |
-| `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused PR benchmarks, runs a sealed three-node correctness/drain smoke, and runs one fresh nightly ten-minute 1,000 SEND/s qualification directly without the diagnostic rate staircase |
+| `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused PR benchmarks, runs a sealed three-node correctness/drain smoke, and runs one fresh nightly ten-minute 500 SEND/s regression directly without the diagnostic rate staircase |
 | `review-agent-pr-signal.yml` | `Safety Automation - Review Agent PR Signal` | Emits a credential-free lifecycle or exact-command wake-up hint |
 | `review-agent.yml` | `Safety Automation - Review Agent Controller` | Re-reads GitHub facts and signed state, then plans one lifecycle transition |
 | `review-agent-run.yml` | `Agent Tool - Review Pull Request` | Runs one exact review or explanation generation |

--- a/.github/workflows/three-node-chat-lifecycle-regression.yml
+++ b/.github/workflows/three-node-chat-lifecycle-regression.yml
@@ -122,7 +122,7 @@ jobs:
           retention-days: 7
 
   nightly-qualification:
-    name: Nightly direct 1000 QPS qualification
+    name: Nightly direct 500 QPS qualification
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -156,7 +156,7 @@ jobs:
             "$MINIMUM_FREE_PERCENT" "$observed_free_percent" \
             >"$evidence_root/filesystem-gate.txt"
           (( observed_free_percent >= MINIMUM_FREE_PERCENT ))
-      - name: Run direct ten-minute 1000 QPS qualification
+      - name: Run direct ten-minute 500 QPS qualification
         shell: bash
         run: |
           set -euo pipefail
@@ -169,7 +169,7 @@ jobs:
             --run-dir "$EVIDENCE_ROOT/artifacts" \
             --base-port 15000 \
             --ready-timeout 180 \
-            --send-rate 1000 \
+            --send-rate 500 \
             --measure-seconds 600 \
             --warmup-seconds 60 \
             --drain-timeout 90 \

--- a/scripts/three_node_chat_lifecycle_workflow_test.go
+++ b/scripts/three_node_chat_lifecycle_workflow_test.go
@@ -82,7 +82,7 @@ func TestThreeNodeChatLifecycleRegressionSeparatesPRSmokeFromNightlyQualificatio
 	require.Contains(t, nightlyRun, "MINIMUM_FREE_PERCENT=15")
 	for _, required := range []string{
 		"run-wukongim-three-node-chat-lifecycle-shakeout.sh",
-		"--send-rate 1000",
+		"--send-rate 500",
 		"--measure-seconds 600",
 		"--warmup-seconds 60",
 		"--drain-timeout 90",
@@ -91,10 +91,11 @@ func TestThreeNodeChatLifecycleRegressionSeparatesPRSmokeFromNightlyQualificatio
 		require.Contains(t, nightlyRun, required)
 	}
 	require.NotContains(t, nightlyRun, "run-wukongim-three-node-chat-lifecycle-local-baseline.sh")
+	require.NotContains(t, nightlyRun, "--send-rate 1000")
 	require.NotContains(t, nightlyRun, "--no-start")
 	require.NotContains(t, nightlyRun, "--no-worker")
 	assertInitializesEvidenceRootFromRunnerTemp(t, nightly.Steps)
-	assertRejectsTrackedTreeMutationAfter(t, nightly.Steps, "Run direct ten-minute 1000 QPS qualification")
+	assertRejectsTrackedTreeMutationAfter(t, nightly.Steps, "Run direct ten-minute 500 QPS qualification")
 	assertRegressionArtifactStep(t, nightly.Steps, 14)
 }
 


### PR DESCRIPTION
## Summary
- run the nightly three-node regression directly at 500 QPS instead of 1000 QPS
- keep the ten-minute measurement, 400 ms hot SENDACK p99 gate, terminal drain proof, and artifact retention unchanged
- retain the PR-only 1000 QPS benchmarks and bounded correctness smoke

## Evidence
- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/*.yml`
- `git diff --check`

The previous direct 1000 QPS nightly failed with sustained hot-latency on the hosted runner while preserving message correctness and converging queues. The hosted nightly is now a stable regression gate; 1000 QPS remains covered by focused PR benchmarks and dedicated capacity runs.