### PR TITLE
ci: run hosted three-node regression at 500 qps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,7 +18,7 @@ authorization and the applicable budget.
 | `chat-lifecycle-formal.yml` | `Safety Automation - Start Fresh Formal Chat Lifecycle` | Consumes an authenticated released rehearsal transition and starts a fresh 96-hour formal Lease |
 | `chat-lifecycle-formal-finalize.yml` | `Safety Automation - Finalize Formal Chat Lifecycle Runs` | Collects the same-Lease Soak/capacity/recovery result before Release and zero-inventory proof |
 | `chat-lifecycle-stop.yml` | `Agent Tool - Stop Chat Lifecycle Request` | Seals one request-level stop marker and requests coordinated cancellation plus bounded operator-stop finalization |
-| `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused PR benchmarks, runs a sealed three-node correctness/drain smoke, and runs one fresh nightly ten-minute 500 SEND/s regression directly without the diagnostic rate staircase |
+| `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused 500 SEND/s PR benchmarks, runs a sealed 500 SEND/s three-node correctness/drain smoke, and runs one fresh nightly ten-minute 500 SEND/s regression directly without the diagnostic rate staircase; 1,000 SEND/s remains a dedicated capacity-environment gate |
 | `review-agent-pr-signal.yml` | `Safety Automation - Review Agent PR Signal` | Emits a credential-free lifecycle or exact-command wake-up hint |
 | `review-agent.yml` | `Safety Automation - Review Agent Controller` | Re-reads GitHub facts and signed state, then plans one lifecycle transition |
 | `review-agent-run.yml` | `Agent Tool - Review Pull Request` | Runs one exact review or explanation generation |

--- a/.github/workflows/three-node-chat-lifecycle-regression.yml
+++ b/.github/workflows/three-node-chat-lifecycle-regression.yml
@@ -50,7 +50,7 @@ jobs:
           echo "EVIDENCE_ROOT=$evidence_root" >>"$GITHUB_ENV"
           install -d -m 0700 "$evidence_root"
           df -Pk "$RUNNER_TEMP" >"$evidence_root/filesystem-preflight.txt"
-      - name: Run benchmark-first 1000 QPS seams
+      - name: Run benchmark-first 500 QPS seams
         shell: bash
         run: |
           set -euo pipefail
@@ -78,18 +78,18 @@ jobs:
             ' "$output_file"
           }
 
-          GOWORK=off go test -tags=integration ./pkg/channel/replication -run '^$' -bench '^BenchmarkThreeNodeChannelAppend1000QPS$' -benchtime=3000x -benchmem -count=1 -timeout=5m \
+          GOWORK=off go test -tags=integration ./pkg/channel/replication -run '^$' -bench '^BenchmarkThreeNodeChannelAppend500QPS$' -benchtime=3000x -benchmem -count=1 -timeout=5m \
             2>&1 | tee "$EVIDENCE_ROOT/channel-append-benchmark.txt"
           assert_benchmark_metric_le_400 "$EVIDENCE_ROOT/channel-append-benchmark.txt" append-p99-ms
 
-          GOWORK=off go test -tags=integration ./internal/app -run '^$' -bench '^BenchmarkThreeNodeMixedSendPath1000QPS$' -benchtime=3000x -benchmem -count=1 -timeout=5m \
+          GOWORK=off go test -tags=integration ./internal/app -run '^$' -bench '^BenchmarkThreeNodeMixedSendPath500QPS$' -benchtime=3000x -benchmem -count=1 -timeout=5m \
             2>&1 | tee "$EVIDENCE_ROOT/mixed-send-benchmark.txt"
           assert_benchmark_metric_le_400 "$EVIDENCE_ROOT/mixed-send-benchmark.txt" all-p99-ms
 
-          GOWORK=off go test -tags=integration ./pkg/client -run '^$' -bench '^BenchmarkRealTCPSendackWithSynchronousRecvackPaced1000QPS$' -benchtime=3000x -benchmem -count=1 -timeout=5m \
+          GOWORK=off go test -tags=integration ./pkg/client -run '^$' -bench '^BenchmarkRealTCPSendackWithSynchronousRecvackPaced500QPS$' -benchtime=3000x -benchmem -count=1 -timeout=5m \
             2>&1 | tee "$EVIDENCE_ROOT/real-tcp-sendack-benchmark.txt"
           assert_benchmark_metric_le_400 "$EVIDENCE_ROOT/real-tcp-sendack-benchmark.txt" send-p99-ms
-      - name: Run bounded three-node 1000 QPS correctness smoke
+      - name: Run bounded three-node 500 QPS correctness smoke
         shell: bash
         run: |
           set -euo pipefail
@@ -102,7 +102,7 @@ jobs:
             --run-dir "$EVIDENCE_ROOT/artifacts" \
             --base-port 15000 \
             --ready-timeout 120 \
-            --send-rate 1000 \
+            --send-rate 500 \
             --measure-seconds 90 \
             --warmup-seconds 60 \
             --drain-timeout 90 \

--- a/internal/app/three_node_mixed_send_benchmark_integration_test.go
+++ b/internal/app/three_node_mixed_send_benchmark_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	threeNodeMixedSendRate          = 1000
+	threeNodeMixedHostedSendRate    = 500
 	threeNodeMixedSendWorkers       = 256
 	threeNodeMixedSendUsers         = 2500
 	threeNodeMixedPersonChannels    = 2000
@@ -37,19 +38,28 @@ const (
 // steady-state reviewed ingress shape after a bounded channel warmup. The
 // separate cold-wave benchmark owns first-message and projector pressure.
 func BenchmarkThreeNodeMixedSendPath1000QPS(b *testing.B) {
-	benchmarkThreeNodeMixedSendPath1000QPS(b, threeNodeMixedHotPersonChannels, true)
+	benchmarkThreeNodeMixedSendPathAtRate(b, threeNodeMixedHotPersonChannels, true, threeNodeMixedSendRate)
+}
+
+// BenchmarkThreeNodeMixedSendPath500QPS is the hosted-runner regression seam.
+// The 1000 QPS variant remains the dedicated capacity-environment benchmark.
+func BenchmarkThreeNodeMixedSendPath500QPS(b *testing.B) {
+	benchmarkThreeNodeMixedSendPathAtRate(b, threeNodeMixedHotPersonChannels, true, threeNodeMixedHostedSendRate)
 }
 
 // BenchmarkThreeNodeMixedSendColdDirectoryWave1000QPS deliberately creates
 // all 2,000 person channels in the short run. It is a projector catch-up and
 // foreground-interference stress benchmark, not the formal p99 distribution.
 func BenchmarkThreeNodeMixedSendColdDirectoryWave1000QPS(b *testing.B) {
-	benchmarkThreeNodeMixedSendPath1000QPS(b, threeNodeMixedPersonChannels, false)
+	benchmarkThreeNodeMixedSendPathAtRate(b, threeNodeMixedPersonChannels, false, threeNodeMixedSendRate)
 }
 
-func benchmarkThreeNodeMixedSendPath1000QPS(b *testing.B, personChannels int, prewarm bool) {
+func benchmarkThreeNodeMixedSendPathAtRate(b *testing.B, personChannels int, prewarm bool, rate int) {
 	if b.N < threeNodeMixedMinimumIterations {
 		return
+	}
+	if rate <= 0 {
+		b.Fatal("mixed SEND benchmark rate must be positive")
 	}
 	apps, nodes := newThreeNodeMixedSendApps(b)
 	seedThreeNodeMixedGroups(b, nodes[0])
@@ -105,7 +115,7 @@ func benchmarkThreeNodeMixedSendPath1000QPS(b *testing.B, personChannels int, pr
 	b.ResetTimer()
 	started := time.Now()
 	for index := 0; index < b.N; index++ {
-		waitThreeNodeMixedSendUntil(started.Add(time.Duration(index) * time.Second / threeNodeMixedSendRate))
+		waitThreeNodeMixedSendUntil(started.Add(time.Duration(index) * time.Second / time.Duration(rate)))
 		jobs <- index
 	}
 	close(jobs)

--- a/pkg/channel/replication/runtime_benchmark_integration_test.go
+++ b/pkg/channel/replication/runtime_benchmark_integration_test.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	threeNodeBenchmarkChannels = 1000
-	threeNodeBenchmarkRate     = 1000
-	threeNodeBenchmarkWorkers  = 256
+	threeNodeBenchmarkChannels   = 1000
+	threeNodeBenchmarkRate       = 1000
+	threeNodeHostedBenchmarkRate = 500
+	threeNodeBenchmarkWorkers    = 256
 )
 
 // BenchmarkThreeNodeDurableQuorumCommit1000QPS measures the public durable-log
@@ -133,6 +134,13 @@ func benchmarkDurableQuorumCluster1000QPS(b *testing.B, cluster *durableQuorumBe
 func BenchmarkThreeNodeChannelAppend1000QPS(b *testing.B) {
 	cluster := newChannelAppendBenchmarkCluster(b, threeNodeBenchmarkChannels)
 	benchmarkThreeNodeChannelAppendCluster1000QPS(b, cluster, "append")
+}
+
+// BenchmarkThreeNodeChannelAppend500QPS is the hosted-runner regression seam.
+// The 1000 QPS variant remains the dedicated capacity-environment benchmark.
+func BenchmarkThreeNodeChannelAppend500QPS(b *testing.B) {
+	cluster := newChannelAppendBenchmarkCluster(b, threeNodeBenchmarkChannels)
+	benchmarkThreeNodeChannelAppendClusterAtRate(b, cluster, "append", threeNodeHostedBenchmarkRate)
 }
 
 // BenchmarkThreeNodeChannelAppendPayloadMixWithGatewayDeliveryPressure1000QPS
@@ -293,7 +301,11 @@ func BenchmarkThreeNodeChannelAppendMixedCold1000QPS(b *testing.B) {
 }
 
 func benchmarkThreeNodeChannelAppendCluster1000QPS(b *testing.B, cluster *durableQuorumBenchmarkCluster, metricPrefix string) {
-	benchmarkThreeNodeChannelAppendClusterWithLoad1000QPS(b, cluster, metricPrefix, nil)
+	benchmarkThreeNodeChannelAppendClusterAtRate(b, cluster, metricPrefix, threeNodeBenchmarkRate)
+}
+
+func benchmarkThreeNodeChannelAppendClusterAtRate(b *testing.B, cluster *durableQuorumBenchmarkCluster, metricPrefix string, rate int) {
+	benchmarkThreeNodeChannelAppendClusterWithLoadAtRate(b, cluster, metricPrefix, nil, rate)
 }
 
 type channelAppendBenchmarkLoad interface {
@@ -302,6 +314,13 @@ type channelAppendBenchmarkLoad interface {
 }
 
 func benchmarkThreeNodeChannelAppendClusterWithLoad1000QPS(b *testing.B, cluster *durableQuorumBenchmarkCluster, metricPrefix string, load channelAppendBenchmarkLoad) {
+	benchmarkThreeNodeChannelAppendClusterWithLoadAtRate(b, cluster, metricPrefix, load, threeNodeBenchmarkRate)
+}
+
+func benchmarkThreeNodeChannelAppendClusterWithLoadAtRate(b *testing.B, cluster *durableQuorumBenchmarkCluster, metricPrefix string, load channelAppendBenchmarkLoad, rate int) {
+	if rate <= 0 {
+		b.Fatal("channel append benchmark rate must be positive")
+	}
 	defer cluster.close(b)
 	if load != nil {
 		defer func() {
@@ -359,7 +378,7 @@ func benchmarkThreeNodeChannelAppendClusterWithLoad1000QPS(b *testing.B, cluster
 	}
 	started := time.Now()
 	for index := 0; index < b.N; index++ {
-		waitUntil(started.Add(time.Duration(index) * time.Second / threeNodeBenchmarkRate))
+		waitUntil(started.Add(time.Duration(index) * time.Second / time.Duration(rate)))
 		jobs <- index
 	}
 	close(jobs)

--- a/pkg/client/send_paced_benchmark_integration_test.go
+++ b/pkg/client/send_paced_benchmark_integration_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	pacedTCPBenchmarkRate     = 1000
-	pacedTCPBenchmarkSessions = 2500
-	pacedTCPBenchmarkWorkers  = 256
+	pacedTCPBenchmarkRate       = 1000
+	pacedTCPHostedBenchmarkRate = 500
+	pacedTCPBenchmarkSessions   = 2500
+	pacedTCPBenchmarkWorkers    = 256
 )
 
 // BenchmarkRealTCPSendackPaced1000QPS measures the full client writer,
@@ -27,7 +28,7 @@ const (
 // path while replaying the retained three-node handler latency distribution.
 // Run with -benchtime=5000x so every session sends twice over five seconds.
 func BenchmarkRealTCPSendackPaced1000QPS(b *testing.B) {
-	benchmarkRealTCPSendackPaced1000QPS(b, false, false)
+	benchmarkRealTCPSendackPacedAtRate(b, false, false, pacedTCPBenchmarkRate)
 }
 
 // BenchmarkRealTCPSendackShuffledPaced1000QPS preserves one SEND per client
@@ -35,7 +36,7 @@ func BenchmarkRealTCPSendackPaced1000QPS(b *testing.B) {
 // gateway session IDs. This models assignment sender order without allowing
 // concurrent SENDs from one client.
 func BenchmarkRealTCPSendackShuffledPaced1000QPS(b *testing.B) {
-	benchmarkRealTCPSendackPaced1000QPS(b, false, true)
+	benchmarkRealTCPSendackPacedAtRate(b, false, true, pacedTCPBenchmarkRate)
 }
 
 // BenchmarkRealTCPSendackWithSynchronousRecvackPaced1000QPS adds the
@@ -43,12 +44,22 @@ func BenchmarkRealTCPSendackShuffledPaced1000QPS(b *testing.B) {
 // paced SENDs. RECVACK completion therefore contends with SEND on each
 // client's single writer exactly as it does in the three-node workload.
 func BenchmarkRealTCPSendackWithSynchronousRecvackPaced1000QPS(b *testing.B) {
-	benchmarkRealTCPSendackPaced1000QPS(b, true, true)
+	benchmarkRealTCPSendackPacedAtRate(b, true, true, pacedTCPBenchmarkRate)
 }
 
-func benchmarkRealTCPSendackPaced1000QPS(b *testing.B, synchronousRecvack bool, shuffledClients bool) {
+// BenchmarkRealTCPSendackWithSynchronousRecvackPaced500QPS is the
+// hosted-runner regression seam. The 1000 QPS variant remains available for
+// dedicated capacity environments.
+func BenchmarkRealTCPSendackWithSynchronousRecvackPaced500QPS(b *testing.B) {
+	benchmarkRealTCPSendackPacedAtRate(b, true, true, pacedTCPHostedBenchmarkRate)
+}
+
+func benchmarkRealTCPSendackPacedAtRate(b *testing.B, synchronousRecvack bool, shuffledClients bool, rate int) {
 	if b.N < 1000 {
 		return
+	}
+	if rate <= 0 {
+		b.Fatal("paced TCP benchmark rate must be positive")
 	}
 	handler := &pacedTCPBenchmarkHandler{}
 	observer := &pacedTCPBenchmarkObserver{}
@@ -141,7 +152,7 @@ func benchmarkRealTCPSendackPaced1000QPS(b *testing.B, synchronousRecvack bool, 
 	}
 	started := time.Now()
 	for index := range b.N {
-		pacedTCPBenchmarkWaitUntil(started.Add(time.Duration(index) * time.Second / pacedTCPBenchmarkRate))
+		pacedTCPBenchmarkWaitUntil(started.Add(time.Duration(index) * time.Second / time.Duration(rate)))
 		jobs <- index
 	}
 	close(jobs)

--- a/scripts/three_node_chat_lifecycle_workflow_test.go
+++ b/scripts/three_node_chat_lifecycle_workflow_test.go
@@ -52,14 +52,14 @@ func TestThreeNodeChatLifecycleRegressionSeparatesPRSmokeFromNightlyQualificatio
 	for _, required := range []string{
 		"GOWORK=off go test ./internal/bench/chatlifecycle ./internal/bench/workload ./internal/bench/worker ./pkg/bench/model ./pkg/client ./pkg/gateway/... -count=1",
 		"GOWORK=off go test -race ./internal/bench/workload ./internal/bench/worker ./pkg/client ./pkg/gateway/transport/gnet -count=1",
-		"BenchmarkThreeNodeMixedSendPath1000QPS",
-		"BenchmarkThreeNodeChannelAppend1000QPS",
-		"BenchmarkRealTCPSendackWithSynchronousRecvackPaced1000QPS",
+		"BenchmarkThreeNodeMixedSendPath500QPS",
+		"BenchmarkThreeNodeChannelAppend500QPS",
+		"BenchmarkRealTCPSendackWithSynchronousRecvackPaced500QPS",
 		"append-p99-ms",
 		"all-p99-ms",
 		"send-p99-ms",
 		"benchmark metric %s exceeded 400ms",
-		"--send-rate 1000",
+		"--send-rate 500",
 		"--measure-seconds 90",
 		"--warmup-seconds 60",
 		"--drain-timeout 90",
@@ -68,9 +68,13 @@ func TestThreeNodeChatLifecycleRegressionSeparatesPRSmokeFromNightlyQualificatio
 		require.Contains(t, prRun, required)
 	}
 	require.NotContains(t, prRun, "run-wukongim-three-node-chat-lifecycle-local-baseline.sh")
+	require.NotContains(t, prRun, "BenchmarkThreeNodeMixedSendPath1000QPS")
+	require.NotContains(t, prRun, "BenchmarkThreeNodeChannelAppend1000QPS")
+	require.NotContains(t, prRun, "BenchmarkRealTCPSendackWithSynchronousRecvackPaced1000QPS")
+	require.NotContains(t, prRun, "--send-rate 1000")
 	require.NotContains(t, prRun, "--measure-seconds 600")
 	assertInitializesEvidenceRootFromRunnerTemp(t, pr.Steps)
-	assertRejectsTrackedTreeMutationAfter(t, pr.Steps, "Run bounded three-node 1000 QPS correctness smoke")
+	assertRejectsTrackedTreeMutationAfter(t, pr.Steps, "Run bounded three-node 500 QPS correctness smoke")
 	assertRegressionArtifactStep(t, pr.Steps, 7)
 
 	nightly, ok := workflow.Jobs["nightly-qualification"]


### PR DESCRIPTION
## Summary
- run hosted PR regression benchmarks at an explicit 500 SEND/s
- run the bounded hosted three-node correctness/drain smoke at 500 SEND/s
- retain the existing 1000 SEND/s benchmark entrypoints for dedicated capacity environments
- document and contract-test the split between hosted regression and dedicated capacity gates

## Validation
- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/*.yml`
- integration compile for `./pkg/channel/replication ./internal/app ./pkg/client`
- exact 500 and existing 1000 benchmark entrypoints (3000x)
- `git diff --check`

Hosted 500 benchmarks were green locally:
- channel append p99 43.95 ms
- mixed SEND p99 63.30 ms
- real TCP SEND p99 176.4 ms
