### PR TITLE
Add native Linux package preview pipeline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,7 @@ authorization and the applicable budget.
 | `issue-agent.yml` | `Safety Automation - GitHub Issue Agent` | Reconciles Issue work and Review Agent repair requests |
 | `issue-agent-engineer.yml` | `Agent Tool - Issue Engineer` | Runs one exact Context Builder, Codex Engineer, and clean Verifier chain |
 | `manager-browser-smoke.yml` | `Safety Automation - Manager Browser Smoke` | Builds the production Manager bundle and runs the desktop/mobile Chromium matrix against a real three-node cluster |
+| `native-package-preview.yml` | `Safety Automation - Validate Native Package Preview` | Builds unsigned amd64 deb/rpm previews and checks non-activating installs on the four supported Linux distributions |
 | `cloud-lease-oidc-setup.yml` | `Agent Tool - Configure Cloud Lease OIDC Roles` | Reconciles and live-verifies the three workflow-conditioned Cloud Lease roles |
 | `cloud-lease-provision.yml` | `Agent Tool - Provision Cloud Lease` | Quotes or explicitly acquires one generic Alibaba Cloud Lease |
 | `cloud-lease-observe.yml` | `Agent Tool - Inspect Cloud Lease` | Reconstructs exact Lease inventory through the read-only Observer role |
@@ -40,6 +41,37 @@ authorization and the applicable budget.
 | `cloud-sim-monitor.yml` | `Safety Automation - Patrol Cloud Simulation Runs` | Patrols retained live runs and records bounded health evidence |
 | `docker-image-publish.yml` | `Safety Automation - Publish Docker Images` | Builds one immutable multi-platform GHCR image, mirrors its digest to Docker Hub and Alibaba Cloud, then advances eligible stable aliases |
 | `binary-release-publish.yml` | `Safety Automation - Publish WuKongIM Binaries` | Builds immutable Linux/macOS release archives for four architectures and publishes them to the exact tag's GitHub Release |
+
+## Native package preview
+
+`native-package-preview.yml` is a credential-free validation workflow, not a
+publisher. It builds unsigned Linux amd64 `.deb` and `.rpm` files from
+`.goreleaser.packages.yaml`. After the build, an integration test creates
+one-run, one-day `TEST ONLY` APT and RPM signing keys outside the repository,
+signs temporary repositories, and verifies both signatures and the exact APT
+`Release -> Packages -> .deb` and RPM `repomd.xml -> primary metadata -> .rpm`
+closures in clean containers. The temporary keys and signed repositories are
+never uploaded or published.
+
+The workflow also inspects package payloads and installs, reinstalls through
+the package-manager upgrade path, and removes them inside Ubuntu 24.04, Debian
+12, Rocky Linux 9, and AlmaLinux 9 containers. The package creates the
+`wukongim` service account and persistent directories but does not create
+`/etc/wukongim/wukongim.toml`, enable the unit, start it, or restart it during
+upgrade. The upgrade check records every `systemctl` request and verifies that
+the operator-owned configuration and data remain byte-identical. Only the
+unsigned preview packages and checksums are retained as Actions artifacts for
+14 days; this workflow still publishes no APT/YUM repository.
+
+The separate public `WuKongIM/packages` repository owns the fail-closed GitHub
+Pages bootstrap at the verified HTTPS endpoint `packages.githubim.com`; it
+currently publishes only a `signing_not_provisioned` status and no package
+indexes. Both repositories enforce immutable Releases, and the custom-domain
+DNS and certificate are provisioned. Reviewed public fingerprints, signing
+custody, exact tagged source package assets, cross-repository dispatch, and the
+production publisher remain intentionally outside this credential-free
+workflow. They must be provisioned and reviewed before package indexes are
+enabled.
 
 ## Docker image publishing
 
@@ -91,7 +123,7 @@ failure, a digest mismatch, or a missing platform fails the complete release.
 `binary-release-publish.yml` publishes downloadable WuKongIM executables from
 the same strict SemVer `v*` source identity used by the container publisher. A
 new tag starts the workflow automatically; the manual `version` input accepts
-one existing tag for first publication or incomplete-release recovery. The tag
+one existing tag for first publication or incomplete-draft recovery. The tag
 must resolve to a commit reachable from `origin/main` and may not contain
 SemVer build metadata.
 
@@ -106,21 +138,33 @@ Actions evidence for 90 days. Tags containing the version command also prove
 the embedded version, full source commit, and `release` build source; older
 tags remain bound by the immutable tag, checksums, and attestation.
 
-The workflow gives every new asset to `gh release create`, so GitHub uploads
-them while the Release is still a draft and publishes the complete set once.
-Recovery downloads and compares every existing expected asset and refuses any
-content conflict. It may fill missing files only while the target Release is
-still mutable; an incomplete immutable Release fails closed and requires an
-explicit operator delete-and-recreate decision. A pre-release SemVer tag must
-correspond to a GitHub pre-release; stable tags must correspond to a normal
-Release. A fully published version fails closed instead of creating duplicate
-evidence.
+The workflow creates a draft Release without publishing it, uploads every
+expected asset, downloads and byte-compares the complete exact asset set, and
+only then publishes the verified draft once. Recovery may compare existing
+assets and fill missing files only in that same draft. Draft discovery scans
+all Releases for one exact tag match, then binds creation, upload, verification,
+and publication to the resulting numeric Release ID; it never relies on the
+published-by-tag endpoint to find a draft. Asset upload accepts only the exact
+numeric-ID `uploads.github.com` URL returned by GitHub and checks each upload
+response against the local size and SHA-256. Immediately before publication it
+rechecks that the remote tag still peels to the validated source commit, that
+repository-level immutable Releases remain enabled, and that the draft still
+has the exact asset names, sizes, and digests verified earlier. Any existing
+published Release fails closed: a complete one is already final, while an
+incomplete one must never be reused and requires a new SemVer tag. A
+pre-release SemVer tag must correspond to a GitHub pre-release; stable tags
+must correspond to a normal Release. After publication, the workflow verifies
+that GitHub sealed the same numeric Release ID as immutable, checks every
+asset's API size and SHA-256 digest against the local file, and falls back to
+an ID-bound download and byte comparison when the API omits a digest.
 
 Repository administrators must configure a `binary-publish` Environment,
 allow protected `main` for manual recovery and trusted version tags for
 automatic publication, and avoid a reviewer gate for tag-triggered runs. The
 workflow uses only its job-scoped `GITHUB_TOKEN`; it requires no standing
-release credential.
+release credential. Until those Environment deployment restrictions have been
+configured and verified remotely, administrators must not push a release tag
+or manually dispatch this workflow.
 
 ## Direct local chat-lifecycle repair
 

--- a/.github/workflows/binary-release-publish.yml
+++ b/.github/workflows/binary-release-publish.yml
@@ -266,7 +266,7 @@ jobs:
             echo "Legacy tag has no version command; provenance remains bound by tag, checksum, and attestation."
           fi
 
-      - name: Classify immutable GitHub Release assets
+      - name: Classify draft GitHub Release assets
         id: publication
         shell: bash
         env:
@@ -287,19 +287,38 @@ jobs:
             "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
             "$CHECKSUM_NAME"
           )
+          gh api "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            | jq -e '.enabled == true' >/dev/null || {
+              echo "repository immutable Releases must remain enabled before publication" >&2
+              exit 1
+            }
           existing_dir="$RUNNER_TEMP/existing-binary-release"
           mkdir -p "$existing_dir"
           missing_file="$RUNNER_TEMP/missing-binary-release-assets.txt"
+          release_pages="$RUNNER_TEMP/existing-binary-release-pages.json"
+          matching_releases="$RUNNER_TEMP/existing-binary-release-matches.json"
           release_json="$RUNNER_TEMP/existing-binary-release.json"
-          release_error="$RUNNER_TEMP/existing-binary-release.err"
           : >"$missing_file"
 
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" >"$release_pages"
+          jq --arg version "$VERSION" \
+            '[.[][] | select(.tag_name == $version)]' \
+            "$release_pages" >"$matching_releases"
+          match_count="$(jq 'length' "$matching_releases")"
+          [[ "$match_count" == 0 || "$match_count" == 1 ]] || {
+            echo "$VERSION resolves to multiple GitHub Releases" >&2
+            exit 1
+          }
+
           release_exists=false
-          release_immutable=false
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" >"$release_json" 2>"$release_error"; then
+          release_id=""
+          if [[ "$match_count" == 1 ]]; then
             release_exists=true
-            jq -e '.draft == false' "$release_json" >/dev/null || {
-              echo "$VERSION already has a draft Release; refusing to publish into it" >&2
+            jq '.[0]' "$matching_releases" >"$release_json"
+            release_id="$(jq -r '.id' "$release_json")"
+            [[ "$release_id" =~ ^[1-9][0-9]*$ ]] || {
+              echo "$VERSION Release has an invalid numeric id" >&2
               exit 1
             }
             existing_prerelease="$(jq -r '.prerelease' "$release_json")"
@@ -309,24 +328,44 @@ jobs:
               echo "$VERSION Release prerelease classification conflicts with SemVer" >&2
               exit 1
             }
-            release_immutable="$(jq -r '.immutable // false' "$release_json")"
-          elif grep -Fq 'HTTP 404' "$release_error"; then
-            jq -n '{assets: []}' >"$release_json"
           else
-            cat "$release_error" >&2
-            exit 1
+            jq -n '{assets: []}' >"$release_json"
           fi
+
+          jq -e '[.assets[].name] | length == (unique | length)' "$release_json" >/dev/null || {
+            echo "$VERSION Release contains duplicate asset names" >&2
+            exit 1
+          }
+          while IFS= read -r existing_asset; do
+            expected=false
+            for asset in "${expected_assets[@]}"; do
+              if [[ "$existing_asset" == "$asset" ]]; then
+                expected=true
+                break
+              fi
+            done
+            [[ "$expected" == true ]] || {
+              echo "$VERSION Release contains unexpected asset: $existing_asset" >&2
+              exit 1
+            }
+          done < <(jq -r '.assets[].name' "$release_json")
 
           existing_count=0
           for asset in "${expected_assets[@]}"; do
-            if jq -e --arg name "$asset" '.assets[] | select(.name == $name)' "$release_json" >/dev/null; then
+            asset_id="$(jq -r --arg name "$asset" \
+              '.assets[] | select(.name == $name) | .id' "$release_json")"
+            if [[ -n "$asset_id" ]]; then
+              [[ "$asset_id" =~ ^[1-9][0-9]*$ ]] || {
+                echo "$asset has an invalid numeric asset id" >&2
+                exit 1
+              }
               existing_count=$((existing_count + 1))
-              gh release download "$VERSION" \
-                --repo "$GITHUB_REPOSITORY" \
-                --pattern "$asset" \
-                --dir "$existing_dir"
+              gh api \
+                -H 'Accept: application/octet-stream' \
+                "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
+                >"$existing_dir/$asset"
               cmp "$RELEASE_DIR/$asset" "$existing_dir/$asset" || {
-                echo "$asset is immutable and its published content conflicts with this source" >&2
+                echo "$asset already exists and its content conflicts with this source" >&2
                 exit 1
               }
             else
@@ -334,16 +373,17 @@ jobs:
             fi
           done
 
-          if [[ "$release_exists" == true && "$existing_count" -eq "${#expected_assets[@]}" ]]; then
-            echo "$VERSION already has the complete immutable binary release" >&2
-            exit 1
-          fi
-          if [[ "$release_exists" == true && "$release_immutable" == true ]]; then
-            echo "$VERSION is already immutable and incomplete; delete and recreate the exact Release explicitly" >&2
+          if [[ "$release_exists" == true ]] && ! jq -e '.draft == true' "$release_json" >/dev/null; then
+            if [[ "$existing_count" -eq "${#expected_assets[@]}" ]]; then
+              echo "$VERSION already has the complete published binary release" >&2
+            else
+              echo "$VERSION is already published but incomplete; refusing to reuse its tag; publish a new SemVer tag" >&2
+            fi
             exit 1
           fi
           {
             echo "release_exists=$release_exists"
+            echo "release_id=$release_id"
             echo "missing_file=$missing_file"
           } >>"$GITHUB_OUTPUT"
 
@@ -355,67 +395,311 @@ jobs:
             ${{ runner.temp }}/wukongim-binary-release/*.tar.gz
             ${{ runner.temp }}/wukongim-binary-release/*_checksums.txt
 
-      - name: Publish absent immutable GitHub Release assets
+      - name: Create or recover draft GitHub Release
+        id: draft
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.identity.outputs.version }}
+          SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
           STABLE: ${{ steps.identity.outputs.stable }}
           RELEASE_EXISTS: ${{ steps.publication.outputs.release_exists }}
+          CLASSIFIED_RELEASE_ID: ${{ steps.publication.outputs.release_id }}
           MISSING_FILE: ${{ steps.publication.outputs.missing_file }}
           RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
         run: |
           set -euo pipefail
+
+          remote_refs="$(git ls-remote origin \
+            "refs/tags/$VERSION" "refs/tags/$VERSION^{}")"
+          raw_tag_sha="$(awk -v ref="refs/tags/$VERSION" '$2 == ref {print $1}' <<<"$remote_refs")"
+          peeled_tag_sha="$(awk -v ref="refs/tags/$VERSION^{}" '$2 == ref {print $1}' <<<"$remote_refs")"
+          [[ "$raw_tag_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "remote release tag is missing or ambiguous: $VERSION" >&2
+            exit 1
+          }
+          remote_source_sha="${peeled_tag_sha:-$raw_tag_sha}"
+          [[ "$remote_source_sha" =~ ^[0-9a-f]{40}$ && "$remote_source_sha" == "$SOURCE_SHA" ]] || {
+            echo "remote release tag no longer peels to the validated source: $VERSION" >&2
+            exit 1
+          }
 
           upload_paths=()
           while IFS= read -r asset; do
             [[ -n "$asset" ]] || continue
             upload_paths+=("$RELEASE_DIR/$asset")
           done <"$MISSING_FILE"
-          ((${#upload_paths[@]} > 0))
-
+          release_id="$CLASSIFIED_RELEASE_ID"
           if [[ "$RELEASE_EXISTS" != true ]]; then
-            create_args=(
-              gh release create "$VERSION"
-              "${upload_paths[@]}"
-              --repo "$GITHUB_REPOSITORY"
-              --verify-tag
-              --title "WuKongIM $VERSION"
-              --generate-notes
-            )
-            [[ "$STABLE" == true ]] || create_args+=(--prerelease)
-            "${create_args[@]}"
-          else
-            gh release upload "$VERSION" \
-              --repo "$GITHUB_REPOSITORY" \
-              "${upload_paths[@]}"
+            expected_prerelease=true
+            [[ "$STABLE" != true ]] || expected_prerelease=false
+            created_release="$RUNNER_TEMP/created-binary-release.json"
+            gh api --method POST "repos/$GITHUB_REPOSITORY/releases" \
+              -f tag_name="$VERSION" \
+              -f name="WuKongIM $VERSION" \
+              -F draft=true \
+              -F prerelease="$expected_prerelease" \
+              -F generate_release_notes=true \
+              >"$created_release"
+            release_id="$(jq -r '.id' "$created_release")"
           fi
+          [[ "$release_id" =~ ^[1-9][0-9]*$ ]] || {
+            echo "$VERSION draft has an invalid numeric release id" >&2
+            exit 1
+          }
+          draft_identity="$RUNNER_TEMP/binary-release-draft-identity.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" >"$draft_identity"
+          upload_url="$(jq -r '.upload_url' "$draft_identity")"
+          expected_upload_url="https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id/assets{?name,label}"
+          [[ "$upload_url" == "$expected_upload_url" ]] || {
+            echo "$VERSION draft returned an unexpected asset upload URL" >&2
+            exit 1
+          }
+          upload_endpoint="${upload_url%%\{*}"
 
-      - name: Verify published Release assets
+          for upload_path in "${upload_paths[@]}"; do
+            asset="$(basename "$upload_path")"
+            [[ "$asset" =~ ^wukongim_[0-9A-Za-z._-]+$ ]] || {
+              echo "refusing unsafe release asset name: $asset" >&2
+              exit 1
+            }
+            upload_response="$RUNNER_TEMP/uploaded-$asset.json"
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              -H 'Content-Type: application/octet-stream' \
+              --data-binary "@$upload_path" \
+              "$upload_endpoint?name=$asset" \
+              >"$upload_response"
+            local_size="$(stat -c '%s' "$upload_path")"
+            local_sha256="$(sha256sum "$upload_path" | awk '{print $1}')"
+            jq -e \
+              --arg name "$asset" \
+              --arg digest "sha256:$local_sha256" \
+              --argjson size "$local_size" \
+              '.id > 0 and .name == $name and .state == "uploaded" and
+               .size == $size and .digest == $digest' \
+              "$upload_response" >/dev/null || {
+                echo "$asset upload response does not match the local asset" >&2
+                exit 1
+              }
+          done
+          echo "release_id=$release_id" >>"$GITHUB_OUTPUT"
+
+      - name: Verify complete draft Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.identity.outputs.version }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
           BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
+          STABLE: ${{ steps.identity.outputs.stable }}
           CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
           RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
         run: |
           set -euo pipefail
-          published_dir="$RUNNER_TEMP/published-binary-release"
-          mkdir -p "$published_dir"
-          gh release download "$VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern "wukongim_${BINARY_VERSION}_*.tar.gz" \
-            --pattern "$CHECKSUM_NAME" \
-            --dir "$published_dir"
+          draft_json="$RUNNER_TEMP/draft-binary-release.json"
+          draft_dir="$RUNNER_TEMP/draft-binary-release"
+          [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" >"$draft_json"
+          jq -e --arg version "$VERSION" \
+            '.tag_name == $version and .draft == true and (.immutable // false) == false' \
+            "$draft_json" >/dev/null || {
+            echo "$VERSION must remain mutable and draft until all assets are verified" >&2
+            exit 1
+          }
+          expected_prerelease=true
+          [[ "$STABLE" != true ]] || expected_prerelease=false
+          test "$(jq -r '.prerelease' "$draft_json")" = "$expected_prerelease" || {
+            echo "$VERSION draft prerelease classification conflicts with SemVer" >&2
+            exit 1
+          }
+          mapfile -t actual_assets < <(jq -r '.assets[].name' "$draft_json" | sort)
+          expected_assets=(
+            "wukongim_${BINARY_VERSION}_linux_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_linux_arm64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
+            "$CHECKSUM_NAME"
+          )
+          mapfile -t expected_assets < <(printf '%s\n' "${expected_assets[@]}" | sort)
+          test "${actual_assets[*]}" = "${expected_assets[*]}" || {
+            echo "$VERSION draft does not contain the exact expected asset set" >&2
+            exit 1
+          }
+
+          mkdir -p "$draft_dir"
           for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR/$CHECKSUM_NAME"; do
             asset="$(basename "$local_asset")"
-            cmp "$local_asset" "$published_dir/$asset"
+            asset_id="$(jq -r --arg name "$asset" \
+              '.assets[] | select(.name == $name) | .id' "$draft_json")"
+            [[ "$asset_id" =~ ^[1-9][0-9]*$ ]]
+            gh api \
+              -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
+              >"$draft_dir/$asset"
+            cmp "$local_asset" "$draft_dir/$asset"
           done
           (
-            cd "$published_dir"
+            cd "$draft_dir"
             sha256sum --check "$CHECKSUM_NAME"
           )
+
+      - name: Publish verified draft Release once
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
+          BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
+          STABLE: ${{ steps.identity.outputs.stable }}
+          CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
+          RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
+
+          remote_refs="$(git ls-remote origin \
+            "refs/tags/$VERSION" "refs/tags/$VERSION^{}")"
+          raw_tag_sha="$(awk -v ref="refs/tags/$VERSION" '$2 == ref {print $1}' <<<"$remote_refs")"
+          peeled_tag_sha="$(awk -v ref="refs/tags/$VERSION^{}" '$2 == ref {print $1}' <<<"$remote_refs")"
+          [[ "$raw_tag_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "remote release tag is missing or ambiguous immediately before publication: $VERSION" >&2
+            exit 1
+          }
+          remote_source_sha="${peeled_tag_sha:-$raw_tag_sha}"
+          [[ "$remote_source_sha" =~ ^[0-9a-f]{40}$ && "$remote_source_sha" == "$SOURCE_SHA" ]] || {
+            echo "remote release tag changed after source validation: $VERSION" >&2
+            exit 1
+          }
+          gh api "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            | jq -e '.enabled == true' >/dev/null || {
+              echo "repository immutable Releases were disabled before publication" >&2
+              exit 1
+            }
+          prepublish_json="$RUNNER_TEMP/prepublish-binary-release.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" >"$prepublish_json"
+          jq -e --arg version "$VERSION" \
+            '.tag_name == $version and .draft == true and (.immutable // false) == false' \
+            "$prepublish_json" >/dev/null || {
+            echo "$VERSION is no longer the verified draft Release" >&2
+            exit 1
+          }
+          expected_prerelease=true
+          [[ "$STABLE" != true ]] || expected_prerelease=false
+          test "$(jq -r '.prerelease' "$prepublish_json")" = "$expected_prerelease" || {
+            echo "$VERSION draft prerelease classification changed before publication" >&2
+            exit 1
+          }
+          mapfile -t actual_assets < <(jq -r '.assets[].name' "$prepublish_json" | sort)
+          expected_assets=(
+            "wukongim_${BINARY_VERSION}_linux_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_linux_arm64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
+            "$CHECKSUM_NAME"
+          )
+          mapfile -t expected_assets < <(printf '%s\n' "${expected_assets[@]}" | sort)
+          test "${actual_assets[*]}" = "${expected_assets[*]}" || {
+            echo "$VERSION draft asset set changed immediately before publication" >&2
+            exit 1
+          }
+          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR/$CHECKSUM_NAME"; do
+            asset="$(basename "$local_asset")"
+            asset_json="$(jq -c --arg name "$asset" \
+              '.assets[] | select(.name == $name)' "$prepublish_json")"
+            api_size="$(jq -r '.size' <<<"$asset_json")"
+            api_digest="$(jq -r '.digest // empty' <<<"$asset_json")"
+            local_size="$(stat -c '%s' "$local_asset")"
+            local_sha256="$(sha256sum "$local_asset" | awk '{print $1}')"
+            [[ "$api_size" =~ ^[0-9]+$ && "$api_size" == "$local_size" ]] || {
+              echo "$asset draft size changed immediately before publication" >&2
+              exit 1
+            }
+            [[ "$api_digest" == "sha256:$local_sha256" ]] || {
+              echo "$asset draft digest changed immediately before publication" >&2
+              exit 1
+            }
+          done
+
+          gh api --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            -F draft=false \
+            >"$RUNNER_TEMP/publish-binary-release.json"
+
+      - name: Verify published immutable Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          RELEASE_ID: ${{ steps.draft.outputs.release_id }}
+          BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
+          STABLE: ${{ steps.identity.outputs.stable }}
+          CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
+          RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
+        run: |
+          set -euo pipefail
+          published_json="$RUNNER_TEMP/published-binary-release.json"
+          published_dir="$RUNNER_TEMP/published-binary-release"
+          [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" >"$published_json"
+          jq -e --arg version "$VERSION" \
+            '.tag_name == $version and .draft == false and .immutable == true' \
+            "$published_json" >/dev/null || {
+            echo "$VERSION was not sealed as an immutable published Release" >&2
+            exit 1
+          }
+          expected_prerelease=true
+          [[ "$STABLE" != true ]] || expected_prerelease=false
+          test "$(jq -r '.prerelease' "$published_json")" = "$expected_prerelease" || {
+            echo "$VERSION published prerelease classification conflicts with SemVer" >&2
+            exit 1
+          }
+          mapfile -t actual_assets < <(jq -r '.assets[].name' "$published_json" | sort)
+          expected_assets=(
+            "wukongim_${BINARY_VERSION}_linux_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_linux_arm64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
+            "$CHECKSUM_NAME"
+          )
+          mapfile -t expected_assets < <(printf '%s\n' "${expected_assets[@]}" | sort)
+          test "${actual_assets[*]}" = "${expected_assets[*]}" || {
+            echo "$VERSION published Release does not contain the exact expected asset set" >&2
+            exit 1
+          }
+
+          mkdir -p "$published_dir"
+          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR/$CHECKSUM_NAME"; do
+            asset="$(basename "$local_asset")"
+            asset_json="$(jq -c --arg name "$asset" \
+              '.assets[] | select(.name == $name)' "$published_json")"
+            asset_id="$(jq -r '.id' <<<"$asset_json")"
+            api_size="$(jq -r '.size' <<<"$asset_json")"
+            api_digest="$(jq -r '.digest // empty' <<<"$asset_json")"
+            local_size="$(stat -c '%s' "$local_asset")"
+            local_sha256="$(sha256sum "$local_asset" | awk '{print $1}')"
+            [[ "$asset_id" =~ ^[1-9][0-9]*$ ]]
+            [[ "$api_size" =~ ^[0-9]+$ && "$api_size" == "$local_size" ]] || {
+              echo "$asset published size conflicts with the verified local asset" >&2
+              exit 1
+            }
+            if [[ -n "$api_digest" ]]; then
+              [[ "$api_digest" == "sha256:$local_sha256" ]] || {
+                echo "$asset published digest conflicts with the verified local asset" >&2
+                exit 1
+              }
+            else
+              gh api \
+                -H 'Accept: application/octet-stream' \
+                "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
+                >"$published_dir/$asset"
+              cmp "$local_asset" "$published_dir/$asset"
+            fi
+          done
 
       - name: Write release receipt and summary
         shell: bash

--- a/.github/workflows/native-package-preview.yml
+++ b/.github/workflows/native-package-preview.yml
@@ -1,0 +1,101 @@
+name: Safety Automation - Validate Native Package Preview
+
+on:
+  pull_request:
+    paths:
+      - ".goreleaser.packages.yaml"
+      - "cmd/wukongim/**"
+      - "internal/app/**"
+      - "internal/config/**"
+      - "packaging/**"
+      - "scripts/native_package_contract_test.go"
+      - "scripts/native_package_repository_integration_test.go"
+      - "scripts/build-native-package-repositories.sh"
+      - "scripts/generate-native-package-test-keyring.sh"
+      - "scripts/sign-native-package-repositories.sh"
+      - "scripts/validate-native-package.sh"
+      - "scripts/validate-native-package-container.sh"
+      - "scripts/validate-native-package-repositories-container.sh"
+      - "scripts/verify-native-package-metadata.py"
+      - "scripts/verify-native-package-repositories.sh"
+      - ".github/workflows/native-package-preview.yml"
+      - ".github/workflows/README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-package-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Build and install deb/rpm preview
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      GOWORK: "off"
+    steps:
+      - name: Check out exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up repository Go toolchain
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run package and CLI contracts
+        run: |
+          go test ./cmd/wukongim ./internal/config ./internal/app -count=1
+          go test ./scripts -run 'TestNativePackage' -count=1
+
+      - name: Build deb and rpm preview
+        uses: goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1 # v7.2.0
+        with:
+          distribution: goreleaser
+          version: v2.18.0
+          args: release --snapshot --clean --config .goreleaser.packages.yaml
+
+      - name: Validate signed repository metadata closure
+        env:
+          WK_NATIVE_PACKAGE_REPOSITORY_INTEGRATION: "1"
+        run: >-
+          go test -tags=integration ./scripts
+          -run '^TestNativePackageSignedRepository$'
+          -count=1 -timeout=30m
+
+      - name: Inspect package metadata
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes rpm
+          WK_NATIVE_PACKAGE_SKIP_BUILD=1 \
+          WK_NATIVE_PACKAGE_REQUIRE_INSPECTORS=1 \
+            ./scripts/validate-native-package.sh
+
+      - name: Install on Ubuntu 24.04
+        run: ./scripts/validate-native-package-container.sh ubuntu:24.04 deb
+
+      - name: Install on Debian 12
+        run: ./scripts/validate-native-package-container.sh debian:12 deb
+
+      - name: Install on Rocky Linux 9
+        run: ./scripts/validate-native-package-container.sh rockylinux:9 rpm
+
+      - name: Install on AlmaLinux 9
+        run: ./scripts/validate-native-package-container.sh almalinux:9 rpm
+
+      - name: Upload preview packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wukongim-native-package-preview-${{ github.run_id }}
+          path: |
+            dist/*.deb
+            dist/*.rpm
+            dist/checksums.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 vendor/
 
 bin/
+dist/
 
 benchmarks/results/
 

--- a/.goreleaser.packages.yaml
+++ b/.goreleaser.packages.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goreleaser/goreleaser/v2.18.0/www/docs/static/schema.json
+version: 2
+
+project_name: wukongim
+
+builds:
+  - id: wukongim-linux-amd64
+    main: ./cmd/wukongim
+    binary: wukongim
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - >-
+        -s -w -buildid=
+        -X main.buildVersion={{ .Version }}
+        -X main.buildCommit={{ .Commit }}
+        -X main.buildSource=release
+    goos:
+      - linux
+    goarch:
+      - amd64
+    goamd64:
+      - v1
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: wukongim-raw-binary
+    ids:
+      - wukongim-linux-amd64
+    formats:
+      - binary
+
+nfpms:
+  - id: wukongim-linux-packages
+    ids:
+      - wukongim-linux-amd64
+    package_name: wukongim
+    formats:
+      - deb
+      - rpm
+    vendor: WuKongIM
+    homepage: https://github.com/WuKongIM/WuKongIM
+    maintainer: WuKongIM Maintainers <support@githubim.com>
+    license: Apache-2.0
+    description: High-performance general-purpose distributed messaging cluster.
+    section: net
+    priority: optional
+    bindir: /usr/bin
+    dependencies:
+      - systemd
+    mtime: "{{ .CommitDate }}"
+    contents:
+      - src: packaging/systemd/wukongim.service
+        dst: /usr/lib/systemd/system/wukongim.service
+        file_info:
+          owner: root
+          group: root
+          mode: 0644
+      - src: packaging/systemd/wukongim.sysusers
+        dst: /usr/lib/sysusers.d/wukongim.conf
+        file_info:
+          owner: root
+          group: root
+          mode: 0644
+      - src: packaging/systemd/wukongim.tmpfiles
+        dst: /usr/lib/tmpfiles.d/wukongim.conf
+        file_info:
+          owner: root
+          group: root
+          mode: 0644
+    scripts:
+      postinstall: packaging/scripts/postinstall.sh
+      preremove: packaging/scripts/preremove.sh
+      postremove: packaging/scripts/postremove.sh
+    rpm:
+      group: System Environment/Daemons
+      summary: High-performance distributed messaging cluster
+
+checksum:
+  name_template: checksums.txt
+  ids:
+    - wukongim-linux-packages
+
+changelog:
+  disable: true
+
+release:
+  disable: true

--- a/cmd/wukongim/command.go
+++ b/cmd/wukongim/command.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/WuKongIM/WuKongIM/internal/app"
+	productconfig "github.com/WuKongIM/WuKongIM/internal/config"
+	"github.com/mattn/go-isatty"
+)
+
+const (
+	exitUsage  = 64
+	exitConfig = 78
+)
+
+type commandIO struct {
+	stdin          io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+	stdoutTerminal bool
+}
+
+type commandError struct {
+	code int
+	err  error
+}
+
+func (e *commandError) Error() string { return e.err.Error() }
+func (e *commandError) Unwrap() error { return e.err }
+
+func newCommandError(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &commandError{code: code, err: err}
+}
+
+func commandExitCode(err error) int {
+	var commandErr *commandError
+	if errors.As(err, &commandErr) {
+		return commandErr.code
+	}
+	if errors.Is(err, app.ErrInvalidConfig) {
+		return exitConfig
+	}
+	return 1
+}
+
+func execute(ctx context.Context, args []string, streams commandIO, newApp appFactory) error {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return run(ctx, args, newApp)
+	}
+	switch args[0] {
+	case "version":
+		return runVersionCommand(args[1:], streams.stdout)
+	case "config":
+		return runConfigCommand(args[1:], streams)
+	default:
+		return newCommandError(exitUsage, fmt.Errorf("unknown command %q; expected version, config, or -config", args[0]))
+	}
+}
+
+func runVersionCommand(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("wukongim version", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	output := fs.String("output", "text", "output format: text or json")
+	if err := fs.Parse(args); err != nil {
+		return newCommandError(exitUsage, fmt.Errorf("version: %w", err))
+	}
+	if fs.NArg() != 0 {
+		return newCommandError(exitUsage, fmt.Errorf("version: unexpected arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	info := currentBuildInfo()
+	switch strings.ToLower(strings.TrimSpace(*output)) {
+	case "text":
+		_, err := fmt.Fprintf(stdout, "wukongim version=%s commit=%s source=%s\n", info.Version, info.Commit, info.BuildSource)
+		return err
+	case "json":
+		return json.NewEncoder(stdout).Encode(info)
+	default:
+		return newCommandError(exitUsage, fmt.Errorf("version: --output must be text or json"))
+	}
+}
+
+func runConfigCommand(args []string, streams commandIO) error {
+	if len(args) == 0 {
+		return newCommandError(exitUsage, fmt.Errorf("config: expected init or validate"))
+	}
+	switch args[0] {
+	case "init":
+		return runConfigInitCommand(args[1:], streams)
+	case "validate":
+		return runConfigValidateCommand(args[1:], streams.stdout)
+	default:
+		return newCommandError(exitUsage, fmt.Errorf("config: unknown command %q; expected init or validate", args[0]))
+	}
+}
+
+func runConfigInitCommand(args []string, streams commandIO) error {
+	fs := flag.NewFlagSet("wukongim config init", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", "", "path to the new wukongim.toml")
+	gatewayPublic := fs.Bool("gateway-public", false, "listen for TCP and WebSocket clients on all interfaces")
+	passwordStdin := fs.Bool("admin-password-stdin", false, "read the initial manager password from stdin")
+	if err := fs.Parse(args); err != nil {
+		return newCommandError(exitUsage, fmt.Errorf("config init: %w", err))
+	}
+	if fs.NArg() != 0 {
+		return newCommandError(exitUsage, fmt.Errorf("config init: unexpected arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	if strings.TrimSpace(*configPath) == "" {
+		return newCommandError(exitUsage, fmt.Errorf("config init: --config is required"))
+	}
+	adminPassword := ""
+	generatedPassword := false
+	if *passwordStdin {
+		body, err := io.ReadAll(io.LimitReader(streams.stdin, 4097))
+		if err != nil {
+			return newCommandError(exitUsage, fmt.Errorf("config init: read manager password: %w", err))
+		}
+		if len(body) > 4096 {
+			return newCommandError(exitUsage, fmt.Errorf("config init: manager password exceeds 4096 bytes"))
+		}
+		adminPassword = strings.TrimRight(string(body), "\r\n")
+		if strings.TrimSpace(adminPassword) == "" {
+			return newCommandError(exitUsage, fmt.Errorf("config init: manager password from stdin is empty"))
+		}
+	} else {
+		if !streams.stdoutTerminal {
+			return newCommandError(exitUsage, fmt.Errorf("config init: non-interactive use requires --admin-password-stdin"))
+		}
+		generatedPassword = true
+	}
+	result, err := productconfig.Init(productconfig.InitOptions{
+		Path:          *configPath,
+		GatewayPublic: *gatewayPublic,
+		AdminPassword: adminPassword,
+	})
+	if err != nil {
+		return newCommandError(exitConfig, err)
+	}
+	if _, err := fmt.Fprintf(streams.stdout, "configuration created: %s\ncluster id: %s\nmanager username: %s\n",
+		result.Path, result.ClusterID, result.AdminUsername); err != nil {
+		return err
+	}
+	if generatedPassword {
+		if _, err := fmt.Fprintf(streams.stdout, "manager password: %s\n", result.AdminPassword); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(streams.stdout, "validate with: wukongim config validate --config %s\n", result.Path)
+	return err
+}
+
+func runConfigValidateCommand(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("wukongim config validate", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", "", "path to wukongim.toml")
+	if err := fs.Parse(args); err != nil {
+		return newCommandError(exitUsage, fmt.Errorf("config validate: %w", err))
+	}
+	if fs.NArg() != 0 {
+		return newCommandError(exitUsage, fmt.Errorf("config validate: unexpected arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	if strings.TrimSpace(*configPath) == "" {
+		return newCommandError(exitUsage, fmt.Errorf("config validate: --config is required"))
+	}
+	cfg, err := loadConfig([]string{"-config", *configPath})
+	if err != nil {
+		return newCommandError(exitConfig, err)
+	}
+	if _, err := app.NormalizeConfig(cfg); err != nil {
+		return newCommandError(exitConfig, err)
+	}
+	_, err = fmt.Fprintf(stdout, "configuration valid: %s\n", cfg.ConfigPath)
+	return err
+}
+
+func isTerminal(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+	fd := file.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}

--- a/cmd/wukongim/command_test.go
+++ b/cmd/wukongim/command_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/app"
+)
+
+func TestVersionCommandTextAndJSON(t *testing.T) {
+	oldVersion, oldCommit, oldSource := buildVersion, buildCommit, buildSource
+	buildVersion, buildCommit, buildSource = "3.2.1-rc.1", "abc123", "release"
+	t.Cleanup(func() {
+		buildVersion, buildCommit, buildSource = oldVersion, oldCommit, oldSource
+	})
+
+	var text bytes.Buffer
+	if err := runVersionCommand(nil, &text); err != nil {
+		t.Fatalf("runVersionCommand(text) error = %v", err)
+	}
+	if got := text.String(); got != "wukongim version=3.2.1-rc.1 commit=abc123 source=release\n" {
+		t.Fatalf("text output = %q", got)
+	}
+
+	var output bytes.Buffer
+	if err := runVersionCommand([]string{"--output", "json"}, &output); err != nil {
+		t.Fatalf("runVersionCommand(json) error = %v", err)
+	}
+	var got buildInfo
+	if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v: %s", err, output.String())
+	}
+	if got != (buildInfo{Version: "3.2.1-rc.1", Commit: "abc123", BuildSource: "release"}) {
+		t.Fatalf("JSON output = %#v", got)
+	}
+}
+
+func TestVersionCommandRejectsUnknownOutput(t *testing.T) {
+	err := runVersionCommand([]string{"--output", "yaml"}, &bytes.Buffer{})
+	if commandExitCode(err) != exitUsage {
+		t.Fatalf("commandExitCode() = %d, want %d: %v", commandExitCode(err), exitUsage, err)
+	}
+}
+
+func TestConfigInitNonInteractiveRequiresPasswordStdin(t *testing.T) {
+	err := runConfigInitCommand([]string{"--config", filepath.Join(t.TempDir(), "wukongim.toml")}, commandIO{
+		stdin:  strings.NewReader(""),
+		stdout: &bytes.Buffer{},
+	})
+	if commandExitCode(err) != exitUsage || !strings.Contains(err.Error(), "--admin-password-stdin") {
+		t.Fatalf("runConfigInitCommand() error = %v code=%d", err, commandExitCode(err))
+	}
+}
+
+func TestConfigInitDoesNotTreatDevNullAsInteractive(t *testing.T) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("OpenFile(%s) error = %v", os.DevNull, err)
+	}
+	t.Cleanup(func() { _ = devNull.Close() })
+	if isTerminal(devNull) {
+		t.Fatalf("isTerminal(%s) = true", os.DevNull)
+	}
+
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	err = runConfigInitCommand([]string{"--config", path}, commandIO{
+		stdin:          strings.NewReader(""),
+		stdout:         devNull,
+		stdoutTerminal: isTerminal(devNull),
+	})
+	if commandExitCode(err) != exitUsage || !strings.Contains(err.Error(), "--admin-password-stdin") {
+		t.Fatalf("runConfigInitCommand() error = %v code=%d", err, commandExitCode(err))
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("config was created despite non-interactive output: %v", statErr)
+	}
+}
+
+func TestConfigInitReadsPasswordFromStdinWithoutEcho(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	var stdout bytes.Buffer
+	err := runConfigInitCommand([]string{
+		"--config", path,
+		"--admin-password-stdin",
+	}, commandIO{
+		stdin:  strings.NewReader("operator-secret-password\n"),
+		stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("runConfigInitCommand() error = %v", err)
+	}
+	if strings.Contains(stdout.String(), "operator-secret-password") {
+		t.Fatalf("stdout disclosed stdin password: %q", stdout.String())
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(body), "operator-secret-password") {
+		t.Fatal("generated config does not contain supplied manager password")
+	}
+}
+
+func TestConfigInitRejectsEmptyPasswordFromStdin(t *testing.T) {
+	var stdout bytes.Buffer
+	err := runConfigInitCommand([]string{
+		"--config", filepath.Join(t.TempDir(), "wukongim.toml"),
+		"--admin-password-stdin",
+	}, commandIO{
+		stdin:  strings.NewReader("\n"),
+		stdout: &stdout,
+	})
+	if commandExitCode(err) != exitUsage {
+		t.Fatalf("commandExitCode() = %d, want %d: %v", commandExitCode(err), exitUsage, err)
+	}
+	if !strings.Contains(err.Error(), "password from stdin is empty") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestConfigInitInteractivePrintsGeneratedPasswordOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	var stdout bytes.Buffer
+	err := runConfigInitCommand([]string{"--config", path}, commandIO{
+		stdin:          strings.NewReader(""),
+		stdout:         &stdout,
+		stdoutTerminal: true,
+	})
+	if err != nil {
+		t.Fatalf("runConfigInitCommand() error = %v", err)
+	}
+	if count := strings.Count(stdout.String(), "manager password:"); count != 1 {
+		t.Fatalf("manager password lines = %d: %q", count, stdout.String())
+	}
+}
+
+func TestConfigValidateIsReadOnly(t *testing.T) {
+	unsetLoadConfigEnv(t)
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "missing-data")
+	logDir := filepath.Join(dir, "missing-logs")
+	path := filepath.Join(dir, "wukongim.toml")
+	writeConf(t, path,
+		"WK_NODE_ID=1",
+		"WK_NODE_DATA_DIR="+dataDir,
+		"WK_CLUSTER_LISTEN_ADDR=127.0.0.1:7001",
+		"WK_LOG_DIR="+logDir,
+		"WK_PLUGIN_ENABLE=false",
+	)
+	var stdout bytes.Buffer
+	if err := runConfigValidateCommand([]string{"--config", path}, &stdout); err != nil {
+		t.Fatalf("runConfigValidateCommand() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "configuration valid:") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	for _, candidate := range []string{dataDir, logDir} {
+		if _, err := os.Stat(candidate); !os.IsNotExist(err) {
+			t.Fatalf("validate created %s: %v", candidate, err)
+		}
+	}
+}
+
+func TestConfigValidateReturnsConfigExitCode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	if err := os.WriteFile(path, []byte("[node]\nid = 1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	err := runConfigValidateCommand([]string{"--config", path}, &bytes.Buffer{})
+	if commandExitCode(err) != exitConfig {
+		t.Fatalf("commandExitCode() = %d, want %d: %v", commandExitCode(err), exitConfig, err)
+	}
+}
+
+func TestExecuteRejectsUnknownCommandWithUsageExit(t *testing.T) {
+	err := execute(context.Background(), []string{"unknown"}, commandIO{stdout: &bytes.Buffer{}}, func(app.Config) (runtimeApp, error) {
+		return &fakeRuntimeApp{}, nil
+	})
+	if commandExitCode(err) != exitUsage {
+		t.Fatalf("commandExitCode() = %d, want %d: %v", commandExitCode(err), exitUsage, err)
+	}
+}

--- a/cmd/wukongim/main.go
+++ b/cmd/wukongim/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -23,19 +23,33 @@ type runtimeApp interface {
 type appFactory func(app.Config) (runtimeApp, error)
 
 func main() {
+	if code := runMain(); code != 0 {
+		os.Exit(code)
+	}
+}
+
+func runMain() int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, os.Args[1:], newInternalApp); err != nil {
-		log.Fatal(err)
+	err := execute(ctx, os.Args[1:], commandIO{
+		stdin:          os.Stdin,
+		stdout:         os.Stdout,
+		stderr:         os.Stderr,
+		stdoutTerminal: isTerminal(os.Stdout),
+	}, newInternalApp)
+	if err == nil {
+		return 0
 	}
+	fmt.Fprintf(os.Stderr, "wukongim: %v\n", err)
+	return commandExitCode(err)
 }
 
 // run loads config, starts the app, waits for cancellation, and stops it.
 func run(ctx context.Context, args []string, newApp appFactory) error {
 	cfg, err := loadConfig(args)
 	if err != nil {
-		return err
+		return newCommandError(exitConfig, err)
 	}
 	application, err := newApp(cfg)
 	if err != nil {

--- a/cmd/wukongim/version.go
+++ b/cmd/wukongim/version.go
@@ -1,0 +1,21 @@
+package main
+
+var (
+	buildVersion = "dev"
+	buildCommit  = "unknown"
+	buildSource  = "source"
+)
+
+type buildInfo struct {
+	Version     string `json:"version"`
+	Commit      string `json:"commit"`
+	BuildSource string `json:"build_source"`
+}
+
+func currentBuildInfo() buildInfo {
+	return buildInfo{
+		Version:     buildVersion,
+		Commit:      buildCommit,
+		BuildSource: buildSource,
+	}
+}

--- a/docs-site/content/docs/server/deployment/linux.en.mdx
+++ b/docs-site/content/docs/server/deployment/linux.en.mdx
@@ -1,91 +1,76 @@
 ---
 title: Linux
-description: Build the WuKongIM binary and supervise a node with explicit configuration, persistent directories, and systemd.
+description: Install WuKongIM from deb/rpm previews or source, initialize it safely, and supervise a cluster node with systemd.
 ---
 
-The Linux path fits teams that want direct control over hosts, filesystems, networking, and service lifecycle. The systemd unit below is an operator-owned reference template, not a repository release package.
+The Linux path fits teams that want direct control over hosts, filesystems, networking, and service lifecycle. The repository can now build deb/rpm preview packages, and the separate `WuKongIM/packages` repository has a fail-closed bootstrap at the verified HTTPS endpoint `packages.githubim.com`. Signing keys and APT/YUM indexes are not enabled yet, however, so that endpoint cannot be used for installation. Do not treat these local previews as a signed production distribution channel.
 
-## 1. Build and record the artifact
+The first preview targets Linux amd64 and runs installation contract checks on Ubuntu 24.04, Debian 12, Rocky Linux 9, and AlmaLinux 9.
 
-The repository currently requires Go `1.25.11`:
+## 1. Build and install a local preview package
+
+The repository requires Go `1.25.11`; the package configuration is validated with GoReleaser `v2.18.0`:
 
 ```bash
 git rev-parse HEAD
 go version
-GOWORK=off go build -trimpath -o ./bin/wukongim ./cmd/wukongim
-sha256sum ./bin/wukongim
+goreleaser release --snapshot --clean \
+  --config .goreleaser.packages.yaml
+(cd dist && sha256sum --check checksums.txt)
 ```
 
-Build in an isolated environment and record the commit SHA, Go version, and SHA-256 in the release record. Do not build independently from a moving branch on every production node.
-
-## 2. Install the account, binary, and configuration
+Install the generated `.deb` on Debian or Ubuntu:
 
 ```bash
-sudo useradd --system \
-  --home-dir /var/lib/wukongim \
-  --shell /usr/sbin/nologin \
-  wukongim
-
-sudo install -m 0755 ./bin/wukongim /usr/local/bin/wukongim
-sudo install -d -o root -g wukongim -m 0750 /etc/wukongim
-sudo install -o root -g wukongim -m 0640 \
-  ./wukongim.toml.example \
-  /etc/wukongim/wukongim.toml
+sudo apt install ./dist/wukongim_*_linux_amd64.deb
 ```
 
-Edit `/etc/wukongim/wukongim.toml`:
-
-- set `node.data_dir = "/var/lib/wukongim"`;
-- set `log.dir = "/var/log/wukongim"`;
-- set `plugin.dir = "/var/lib/wukongim/plugins"`, `plugin.sandbox_dir = "/var/lib/wukongim/plugin-sandbox"`, and `plugin.state_dir = "/var/lib/wukongim/plugin-state"`;
-- set `plugin.socket_path = "/run/wukongim/plugin.sock"`;
-- give the node a unique `node.id` and reachable cluster address;
-- replace the join token, Manager JWT secret, users, and every example credential;
-- set `api.external_tcp_addr`, `external_ws_addr`, or `external_wss_addr` to client-reachable addresses;
-- disable benchmark and debug APIs by default in production.
-
-The loader rejects unknown TOML keys and unknown `WK_*` environment variables. An explicit `-config` avoids lookup changes caused by the systemd working directory.
-The reference unit does not set `WorkingDirectory`, so every writable path must be absolute as shown above. Do not leave the example `./data/...` paths for systemd to resolve.
-
-## 3. Create the systemd unit
-
-Write `/etc/systemd/system/wukongim.service`:
-
-```ini
-[Unit]
-Description=WuKongIM cluster node
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=simple
-User=wukongim
-Group=wukongim
-ExecStart=/usr/local/bin/wukongim -config /etc/wukongim/wukongim.toml
-Restart=on-failure
-RestartSec=5s
-TimeoutStopSec=30s
-KillSignal=SIGTERM
-LimitNOFILE=1048576
-StateDirectory=wukongim
-LogsDirectory=wukongim
-RuntimeDirectory=wukongim
-StateDirectoryMode=0750
-LogsDirectoryMode=0750
-RuntimeDirectoryMode=0750
-NoNewPrivileges=true
-PrivateTmp=true
-
-[Install]
-WantedBy=multi-user.target
-```
-
-`StateDirectory`, `LogsDirectory`, and `RuntimeDirectory` create `/var/lib/wukongim`, `/var/log/wukongim`, and `/run/wukongim`. If data lives on a separate mounted disk, complete the mount and permissions before starting the service.
-
-## 4. Start and verify
+Install the generated `.rpm` on Rocky or AlmaLinux:
 
 ```bash
-sudo systemctl daemon-reload
+sudo dnf install ./dist/wukongim_*_linux_amd64.rpm
+```
+
+The package installs `/usr/bin/wukongim` and a hardened `wukongim.service`, then creates the `wukongim` system account and `/etc/wukongim`, `/var/lib/wukongim`, `/var/log/wukongim`, and `/run/wukongim`. It does not create an active configuration, enable or start the service, or restart it.
+
+Confirm the binary identity:
+
+```bash
+wukongim version
+wukongim version --output json
+```
+
+## 2. Initialize a secure configuration
+
+Interactive initialization creates a single-node cluster configuration with a random Cluster ID, join token, Manager JWT secret, and administrator password. The generated administrator password is shown only once:
+
+```bash
+sudo wukongim config init \
+  --config /etc/wukongim/wukongim.toml
+```
+
+Automation must supply an administrator password of at least 12 characters through standard input; the command does not echo it:
+
+```bash
+sudo wukongim config init \
+  --config /etc/wukongim/wukongim.toml \
+  --admin-password-stdin < /secure/path/manager-password
+```
+
+Initialization binds TCP, WebSocket, API, Manager, and node transport to loopback by default. Add `--gateway-public` during first initialization only after the host firewall, TLS termination, and ingress policy are ready. That option exposes only the client TCP/WebSocket Gateway on all interfaces; it does not expose Manager or node transport.
+
+The generator refuses to overwrite an existing file and applies the same configuration validation as service startup before atomically publishing it. When run as root with the `wukongim` group present, it writes `root:wukongim 0640`; otherwise it uses `0600`. Review advertised addresses, node identity, mounts, and network policy, then validate explicitly:
+
+```bash
+sudo wukongim config validate \
+  --config /etc/wukongim/wukongim.toml
+```
+
+Configuration errors return exit code `78`. The systemd unit includes that code in `RestartPreventExitStatus` so invalid configuration cannot create a restart storm. The loader also rejects unknown TOML keys and unknown `WK_*` environment variables.
+
+## 3. Start and verify
+
+```bash
 sudo systemctl enable --now wukongim
 sudo systemctl status wukongim
 sudo journalctl -u wukongim -n 100 --no-pager
@@ -93,24 +78,28 @@ sudo journalctl -u wukongim -n 100 --no-pager
 curl --fail http://127.0.0.1:5001/readyz
 ```
 
-On `SIGTERM`, the process performs a graceful shutdown using the configured cluster stop budget; the reference unit provides a 30-second external ceiling. If `/healthz` succeeds while `/readyz` returns `503`, do not add the node to the load balancer. Inspect the response `reason` and service logs first.
+On `SIGTERM`, the process performs a graceful shutdown using the configured cluster stop budget; the unit provides a 30-second external ceiling. If `/healthz` succeeds while `/readyz` returns `503`, do not add the node to the load balancer. Inspect the response `reason` and service logs first.
 
-Also confirm that `/var/lib/wukongim`, logs, and plugin-state directories belong to the `wukongim` user, test `api.external_*` from the target client network, and recheck persistent mounts and `/readyz` after a service restart.
+Also verify persistent mounts, directory ownership, and advertised addresses from the target client network, then recheck `/readyz` after a service restart.
 
-## Network and permissions
+## Package lifecycle
 
-| Surface | Default policy |
-| --- | --- |
-| API / Gateway | Expose only to product services, client ingress, or controlled load balancers |
-| Manager | Management network with strong authentication; never direct public exposure |
-| `/metrics` | Monitoring collection network only |
-| Debug / benchmark / diagnostics | Disabled in production or limited to a temporary diagnostic window |
-| Node transport | Cluster nodes only |
+- Installation creates no active configuration and does not enable or start the service.
+- Upgrade replaces package files but does not automatically restart a running node. Validate compatibility and configuration, then restart explicitly during a planned window.
+- Removal stops and disables the service but preserves configuration, data, logs, and the service account.
+- The service process applies the same configuration validation before constructing runtimes. Configuration errors exit with `78` and are not restarted. The unit permits writes only to package-managed state, log, and runtime directories.
 
-WuKongIM does not replace production TLS termination or the external authentication boundary for product HTTP APIs. Use a reverse proxy, load balancer, or service mesh for certificates and access policy.
+Before an upgrade, validate the target commit, artifact, configuration, backup, and recovery path outside production. Roll one node at a time only when the target release explicitly supports mixed operation with the current version; otherwise use a full maintenance window. See [Upgrade & Migration](/en/server/operations/upgrade-and-migration) for the complete boundary.
 
-## Upgrade boundary
+## Install from source
 
-Do not overwrite a running binary. Validate the target commit, artifact, configuration, backup, and recovery path outside production. Roll one node at a time only when the target release explicitly supports mixed operation with the current version; otherwise use a full maintenance window. See [Upgrade & Migration](/en/server/operations/upgrade-and-migration) for compatibility decisions, rolling steps, irreversible boundaries, rollback, and v2-to-v3 limits.
+Until the public repository is enabled, you can also build the binary directly:
+
+```bash
+GOWORK=off go build -trimpath -o ./bin/wukongim ./cmd/wukongim
+sha256sum ./bin/wukongim
+```
+
+A source deployment should still reuse `packaging/systemd/wukongim.service`, the repository sysusers/tmpfiles definitions, and the secure initialization command. Do not build separately from a moving branch on every production node, and do not copy the root development example directly into an active production configuration.
 
 For multi-node configuration, continue to [Multi-node Cluster](/en/server/deployment/multi-node).

--- a/docs-site/content/docs/server/deployment/linux.mdx
+++ b/docs-site/content/docs/server/deployment/linux.mdx
@@ -1,91 +1,76 @@
 ---
 title: Linux 部署
-description: 构建 WuKongIM 二进制，并用显式配置、持久化目录和 systemd 托管节点。
+description: 用 deb/rpm 预览包或源码安装 WuKongIM，并通过安全初始化和 systemd 托管集群节点。
 ---
 
-Linux 路径适合希望直接控制主机、文件系统、网络和服务生命周期的团队。以下 systemd 单元是参考模板，由部署者维护，不是仓库发布的安装包。
+Linux 路径适合希望直接控制主机、文件系统、网络和服务生命周期的团队。仓库现在能够构建 deb/rpm 预览包，独立的 `WuKongIM/packages` 仓库也已在完成验证的 HTTPS 地址 `packages.githubim.com` 建立 fail-closed bootstrap；但签名密钥和 APT/YUM 索引尚未启用，因此该地址还不能用于安装。不要把下面的本地预览包当作已签名的正式发布渠道。
 
-## 1. 构建并记录制品
+首批预览支持 Linux amd64，并在 Ubuntu 24.04、Debian 12、Rocky Linux 9 和 AlmaLinux 9 上执行安装契约检查。
 
-仓库当前要求 Go `1.25.11`：
+## 1. 构建并安装本地预览包
+
+仓库要求 Go `1.25.11`，打包配置固定按 GoReleaser `v2.18.0` 校验：
 
 ```bash
 git rev-parse HEAD
 go version
-GOWORK=off go build -trimpath -o ./bin/wukongim ./cmd/wukongim
-sha256sum ./bin/wukongim
+goreleaser release --snapshot --clean \
+  --config .goreleaser.packages.yaml
+(cd dist && sha256sum --check checksums.txt)
 ```
 
-在隔离的构建环境中完成构建，把提交 SHA、Go 版本和 SHA-256 写入发布记录。不要在每台生产节点上分别从移动分支构建。
-
-## 2. 安装账号、二进制和配置
+Debian/Ubuntu 安装生成的 `.deb`：
 
 ```bash
-sudo useradd --system \
-  --home-dir /var/lib/wukongim \
-  --shell /usr/sbin/nologin \
-  wukongim
-
-sudo install -m 0755 ./bin/wukongim /usr/local/bin/wukongim
-sudo install -d -o root -g wukongim -m 0750 /etc/wukongim
-sudo install -o root -g wukongim -m 0640 \
-  ./wukongim.toml.example \
-  /etc/wukongim/wukongim.toml
+sudo apt install ./dist/wukongim_*_linux_amd64.deb
 ```
 
-编辑 `/etc/wukongim/wukongim.toml`：
-
-- `node.data_dir = "/var/lib/wukongim"`；
-- `log.dir = "/var/log/wukongim"`；
-- `plugin.dir = "/var/lib/wukongim/plugins"`、`plugin.sandbox_dir = "/var/lib/wukongim/plugin-sandbox"`、`plugin.state_dir = "/var/lib/wukongim/plugin-state"`；
-- `plugin.socket_path = "/run/wukongim/plugin.sock"`；
-- 为该节点设置唯一 `node.id` 和可达的集群地址；
-- 替换 Join Token、Manager JWT Secret、账号和其他示例凭据；
-- 设置客户端真正可达的 `api.external_tcp_addr`、`external_ws_addr` 或 `external_wss_addr`；
-- 生产默认关闭 Benchmark 和 Debug API。
-
-配置加载器会拒绝未知 TOML 键和未知 `WK_*` 环境变量。显式 `-config` 可以避免 systemd 工作目录改变查找结果。
-参考单元没有设置 `WorkingDirectory`，因此所有可写路径都必须是上面的绝对路径；不要把示例中的 `./data/...` 留给 systemd 服务解析。
-
-## 3. 创建 systemd 单元
-
-写入 `/etc/systemd/system/wukongim.service`：
-
-```ini
-[Unit]
-Description=WuKongIM cluster node
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=simple
-User=wukongim
-Group=wukongim
-ExecStart=/usr/local/bin/wukongim -config /etc/wukongim/wukongim.toml
-Restart=on-failure
-RestartSec=5s
-TimeoutStopSec=30s
-KillSignal=SIGTERM
-LimitNOFILE=1048576
-StateDirectory=wukongim
-LogsDirectory=wukongim
-RuntimeDirectory=wukongim
-StateDirectoryMode=0750
-LogsDirectoryMode=0750
-RuntimeDirectoryMode=0750
-NoNewPrivileges=true
-PrivateTmp=true
-
-[Install]
-WantedBy=multi-user.target
-```
-
-`StateDirectory`、`LogsDirectory` 和 `RuntimeDirectory` 分别创建 `/var/lib/wukongim`、`/var/log/wukongim` 和 `/run/wukongim`。如果数据放在独立挂载盘，先完成挂载和权限，再启动服务。
-
-## 4. 启动并验证
+Rocky/AlmaLinux 安装生成的 `.rpm`：
 
 ```bash
-sudo systemctl daemon-reload
+sudo dnf install ./dist/wukongim_*_linux_amd64.rpm
+```
+
+安装包会安装 `/usr/bin/wukongim` 和加固的 `wukongim.service`，创建 `wukongim` 系统账号以及 `/etc/wukongim`、`/var/lib/wukongim`、`/var/log/wukongim`、`/run/wukongim`。它不会生成活动配置，也不会启用、启动或重启服务。
+
+用下面的命令确认二进制身份：
+
+```bash
+wukongim version
+wukongim version --output json
+```
+
+## 2. 安全初始化配置
+
+交互式初始化会生成单节点集群配置、随机 Cluster ID、Join Token、Manager JWT Secret 和管理员密码；生成的管理员密码只显示一次：
+
+```bash
+sudo wukongim config init \
+  --config /etc/wukongim/wukongim.toml
+```
+
+自动化环境必须从标准输入提供至少 12 个字符的管理员密码，命令不会回显它：
+
+```bash
+sudo wukongim config init \
+  --config /etc/wukongim/wukongim.toml \
+  --admin-password-stdin < /secure/path/manager-password
+```
+
+初始化默认只让 TCP、WebSocket、API、Manager 和节点 Transport 监听回环地址。只有确认主机防火墙、TLS 终止和入口策略后，才可在首次初始化时添加 `--gateway-public`；该选项只将客户端 TCP/WebSocket Gateway 改为监听所有接口，不会公开 Manager 或节点 Transport。
+
+生成器拒绝覆盖现有文件，并在原子发布前完成与服务启动相同的配置校验。以 root 运行且 `wukongim` 组存在时，文件权限为 `root:wukongim 0640`；其他情况使用 `0600`。随后检查外部地址、节点 ID、挂载和网络策略，再显式校验：
+
+```bash
+sudo wukongim config validate \
+  --config /etc/wukongim/wukongim.toml
+```
+
+配置错误返回退出码 `78`。systemd 单元把这个退出码列入 `RestartPreventExitStatus`，避免错误配置形成重启风暴。配置加载器也会拒绝未知 TOML 键和未知 `WK_*` 环境变量。
+
+## 3. 启动并验证
+
+```bash
 sudo systemctl enable --now wukongim
 sudo systemctl status wukongim
 sudo journalctl -u wukongim -n 100 --no-pager
@@ -93,24 +78,28 @@ sudo journalctl -u wukongim -n 100 --no-pager
 curl --fail http://127.0.0.1:5001/readyz
 ```
 
-进程收到 `SIGTERM` 后会按配置的集群停止预算执行优雅停止；参考单元给出 30 秒的外部上限。若 `/healthz` 成功而 `/readyz` 返回 `503`，不要把节点加入负载均衡，先检查返回的 `reason` 和服务日志。
+进程收到 `SIGTERM` 后会按配置的集群停止预算执行优雅停止，服务单元给出 30 秒的外部上限。若 `/healthz` 成功而 `/readyz` 返回 `503`，不要把节点加入负载均衡；先检查返回的 `reason` 和服务日志。
 
-同时确认 `/var/lib/wukongim`、日志和插件状态目录由 `wukongim` 用户持有，从目标客户端网络验证 `api.external_*`，并在服务重启后再次检查持久化挂载与 `/readyz`。
+同时确认持久化挂载、目录所有者和从目标客户端网络可达的外部地址，并在服务重启后再次检查 `/readyz`。
 
-## 网络与权限
+## 包生命周期
 
-| 表面 | 默认策略 |
-| --- | --- |
-| API / Gateway | 只开放给业务服务、客户端入口或受控负载均衡 |
-| Manager | 管理网，强认证，不直接暴露公网 |
-| `/metrics` | 仅监控采集网 |
-| Debug / Benchmark / Diagnostics | 生产关闭或限制到临时诊断窗口 |
-| 节点 Transport | 仅集群节点互通 |
+- 安装不创建活动配置，也不启用或启动服务。
+- 升级替换包文件，但不自动重启正在运行的节点；先验证兼容性和配置，再在计划窗口中显式重启。
+- 卸载会停止并禁用服务，但保留配置、数据、日志和服务账号。
+- 服务进程在创建运行时前执行同一套配置校验；配置错误以 `78` 退出且不会自动重启。单元只允许写入包管理的状态、日志和运行时目录。
 
-WuKongIM 不替代生产 TLS 终止或产品 HTTP API 的外部鉴权边界。使用反向代理、负载均衡或服务网格完成证书和访问策略。
+升级前先在非生产环境验证目标提交、制品、配置、备份和恢复路径。只有目标版本明确声明支持与当前版本混跑时，才能逐节点滚动升级；否则使用全体维护窗口。完整边界见[升级与迁移](/zh/server/operations/upgrade-and-migration)。
 
-## 升级边界
+## 从源码安装
 
-不要直接覆盖正在运行的二进制。先在非生产环境验证目标提交、制品、配置、备份和恢复路径；只有目标版本明确声明支持当前版本混跑时，才能逐节点滚动升级，否则使用全体维护窗口。完整的兼容性决策、滚动步骤、不可逆边界、回滚与 v2→v3 限制见[升级与迁移](/zh/server/operations/upgrade-and-migration)。
+公共软件源启用前，也可以直接构建二进制：
+
+```bash
+GOWORK=off go build -trimpath -o ./bin/wukongim ./cmd/wukongim
+sha256sum ./bin/wukongim
+```
+
+源码部署仍应复用仓库中的 `packaging/systemd/wukongim.service`、sysusers/tmpfiles 定义和安全初始化命令，不要从移动分支在每台生产节点上分别构建，也不要把根目录中的开发示例配置直接复制成活动生产配置。
 
 多节点配置继续阅读[多节点集群](/zh/server/deployment/multi-node)。

--- a/docs-site/lib/native-deployment-contract.test.ts
+++ b/docs-site/lib/native-deployment-contract.test.ts
@@ -28,19 +28,25 @@ describe('native deployment publication contract', () => {
     }
   });
 
-  test('keeps every systemd writable path absolute', async () => {
+  test('documents the secure native package and systemd lifecycle', async () => {
     const pages = await Promise.all([page('linux.mdx'), page('linux.en.mdx')]);
 
     for (const content of pages) {
       for (const contract of [
-        '/var/lib/wukongim/plugins',
-        '/var/lib/wukongim/plugin-sandbox',
-        '/var/lib/wukongim/plugin-state',
-        '/run/wukongim/plugin.sock',
-        'WorkingDirectory',
+        '.goreleaser.packages.yaml',
+        'wukongim config init',
+        '--admin-password-stdin',
+        'wukongim config validate',
+        'RestartPreventExitStatus',
+        '/var/lib/wukongim',
+        '/var/log/wukongim',
+        '/run/wukongim',
+        'packages.githubim.com',
       ]) {
         expect(content).toContain(contract);
       }
+      expect(content).not.toContain('deb [signed-by=');
+      expect(content).not.toContain('baseurl=https://packages.githubim.com');
     }
   });
 

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -88,6 +88,20 @@
   cluster runtime, the multi-reactor channel runtime, and the new business
   kernel are canonical under `pkg/controller`, `pkg/cluster`, `pkg/channel`,
   and `internal`; the former v1 server runtime tree has been removed.
+- Native Linux packages are an unsigned amd64 preview. CI builds temporary
+  signed APT/RPM repositories with one-run, one-day `TEST ONLY` keys outside
+  the repository and verifies their signatures plus the exact APT and RPM
+  metadata-to-package closures in containers; neither those keys nor the
+  signed repositories are published. The separate public `WuKongIM/packages`
+  repository owns a fail-closed GitHub Pages bootstrap at the verified HTTPS
+  endpoint `packages.githubim.com`; both repositories enforce immutable
+  Releases. It publishes no APT/YUM indexes until reviewed public fingerprints,
+  signing custody, exact tagged source package assets, and the production
+  publisher are ready. The package installs the
+  binary, hardened systemd unit, service identity, and persistent directories,
+  but never creates an active configuration or starts/restarts the node.
+  Operators initialize atomically with `wukongim config init`, validate with
+  `wukongim config validate`, and own enablement plus upgrade restart timing.
 - Runnable `wukongim` helper-script configs live under `scripts/wukongim/` as `.toml`; `.toml.example` files are samples only and should not be script defaults.
 - `wukongim` bottleneck attribution uses Prometheus `/metrics` when `WK_METRICS_ENABLE=true`; compare gateway async SEND, Channel runtime reactor/worker queue plus in-flight peak, and storage commit request-vs-batch metrics split by `leader_append` / `follower_apply` lane. `/bench/v1/snapshot` remains a benchmark setup counter surface.
 - Default Slot Raft timing is a 50-millisecond tick, two-tick heartbeat, and 40-tick election floor: heartbeats run every 100 milliseconds and elections start after at least two seconds. Chat-lifecycle cloud templates pin the same values. This keeps sub-second storage or transport tails from creating avoidable terms while proposal replication remains event-driven; override all three values together when a deployment proves a different failure-detection budget.

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,12 +1,27 @@
 package app
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestNormalizeConfigIsPure(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "not-created")
+	normalized, err := NormalizeConfig(Config{DataDir: dataDir})
+	if err != nil {
+		t.Fatalf("NormalizeConfig() error = %v", err)
+	}
+	if normalized.Plugin.Dir != filepath.Join(dataDir, "plugins") {
+		t.Fatalf("Plugin.Dir = %q", normalized.Plugin.Dir)
+	}
+	if _, err := os.Stat(dataDir); !os.IsNotExist(err) {
+		t.Fatalf("NormalizeConfig() created data directory: %v", err)
+	}
+}
 
 func TestWebhookConfigDefaultsWhenEndpointConfigured(t *testing.T) {
 	cfg, err := NormalizeWebhookConfig(WebhookConfig{

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -38,60 +38,71 @@ import (
 )
 
 func (a *App) applyConfigDefaults() error {
-	var err error
-	a.cfg.Manager = defaultManagerConfig(a.cfg.Manager)
-	if err := validateManagerConfig(a.cfg.Manager); err != nil {
-		return err
-	}
-	a.cfg.Message = defaultMessageConfig(a.cfg.Message)
-	if err := validateMessageConfig(a.cfg.Message); err != nil {
-		return err
-	}
-	a.cfg.ChannelMessageRetention = defaultChannelMessageRetentionConfig(a.cfg.ChannelMessageRetention)
-	if err := validateChannelMessageRetentionConfig(a.cfg.ChannelMessageRetention); err != nil {
-		return err
-	}
-	a.cfg.Presence = defaultPresenceConfig(a.cfg.Presence)
-	if err := validatePresenceConfig(a.cfg.Presence); err != nil {
-		return err
-	}
-	a.cfg.Channel = defaultChannelConfig(a.cfg.Channel)
-	if err := validateChannelConfig(a.cfg.Channel); err != nil {
-		return err
-	}
-	a.cfg.ChannelAppend = defaultChannelAppendConfig(a.cfg.ChannelAppend)
-	if err := validateChannelAppendConfig(a.cfg.ChannelAppend); err != nil {
-		return err
-	}
-	a.cfg.Delivery = defaultDeliveryConfig(a.cfg.Delivery)
-	if err := validateDeliveryConfig(a.cfg.Delivery); err != nil {
-		return err
-	}
-	{
-		webhook, err := NormalizeWebhookConfig(a.cfg.Webhook)
-		if err != nil {
-			return err
-		}
-		a.cfg.Webhook = webhook
-	}
-	a.cfg.Plugin = defaultPluginConfig(a.cfg.DataDir, a.cfg.Plugin)
-	if err := validatePluginConfig(a.cfg.Plugin); err != nil {
-		return err
-	}
-	a.cfg.Observability = defaultObservabilityConfig(a.cfg.Observability)
-	a.cfg.Observability.Prometheus = defaultPrometheusConfigForApp(a.cfg)
-	if err := validateObservabilityConfig(a.cfg.Observability); err != nil {
-		return err
-	}
-	if err := validatePrometheusConfig(a.cfg); err != nil {
-		return err
-	}
-	a.cfg.Top, err = NormalizeTopConfig(a.cfg.Top)
+	normalized, err := NormalizeConfig(a.cfg)
 	if err != nil {
 		return err
 	}
-	a.cfg.Log = defaultLogConfig(a.cfg.Log)
+	a.cfg = normalized
 	return nil
+}
+
+// NormalizeConfig applies product defaults and validates the configuration
+// without constructing runtimes or touching the filesystem.
+func NormalizeConfig(cfg Config) (Config, error) {
+	var err error
+	cfg.Manager = defaultManagerConfig(cfg.Manager)
+	if err := validateManagerConfig(cfg.Manager); err != nil {
+		return Config{}, err
+	}
+	cfg.Message = defaultMessageConfig(cfg.Message)
+	if err := validateMessageConfig(cfg.Message); err != nil {
+		return Config{}, err
+	}
+	cfg.ChannelMessageRetention = defaultChannelMessageRetentionConfig(cfg.ChannelMessageRetention)
+	if err := validateChannelMessageRetentionConfig(cfg.ChannelMessageRetention); err != nil {
+		return Config{}, err
+	}
+	cfg.Presence = defaultPresenceConfig(cfg.Presence)
+	if err := validatePresenceConfig(cfg.Presence); err != nil {
+		return Config{}, err
+	}
+	cfg.Channel = defaultChannelConfig(cfg.Channel)
+	if err := validateChannelConfig(cfg.Channel); err != nil {
+		return Config{}, err
+	}
+	cfg.ChannelAppend = defaultChannelAppendConfig(cfg.ChannelAppend)
+	if err := validateChannelAppendConfig(cfg.ChannelAppend); err != nil {
+		return Config{}, err
+	}
+	cfg.Delivery = defaultDeliveryConfig(cfg.Delivery)
+	if err := validateDeliveryConfig(cfg.Delivery); err != nil {
+		return Config{}, err
+	}
+	{
+		webhook, err := NormalizeWebhookConfig(cfg.Webhook)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Webhook = webhook
+	}
+	cfg.Plugin = defaultPluginConfig(cfg.DataDir, cfg.Plugin)
+	if err := validatePluginConfig(cfg.Plugin); err != nil {
+		return Config{}, err
+	}
+	cfg.Observability = defaultObservabilityConfig(cfg.Observability)
+	cfg.Observability.Prometheus = defaultPrometheusConfigForApp(cfg)
+	if err := validateObservabilityConfig(cfg.Observability); err != nil {
+		return Config{}, err
+	}
+	if err := validatePrometheusConfig(cfg); err != nil {
+		return Config{}, err
+	}
+	cfg.Top, err = NormalizeTopConfig(cfg.Top)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Log = defaultLogConfig(cfg.Log)
+	return cfg, nil
 }
 
 func (a *App) applyOptions(opts []Option) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -1,0 +1,374 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/WuKongIM/WuKongIM/internal/app"
+	"github.com/pelletier/go-toml/v2"
+)
+
+const initialAdminUsername = "admin"
+
+// InitOptions controls creation of one package-oriented single-node cluster
+// configuration. Init never overwrites an existing file.
+type InitOptions struct {
+	Path          string
+	GatewayPublic bool
+	AdminPassword string
+	RandomReader  func([]byte) (int, error)
+}
+
+// InitResult reports the newly created configuration and its one-time
+// bootstrap credential.
+type InitResult struct {
+	Path          string
+	AdminUsername string
+	AdminPassword string
+	ClusterID     string
+}
+
+// Init creates and validates a secure single-node cluster configuration using
+// package-owned absolute paths. The completed file appears atomically.
+func Init(opts InitOptions) (InitResult, error) {
+	path := strings.TrimSpace(opts.Path)
+	if path == "" {
+		return InitResult{}, fmt.Errorf("config init: --config is required")
+	}
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return InitResult{}, fmt.Errorf("config init: resolve path: %w", err)
+	}
+	if _, err := os.Lstat(resolved); err == nil {
+		return InitResult{}, fmt.Errorf("config init: %s already exists", resolved)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return InitResult{}, fmt.Errorf("config init: inspect %s: %w", resolved, err)
+	}
+
+	randomReader := opts.RandomReader
+	if randomReader == nil {
+		randomReader = rand.Read
+	}
+	clusterSuffix, err := randomHex(randomReader, 8)
+	if err != nil {
+		return InitResult{}, fmt.Errorf("config init: generate cluster identity: %w", err)
+	}
+	joinToken, err := randomHex(randomReader, 32)
+	if err != nil {
+		return InitResult{}, fmt.Errorf("config init: generate join token: %w", err)
+	}
+	jwtSecret, err := randomHex(randomReader, 32)
+	if err != nil {
+		return InitResult{}, fmt.Errorf("config init: generate manager jwt secret: %w", err)
+	}
+	adminPassword := strings.TrimSpace(opts.AdminPassword)
+	if adminPassword == "" {
+		adminPassword, err = randomPassword(randomReader, 18)
+		if err != nil {
+			return InitResult{}, fmt.Errorf("config init: generate manager password: %w", err)
+		}
+	}
+	if len(adminPassword) < 12 {
+		return InitResult{}, fmt.Errorf("config init: manager password must contain at least 12 characters")
+	}
+
+	clusterID := "wukongim-" + clusterSuffix
+	body, err := renderInitialConfig(clusterID, joinToken, jwtSecret, adminPassword, opts.GatewayPublic)
+	if err != nil {
+		return InitResult{}, err
+	}
+	if err := writeValidatedConfig(resolved, body); err != nil {
+		return InitResult{}, err
+	}
+	return InitResult{
+		Path:          resolved,
+		AdminUsername: initialAdminUsername,
+		AdminPassword: adminPassword,
+		ClusterID:     clusterID,
+	}, nil
+}
+
+type initialConfigDocument struct {
+	Node          initialNodeConfig          `toml:"node"`
+	Cluster       initialClusterConfig       `toml:"cluster"`
+	API           initialAPIConfig           `toml:"api"`
+	Manager       initialManagerConfig       `toml:"manager"`
+	Bench         initialBenchConfig         `toml:"bench"`
+	Observability initialObservabilityConfig `toml:"observability"`
+	Prometheus    initialPrometheusConfig    `toml:"prometheus"`
+	Top           initialTopConfig           `toml:"top"`
+	Diagnostics   initialDiagnosticsConfig   `toml:"diagnostics"`
+	Log           initialLogConfig           `toml:"log"`
+	Gateway       initialGatewayConfig       `toml:"gateway"`
+	Plugin        initialPluginConfig        `toml:"plugin"`
+}
+
+type initialNodeConfig struct {
+	ID      uint64 `toml:"id"`
+	DataDir string `toml:"data_dir"`
+}
+
+type initialClusterConfig struct {
+	ListenAddr      string               `toml:"listen_addr"`
+	ID              string               `toml:"id"`
+	Nodes           []initialClusterNode `toml:"nodes"`
+	JoinToken       string               `toml:"join_token"`
+	InitialSlots    uint32               `toml:"initial_slot_count"`
+	HashSlots       uint16               `toml:"hash_slot_count"`
+	SlotReplicas    uint16               `toml:"slot_replica_n"`
+	ChannelReplicas uint16               `toml:"channel_replica_n"`
+}
+
+type initialClusterNode struct {
+	ID   uint64 `toml:"id"`
+	Addr string `toml:"addr"`
+}
+
+type initialAPIConfig struct {
+	ListenAddr string `toml:"listen_addr"`
+}
+
+type initialManagerConfig struct {
+	ListenAddr string               `toml:"listen_addr"`
+	AuthOn     bool                 `toml:"auth_on"`
+	JWTSecret  string               `toml:"jwt_secret"`
+	JWTIssuer  string               `toml:"jwt_issuer"`
+	JWTExpire  string               `toml:"jwt_expire"`
+	Users      []initialManagerUser `toml:"users"`
+}
+
+type initialManagerUser struct {
+	Username    string                     `toml:"username"`
+	Password    string                     `toml:"password"`
+	Permissions []initialManagerPermission `toml:"permissions"`
+}
+
+type initialManagerPermission struct {
+	Resource string   `toml:"resource"`
+	Actions  []string `toml:"actions"`
+}
+
+type initialBenchConfig struct {
+	APIEnable bool `toml:"api_enable"`
+}
+
+type initialObservabilityConfig struct {
+	MetricsEnable  bool `toml:"metrics_enable"`
+	DebugAPIEnable bool `toml:"debug_api_enable"`
+}
+
+type initialPrometheusConfig struct {
+	Enable bool `toml:"enable"`
+}
+
+type initialTopConfig struct {
+	APIEnable bool `toml:"api_enable"`
+}
+
+type initialDiagnosticsConfig struct {
+	Enable bool `toml:"enable"`
+}
+
+type initialLogConfig struct {
+	Level      string `toml:"level"`
+	Dir        string `toml:"dir"`
+	MaxSize    int    `toml:"max_size"`
+	MaxAge     int    `toml:"max_age"`
+	MaxBackups int    `toml:"max_backups"`
+	Compress   bool   `toml:"compress"`
+	Console    bool   `toml:"console"`
+	Format     string `toml:"format"`
+}
+
+type initialGatewayConfig struct {
+	Listeners []initialGatewayListener `toml:"listeners"`
+}
+
+type initialGatewayListener struct {
+	Name      string `toml:"name"`
+	Network   string `toml:"network"`
+	Address   string `toml:"address"`
+	Transport string `toml:"transport"`
+	Protocol  string `toml:"protocol"`
+}
+
+type initialPluginConfig struct {
+	Enable     bool   `toml:"enable"`
+	Dir        string `toml:"dir"`
+	SocketPath string `toml:"socket_path"`
+	SandboxDir string `toml:"sandbox_dir"`
+	StateDir   string `toml:"state_dir"`
+}
+
+func renderInitialConfig(clusterID, joinToken, jwtSecret, adminPassword string, gatewayPublic bool) ([]byte, error) {
+	gatewayHost := "127.0.0.1"
+	if gatewayPublic {
+		gatewayHost = "0.0.0.0"
+	}
+	document := initialConfigDocument{
+		Node: initialNodeConfig{ID: 1, DataDir: "/var/lib/wukongim"},
+		Cluster: initialClusterConfig{
+			ListenAddr:      "127.0.0.1:7001",
+			ID:              clusterID,
+			Nodes:           []initialClusterNode{{ID: 1, Addr: "127.0.0.1:7001"}},
+			JoinToken:       joinToken,
+			InitialSlots:    10,
+			HashSlots:       256,
+			SlotReplicas:    1,
+			ChannelReplicas: 1,
+		},
+		API: initialAPIConfig{ListenAddr: "127.0.0.1:5001"},
+		Manager: initialManagerConfig{
+			ListenAddr: "127.0.0.1:5301",
+			AuthOn:     true,
+			JWTSecret:  jwtSecret,
+			JWTIssuer:  "wukongim-manager",
+			JWTExpire:  "24h",
+			Users: []initialManagerUser{{
+				Username: initialAdminUsername,
+				Password: adminPassword,
+				Permissions: []initialManagerPermission{{
+					Resource: "*",
+					Actions:  []string{"*"},
+				}},
+			}},
+		},
+		Bench:         initialBenchConfig{APIEnable: false},
+		Observability: initialObservabilityConfig{MetricsEnable: true, DebugAPIEnable: false},
+		Prometheus:    initialPrometheusConfig{Enable: false},
+		Top:           initialTopConfig{APIEnable: false},
+		Diagnostics:   initialDiagnosticsConfig{Enable: false},
+		Log: initialLogConfig{
+			Level:      "info",
+			Dir:        "/var/log/wukongim",
+			MaxSize:    100,
+			MaxAge:     30,
+			MaxBackups: 10,
+			Compress:   true,
+			Console:    false,
+			Format:     "json",
+		},
+		Gateway: initialGatewayConfig{Listeners: []initialGatewayListener{
+			{Name: "tcp-wkproto", Network: "tcp", Address: gatewayHost + ":5100", Transport: "gnet", Protocol: "wkproto"},
+			{Name: "ws-gateway", Network: "websocket", Address: gatewayHost + ":5200", Transport: "gnet", Protocol: "wsmux"},
+		}},
+		Plugin: initialPluginConfig{
+			Enable:     false,
+			Dir:        "/var/lib/wukongim/plugins",
+			SocketPath: "/run/wukongim/plugin.sock",
+			SandboxDir: "/var/lib/wukongim/plugin-sandbox",
+			StateDir:   "/var/lib/wukongim/plugin-state",
+		},
+	}
+	body, err := toml.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("config init: render TOML: %w", err)
+	}
+	header := "# Generated by `wukongim config init`.\n" +
+		"# Review advertised addresses and network policy before enabling the service.\n\n"
+	return append([]byte(header), body...), nil
+}
+
+func writeValidatedConfig(path string, body []byte) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return fmt.Errorf("config init: create %s: %w", parent, err)
+	}
+	temporary, err := os.CreateTemp(parent, ".wukongim.toml.*")
+	if err != nil {
+		return fmt.Errorf("config init: create temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+
+	mode, gid := initialConfigOwnership()
+	if err := temporary.Chmod(mode); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("config init: set temporary permissions: %w", err)
+	}
+	if gid >= 0 {
+		if err := temporary.Chown(-1, gid); err != nil {
+			_ = temporary.Close()
+			return fmt.Errorf("config init: set wukongim group: %w", err)
+		}
+	}
+	if _, err := temporary.Write(body); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("config init: write temporary file: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("config init: sync temporary file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("config init: close temporary file: %w", err)
+	}
+
+	cfg, err := Load(Options{Args: []string{"-config", temporaryPath}, Environ: []string{}})
+	if err != nil {
+		return fmt.Errorf("config init: validate generated config: %w", err)
+	}
+	if _, err := app.NormalizeConfig(cfg); err != nil {
+		return fmt.Errorf("config init: validate generated config: %w", err)
+	}
+	if err := os.Link(temporaryPath, path); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("config init: %s already exists", path)
+		}
+		return fmt.Errorf("config init: publish %s atomically: %w", path, err)
+	}
+	return nil
+}
+
+func initialConfigOwnership() (os.FileMode, int) {
+	if os.Geteuid() != 0 {
+		return 0o600, -1
+	}
+	group, err := user.LookupGroup("wukongim")
+	if err != nil {
+		return 0o600, -1
+	}
+	gid, err := strconv.Atoi(group.Gid)
+	if err != nil {
+		return 0o600, -1
+	}
+	return 0o640, gid
+}
+
+func randomHex(read func([]byte) (int, error), size int) (string, error) {
+	data := make([]byte, size)
+	if err := readFull(read, data); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(data), nil
+}
+
+func randomPassword(read func([]byte) (int, error), size int) (string, error) {
+	data := make([]byte, size)
+	if err := readFull(read, data); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func readFull(read func([]byte) (int, error), data []byte) error {
+	for len(data) > 0 {
+		n, err := read(data)
+		if err != nil {
+			return err
+		}
+		if n <= 0 || n > len(data) {
+			return fmt.Errorf("random source returned invalid byte count %d", n)
+		}
+		data = data[n:]
+	}
+	return nil
+}

--- a/internal/config/init_test.go
+++ b/internal/config/init_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/WuKongIM/WuKongIM/internal/app"
+)
+
+func TestInitCreatesValidatedSingleNodeClusterConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "etc", "wukongim.toml")
+	result, err := Init(InitOptions{
+		Path:          path,
+		AdminPassword: "test-admin-password",
+		RandomReader:  deterministicRandomReader(),
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if result.Path != path || result.AdminUsername != "admin" || result.AdminPassword != "test-admin-password" {
+		t.Fatalf("Init() result = %#v", result)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 && mode != 0o640 {
+		t.Fatalf("config mode = %#o, want 0600 or 0640", mode)
+	}
+
+	cfg, err := Load(Options{Args: []string{"-config", path}, Environ: cleanEnv()})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if _, err := app.NormalizeConfig(cfg); err != nil {
+		t.Fatalf("NormalizeConfig() error = %v", err)
+	}
+	if cfg.NodeID != 1 || cfg.DataDir != "/var/lib/wukongim" {
+		t.Fatalf("node config = id %d data %q", cfg.NodeID, cfg.DataDir)
+	}
+	if cfg.Cluster.Slots.HashSlotCount != 256 || cfg.Cluster.Slots.ReplicaCount != 1 || cfg.Cluster.Channel.ReplicaCount != 1 {
+		t.Fatalf("cluster slots/channel = %#v/%#v", cfg.Cluster.Slots, cfg.Cluster.Channel)
+	}
+	if cfg.Manager.ListenAddr != "127.0.0.1:5301" || !cfg.Manager.AuthOn || len(cfg.Manager.Users) != 1 || cfg.Manager.Users[0].Password != "test-admin-password" {
+		t.Fatalf("manager config = %#v", cfg.Manager)
+	}
+	if len(cfg.Gateway.Listeners) != 2 || cfg.Gateway.Listeners[0].Address != "127.0.0.1:5100" || cfg.Gateway.Listeners[1].Address != "127.0.0.1:5200" {
+		t.Fatalf("gateway listeners = %#v", cfg.Gateway.Listeners)
+	}
+	if cfg.Bench.APIEnabled || cfg.Observability.DebugAPIEnabled || cfg.Observability.Prometheus.Enabled || cfg.Plugin.Enable {
+		t.Fatalf("unsafe optional services enabled: bench=%t debug=%t prometheus=%t plugin=%t",
+			cfg.Bench.APIEnabled, cfg.Observability.DebugAPIEnabled, cfg.Observability.Prometheus.Enabled, cfg.Plugin.Enable)
+	}
+	if cfg.Log.Dir != "/var/log/wukongim" || cfg.Log.Console {
+		t.Fatalf("log config = %#v", cfg.Log)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	for _, forbidden := range []string{"change-me", "a1234567", "wukongim-dev-manager-secret", "./data/"} {
+		if strings.Contains(string(body), forbidden) {
+			t.Fatalf("generated config contains unsafe value %q", forbidden)
+		}
+	}
+}
+
+func TestInitGatewayPublicIsExplicit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	_, err := Init(InitOptions{
+		Path:          path,
+		GatewayPublic: true,
+		AdminPassword: "test-admin-password",
+		RandomReader:  deterministicRandomReader(),
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	cfg, err := Load(Options{Args: []string{"-config", path}, Environ: cleanEnv()})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Gateway.Listeners[0].Address != "0.0.0.0:5100" || cfg.Gateway.Listeners[1].Address != "0.0.0.0:5200" {
+		t.Fatalf("gateway listeners = %#v", cfg.Gateway.Listeners)
+	}
+	if cfg.API.ListenAddr != "127.0.0.1:5001" || cfg.Manager.ListenAddr != "127.0.0.1:5301" || cfg.Cluster.ListenAddr != "127.0.0.1:7001" {
+		t.Fatalf("non-gateway listeners escaped loopback: api=%q manager=%q cluster=%q",
+			cfg.API.ListenAddr, cfg.Manager.ListenAddr, cfg.Cluster.ListenAddr)
+	}
+}
+
+func TestInitRefusesOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	if err := os.WriteFile(path, []byte("owned-by-operator\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	_, err := Init(InitOptions{Path: path, AdminPassword: "test-admin-password", RandomReader: deterministicRandomReader()})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("Init() error = %v, want already exists", err)
+	}
+	body, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(body) != "owned-by-operator\n" {
+		t.Fatalf("existing config changed to %q", body)
+	}
+}
+
+func TestInitRandomFailureLeavesNoConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wukongim.toml")
+	want := errors.New("random unavailable")
+	_, err := Init(InitOptions{
+		Path:          path,
+		AdminPassword: "test-admin-password",
+		RandomReader: func([]byte) (int, error) {
+			return 0, want
+		},
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Init() error = %v, want %v", err, want)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Stat() error = %v, want not exist", statErr)
+	}
+}
+
+func TestInitRejectsShortAdminPassword(t *testing.T) {
+	_, err := Init(InitOptions{
+		Path:          filepath.Join(t.TempDir(), "wukongim.toml"),
+		AdminPassword: "short",
+		RandomReader:  deterministicRandomReader(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "at least 12") {
+		t.Fatalf("Init() error = %v, want minimum password length", err)
+	}
+}
+
+func deterministicRandomReader() func([]byte) (int, error) {
+	var next byte = 1
+	return func(data []byte) (int, error) {
+		for i := range data {
+			data[i] = next
+			next++
+		}
+		return len(data), nil
+	}
+}

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# The package owns the service account and writable directories, but it never
+# creates an active configuration or starts/enables the service.
+systemd-sysusers /usr/lib/sysusers.d/wukongim.conf
+systemd-tmpfiles --create /usr/lib/tmpfiles.d/wukongim.conf
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1 || :
+fi

--- a/packaging/scripts/postremove.sh
+++ b/packaging/scripts/postremove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+# Configuration, data, logs, and the service account intentionally survive
+# removal so an uninstall or rollback cannot destroy operator-owned state.
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1 || :
+fi

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# Debian passes "remove" for a final uninstall; RPM passes 0. Upgrades must not
+# interrupt a running cluster node because the operator owns restart timing.
+case "${1:-}" in
+  remove|purge|0)
+    if command -v systemctl >/dev/null 2>&1; then
+      systemctl stop wukongim.service >/dev/null 2>&1 || :
+      systemctl disable wukongim.service >/dev/null 2>&1 || :
+    fi
+    ;;
+esac

--- a/packaging/systemd/wukongim.service
+++ b/packaging/systemd/wukongim.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=WuKongIM cluster node
+Documentation=https://github.com/WuKongIM/WuKongIM
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=/etc/wukongim/wukongim.toml
+
+[Service]
+Type=simple
+User=wukongim
+Group=wukongim
+WorkingDirectory=/var/lib/wukongim
+ExecStart=/usr/bin/wukongim -config /etc/wukongim/wukongim.toml
+Restart=on-failure
+RestartPreventExitStatus=78
+RestartSec=5s
+TimeoutStopSec=30s
+KillSignal=SIGTERM
+LimitNOFILE=1048576
+UMask=0027
+StateDirectory=wukongim
+LogsDirectory=wukongim
+RuntimeDirectory=wukongim
+StateDirectoryMode=0750
+LogsDirectoryMode=0750
+RuntimeDirectoryMode=0750
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+ReadWritePaths=/var/lib/wukongim /var/log/wukongim /run/wukongim
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/wukongim.sysusers
+++ b/packaging/systemd/wukongim.sysusers
@@ -1,0 +1,1 @@
+u wukongim - "WuKongIM service user" /var/lib/wukongim /usr/sbin/nologin

--- a/packaging/systemd/wukongim.tmpfiles
+++ b/packaging/systemd/wukongim.tmpfiles
@@ -1,0 +1,4 @@
+d /etc/wukongim 0750 root wukongim -
+d /var/lib/wukongim 0750 wukongim wukongim -
+d /var/log/wukongim 0750 wukongim wukongim -
+d /run/wukongim 0750 wukongim wukongim -

--- a/scripts/binary_release_workflow_test.go
+++ b/scripts/binary_release_workflow_test.go
@@ -30,6 +30,10 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 			RunsOn         string `yaml:"runs-on"`
 			TimeoutMinutes int    `yaml:"timeout-minutes"`
 			Environment    string `yaml:"environment"`
+			Steps          []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
 		} `yaml:"jobs"`
 	}
 	require.NoError(t, yaml.Unmarshal(raw, &workflow))
@@ -69,14 +73,36 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		"sha256sum --check",
 		"docker/setup-qemu-action@",
 		"actions/attest@",
-		"gh api \"repos/$GITHUB_REPOSITORY/releases/tags/$VERSION\"",
+		"gh api \"repos/$GITHUB_REPOSITORY/immutable-releases\"",
+		"repository immutable Releases must remain enabled before publication",
+		"gh api --paginate --slurp",
+		"repos/$GITHUB_REPOSITORY/releases?per_page=100",
+		"select(.tag_name == $version)",
+		"resolves to multiple GitHub Releases",
+		"release_id=$release_id",
+		"repos/$GITHUB_REPOSITORY/releases/assets/$asset_id",
 		"cmp \"$RELEASE_DIR/$asset\" \"$existing_dir/$asset\"",
-		"already has the complete immutable binary release",
-		"already immutable and incomplete",
-		"gh release create \"$VERSION\"",
-		"\"${upload_paths[@]}\"",
-		"create_args+=(--prerelease)",
-		"gh release upload \"$VERSION\"",
+		"already has the complete published binary release",
+		"already published but incomplete; refusing to reuse its tag; publish a new SemVer tag",
+		"Release contains unexpected asset",
+		"git ls-remote origin",
+		"remote_source_sha=\"${peeled_tag_sha:-$raw_tag_sha}\"",
+		"gh api --method POST \"repos/$GITHUB_REPOSITORY/releases\"",
+		"-F draft=true",
+		"https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id/assets{?name,label}",
+		"curl --fail-with-body --silent --show-error",
+		"$upload_endpoint?name=$asset",
+		"upload response does not match the local asset",
+		"must remain mutable and draft until all assets are verified",
+		"draft does not contain the exact expected asset set",
+		"repository immutable Releases were disabled before publication",
+		"gh api --method PATCH",
+		"-F draft=false",
+		".tag_name == $version and .draft == false and .immutable == true",
+		"published Release does not contain the exact expected asset set",
+		"api_digest=\"$(jq -r '.digest // empty'",
+		"local_size=\"$(stat -c '%s'",
+		"$api_digest\" == \"sha256:$local_sha256",
 		"wukongim/binary-release-receipt/v1",
 		"retention-days: 90",
 		"git diff --exit-code HEAD --",
@@ -89,19 +115,25 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		"release:",
 		"cancel-in-progress: true",
 		"--clobber",
+		"delete and recreate the exact Release",
+		"releases/tags/",
 		"windows/",
 	} {
 		require.NotContains(t, text, forbidden)
 	}
+	require.Equal(t, 2, strings.Count(text, "git ls-remote origin"))
+	require.Equal(t, 2, strings.Count(text, "repos/$GITHUB_REPOSITORY/immutable-releases"))
 
 	orderedSteps := []string{
 		"- name: Validate release identity and tag policy",
 		"- name: Build deterministic release archives",
 		"- name: Validate binary identities and archive contents",
-		"- name: Classify immutable GitHub Release assets",
+		"- name: Classify draft GitHub Release assets",
 		"- name: Create GitHub build provenance",
-		"- name: Publish absent immutable GitHub Release assets",
-		"- name: Verify published Release assets",
+		"- name: Create or recover draft GitHub Release",
+		"- name: Verify complete draft Release",
+		"- name: Publish verified draft Release once",
+		"- name: Verify published immutable Release",
 		"- name: Write release receipt and summary",
 	}
 	previous := -1
@@ -110,4 +142,55 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		require.Greater(t, position, previous, step)
 		previous = position
 	}
+
+	stepRuns := make(map[string]string, len(publish.Steps))
+	for _, step := range publish.Steps {
+		stepRuns[step.Name] = step.Run
+	}
+	classifyRun := stepRuns["Classify draft GitHub Release assets"]
+	require.Contains(t, classifyRun, "gh api --paginate --slurp")
+	require.Contains(t, classifyRun, "[.[][] | select(.tag_name == $version)]")
+	require.Contains(t, classifyRun, "release_id=\"$(jq -r '.id'")
+	require.NotContains(t, classifyRun, "releases/tags/")
+
+	createRun := stepRuns["Create or recover draft GitHub Release"]
+	require.Contains(t, createRun, "release_id=\"$(jq -r '.id' \"$created_release\")\"")
+	require.Contains(t, createRun, "repos/$GITHUB_REPOSITORY/releases/$release_id")
+	require.Contains(t, createRun, "expected_upload_url=\"https://uploads.github.com/")
+	require.Contains(t, createRun, "upload_endpoint=\"${upload_url%%\\{*}\"")
+	require.Contains(t, createRun, "\"$upload_endpoint?name=$asset\"")
+	require.Contains(t, createRun, ".size == $size and .digest == $digest")
+	require.NotContains(t, createRun, "gh release")
+	require.NotContains(t, createRun, "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?name=$asset")
+
+	verifyDraftRun := stepRuns["Verify complete draft Release"]
+	require.Contains(t, verifyDraftRun, "releases/$RELEASE_ID")
+	require.Contains(t, verifyDraftRun, "releases/assets/$asset_id")
+	require.NotContains(t, verifyDraftRun, "releases/tags/")
+	require.NotContains(t, verifyDraftRun, "--method PATCH")
+
+	publishRun := stepRuns["Publish verified draft Release once"]
+	tagCheck := strings.Index(publishRun, "git ls-remote origin")
+	immutableCheck := strings.Index(publishRun, "immutable-releases")
+	assetSetCheck := strings.Index(publishRun, "draft asset set changed immediately before publication")
+	digestCheck := strings.Index(publishRun, "draft digest changed immediately before publication")
+	prereleaseCheck := strings.Index(publishRun, "draft prerelease classification changed before publication")
+	publishCall := strings.Index(publishRun, "gh api --method PATCH")
+	require.GreaterOrEqual(t, tagCheck, 0)
+	require.Greater(t, immutableCheck, tagCheck)
+	require.Greater(t, prereleaseCheck, immutableCheck)
+	require.Greater(t, assetSetCheck, prereleaseCheck)
+	require.Greater(t, digestCheck, assetSetCheck)
+	require.Greater(t, publishCall, digestCheck)
+	require.Contains(t, publishRun, "releases/$RELEASE_ID")
+	require.Contains(t, publishRun, "stat -c '%s'")
+	require.Contains(t, publishRun, "sha256:$local_sha256")
+
+	verifyPublishedRun := stepRuns["Verify published immutable Release"]
+	require.Contains(t, verifyPublishedRun, "releases/$RELEASE_ID")
+	require.Contains(t, verifyPublishedRun, ".digest // empty")
+	require.Contains(t, verifyPublishedRun, "stat -c '%s'")
+	require.Contains(t, verifyPublishedRun, "sha256:$local_sha256")
+	require.Contains(t, verifyPublishedRun, "releases/assets/$asset_id")
+	require.NotContains(t, verifyPublishedRun, "releases/tags/")
 }

--- a/scripts/build-native-package-repositories.sh
+++ b/scripts/build-native-package-repositories.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: build-native-package-repositories.sh \
+  --packages-dir DIR --output DIR \
+  --apt-suite SUITE --apt-architecture ARCH \
+  --rpm-channel CHANNEL --rpm-basearch ARCH
+
+Build unsigned APT and RPM repository trees atomically. DIR must contain at
+least one .deb and one .rpm. The output is staging data and is not publishable
+until sign-native-package-repositories.sh succeeds.
+EOF
+}
+
+packages_dir=""
+output_dir=""
+apt_suite=""
+apt_architecture=""
+rpm_channel=""
+rpm_basearch=""
+while (($# > 0)); do
+  case "$1" in
+    --packages-dir) (($# >= 2)) || { usage; exit 64; }; packages_dir="$2"; shift 2 ;;
+    --output) (($# >= 2)) || { usage; exit 64; }; output_dir="$2"; shift 2 ;;
+    --apt-suite) (($# >= 2)) || { usage; exit 64; }; apt_suite="$2"; shift 2 ;;
+    --apt-architecture) (($# >= 2)) || { usage; exit 64; }; apt_architecture="$2"; shift 2 ;;
+    --rpm-channel) (($# >= 2)) || { usage; exit 64; }; rpm_channel="$2"; shift 2 ;;
+    --rpm-basearch) (($# >= 2)) || { usage; exit 64; }; rpm_basearch="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 64 ;;
+  esac
+done
+
+for value_name in packages_dir output_dir apt_suite apt_architecture rpm_channel rpm_basearch; do
+  [[ -n "${!value_name}" ]] || { echo "missing --${value_name//_/-}" >&2; usage; exit 64; }
+done
+[[ -d "$packages_dir" ]] || { echo "packages directory does not exist: $packages_dir" >&2; exit 66; }
+[[ ! -L "$packages_dir" ]] || { echo "packages directory must not be a symbolic link" >&2; exit 65; }
+[[ ! -e "$output_dir" ]] || { echo "output already exists: $output_dir" >&2; exit 73; }
+[[ "$apt_suite" =~ ^[a-z0-9][a-z0-9.-]{0,63}$ ]] || { echo "invalid APT suite" >&2; exit 64; }
+[[ "$apt_architecture" =~ ^[a-z0-9][a-z0-9_-]{0,31}$ ]] || { echo "invalid APT architecture" >&2; exit 64; }
+[[ "$rpm_channel" =~ ^[a-z0-9][a-z0-9.-]{0,63}$ ]] || { echo "invalid RPM channel" >&2; exit 64; }
+[[ "$rpm_basearch" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$ ]] || { echo "invalid RPM base architecture" >&2; exit 64; }
+
+for tool in dpkg-scanpackages apt-ftparchive createrepo_c gzip sha256sum; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "$tool is required" >&2; exit 69; }
+done
+
+shopt -s nullglob
+deb_packages=("$packages_dir"/*.deb)
+rpm_packages=("$packages_dir"/*.rpm)
+((${#deb_packages[@]} > 0)) || { echo "no .deb packages found" >&2; exit 66; }
+((${#rpm_packages[@]} > 0)) || { echo "no .rpm packages found" >&2; exit 66; }
+
+output_parent="$(dirname "$output_dir")"
+output_name="$(basename "$output_dir")"
+mkdir -p "$output_parent"
+output_parent="$(cd "$output_parent" && pwd -P)"
+output_dir="$output_parent/$output_name"
+stage="$(mktemp -d "$output_parent/.${output_name}.tmp.XXXXXX")"
+cleanup() { rm -rf -- "$stage"; }
+trap cleanup EXIT HUP INT TERM
+
+apt_root="$stage/apt"
+apt_pool="$apt_root/pool/main/w/wukongim"
+apt_binary="$apt_root/dists/$apt_suite/main/binary-$apt_architecture"
+rpm_root="$stage/rpm/$rpm_channel/el/9/$rpm_basearch"
+mkdir -p "$apt_pool" "$apt_binary" "$rpm_root/Packages"
+
+for package in "${deb_packages[@]}"; do
+  [[ -f "$package" && ! -L "$package" ]] || { echo "packages must be regular files: $package" >&2; exit 65; }
+  cp -- "$package" "$apt_pool/"
+done
+for package in "${rpm_packages[@]}"; do
+  [[ -f "$package" && ! -L "$package" ]] || { echo "packages must be regular files: $package" >&2; exit 65; }
+  cp -- "$package" "$rpm_root/Packages/"
+done
+
+(
+  cd "$apt_root"
+  dpkg-scanpackages --multiversion --arch "$apt_architecture" pool /dev/null \
+    >"dists/$apt_suite/main/binary-$apt_architecture/Packages"
+  gzip -9n -c "dists/$apt_suite/main/binary-$apt_architecture/Packages" \
+    >"dists/$apt_suite/main/binary-$apt_architecture/Packages.gz"
+  apt-ftparchive \
+    -o "APT::FTPArchive::Release::Origin=WuKongIM" \
+    -o "APT::FTPArchive::Release::Label=WuKongIM" \
+    -o "APT::FTPArchive::Release::Suite=$apt_suite" \
+    -o "APT::FTPArchive::Release::Codename=$apt_suite" \
+    -o "APT::FTPArchive::Release::Architectures=$apt_architecture" \
+    -o "APT::FTPArchive::Release::Components=main" \
+    -o "APT::FTPArchive::Release::Acquire-By-Hash=yes" \
+    release "dists/$apt_suite" >"Release.tmp"
+  mv -- "Release.tmp" "dists/$apt_suite/Release"
+
+  by_hash="dists/$apt_suite/main/binary-$apt_architecture/by-hash/SHA256"
+  mkdir -p "$by_hash"
+  for metadata in Packages Packages.gz; do
+    metadata_path="dists/$apt_suite/main/binary-$apt_architecture/$metadata"
+    digest="$(sha256sum "$metadata_path" | awk '{print $1}')"
+    cp -- "$metadata_path" "$by_hash/$digest"
+  done
+)
+
+createrepo_c --quiet --simple-md-filenames "$rpm_root"
+cat >"$stage/repository-layout.txt" <<EOF
+TEST_ONLY_UNSIGNED_STAGING=1
+APT_RELEASE=apt/dists/$apt_suite/Release
+RPM_REPOSITORY=rpm/$rpm_channel/el/9/$rpm_basearch
+EOF
+
+find "$stage" -type d -exec chmod 0755 {} +
+find "$stage" -type f -exec chmod 0644 {} +
+
+mv -- "$stage" "$output_dir"
+trap - EXIT HUP INT TERM
+echo "unsigned native-package repositories built at $output_dir"

--- a/scripts/generate-native-package-test-keyring.sh
+++ b/scripts/generate-native-package-test-keyring.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: generate-native-package-test-keyring.sh --output DIR
+
+Generate two ephemeral, one-day OpenPGP test certificates in DIR. DIR must
+not already exist and must be outside the repository. The result is TEST ONLY
+and contains unprotected signing subkeys for credential-free integration tests.
+EOF
+}
+
+output_dir=""
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      (($# >= 2)) || { usage; exit 64; }
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+[[ -n "$output_dir" ]] || { usage; exit 64; }
+for tool in gpg gpgconf; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "$tool is required" >&2; exit 69; }
+done
+[[ ! -e "$output_dir" ]] || { echo "output already exists: $output_dir" >&2; exit 73; }
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+output_parent="$(dirname "$output_dir")"
+output_name="$(basename "$output_dir")"
+mkdir -p "$output_parent"
+output_parent="$(cd "$output_parent" && pwd -P)"
+output_dir="$output_parent/$output_name"
+case "$output_dir" in
+  "$repository_root"|"$repository_root"/*)
+    echo "test secret keys must be generated outside the repository: $output_dir" >&2
+    exit 64
+    ;;
+esac
+
+stage="$(mktemp -d "$output_parent/.${output_name}.tmp.XXXXXX")"
+cleanup() {
+  rm -rf -- "$stage"
+}
+trap cleanup EXIT HUP INT TERM
+
+generation_home="$stage/generation-gnupg"
+signing_home="$stage/gnupg"
+public_dir="$stage/public"
+secret_dir="$stage/secret-transfer"
+mkdir -m 0700 "$generation_home" "$signing_home" "$secret_dir"
+mkdir -m 0700 "$public_dir"
+
+generate_certificate() {
+  local role="$1"
+  local uid="$2"
+  local public_path="$public_dir/$role.asc"
+  local secret_path="$secret_dir/$role.gpg"
+  local primary_fingerprint signing_fingerprint
+
+  gpg --homedir "$generation_home" --batch --quiet --pinentry-mode loopback \
+    --passphrase '' --quick-generate-key "$uid" rsa3072 cert 1d
+  primary_fingerprint="$(
+    gpg --homedir "$generation_home" --batch --with-colons --fingerprint "$uid" |
+      awk -F: '$1 == "fpr" { print $10; exit }'
+  )"
+  [[ "$primary_fingerprint" =~ ^[0-9A-F]{40}$ ]] || {
+    echo "failed to resolve $role primary fingerprint" >&2
+    exit 70
+  }
+
+  gpg --homedir "$generation_home" --batch --quiet --pinentry-mode loopback \
+    --passphrase '' --quick-add-key "$primary_fingerprint" rsa3072 sign 1d
+  signing_fingerprint="$(
+    gpg --homedir "$generation_home" --batch --with-colons --fingerprint "$primary_fingerprint" |
+      awk -F: '$1 == "sub" { want = 1; next } want && $1 == "fpr" { print $10; exit }'
+  )"
+  [[ "$signing_fingerprint" =~ ^[0-9A-F]{40}$ ]] || {
+    echo "failed to resolve $role signing fingerprint" >&2
+    exit 70
+  }
+
+  gpg --homedir "$generation_home" --batch --armor \
+    --output "$public_path" --export "$primary_fingerprint"
+  gpg --homedir "$generation_home" --batch --pinentry-mode loopback --passphrase '' \
+    --output "$secret_path" --export-secret-subkeys "$primary_fingerprint"
+  gpg --homedir "$signing_home" --batch --quiet --import "$public_path"
+  gpg --homedir "$signing_home" --batch --quiet --pinentry-mode loopback \
+    --passphrase '' --import "$secret_path"
+
+  printf '%s\t%s\n' "$primary_fingerprint" "$signing_fingerprint"
+}
+
+apt_fingerprints="$(generate_certificate apt 'WuKongIM Native Package APT TEST ONLY <test-only@invalid>')"
+rpm_fingerprints="$(generate_certificate rpm 'WuKongIM Native Package RPM TEST ONLY <test-only@invalid>')"
+read -r apt_primary apt_signing <<<"$apt_fingerprints"
+read -r rpm_primary rpm_signing <<<"$rpm_fingerprints"
+
+# Stop path-bound agents before the atomic directory rename. GnuPG 2.4 may
+# otherwise leave keyboxd sockets that still refer to the temporary path.
+gpgconf --homedir "$generation_home" --kill all
+gpgconf --homedir "$signing_home" --kill all
+rm -rf -- "$generation_home" "$secret_dir"
+touch "$stage/apt-passphrase.txt" "$stage/rpm-passphrase.txt"
+chmod 0600 "$stage/apt-passphrase.txt" "$stage/rpm-passphrase.txt"
+chmod 0644 "$public_dir/apt.asc" "$public_dir/rpm.asc"
+
+cat >"$stage/manifest.env" <<EOF
+WK_NATIVE_PACKAGE_TEST_ONLY=1
+WK_APT_PRIMARY_FINGERPRINT=$apt_primary
+WK_APT_SIGNING_FINGERPRINT=$apt_signing
+WK_RPM_PRIMARY_FINGERPRINT=$rpm_primary
+WK_RPM_SIGNING_FINGERPRINT=$rpm_signing
+EOF
+chmod 0600 "$stage/manifest.env"
+
+mv -- "$stage" "$output_dir"
+trap - EXIT HUP INT TERM
+echo "TEST ONLY native-package keyring generated at $output_dir"

--- a/scripts/github_workflows_test.go
+++ b/scripts/github_workflows_test.go
@@ -35,6 +35,7 @@ var workflowCatalog = map[string]string{
 	"issue-agent-pr-signal.yml":                "Safety Automation - Issue Agent PR Signal",
 	"issue-agent.yml":                          "Safety Automation - GitHub Issue Agent",
 	"manager-browser-smoke.yml":                "Safety Automation - Manager Browser Smoke",
+	"native-package-preview.yml":               "Safety Automation - Validate Native Package Preview",
 	"review-agent-pr-signal.yml":               "Safety Automation - Review Agent PR Signal",
 	"review-agent-run.yml":                     "Agent Tool - Review Pull Request",
 	"review-agent.yml":                         "Safety Automation - Review Agent Controller",

--- a/scripts/native_package_contract_test.go
+++ b/scripts/native_package_contract_test.go
@@ -46,6 +46,10 @@ func TestNativePackageConfigurationIsPreviewOnly(t *testing.T) {
 	require.Contains(t, artifactValidation, `if [[ "${WK_NATIVE_PACKAGE_SKIP_BUILD:-0}" != "1" ]]; then
   if ! command -v goreleaser`)
 	require.Contains(t, artifactValidation, "goreleaser check --config .goreleaser.packages.yaml")
+	require.Contains(t, artifactValidation, `deb_contents="$(dpkg-deb --contents`)
+	require.Contains(t, artifactValidation, `rpm_contents="$(rpm -qpl`)
+	require.NotContains(t, artifactValidation, `dpkg-deb --contents "${deb_packages[0]}" |`)
+	require.NotContains(t, artifactValidation, `rpm -qpl "${rpm_packages[0]}" |`)
 	containerValidation := readNativePackageFile(t, root, "scripts/validate-native-package-container.sh")
 	for _, required := range []string{
 		"--platform linux/amd64",

--- a/scripts/native_package_contract_test.go
+++ b/scripts/native_package_contract_test.go
@@ -128,6 +128,9 @@ func TestNativePackageRepositorySigningFailsClosed(t *testing.T) {
 		"--network none",
 		"--read-only",
 		"find /work -xdev -mindepth 1 -depth -delete",
+		"trap - EXIT HUP INT TERM",
+		"if ((status != 0)); then",
+		"exit \"$cleanup_status\"",
 	} {
 		require.Contains(t, containerVerifier, required)
 	}

--- a/scripts/native_package_contract_test.go
+++ b/scripts/native_package_contract_test.go
@@ -1,0 +1,285 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestNativePackageConfigurationIsPreviewOnly(t *testing.T) {
+	root := repoRoot(t)
+	raw := readNativePackageFile(t, root, ".goreleaser.packages.yaml")
+	var document any
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &document))
+
+	for _, required := range []string{
+		"version: 2",
+		"CGO_ENABLED=0",
+		"goos:",
+		"- linux",
+		"goarch:",
+		"- amd64",
+		"- deb",
+		"- rpm",
+		"bindir: /usr/bin",
+		"-X main.buildVersion={{ .Version }}",
+		"-X main.buildCommit={{ .Commit }}",
+		"-X main.buildSource=release",
+		"disable: true",
+	} {
+		require.Contains(t, raw, required)
+	}
+	for _, forbidden := range []string{
+		"arm64",
+		"signs:",
+		"publishers:",
+		"uploads:",
+		"packages.githubim.com",
+	} {
+		require.NotContains(t, raw, forbidden)
+	}
+	containerValidation := readNativePackageFile(t, root, "scripts/validate-native-package-container.sh")
+	for _, required := range []string{
+		"--platform linux/amd64",
+		"WK_NATIVE_PACKAGE_DIST_DIR",
+		"NATIVE_PACKAGE_TEST_APT_MIRROR",
+		"apt-get install --reinstall",
+		"dnf reinstall",
+		"wukongim-systemctl.calls",
+		"native package upgrade changed service activation state",
+		"sha256sum --check /tmp/wukongim-package-state.sha256",
+		"package-upgrade-sentinel",
+	} {
+		require.Contains(t, containerValidation, required)
+	}
+}
+
+func TestNativePackageDoesNotActivateAnUnconfiguredService(t *testing.T) {
+	root := repoRoot(t)
+	postinstall := readNativePackageFile(t, root, "packaging/scripts/postinstall.sh")
+	preremove := readNativePackageFile(t, root, "packaging/scripts/preremove.sh")
+	postremove := readNativePackageFile(t, root, "packaging/scripts/postremove.sh")
+	service := readNativePackageFile(t, root, "packaging/systemd/wukongim.service")
+
+	for _, forbidden := range []string{
+		"systemctl start",
+		"systemctl restart",
+		"systemctl enable",
+		"enable --now",
+		"wukongim.toml.example",
+	} {
+		require.NotContains(t, postinstall, forbidden)
+	}
+	require.Contains(t, postinstall, "systemd-sysusers")
+	require.Contains(t, postinstall, "systemd-tmpfiles --create")
+	require.Contains(t, postinstall, "systemctl daemon-reload")
+
+	require.Contains(t, service, "ConditionPathExists=/etc/wukongim/wukongim.toml")
+	require.Contains(t, service, "ExecStart=/usr/bin/wukongim -config")
+	require.Contains(t, service, "RestartPreventExitStatus=78")
+	require.NotContains(t, service, "ExecStartPre=")
+	require.Contains(t, service, "ProtectSystem=strict")
+	require.Contains(t, service, "ReadWritePaths=/var/lib/wukongim /var/log/wukongim /run/wukongim")
+
+	require.Contains(t, preremove, "remove|purge|0)")
+	require.NotContains(t, preremove, "systemctl restart")
+	for _, script := range []string{postinstall, preremove, postremove} {
+		for _, destructive := range []string{"rm -", "userdel", "groupdel", "/etc/wukongim/wukongim.toml"} {
+			require.NotContains(t, script, destructive)
+		}
+	}
+}
+
+func TestNativePackageFilesUseExpectedModes(t *testing.T) {
+	root := repoRoot(t)
+	for _, path := range []string{
+		"packaging/scripts/postinstall.sh",
+		"packaging/scripts/preremove.sh",
+		"packaging/scripts/postremove.sh",
+	} {
+		info, err := os.Stat(filepath.Join(root, path))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o755), info.Mode().Perm(), path)
+	}
+	for _, path := range []string{
+		"packaging/systemd/wukongim.service",
+		"packaging/systemd/wukongim.sysusers",
+		"packaging/systemd/wukongim.tmpfiles",
+	} {
+		info, err := os.Stat(filepath.Join(root, path))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o644), info.Mode().Perm(), path)
+	}
+}
+
+func TestNativePackageRepositorySigningFailsClosed(t *testing.T) {
+	root := repoRoot(t)
+	generator := readNativePackageFile(t, root, "scripts/generate-native-package-test-keyring.sh")
+	builder := readNativePackageFile(t, root, "scripts/build-native-package-repositories.sh")
+	signer := readNativePackageFile(t, root, "scripts/sign-native-package-repositories.sh")
+	verifier := readNativePackageFile(t, root, "scripts/verify-native-package-repositories.sh")
+	metadataVerifier := readNativePackageFile(t, root, "scripts/verify-native-package-metadata.py")
+	containerVerifier := readNativePackageFile(t, root, "scripts/validate-native-package-repositories-container.sh")
+
+	for _, required := range []string{
+		"TEST ONLY",
+		"must be generated outside the repository",
+		"--export-secret-subkeys",
+		"gpgconf --homedir \"$signing_home\" --kill all",
+	} {
+		require.Contains(t, generator, required)
+	}
+	for _, required := range []string{
+		"dpkg-scanpackages --multiversion",
+		"APT::FTPArchive::Release::Acquire-By-Hash=yes",
+		">\"Release.tmp\"",
+		"by-hash/SHA256",
+		"find \"$stage\" -type d -exec chmod 0755",
+	} {
+		require.Contains(t, builder, required)
+	}
+	for _, required := range []string{
+		"--test-only",
+		"minimum-valid-days",
+		"fingerprints must be complete 40-hex values",
+		"must be owned by the signing user",
+		"must not be accessible by group or other",
+		"primary secret material must not be present",
+		"primary certificate must match exactly, remain valid, and be certify-only",
+		"exactly the requested sign-only subkey",
+		"--test-only certificate UID must contain TEST ONLY",
+		"TEST ONLY certificate is forbidden for production signing",
+		"output repository must not be located inside the input repository",
+		"input repository may contain only regular files and directories",
+		"APT repository contains an unsupported Packages index",
+		"--local-user \"$signing!\"",
+		"--define \"__gpg $(command -v gpg)\"",
+		"rpm --dbpath \"$rpm_verify_db\" --import",
+		"rpmkeys --dbpath \"$rpm_verify_db\" --verbose --checksig",
+		"issuer fpr v4 $rpm_signing",
+		"TEST_ONLY=$test_only",
+	} {
+		require.Contains(t, signer, required)
+	}
+	rpmSigningIndex := strings.Index(signer, "--addsign")
+	rpmMetadataResetIndex := strings.Index(signer, "rm -rf -- \"$rpm_repository_path/repodata\"")
+	rpmMetadataSignatureIndex := strings.Index(signer, "repomd.xml.asc")
+	require.NotEqual(t, -1, rpmSigningIndex)
+	require.NotEqual(t, -1, rpmMetadataResetIndex)
+	require.NotEqual(t, -1, rpmMetadataSignatureIndex)
+	require.Less(t, rpmSigningIndex, rpmMetadataResetIndex)
+	require.Less(t, rpmMetadataResetIndex, rpmMetadataSignatureIndex)
+	aptIndexPolicyIndex := strings.Index(signer, "unsupported_apt_index=")
+	require.NotEqual(t, -1, aptIndexPolicyIndex)
+	require.Less(t, aptIndexPolicyIndex, rpmSigningIndex)
+	for _, required := range []string{
+		"--allow-test-only",
+		"a zero-day validity floor requires --allow-test-only",
+		"public key must contain exactly one primary certificate",
+		"public key must contain exactly the requested valid sign-only subkey",
+		"test-only certificate is forbidden without --allow-test-only",
+		"gpgv --status-fd 1",
+		"InRelease cleartext differs from Release",
+		"APT Release must enable Acquire-By-Hash",
+		"APT Release contains no SHA256 entries",
+		"APT by-hash target differs",
+		"rpmkeys --dbpath \"$rpm_db\" --checksig",
+		"issuer fpr v4 $rpm_signing",
+		"repomd.xml.asc",
+		"python3 \"$metadata_verifier\"",
+	} {
+		require.Contains(t, verifier, required)
+	}
+	for _, required := range []string{
+		"APT Packages indexes do not close over the exact pool payload set",
+		"APT Release authenticates unsupported Packages indexes",
+		"APT Release does not close over the exact Packages index set",
+		"RPM repomd.xml does not close over the exact repodata file set",
+		"RPM primary metadata does not close over the exact package set",
+		"APT payload digest or size mismatch",
+		"RPM compressed metadata digest or size mismatch",
+		"open size exceeds the repository budget",
+		"zstd failed for",
+		"target.is_symlink() or not stat.S_ISREG(mode)",
+	} {
+		require.Contains(t, metadataVerifier, required)
+	}
+	for _, required := range []string{
+		"--allow-test-only",
+		"production verifier accepted test-only keys",
+		"signed unsupported APT Packages.xz was accepted",
+		"signer accepted an unsupported APT Packages.xz",
+		"signer accepted an output repository inside its input",
+		"missing deb was accepted",
+		"tampered RPM metadata was accepted",
+		"unindexed validly signed RPM was accepted",
+		"expanded APT key bundle was accepted",
+		"group-readable signing passphrase was accepted",
+		"special repository input was accepted",
+		"repo_gpgcheck=1",
+		"gpgcheck=1",
+	} {
+		require.Contains(t, containerVerifier, required)
+	}
+
+	for _, path := range []string{
+		"scripts/generate-native-package-test-keyring.sh",
+		"scripts/build-native-package-repositories.sh",
+		"scripts/sign-native-package-repositories.sh",
+		"scripts/verify-native-package-repositories.sh",
+		"scripts/verify-native-package-metadata.py",
+		"scripts/validate-native-package-repositories-container.sh",
+	} {
+		info, err := os.Stat(filepath.Join(root, path))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o755), info.Mode().Perm(), path)
+	}
+}
+
+func TestNativePackageWorkflowIsCredentialFreeAndBounded(t *testing.T) {
+	root := repoRoot(t)
+	raw := readNativePackageFile(t, root, ".github/workflows/native-package-preview.yml")
+	var document any
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &document))
+
+	for _, required := range []string{
+		"permissions:\n  contents: read",
+		"persist-credentials: false",
+		"goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1",
+		"version: v2.18.0",
+		"scripts/native_package_repository_integration_test.go",
+		"scripts/validate-native-package-repositories-container.sh",
+		"scripts/verify-native-package-metadata.py",
+		"WK_NATIVE_PACKAGE_REPOSITORY_INTEGRATION: \"1\"",
+		"go test -tags=integration ./scripts",
+		"-run '^TestNativePackageSignedRepository$'",
+		"ubuntu:24.04 deb",
+		"debian:12 deb",
+		"rockylinux:9 rpm",
+		"almalinux:9 rpm",
+		"retention-days: 14",
+	} {
+		require.Contains(t, raw, required)
+	}
+	for _, forbidden := range []string{
+		"contents: write",
+		"packages: write",
+		"id-token: write",
+		"secrets.",
+		"packages.githubim.com",
+		"release --clean",
+	} {
+		require.NotContains(t, raw, forbidden)
+	}
+}
+
+func readNativePackageFile(t *testing.T, root, relative string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relative)))
+	require.NoError(t, err)
+	return strings.ReplaceAll(string(body), "\r\n", "\n")
+}

--- a/scripts/native_package_contract_test.go
+++ b/scripts/native_package_contract_test.go
@@ -124,6 +124,13 @@ func TestNativePackageRepositorySigningFailsClosed(t *testing.T) {
 	verifier := readNativePackageFile(t, root, "scripts/verify-native-package-repositories.sh")
 	metadataVerifier := readNativePackageFile(t, root, "scripts/verify-native-package-metadata.py")
 	containerVerifier := readNativePackageFile(t, root, "scripts/validate-native-package-repositories-container.sh")
+	for _, required := range []string{
+		"--network none",
+		"--read-only",
+		"find /work -xdev -mindepth 1 -depth -delete",
+	} {
+		require.Contains(t, containerVerifier, required)
+	}
 
 	for _, required := range []string{
 		"TEST ONLY",

--- a/scripts/native_package_contract_test.go
+++ b/scripts/native_package_contract_test.go
@@ -42,6 +42,10 @@ func TestNativePackageConfigurationIsPreviewOnly(t *testing.T) {
 	} {
 		require.NotContains(t, raw, forbidden)
 	}
+	artifactValidation := readNativePackageFile(t, root, "scripts/validate-native-package.sh")
+	require.Contains(t, artifactValidation, `if [[ "${WK_NATIVE_PACKAGE_SKIP_BUILD:-0}" != "1" ]]; then
+  if ! command -v goreleaser`)
+	require.Contains(t, artifactValidation, "goreleaser check --config .goreleaser.packages.yaml")
 	containerValidation := readNativePackageFile(t, root, "scripts/validate-native-package-container.sh")
 	for _, required := range []string{
 		"--platform linux/amd64",

--- a/scripts/native_package_repository_integration_test.go
+++ b/scripts/native_package_repository_integration_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestNativePackageSignedRepository(t *testing.T) {
+	if os.Getenv("WK_NATIVE_PACKAGE_REPOSITORY_INTEGRATION") != "1" {
+		t.Skip("set WK_NATIVE_PACKAGE_REPOSITORY_INTEGRATION=1 to run the signed repository container validation")
+	}
+
+	runHeavyShellScriptTestInParallel(t)
+	root := repoRoot(t)
+	command := exec.Command(
+		"bash",
+		filepath.Join(root, "scripts", "validate-native-package-repositories-container.sh"),
+	)
+	command.Dir = root
+	command.Env = os.Environ()
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("signed native package repository validation failed: %v\n%s", err, output)
+	}
+}

--- a/scripts/sign-native-package-repositories.sh
+++ b/scripts/sign-native-package-repositories.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: sign-native-package-repositories.sh \
+  --input DIR --output DIR --gnupg-home DIR \
+  [--test-only] \
+  [--minimum-valid-days DAYS] \
+  --apt-release RELATIVE_PATH \
+  --apt-primary-fingerprint FPR --apt-signing-fingerprint FPR \
+  --apt-passphrase-file FILE \
+  --rpm-repository RELATIVE_PATH \
+  --rpm-primary-fingerprint FPR --rpm-signing-fingerprint FPR \
+  --rpm-passphrase-file FILE
+
+Copy an unsigned staging tree, sign every RPM package, regenerate RPM metadata,
+and sign APT and RPM metadata. All fingerprints must be full 40-hex values.
+The input is never modified and no key is generated or selected implicitly.
+The production validity floor defaults to 30 days. A zero-day floor requires
+--test-only and both certificates must have a UID containing TEST ONLY.
+EOF
+}
+
+input_dir=""; output_dir=""; gnupg_home=""; test_only="false"; minimum_valid_days="30"; apt_release=""; rpm_repository=""
+apt_primary=""; apt_signing=""; apt_passphrase_file=""
+rpm_primary=""; rpm_signing=""; rpm_passphrase_file=""
+while (($# > 0)); do
+  case "$1" in
+    --input) (($# >= 2)) || { usage; exit 64; }; input_dir="$2"; shift 2 ;;
+    --output) (($# >= 2)) || { usage; exit 64; }; output_dir="$2"; shift 2 ;;
+    --gnupg-home) (($# >= 2)) || { usage; exit 64; }; gnupg_home="$2"; shift 2 ;;
+    --test-only) test_only="true"; shift ;;
+    --minimum-valid-days) (($# >= 2)) || { usage; exit 64; }; minimum_valid_days="$2"; shift 2 ;;
+    --apt-release) (($# >= 2)) || { usage; exit 64; }; apt_release="$2"; shift 2 ;;
+    --apt-primary-fingerprint) (($# >= 2)) || { usage; exit 64; }; apt_primary="${2^^}"; shift 2 ;;
+    --apt-signing-fingerprint) (($# >= 2)) || { usage; exit 64; }; apt_signing="${2^^}"; shift 2 ;;
+    --apt-passphrase-file) (($# >= 2)) || { usage; exit 64; }; apt_passphrase_file="$2"; shift 2 ;;
+    --rpm-repository) (($# >= 2)) || { usage; exit 64; }; rpm_repository="$2"; shift 2 ;;
+    --rpm-primary-fingerprint) (($# >= 2)) || { usage; exit 64; }; rpm_primary="${2^^}"; shift 2 ;;
+    --rpm-signing-fingerprint) (($# >= 2)) || { usage; exit 64; }; rpm_signing="${2^^}"; shift 2 ;;
+    --rpm-passphrase-file) (($# >= 2)) || { usage; exit 64; }; rpm_passphrase_file="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 64 ;;
+  esac
+done
+
+for value_name in input_dir output_dir gnupg_home apt_release apt_primary apt_signing apt_passphrase_file rpm_repository rpm_primary rpm_signing rpm_passphrase_file; do
+  [[ -n "${!value_name}" ]] || { echo "missing required argument for ${value_name//_/-}" >&2; usage; exit 64; }
+done
+[[ -d "$input_dir" ]] || { echo "input directory does not exist: $input_dir" >&2; exit 66; }
+[[ ! -L "$input_dir" ]] || { echo "input directory must not be a symbolic link" >&2; exit 65; }
+[[ -d "$gnupg_home" ]] || { echo "GNUPG home does not exist: $gnupg_home" >&2; exit 66; }
+[[ ! -L "$gnupg_home" ]] || { echo "GNUPG home must not be a symbolic link" >&2; exit 65; }
+[[ -f "$apt_passphrase_file" && ! -L "$apt_passphrase_file" ]] || { echo "APT passphrase must be a regular non-symbolic-link file" >&2; exit 66; }
+[[ -f "$rpm_passphrase_file" && ! -L "$rpm_passphrase_file" ]] || { echo "RPM passphrase must be a regular non-symbolic-link file" >&2; exit 66; }
+[[ ! -e "$output_dir" && ! -L "$output_dir" ]] || { echo "output already exists or is a symbolic link: $output_dir" >&2; exit 73; }
+
+require_private_mode() {
+  local role="$1" path="$2" mode owner
+  mode="$(stat -c %a "$path")"
+  owner="$(stat -c %u "$path")"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || { echo "cannot determine permissions for $role" >&2; exit 65; }
+  [[ "$owner" == "$(id -u)" ]] || { echo "$role must be owned by the signing user" >&2; exit 65; }
+  (( (8#$mode & 077) == 0 )) || { echo "$role must not be accessible by group or other" >&2; exit 65; }
+}
+require_private_mode "GNUPG home" "$gnupg_home"
+require_private_mode "APT passphrase file" "$apt_passphrase_file"
+require_private_mode "RPM passphrase file" "$rpm_passphrase_file"
+[[ "$minimum_valid_days" =~ ^[0-9]+$ && "$minimum_valid_days" -le 3650 ]] || {
+  echo "minimum-valid-days must be an integer from 0 through 3650" >&2
+  exit 64
+}
+if [[ "$minimum_valid_days" == 0 && "$test_only" != true ]]; then
+  echo "a zero-day validity floor requires --test-only" >&2
+  exit 64
+fi
+for fingerprint in "$apt_primary" "$apt_signing" "$rpm_primary" "$rpm_signing"; do
+  [[ "$fingerprint" =~ ^[0-9A-F]{40}$ ]] || { echo "fingerprints must be complete 40-hex values" >&2; exit 64; }
+done
+for path in "$apt_release" "$rpm_repository"; do
+  [[ "$path" != /* && "$path" != ".." && "$path" != ../* && "$path" != */../* && "$path" != */.. ]] || {
+    echo "repository paths must be relative and must not contain '..': $path" >&2
+    exit 64
+  }
+done
+for tool in gpg id realpath rpm rpmsign rpmkeys createrepo_c stat; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "$tool is required" >&2; exit 69; }
+done
+
+input_dir="$(realpath -e -- "$input_dir")"
+output_dir="$(realpath -m -- "$output_dir")"
+case "$output_dir/" in
+  "$input_dir"/*)
+    echo "output repository must not be located inside the input repository" >&2
+    exit 65
+    ;;
+esac
+
+validate_key() {
+  local role="$1" primary="$2" signing="$3" passphrase_file="$4"
+  local listing primary_count status_file probe_dir minimum_expiry
+  minimum_expiry="$(( $(date +%s) + minimum_valid_days * 86400 ))"
+  listing="$(gpg --homedir "$gnupg_home" --batch --with-colons --fingerprint --fingerprint "$primary")"
+  primary_count="$(awk -F: '$1 == "pub" { count++ } END { print count + 0 }' <<<"$listing")"
+  [[ "$primary_count" == 1 ]] || {
+    echo "$role key selection must resolve to exactly one primary certificate" >&2
+    exit 65
+  }
+  awk -F: -v wanted="$primary" -v minimum_expiry="$minimum_expiry" '
+    $1 == "pub" { valid = $2; expiry = $7; capabilities = $12; want_fpr = 1; next }
+    want_fpr && $1 == "fpr" {
+      exit !($10 == wanted && valid !~ /[re]/ &&
+        capabilities ~ /c/ && capabilities !~ /[sea]/ &&
+        (expiry == 0 || expiry >= minimum_expiry))
+    }
+    END { if (NR == 0) exit 1 }
+  ' <<<"$listing" || {
+    echo "$role primary certificate must match exactly, remain valid, and be certify-only" >&2
+    exit 65
+  }
+  awk -F: -v wanted="$signing" -v minimum_expiry="$minimum_expiry" '
+    $1 == "sub" { valid = $2; expiry = $7; capabilities = $12; want_fpr = 1; next }
+    want_fpr && $1 == "fpr" {
+      if (capabilities ~ /s/) {
+        signing_count++
+        if ($10 == wanted && valid !~ /[re]/ && capabilities !~ /[eca]/ &&
+            (expiry == 0 || expiry >= minimum_expiry)) found = 1
+      }
+      want_fpr = 0
+    }
+    END { exit !(found && signing_count == 1) }
+  ' <<<"$listing" || {
+    echo "$role certificate must have exactly the requested sign-only subkey, valid for at least $minimum_valid_days days" >&2
+    exit 65
+  }
+  if [[ "$test_only" == true ]]; then
+    awk -F: '$1 == "uid" && toupper($10) ~ /TEST ONLY/ { found = 1 } END { exit !found }' <<<"$listing" || {
+      echo "$role --test-only certificate UID must contain TEST ONLY" >&2
+      exit 65
+    }
+  else
+    awk -F: '$1 == "uid" && toupper($10) ~ /TEST ONLY/ { found = 1 } END { exit found ? 0 : 1 }' <<<"$listing" && {
+      echo "$role TEST ONLY certificate is forbidden for production signing" >&2
+      exit 65
+    }
+  fi
+
+  listing="$(gpg --homedir "$gnupg_home" --batch --with-colons --list-secret-keys "$primary")"
+  awk -F: '$1 == "sec" { exit ($15 ~ /#/) ? 0 : 1 } END { if (NR == 0) exit 1 }' <<<"$listing" || {
+    echo "$role primary secret material must not be present in the signing keyring" >&2
+    exit 65
+  }
+
+  probe_dir="$(mktemp -d)"
+  (
+    trap 'rm -rf -- "$probe_dir"' EXIT HUP INT TERM
+    status_file="$probe_dir/status"
+    printf '%s\n' "native-package $role signing-key probe" >"$probe_dir/data"
+    gpg --homedir "$gnupg_home" --batch --yes --pinentry-mode loopback \
+      --passphrase-file "$passphrase_file" --local-user "$signing!" \
+      --digest-algo SHA256 --output "$probe_dir/signature" --detach-sign "$probe_dir/data"
+    gpg --homedir "$gnupg_home" --batch --status-fd 1 \
+      --verify "$probe_dir/signature" "$probe_dir/data" >"$status_file" 2>/dev/null
+    grep -Eq "^\[GNUPG:\] VALIDSIG $signing( |$)" "$status_file" || {
+      echo "$role signing probe did not use the exact requested subkey" >&2
+      exit 65
+    }
+  )
+}
+
+validate_key APT "$apt_primary" "$apt_signing" "$apt_passphrase_file"
+validate_key RPM "$rpm_primary" "$rpm_signing" "$rpm_passphrase_file"
+
+output_parent="$(dirname "$output_dir")"
+output_name="$(basename "$output_dir")"
+mkdir -p "$output_parent"
+output_parent="$(cd "$output_parent" && pwd -P)"
+output_dir="$output_parent/$output_name"
+stage="$(mktemp -d "$output_parent/.${output_name}.tmp.XXXXXX")"
+cleanup() { rm -rf -- "$stage"; }
+trap cleanup EXIT HUP INT TERM
+unsafe_input="$(find "$input_dir" ! -type d ! -type f -print -quit)"
+if [[ -n "$unsafe_input" ]]; then
+  echo "input repository may contain only regular files and directories: $unsafe_input" >&2
+  exit 65
+fi
+cp -a -- "$input_dir"/. "$stage"/
+
+apt_release_path="$stage/$apt_release"
+apt_directory="${apt_release_path%/*}"
+rpm_repository_path="$stage/$rpm_repository"
+[[ -f "$apt_release_path" ]] || { echo "APT Release file not found: $apt_release" >&2; exit 66; }
+[[ -d "$rpm_repository_path/Packages" ]] || { echo "RPM Packages directory not found: $rpm_repository" >&2; exit 66; }
+unsupported_apt_index="$(find "$apt_directory" -name 'Packages*' ! -name 'Packages' ! -name 'Packages.gz' -print -quit)"
+if [[ -n "$unsupported_apt_index" ]]; then
+  echo "APT repository contains an unsupported Packages index: $unsupported_apt_index" >&2
+  exit 65
+fi
+unsupported_release_index="$(awk '
+  /^SHA256:$/ { in_sha256 = 1; next }
+  /^[A-Za-z0-9-]+:$/ { in_sha256 = 0 }
+  in_sha256 && NF == 3 {
+    count = split($3, parts, "/")
+    name = parts[count]
+    if (name ~ /^Packages/ && name != "Packages" && name != "Packages.gz") {
+      print $3
+      exit
+    }
+  }
+' "$apt_release_path")"
+if [[ -n "$unsupported_release_index" ]]; then
+  echo "APT Release authenticates an unsupported Packages index: $unsupported_release_index" >&2
+  exit 65
+fi
+
+shopt -s nullglob
+rpm_packages=("$rpm_repository_path"/Packages/*.rpm)
+((${#rpm_packages[@]} > 0)) || { echo "no RPM packages found in repository" >&2; exit 66; }
+
+mkdir -p "$stage/keys"
+gpg --homedir "$gnupg_home" --batch --armor --export-options export-minimal \
+  --output "$stage/keys/apt-signing-key.asc" --export "$apt_primary"
+gpg --homedir "$gnupg_home" --batch --armor --export-options export-minimal \
+  --output "$stage/keys/rpm-signing-key.asc" --export "$rpm_primary"
+
+rpm_verify_db="$stage/.rpm-verify-db"
+mkdir -p "$rpm_verify_db"
+rpm --dbpath "$rpm_verify_db" --initdb
+rpm --dbpath "$rpm_verify_db" --import "$stage/keys/rpm-signing-key.asc"
+
+verify_exact_rpm_signature() {
+  local package="$1" output packet_listing signature_file
+  output="$(rpmkeys --dbpath "$rpm_verify_db" --verbose --checksig "$package")"
+  grep -Eq 'Header V4 RSA/SHA(256|512) Signature, key ID [0-9a-fA-F]{8}: OK' <<<"$output" || {
+    echo "RPM package signature verification failed: $package" >&2
+    exit 65
+  }
+  signature_file="$stage/.rpm-signature.asc"
+  rpm --dbpath "$rpm_verify_db" -qp --queryformat '%{RSAHEADER:armor}\n' "$package" >"$signature_file"
+  packet_listing="$(gpg --homedir "$gnupg_home" --batch --list-packets "$signature_file" 2>&1)"
+  rm -f -- "$signature_file"
+  grep -Fqi "issuer fpr v4 $rpm_signing" <<<"$packet_listing" || {
+    echo "RPM package was not signed by exact subkey $rpm_signing: $package" >&2
+    exit 65
+  }
+}
+
+# The signing-key probe above unlocks the exact RPM subkey in gpg-agent. RPM
+# 4.16 invokes GnuPG itself; an unavailable passphrase cache therefore fails
+# closed instead of opening an interactive fallback in this non-TTY script.
+for package in "${rpm_packages[@]}"; do
+  GNUPGHOME="$gnupg_home" rpmsign \
+    --define "_gpg_name $rpm_signing!" \
+    --define "_gpg_path $gnupg_home" \
+    --define "__gpg $(command -v gpg)" \
+    --addsign "$package"
+  verify_exact_rpm_signature "$package"
+done
+rm -rf -- "$rpm_verify_db"
+
+rm -rf -- "$rpm_repository_path/repodata"
+createrepo_c --quiet --simple-md-filenames "$rpm_repository_path"
+
+gpg --homedir "$gnupg_home" --batch --yes --pinentry-mode loopback \
+  --passphrase-file "$apt_passphrase_file" --local-user "$apt_signing!" \
+  --digest-algo SHA256 --output "$apt_directory/InRelease" --clearsign "$apt_release_path"
+gpg --homedir "$gnupg_home" --batch --yes --pinentry-mode loopback \
+  --passphrase-file "$apt_passphrase_file" --local-user "$apt_signing!" \
+  --digest-algo SHA256 --armor --output "$apt_release_path.gpg" --detach-sign "$apt_release_path"
+gpg --homedir "$gnupg_home" --batch --yes --pinentry-mode loopback \
+  --passphrase-file "$rpm_passphrase_file" --local-user "$rpm_signing!" \
+  --digest-algo SHA256 --armor \
+  --output "$rpm_repository_path/repodata/repomd.xml.asc" \
+  --detach-sign "$rpm_repository_path/repodata/repomd.xml"
+
+rm -f -- "$stage/repository-layout.txt"
+cat >"$stage/signing-manifest.txt" <<EOF
+TEST_ONLY=$test_only
+APT_PRIMARY_FINGERPRINT=$apt_primary
+APT_SIGNING_FINGERPRINT=$apt_signing
+RPM_PRIMARY_FINGERPRINT=$rpm_primary
+RPM_SIGNING_FINGERPRINT=$rpm_signing
+APT_RELEASE=$apt_release
+RPM_REPOSITORY=$rpm_repository
+EOF
+
+find "$stage" -type d -exec chmod 0755 {} +
+find "$stage" -type f -exec chmod 0644 {} +
+
+mv -- "$stage" "$output_dir"
+trap - EXIT HUP INT TERM
+echo "signed native-package repositories created at $output_dir"

--- a/scripts/validate-native-package-container.sh
+++ b/scripts/validate-native-package-container.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <container-image> <deb|rpm>" >&2
+  exit 64
+fi
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_dir="${WK_NATIVE_PACKAGE_DIST_DIR:-$repository_root/dist}"
+[[ -d "$package_dir" && ! -L "$package_dir" ]] || {
+  echo "native package directory is missing or unsafe: $package_dir" >&2
+  exit 66
+}
+package_dir="$(cd "$package_dir" && pwd -P)"
+image="$1"
+format="$2"
+
+case "$format" in
+  deb)
+    package="$(find "$package_dir" -maxdepth 1 -type f -name 'wukongim*.deb' -print -quit)"
+    install_command='apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 install -y /tmp/wukongim.deb'
+    upgrade_command='DEBIAN_FRONTEND=noninteractive apt-get install --reinstall -y /tmp/wukongim.deb'
+    remove_command='DEBIAN_FRONTEND=noninteractive apt-get remove -y wukongim'
+    mount_target='/tmp/wukongim.deb'
+    ;;
+  rpm)
+    package="$(find "$package_dir" -maxdepth 1 -type f -name 'wukongim*.rpm' -print -quit)"
+    install_command='dnf install -y /tmp/wukongim.rpm'
+    upgrade_command='dnf reinstall -y /tmp/wukongim.rpm'
+    remove_command='dnf remove -y wukongim'
+    mount_target='/tmp/wukongim.rpm'
+    ;;
+  *)
+    echo "unsupported package format: $format" >&2
+    exit 64
+    ;;
+esac
+
+[[ -n "$package" ]]
+
+wrapper_dir="$(mktemp -d)"
+cleanup() { find "$wrapper_dir" -depth -delete; }
+trap cleanup EXIT HUP INT TERM
+cat >"$wrapper_dir/systemctl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>/tmp/wukongim-systemctl.calls
+exit 0
+EOF
+chmod 0755 "$wrapper_dir/systemctl"
+
+docker run --rm \
+  --platform linux/amd64 \
+  --env "NATIVE_PACKAGE_TEST_APT_MIRROR=${WK_NATIVE_PACKAGE_APT_MIRROR:-}" \
+  --volume "$package:$mount_target:ro" \
+  --volume "$wrapper_dir/systemctl:/tmp/wukongim-systemctl-wrapper:ro" \
+  "$image" \
+  /bin/sh -euxc "
+    : >/tmp/wukongim-systemctl.calls
+    if [ -n \"\$NATIVE_PACKAGE_TEST_APT_MIRROR\" ] && \
+      [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+      sed -i \
+        -e \"s#http://archive.ubuntu.com/ubuntu/#\$NATIVE_PACKAGE_TEST_APT_MIRROR/#\" \
+        -e \"s#http://security.ubuntu.com/ubuntu/#\$NATIVE_PACKAGE_TEST_APT_MIRROR/#\" \
+        /etc/apt/sources.list.d/ubuntu.sources
+    fi
+    $install_command
+    test -x /usr/bin/wukongim
+    test -f /usr/lib/systemd/system/wukongim.service
+    getent passwd wukongim
+    systemd-analyze verify /usr/lib/systemd/system/wukongim.service
+    test -x /usr/bin/systemctl
+    mv /usr/bin/systemctl /usr/bin/systemctl.real
+    cp /tmp/wukongim-systemctl-wrapper /usr/bin/systemctl
+    chmod 0755 /usr/bin/systemctl
+    /usr/bin/wukongim version --output json | grep -F '\"build_source\":\"release\"'
+    test ! -e /etc/wukongim/wukongim.toml
+    test ! -e /etc/systemd/system/multi-user.target.wants/wukongim.service
+    printf '%s\n' 'native-package-container-test' | /usr/bin/wukongim config init \
+      --config /etc/wukongim/wukongim.toml \
+      --admin-password-stdin
+    /usr/bin/wukongim config validate --config /etc/wukongim/wukongim.toml
+    test \"\$(stat -c '%a %U %G' /etc/wukongim/wukongim.toml)\" = '640 root wukongim'
+    printf '%s\n' 'package-upgrade-state' >/var/lib/wukongim/package-upgrade-sentinel
+    (cd / && sha256sum \
+      etc/wukongim/wukongim.toml \
+      var/lib/wukongim/package-upgrade-sentinel) \
+      >/tmp/wukongim-package-state.sha256
+    : >/tmp/wukongim-systemctl.calls
+    $upgrade_command
+    test -s /tmp/wukongim-systemctl.calls
+    if grep -Eq '(^|[[:space:]])(start|stop|restart|enable|disable|try-restart|reload-or-restart|preset)([[:space:]]|$)' \
+      /tmp/wukongim-systemctl.calls; then
+      cat /tmp/wukongim-systemctl.calls >&2
+      echo 'native package upgrade changed service activation state' >&2
+      exit 1
+    fi
+    if grep -Fvx 'daemon-reload' /tmp/wukongim-systemctl.calls; then
+      cat /tmp/wukongim-systemctl.calls >&2
+      echo 'native package upgrade made an unexpected systemctl call' >&2
+      exit 1
+    fi
+    (cd / && sha256sum --check /tmp/wukongim-package-state.sha256)
+    test ! -e /etc/systemd/system/multi-user.target.wants/wukongim.service
+    /usr/bin/wukongim config validate --config /etc/wukongim/wukongim.toml
+    $remove_command
+    test -d /var/lib/wukongim
+    test -f /etc/wukongim/wukongim.toml
+    test -f /var/lib/wukongim/package-upgrade-sentinel
+  "

--- a/scripts/validate-native-package-repositories-container.sh
+++ b/scripts/validate-native-package-repositories-container.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+command -v docker >/dev/null 2>&1 || { echo "docker is required" >&2; exit 69; }
+package_dir="${WK_NATIVE_PACKAGE_DIST_DIR:-$repository_root/dist}"
+[[ -d "$package_dir" && ! -L "$package_dir" ]] || {
+  echo "native package directory is missing or unsafe: $package_dir" >&2
+  exit 66
+}
+package_dir="$(cd "$package_dir" && pwd -P)"
+
+shopt -s nullglob
+deb_packages=("$package_dir"/wukongim*.deb)
+rpm_packages=("$package_dir"/wukongim*.rpm)
+((${#deb_packages[@]} == 1)) || { echo "exactly one deb preview is required" >&2; exit 66; }
+((${#rpm_packages[@]} == 1)) || { echo "exactly one rpm preview is required" >&2; exit 66; }
+
+work_dir="$(mktemp -d)"
+cleanup() {
+  find "$work_dir" -depth -delete
+}
+trap cleanup EXIT HUP INT TERM
+chmod 0755 "$work_dir"
+
+docker run --rm \
+  --platform linux/amd64 \
+  --env "WK_NATIVE_PACKAGE_APT_MIRROR=${WK_NATIVE_PACKAGE_APT_MIRROR:-}" \
+  --volume "$repository_root:/workspace:ro" \
+  --volume "$package_dir:/packages:ro" \
+  --volume "$work_dir:/work" \
+  ubuntu:24.04 \
+  bash -lc '
+    set -euo pipefail
+    if [[ -n "$WK_NATIVE_PACKAGE_APT_MIRROR" ]]; then
+      sed -i \
+        -e "s#http://archive.ubuntu.com/ubuntu/#$WK_NATIVE_PACKAGE_APT_MIRROR/#" \
+        -e "s#http://security.ubuntu.com/ubuntu/#$WK_NATIVE_PACKAGE_APT_MIRROR/#" \
+        /etc/apt/sources.list.d/ubuntu.sources
+    fi
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+      apt-utils createrepo-c dpkg-dev gnupg rpm python3 xz-utils zstd
+
+    /workspace/scripts/generate-native-package-test-keyring.sh --output /work/keyring
+    /workspace/scripts/build-native-package-repositories.sh \
+      --packages-dir /packages \
+      --output /work/unsigned \
+      --apt-suite preview \
+      --apt-architecture amd64 \
+      --rpm-channel preview \
+      --rpm-basearch x86_64
+    source /work/keyring/manifest.env
+    /workspace/scripts/sign-native-package-repositories.sh \
+      --input /work/unsigned \
+      --output /work/signed \
+      --gnupg-home /work/keyring/gnupg \
+      --test-only \
+      --minimum-valid-days 0 \
+      --apt-release apt/dists/preview/Release \
+      --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+      --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+      --apt-passphrase-file /work/keyring/apt-passphrase.txt \
+      --rpm-repository rpm/preview/el/9/x86_64 \
+      --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+      --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT" \
+      --rpm-passphrase-file /work/keyring/rpm-passphrase.txt
+
+    verify_test_repository() {
+      /workspace/scripts/verify-native-package-repositories.sh \
+        --repository "$1" \
+        --allow-test-only \
+        --minimum-valid-days 0 \
+        --apt-release apt/dists/preview/Release \
+        --apt-public-key "${2:-/work/keyring/public/apt.asc}" \
+        --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+        --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+        --rpm-repository rpm/preview/el/9/x86_64 \
+        --rpm-public-key /work/keyring/public/rpm.asc \
+        --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+        --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT"
+    }
+
+    verify_test_repository /work/signed
+    if /workspace/scripts/verify-native-package-repositories.sh \
+      --repository /work/signed \
+      --apt-release apt/dists/preview/Release \
+      --apt-public-key /work/keyring/public/apt.asc \
+      --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+      --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+      --rpm-repository rpm/preview/el/9/x86_64 \
+      --rpm-public-key /work/keyring/public/rpm.asc \
+      --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+      --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT" \
+      >/tmp/default-verifier.out 2>&1; then
+      echo "production verifier accepted test-only keys" >&2
+      exit 1
+    fi
+
+    cp -a /work/signed /work/unsupported-apt-index
+    apt_release=/work/unsupported-apt-index/apt/dists/preview/Release
+    apt_suite_dir="${apt_release%/*}"
+    apt_packages="$apt_suite_dir/main/binary-amd64/Packages"
+    sed "s#Filename: pool/#Filename: pool/missing/#" "$apt_packages" \
+      | xz --compress --stdout >"$apt_packages.xz"
+    apt_xz_relative=main/binary-amd64/Packages.xz
+    apt_xz_digest="$(sha256sum "$apt_packages.xz" | awk "{print \$1}")"
+    apt_xz_size="$(stat -c %s "$apt_packages.xz")"
+    awk -v digest="$apt_xz_digest" -v size="$apt_xz_size" -v relative="$apt_xz_relative" "
+      \$0 == \"SHA256:\" && !inserted {
+        print
+        printf \" %s %16d %s\\n\", digest, size, relative
+        inserted = 1
+        next
+      }
+      { print }
+      END { if (!inserted) exit 1 }
+    " "$apt_release" >"$apt_release.tmp"
+    mv "$apt_release.tmp" "$apt_release"
+    cp "$apt_packages.xz" \
+      "$apt_suite_dir/main/binary-amd64/by-hash/SHA256/$apt_xz_digest"
+    rm -f "$apt_suite_dir/InRelease" "$apt_release.gpg"
+    gpg --homedir /work/keyring/gnupg --batch --yes --pinentry-mode loopback \
+      --passphrase-file /work/keyring/apt-passphrase.txt \
+      --local-user "$WK_APT_SIGNING_FINGERPRINT!" --digest-algo SHA256 \
+      --output "$apt_suite_dir/InRelease" --clearsign "$apt_release"
+    gpg --homedir /work/keyring/gnupg --batch --yes --pinentry-mode loopback \
+      --passphrase-file /work/keyring/apt-passphrase.txt \
+      --local-user "$WK_APT_SIGNING_FINGERPRINT!" --digest-algo SHA256 --armor \
+      --output "$apt_release.gpg" --detach-sign "$apt_release"
+    if verify_test_repository /work/unsupported-apt-index \
+      >/tmp/unsupported-apt-index.out 2>&1; then
+      echo "signed unsupported APT Packages.xz was accepted" >&2
+      exit 1
+    fi
+    grep -Fq "APT Release authenticates unsupported Packages indexes" \
+      /tmp/unsupported-apt-index.out || {
+        cat /tmp/unsupported-apt-index.out >&2
+        echo "signed unsupported APT Packages.xz failed at the wrong validation layer" >&2
+        exit 1
+      }
+    find /work/unsupported-apt-index -depth -delete
+
+    cp -a /work/unsigned /work/unsigned-apt-index
+    unsigned_packages=/work/unsigned-apt-index/apt/dists/preview/main/binary-amd64/Packages
+    xz --compress --stdout "$unsigned_packages" >"$unsigned_packages.xz"
+    if /workspace/scripts/sign-native-package-repositories.sh \
+      --input /work/unsigned-apt-index \
+      --output /work/unsupported-signed-output \
+      --gnupg-home /work/keyring/gnupg \
+      --test-only \
+      --minimum-valid-days 0 \
+      --apt-release apt/dists/preview/Release \
+      --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+      --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+      --apt-passphrase-file /work/keyring/apt-passphrase.txt \
+      --rpm-repository rpm/preview/el/9/x86_64 \
+      --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+      --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT" \
+      --rpm-passphrase-file /work/keyring/rpm-passphrase.txt \
+      >/tmp/unsupported-signer.out 2>&1; then
+      echo "signer accepted an unsupported APT Packages.xz" >&2
+      exit 1
+    fi
+    grep -Fq "APT repository contains an unsupported Packages index" \
+      /tmp/unsupported-signer.out || {
+        cat /tmp/unsupported-signer.out >&2
+        echo "unsupported APT Packages.xz failed at the wrong signing layer" >&2
+        exit 1
+      }
+    find /work/unsigned-apt-index -depth -delete
+
+    if /workspace/scripts/sign-native-package-repositories.sh \
+      --input /work/unsigned \
+      --output /work/unsigned/nested-output \
+      --gnupg-home /work/keyring/gnupg \
+      --test-only \
+      --minimum-valid-days 0 \
+      --apt-release apt/dists/preview/Release \
+      --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+      --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+      --apt-passphrase-file /work/keyring/apt-passphrase.txt \
+      --rpm-repository rpm/preview/el/9/x86_64 \
+      --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+      --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT" \
+      --rpm-passphrase-file /work/keyring/rpm-passphrase.txt \
+      >/tmp/nested-output.out 2>&1; then
+      echo "signer accepted an output repository inside its input" >&2
+      exit 1
+    fi
+    grep -Fq "output repository must not be located inside the input repository" \
+      /tmp/nested-output.out || {
+        cat /tmp/nested-output.out >&2
+        echo "nested signer output failed at the wrong validation layer" >&2
+        exit 1
+      }
+    test ! -e /work/unsigned/nested-output
+
+    cp -a /work/signed /work/tamper-deb
+    find /work/tamper-deb/apt/pool -type f -name "*.deb" -delete
+    if verify_test_repository /work/tamper-deb >/tmp/tamper-deb.out 2>&1; then
+      echo "missing deb was accepted" >&2
+      exit 1
+    fi
+    find /work/tamper-deb -depth -delete
+
+    cp -a /work/signed /work/tamper-repodata
+    cp /work/tamper-repodata/rpm/preview/el/9/x86_64/repodata/other.xml.gz \
+      /work/tamper-repodata/rpm/preview/el/9/x86_64/repodata/primary.xml.gz
+    if verify_test_repository /work/tamper-repodata >/tmp/tamper-repodata.out 2>&1; then
+      echo "tampered RPM metadata was accepted" >&2
+      exit 1
+    fi
+    find /work/tamper-repodata -depth -delete
+
+    cp -a /work/signed /work/extra-rpm
+    rpm_payload="$(find /work/extra-rpm/rpm/preview/el/9/x86_64/Packages -type f -name "*.rpm" -print -quit)"
+    cp "$rpm_payload" "${rpm_payload%.rpm}.extra.rpm"
+    if verify_test_repository /work/extra-rpm >/tmp/extra-rpm.out 2>&1; then
+      echo "unindexed validly signed RPM was accepted" >&2
+      exit 1
+    fi
+    find /work/extra-rpm -depth -delete
+
+    gpg --homedir /work/keyring/gnupg --batch --armor \
+      --output /work/expanded-apt-trust.asc \
+      --export "$WK_APT_PRIMARY_FINGERPRINT" "$WK_RPM_PRIMARY_FINGERPRINT"
+    if verify_test_repository /work/signed /work/expanded-apt-trust.asc \
+      >/tmp/expanded-trust.out 2>&1; then
+      echo "expanded APT key bundle was accepted" >&2
+      exit 1
+    fi
+
+    cp /work/keyring/apt-passphrase.txt /work/insecure-passphrase.txt
+    chmod 0644 /work/insecure-passphrase.txt
+    if /workspace/scripts/sign-native-package-repositories.sh \
+      --input /work/unsigned \
+      --output /work/insecure-output \
+      --gnupg-home /work/keyring/gnupg \
+      --test-only \
+      --minimum-valid-days 0 \
+      --apt-release apt/dists/preview/Release \
+      --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+      --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+      --apt-passphrase-file /work/insecure-passphrase.txt \
+      --rpm-repository rpm/preview/el/9/x86_64 \
+      --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+      --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT" \
+      --rpm-passphrase-file /work/keyring/rpm-passphrase.txt \
+      >/tmp/insecure-passphrase.out 2>&1; then
+      echo "group-readable signing passphrase was accepted" >&2
+      exit 1
+    fi
+
+    cp -a /work/unsigned /work/special-input
+    mkfifo /work/special-input/untrusted.fifo
+    if /workspace/scripts/sign-native-package-repositories.sh \
+      --input /work/special-input \
+      --output /work/special-output \
+      --gnupg-home /work/keyring/gnupg \
+      --test-only \
+      --minimum-valid-days 0 \
+      --apt-release apt/dists/preview/Release \
+      --apt-primary-fingerprint "$WK_APT_PRIMARY_FINGERPRINT" \
+      --apt-signing-fingerprint "$WK_APT_SIGNING_FINGERPRINT" \
+      --apt-passphrase-file /work/keyring/apt-passphrase.txt \
+      --rpm-repository rpm/preview/el/9/x86_64 \
+      --rpm-primary-fingerprint "$WK_RPM_PRIMARY_FINGERPRINT" \
+      --rpm-signing-fingerprint "$WK_RPM_SIGNING_FINGERPRINT" \
+      --rpm-passphrase-file /work/keyring/rpm-passphrase.txt \
+      >/tmp/special-input.out 2>&1; then
+      echo "special repository input was accepted" >&2
+      exit 1
+    fi
+    find /work/special-input -depth -delete
+
+    gpg --batch --dearmor \
+      --output /work/apt-signing-key.gpg \
+      /work/signed/keys/apt-signing-key.asc
+    printf "%s\n" \
+      "deb [arch=amd64 signed-by=/work/apt-signing-key.gpg] file:/work/signed/apt preview main" \
+      >/tmp/wukongim-preview.list
+    mkdir -p /tmp/apt-download
+    cd /tmp/apt-download
+    apt-get \
+      -o Dir::Etc::sourcelist=/tmp/wukongim-preview.list \
+      -o Dir::Etc::sourceparts=- \
+      -o APT::Get::List-Cleanup=0 \
+      update
+    apt-get \
+      -o Dir::Etc::sourcelist=/tmp/wukongim-preview.list \
+      -o Dir::Etc::sourceparts=- \
+      download wukongim
+    test -f wukongim_*.deb
+  '
+
+docker run --rm \
+  --platform linux/amd64 \
+  --volume "$work_dir:/work:ro" \
+  rockylinux:9 \
+  bash -lc '
+    set -euo pipefail
+    cat >/etc/yum.repos.d/wukongim-preview.repo <<EOF
+[wukongim-preview]
+name=WuKongIM preview integration test
+baseurl=file:///work/signed/rpm/preview/el/9/x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///work/signed/keys/rpm-signing-key.asc
+EOF
+    # Keep the dependency source explicit: wukongim correctly requires
+    # systemd, which is provided by BaseOS rather than the repository under
+    # test. The preview repository still enforces both metadata and package
+    # signature verification through repo_gpgcheck/gpgcheck above.
+    dnf --disablerepo="*" \
+      --enablerepo=baseos \
+      --enablerepo=appstream \
+      --enablerepo=wukongim-preview \
+      --setopt=install_weak_deps=False install --assumeyes wukongim
+    version_output="$(/usr/bin/wukongim version --output json)"
+    grep -Fq "\"build_source\":\"release\"" <<<"$version_output"
+    test ! -e /etc/wukongim/wukongim.toml
+  '
+
+echo "native-package signed repository container validation passed"

--- a/scripts/validate-native-package-repositories-container.sh
+++ b/scripts/validate-native-package-repositories-container.sh
@@ -19,21 +19,34 @@ rpm_packages=("$package_dir"/wukongim*.rpm)
 work_dir="$(mktemp -d)"
 cleanup() {
   local status=$?
+  local cleanup_status=0
+  trap - EXIT HUP INT TERM
   if [[ -d "$work_dir" ]]; then
-    # Containers run as root and leave root-owned repository metadata behind on
-    # Linux runners. Delete only this dedicated mount from an isolated
-    # container, then let the invoking user remove the empty directory.
-    docker run --rm \
-      --network none \
-      --read-only \
-      --volume "$work_dir:/work" \
-      ubuntu:24.04 \
-      find /work -xdev -mindepth 1 -depth -delete >/dev/null 2>&1 || true
-    rmdir "$work_dir" 2>/dev/null || true
+    if ! rmdir "$work_dir" 2>/dev/null; then
+      # Containers run as root and leave root-owned repository metadata behind
+      # on Linux runners. Delete only this dedicated mount from an isolated
+      # container, then let the invoking user remove the empty directory.
+      if ! docker run --rm \
+        --network none \
+        --read-only \
+        --volume "$work_dir:/work" \
+        ubuntu:24.04 \
+        find /work -xdev -mindepth 1 -depth -delete >/dev/null; then
+        cleanup_status=1
+      elif ! rmdir "$work_dir"; then
+        cleanup_status=1
+      fi
+    fi
   fi
-  return "$status"
+  if ((status != 0)); then
+    exit "$status"
+  fi
+  exit "$cleanup_status"
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 chmod 0755 "$work_dir"
 
 docker run --rm \

--- a/scripts/validate-native-package-repositories-container.sh
+++ b/scripts/validate-native-package-repositories-container.sh
@@ -18,7 +18,20 @@ rpm_packages=("$package_dir"/wukongim*.rpm)
 
 work_dir="$(mktemp -d)"
 cleanup() {
-  find "$work_dir" -depth -delete
+  local status=$?
+  if [[ -d "$work_dir" ]]; then
+    # Containers run as root and leave root-owned repository metadata behind on
+    # Linux runners. Delete only this dedicated mount from an isolated
+    # container, then let the invoking user remove the empty directory.
+    docker run --rm \
+      --network none \
+      --read-only \
+      --volume "$work_dir:/work" \
+      ubuntu:24.04 \
+      find /work -xdev -mindepth 1 -depth -delete >/dev/null 2>&1 || true
+    rmdir "$work_dir" 2>/dev/null || true
+  fi
+  return "$status"
 }
 trap cleanup EXIT HUP INT TERM
 chmod 0755 "$work_dir"

--- a/scripts/validate-native-package.sh
+++ b/scripts/validate-native-package.sh
@@ -4,13 +4,12 @@ set -euo pipefail
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repository_root"
 
-if ! command -v goreleaser >/dev/null 2>&1; then
-  echo "goreleaser is required (validated with v2.18.0)" >&2
-  exit 1
-fi
-
-goreleaser check --config .goreleaser.packages.yaml
 if [[ "${WK_NATIVE_PACKAGE_SKIP_BUILD:-0}" != "1" ]]; then
+  if ! command -v goreleaser >/dev/null 2>&1; then
+    echo "goreleaser is required (validated with v2.18.0)" >&2
+    exit 1
+  fi
+  goreleaser check --config .goreleaser.packages.yaml
   goreleaser release --snapshot --clean --config .goreleaser.packages.yaml
 fi
 

--- a/scripts/validate-native-package.sh
+++ b/scripts/validate-native-package.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repository_root"
+
+if ! command -v goreleaser >/dev/null 2>&1; then
+  echo "goreleaser is required (validated with v2.18.0)" >&2
+  exit 1
+fi
+
+goreleaser check --config .goreleaser.packages.yaml
+if [[ "${WK_NATIVE_PACKAGE_SKIP_BUILD:-0}" != "1" ]]; then
+  goreleaser release --snapshot --clean --config .goreleaser.packages.yaml
+fi
+
+shopt -s nullglob
+deb_packages=(dist/wukongim*.deb)
+rpm_packages=(dist/wukongim*.rpm)
+[[ "${#deb_packages[@]}" -eq 1 ]]
+[[ "${#rpm_packages[@]}" -eq 1 ]]
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd dist && sha256sum --check checksums.txt)
+fi
+
+if command -v dpkg-deb >/dev/null 2>&1; then
+  dpkg-deb --contents "${deb_packages[0]}" | grep -Fq './usr/bin/wukongim'
+  dpkg-deb --contents "${deb_packages[0]}" | grep -Fq './usr/lib/systemd/system/wukongim.service'
+elif [[ "${WK_NATIVE_PACKAGE_REQUIRE_INSPECTORS:-0}" == "1" ]]; then
+  echo "dpkg-deb is required" >&2
+  exit 1
+fi
+
+if command -v rpm >/dev/null 2>&1; then
+  rpm -qpl "${rpm_packages[0]}" | grep -Fq '/usr/bin/wukongim'
+  rpm -qpl "${rpm_packages[0]}" | grep -Fq '/usr/lib/systemd/system/wukongim.service'
+elif [[ "${WK_NATIVE_PACKAGE_REQUIRE_INSPECTORS:-0}" == "1" ]]; then
+  echo "rpm is required" >&2
+  exit 1
+fi
+
+echo "native package artifacts validated"

--- a/scripts/validate-native-package.sh
+++ b/scripts/validate-native-package.sh
@@ -24,16 +24,18 @@ if command -v sha256sum >/dev/null 2>&1; then
 fi
 
 if command -v dpkg-deb >/dev/null 2>&1; then
-  dpkg-deb --contents "${deb_packages[0]}" | grep -Fq './usr/bin/wukongim'
-  dpkg-deb --contents "${deb_packages[0]}" | grep -Fq './usr/lib/systemd/system/wukongim.service'
+  deb_contents="$(dpkg-deb --contents "${deb_packages[0]}")"
+  grep -Fq './usr/bin/wukongim' <<<"$deb_contents"
+  grep -Fq './usr/lib/systemd/system/wukongim.service' <<<"$deb_contents"
 elif [[ "${WK_NATIVE_PACKAGE_REQUIRE_INSPECTORS:-0}" == "1" ]]; then
   echo "dpkg-deb is required" >&2
   exit 1
 fi
 
 if command -v rpm >/dev/null 2>&1; then
-  rpm -qpl "${rpm_packages[0]}" | grep -Fq '/usr/bin/wukongim'
-  rpm -qpl "${rpm_packages[0]}" | grep -Fq '/usr/lib/systemd/system/wukongim.service'
+  rpm_contents="$(rpm -qpl "${rpm_packages[0]}")"
+  grep -Fxq '/usr/bin/wukongim' <<<"$rpm_contents"
+  grep -Fxq '/usr/lib/systemd/system/wukongim.service' <<<"$rpm_contents"
 elif [[ "${WK_NATIVE_PACKAGE_REQUIRE_INSPECTORS:-0}" == "1" ]]; then
   echo "rpm is required" >&2
   exit 1

--- a/scripts/verify-native-package-metadata.py
+++ b/scripts/verify-native-package-metadata.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Verify that signed APT/RPM indexes close over every package payload."""
+
+from __future__ import annotations
+
+import argparse
+import bz2
+import gzip
+import hashlib
+import lzma
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+
+MAX_OPEN_METADATA_SIZE = 786_432_000
+
+
+class ValidationError(Exception):
+    """A repository metadata or payload contract was violated."""
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def direct_child(element: ET.Element, name: str) -> ET.Element:
+    matches = [child for child in element if local_name(child.tag) == name]
+    if len(matches) != 1:
+        raise ValidationError(
+            f"metadata element {local_name(element.tag)!r} must contain one {name!r} child"
+        )
+    return matches[0]
+
+
+def validate_relative_path(value: str, role: str) -> tuple[str, ...]:
+    if not value or value.startswith("/") or "\\" in value:
+        raise ValidationError(f"{role} is not a safe relative path: {value!r}")
+    parts = tuple(value.split("/"))
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValidationError(f"{role} is not a safe relative path: {value!r}")
+    return parts
+
+
+def safe_file(root: Path, relative: str, role: str) -> Path:
+    parts = validate_relative_path(relative, role)
+    root = root.resolve(strict=True)
+    target = root.joinpath(*parts)
+    resolved = target.resolve(strict=True)
+    if os.path.commonpath((str(root), str(resolved))) != str(root):
+        raise ValidationError(f"{role} escapes its repository root: {relative!r}")
+    mode = target.lstat().st_mode
+    if target.is_symlink() or not stat.S_ISREG(mode):
+        raise ValidationError(f"{role} is not a regular file: {relative!r}")
+    return target
+
+
+def safe_directory(root: Path, relative: str, role: str) -> Path:
+    parts = validate_relative_path(relative, role)
+    root = root.resolve(strict=True)
+    target = root.joinpath(*parts)
+    resolved = target.resolve(strict=True)
+    if os.path.commonpath((str(root), str(resolved))) != str(root):
+        raise ValidationError(f"{role} escapes its repository root: {relative!r}")
+    mode = target.lstat().st_mode
+    if target.is_symlink() or not stat.S_ISDIR(mode):
+        raise ValidationError(f"{role} is not a directory: {relative!r}")
+    return target
+
+
+def sha256_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def require_sha256(value: str, role: str) -> str:
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(character not in "0123456789abcdef" for character in normalized):
+        raise ValidationError(f"{role} is not a SHA-256 digest")
+    return normalized
+
+
+def require_nonnegative_integer(value: str | None, role: str) -> int:
+    if value is None or not value.isdigit():
+        raise ValidationError(f"{role} is not a non-negative integer")
+    return int(value)
+
+
+def compare_gzip_to_plain(compressed: Path, plain: Path, role: str) -> None:
+    with gzip.open(compressed, "rb") as compressed_stream, plain.open("rb") as plain_stream:
+        while True:
+            compressed_chunk = compressed_stream.read(1024 * 1024)
+            plain_chunk = plain_stream.read(1024 * 1024)
+            if compressed_chunk != plain_chunk:
+                raise ValidationError(f"{role} does not expand to the signed Packages bytes")
+            if not compressed_chunk:
+                return
+
+
+def parse_debian_control(path: Path):
+    paragraph: dict[str, str] = {}
+    last_key: str | None = None
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        for raw_line in stream:
+            line = raw_line.rstrip("\r\n")
+            if not line:
+                if paragraph:
+                    yield paragraph
+                    paragraph = {}
+                    last_key = None
+                continue
+            if line[0] in " \t":
+                if last_key is None:
+                    raise ValidationError(f"invalid continuation line in {path}")
+                paragraph[last_key] += "\n" + line[1:]
+                continue
+            if ":" not in line:
+                raise ValidationError(f"invalid field in {path}: {line!r}")
+            key, value = line.split(":", 1)
+            if not key or key in paragraph:
+                raise ValidationError(f"duplicate or empty field in {path}: {key!r}")
+            paragraph[key] = value.lstrip()
+            last_key = key
+    if paragraph:
+        yield paragraph
+
+
+def release_sha256_paths(release: Path) -> set[str]:
+    paths: set[str] = set()
+    in_sha256 = False
+    with release.open("r", encoding="utf-8", newline="") as stream:
+        for raw_line in stream:
+            line = raw_line.rstrip("\r\n")
+            if line == "SHA256:":
+                in_sha256 = True
+                continue
+            if in_sha256 and line.startswith(" "):
+                fields = line.split()
+                if len(fields) != 3:
+                    raise ValidationError("APT Release contains a malformed SHA256 entry")
+                require_sha256(fields[0], "APT Release digest")
+                require_nonnegative_integer(fields[1], "APT Release size")
+                validate_relative_path(fields[2], "APT Release target")
+                if fields[2] in paths:
+                    raise ValidationError(f"APT Release repeats a SHA256 target: {fields[2]}")
+                paths.add(fields[2])
+                continue
+            if in_sha256:
+                break
+    if not paths:
+        raise ValidationError("APT Release contains no SHA256 entries")
+    return paths
+
+
+def verify_apt_closure(repository: Path, apt_release_relative: str) -> None:
+    release = safe_file(repository, apt_release_relative, "APT Release")
+    release_directory = release.parent
+    if release_directory.parent.name != "dists":
+        raise ValidationError("APT Release must live at apt/dists/<suite>/Release")
+    apt_root = release_directory.parent.parent.resolve(strict=True)
+    release_paths = release_sha256_paths(release)
+    release_index_paths = {
+        path for path in release_paths if Path(path).name.startswith("Packages")
+    }
+    unsupported_release_indexes = sorted(
+        path
+        for path in release_index_paths
+        if Path(path).name not in {"Packages", "Packages.gz"}
+    )
+    if unsupported_release_indexes:
+        raise ValidationError(
+            "APT Release authenticates unsupported Packages indexes: "
+            + ", ".join(unsupported_release_indexes)
+        )
+    packages_paths = sorted(path for path in release_paths if path.endswith("/Packages"))
+    compressed_paths = {path for path in release_paths if path.endswith("/Packages.gz")}
+    if not packages_paths:
+        raise ValidationError("APT Release does not authenticate an uncompressed Packages index")
+    expected_compressed = {path + ".gz" for path in packages_paths}
+    if compressed_paths != expected_compressed:
+        raise ValidationError("APT Release must authenticate one Packages.gz for every Packages index")
+    expected_indexes = set(packages_paths) | expected_compressed
+    actual_indexes: set[str] = set()
+    for path in release_directory.rglob("Packages*"):
+        relative = path.relative_to(release_directory).as_posix()
+        if path.name not in {"Packages", "Packages.gz"}:
+            raise ValidationError(f"APT repository contains an unsupported Packages index: {relative}")
+        if path.is_symlink() or not path.is_file():
+            raise ValidationError(f"APT Packages index is not a regular file: {relative}")
+        actual_indexes.add(relative)
+    if actual_indexes != expected_indexes:
+        raise ValidationError("APT Release does not close over the exact Packages index set")
+
+    package_records: dict[str, tuple[int, str]] = {}
+    for packages_relative in packages_paths:
+        packages = safe_file(release_directory, packages_relative, "APT Packages index")
+        compressed = safe_file(
+            release_directory, packages_relative + ".gz", "APT compressed Packages index"
+        )
+        compare_gzip_to_plain(compressed, packages, packages_relative + ".gz")
+        for paragraph in parse_debian_control(packages):
+            missing = {"Filename", "Size", "SHA256"} - paragraph.keys()
+            if missing:
+                raise ValidationError(
+                    f"APT package stanza is missing fields: {', '.join(sorted(missing))}"
+                )
+            filename = paragraph["Filename"]
+            if not filename.startswith("pool/"):
+                raise ValidationError(f"APT payload must live below pool/: {filename!r}")
+            expected_size = require_nonnegative_integer(paragraph["Size"], "APT payload size")
+            expected_digest = require_sha256(paragraph["SHA256"], "APT payload digest")
+            payload = safe_file(apt_root, filename, "APT payload")
+            actual_digest, actual_size = sha256_and_size(payload)
+            if (actual_size, actual_digest) != (expected_size, expected_digest):
+                raise ValidationError(f"APT payload digest or size mismatch: {filename}")
+            previous = package_records.setdefault(filename, (expected_size, expected_digest))
+            if previous != (expected_size, expected_digest):
+                raise ValidationError(f"APT indexes disagree about payload: {filename}")
+
+    if not package_records:
+        raise ValidationError("APT Packages indexes contain no payloads")
+    pool = apt_root / "pool"
+    if not pool.is_dir() or pool.is_symlink():
+        raise ValidationError("APT pool directory is missing or unsafe")
+    actual_payloads: set[str] = set()
+    for path in pool.rglob("*"):
+        if path.is_dir():
+            continue
+        if path.is_symlink() or not path.is_file() or path.suffix != ".deb":
+            raise ValidationError(f"APT pool contains a non-deb or unsafe file: {path}")
+        actual_payloads.add(path.relative_to(apt_root).as_posix())
+    if actual_payloads != set(package_records):
+        raise ValidationError("APT Packages indexes do not close over the exact pool payload set")
+
+
+def materialize_open_metadata(source: Path, destination: Path, expected_size: int) -> tuple[str, int]:
+    process: subprocess.Popen[bytes] | None = None
+    suffix = source.suffix.lower()
+    if suffix == ".gz":
+        source_stream = gzip.open(source, "rb")
+    elif suffix == ".bz2":
+        source_stream = bz2.open(source, "rb")
+    elif suffix in {".xz", ".lzma"}:
+        source_stream = lzma.open(source, "rb")
+    elif suffix in {".zst", ".zstd"}:
+        process = subprocess.Popen(
+            ["zstd", "--quiet", "--decompress", "--stdout", str(source)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if process.stdout is None:
+            raise ValidationError("failed to open zstd metadata stream")
+        source_stream = process.stdout
+    else:
+        source_stream = source.open("rb")
+
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with source_stream, destination.open("wb") as output:
+            while chunk := source_stream.read(1024 * 1024):
+                total += len(chunk)
+                if total > expected_size:
+                    raise ValidationError(f"opened metadata exceeds declared size: {source}")
+                digest.update(chunk)
+                output.write(chunk)
+    except BaseException:
+        if process is not None and process.poll() is None:
+            process.kill()
+            process.wait()
+        raise
+    if process is not None:
+        stderr = process.stderr.read() if process.stderr is not None else b""
+        process.wait()
+        if process.returncode != 0:
+            raise ValidationError(
+                f"zstd failed for {source}: {stderr.decode('utf-8', errors='replace').strip()}"
+            )
+    return digest.hexdigest(), total
+
+
+def verify_rpm_closure(repository: Path, rpm_repository_relative: str) -> None:
+    rpm_root = safe_directory(repository, rpm_repository_relative, "RPM repository")
+    repomd = safe_file(rpm_root, "repodata/repomd.xml", "RPM repomd.xml")
+    try:
+        root = ET.parse(repomd).getroot()
+    except ET.ParseError as error:
+        raise ValidationError(f"RPM repomd.xml is invalid XML: {error}") from error
+
+    data_entries = [element for element in root if local_name(element.tag) == "data"]
+    if not data_entries:
+        raise ValidationError("RPM repomd.xml contains no data entries")
+    referenced: set[str] = set()
+    opened_by_type: dict[str, Path] = {}
+    with tempfile.TemporaryDirectory(prefix="wukongim-rpm-metadata-") as temporary:
+        temporary_root = Path(temporary)
+        for index, data in enumerate(data_entries):
+            data_type = data.get("type", "")
+            if not data_type or data_type in opened_by_type:
+                raise ValidationError(f"RPM repomd.xml has an empty or duplicate data type: {data_type!r}")
+            checksum = direct_child(data, "checksum")
+            open_checksum = direct_child(data, "open-checksum")
+            location = direct_child(data, "location")
+            size = direct_child(data, "size")
+            open_size = direct_child(data, "open-size")
+            if checksum.get("type") != "sha256" or open_checksum.get("type") != "sha256":
+                raise ValidationError(f"RPM metadata {data_type} must use SHA-256 checksums")
+            expected_digest = require_sha256(checksum.text or "", f"RPM {data_type} checksum")
+            expected_open_digest = require_sha256(
+                open_checksum.text or "", f"RPM {data_type} open checksum"
+            )
+            expected_size = require_nonnegative_integer(size.text, f"RPM {data_type} size")
+            expected_open_size = require_nonnegative_integer(
+                open_size.text, f"RPM {data_type} open size"
+            )
+            if expected_open_size > MAX_OPEN_METADATA_SIZE:
+                raise ValidationError(
+                    f"RPM {data_type} open size exceeds the repository budget"
+                )
+            href = location.get("href", "")
+            if not href.startswith("repodata/"):
+                raise ValidationError(f"RPM metadata must live below repodata/: {href!r}")
+            if href in referenced:
+                raise ValidationError(f"RPM repomd.xml repeats a metadata target: {href}")
+            referenced.add(href)
+            metadata = safe_file(rpm_root, href, f"RPM {data_type} metadata")
+            actual_digest, actual_size = sha256_and_size(metadata)
+            if (actual_size, actual_digest) != (expected_size, expected_digest):
+                raise ValidationError(f"RPM compressed metadata digest or size mismatch: {href}")
+            opened = temporary_root / f"{index}.opened"
+            actual_open_digest, actual_open_size = materialize_open_metadata(
+                metadata, opened, expected_open_size
+            )
+            if (actual_open_size, actual_open_digest) != (
+                expected_open_size,
+                expected_open_digest,
+            ):
+                raise ValidationError(f"RPM opened metadata digest or size mismatch: {href}")
+            opened_by_type[data_type] = opened
+
+        required_types = {"primary", "filelists", "other"}
+        if not required_types.issubset(opened_by_type):
+            missing = ", ".join(sorted(required_types - opened_by_type.keys()))
+            raise ValidationError(f"RPM repomd.xml is missing required metadata types: {missing}")
+        actual_metadata: set[str] = set()
+        repodata = rpm_root / "repodata"
+        for path in repodata.iterdir():
+            if path.name in {"repomd.xml", "repomd.xml.asc"}:
+                continue
+            if path.is_symlink() or not path.is_file():
+                raise ValidationError(f"RPM repodata contains an unsafe entry: {path}")
+            actual_metadata.add(path.relative_to(rpm_root).as_posix())
+        if actual_metadata != referenced:
+            raise ValidationError("RPM repomd.xml does not close over the exact repodata file set")
+
+        try:
+            primary_root = ET.parse(opened_by_type["primary"]).getroot()
+        except ET.ParseError as error:
+            raise ValidationError(f"RPM primary metadata is invalid XML: {error}") from error
+        package_records: dict[str, tuple[int, str]] = {}
+        for package in primary_root:
+            if local_name(package.tag) != "package":
+                continue
+            if package.get("type") != "rpm":
+                raise ValidationError("RPM primary metadata contains a non-rpm package")
+            checksum = direct_child(package, "checksum")
+            location = direct_child(package, "location")
+            size = direct_child(package, "size")
+            if checksum.get("type") != "sha256" or checksum.get("pkgid", "").upper() != "YES":
+                raise ValidationError("RPM payload checksum must be the SHA-256 package identifier")
+            expected_digest = require_sha256(checksum.text or "", "RPM payload checksum")
+            expected_size = require_nonnegative_integer(size.get("package"), "RPM payload size")
+            href = location.get("href", "")
+            if not href.startswith("Packages/"):
+                raise ValidationError(f"RPM payload must live below Packages/: {href!r}")
+            if href in package_records:
+                raise ValidationError(f"RPM primary metadata repeats a payload: {href}")
+            payload = safe_file(rpm_root, href, "RPM payload")
+            actual_digest, actual_size = sha256_and_size(payload)
+            if (actual_size, actual_digest) != (expected_size, expected_digest):
+                raise ValidationError(f"RPM payload digest or size mismatch: {href}")
+            package_records[href] = (expected_size, expected_digest)
+
+        if not package_records:
+            raise ValidationError("RPM primary metadata contains no packages")
+        packages_directory = rpm_root / "Packages"
+        if not packages_directory.is_dir() or packages_directory.is_symlink():
+            raise ValidationError("RPM Packages directory is missing or unsafe")
+        actual_payloads: set[str] = set()
+        for path in packages_directory.rglob("*"):
+            if path.is_dir():
+                continue
+            if path.is_symlink() or not path.is_file() or path.suffix != ".rpm":
+                raise ValidationError(f"RPM Packages contains a non-rpm or unsafe file: {path}")
+            actual_payloads.add(path.relative_to(rpm_root).as_posix())
+        if actual_payloads != set(package_records):
+            raise ValidationError("RPM primary metadata does not close over the exact package set")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--apt-release", required=True)
+    parser.add_argument("--rpm-repository", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        repository = Path(arguments.repository)
+        if repository.is_symlink() or not repository.is_dir():
+            raise ValidationError("repository must be a non-symbolic-link directory")
+        verify_apt_closure(repository, arguments.apt_release)
+        verify_rpm_closure(repository, arguments.rpm_repository)
+    except (OSError, ValidationError, subprocess.SubprocessError) as error:
+        print(f"native-package metadata validation failed: {error}", file=sys.stderr)
+        return 65
+    print("native-package metadata closure validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-native-package-repositories.sh
+++ b/scripts/verify-native-package-repositories.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: verify-native-package-repositories.sh \
+  --repository DIR --apt-release RELATIVE_PATH \
+  [--allow-test-only] \
+  [--minimum-valid-days DAYS] \
+  --apt-public-key FILE --apt-primary-fingerprint FPR \
+  --apt-signing-fingerprint FPR \
+  --rpm-repository RELATIVE_PATH --rpm-public-key FILE \
+  --rpm-primary-fingerprint FPR --rpm-signing-fingerprint FPR
+
+Verify exact APT/RPM signing subkeys and the full Release -> Packages -> deb and
+repomd.xml -> metadata -> rpm digest closures. Test-only certificates are
+rejected unless --allow-test-only is explicit. No host trust database is
+modified.
+EOF
+}
+
+repository=""; apt_release=""; allow_test_only="false"; minimum_valid_days="30"; apt_public_key=""; apt_primary=""; apt_signing=""
+rpm_repository=""; rpm_public_key=""; rpm_primary=""; rpm_signing=""
+while (($# > 0)); do
+  case "$1" in
+    --repository) (($# >= 2)) || { usage; exit 64; }; repository="$2"; shift 2 ;;
+    --apt-release) (($# >= 2)) || { usage; exit 64; }; apt_release="$2"; shift 2 ;;
+    --allow-test-only) allow_test_only="true"; shift ;;
+    --minimum-valid-days) (($# >= 2)) || { usage; exit 64; }; minimum_valid_days="$2"; shift 2 ;;
+    --apt-public-key) (($# >= 2)) || { usage; exit 64; }; apt_public_key="$2"; shift 2 ;;
+    --apt-primary-fingerprint) (($# >= 2)) || { usage; exit 64; }; apt_primary="${2^^}"; shift 2 ;;
+    --apt-signing-fingerprint) (($# >= 2)) || { usage; exit 64; }; apt_signing="${2^^}"; shift 2 ;;
+    --rpm-repository) (($# >= 2)) || { usage; exit 64; }; rpm_repository="$2"; shift 2 ;;
+    --rpm-public-key) (($# >= 2)) || { usage; exit 64; }; rpm_public_key="$2"; shift 2 ;;
+    --rpm-primary-fingerprint) (($# >= 2)) || { usage; exit 64; }; rpm_primary="${2^^}"; shift 2 ;;
+    --rpm-signing-fingerprint) (($# >= 2)) || { usage; exit 64; }; rpm_signing="${2^^}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 64 ;;
+  esac
+done
+
+for value_name in repository apt_release apt_public_key apt_primary apt_signing rpm_repository rpm_public_key rpm_primary rpm_signing; do
+  [[ -n "${!value_name}" ]] || { echo "missing required argument for ${value_name//_/-}" >&2; usage; exit 64; }
+done
+[[ -d "$repository" && ! -L "$repository" ]] || { echo "repository must be a non-symbolic-link directory: $repository" >&2; exit 66; }
+[[ -f "$apt_public_key" && ! -L "$apt_public_key" ]] || { echo "APT public key must be a regular non-symbolic-link file" >&2; exit 66; }
+[[ -f "$rpm_public_key" && ! -L "$rpm_public_key" ]] || { echo "RPM public key must be a regular non-symbolic-link file" >&2; exit 66; }
+for fingerprint in "$apt_primary" "$apt_signing" "$rpm_primary" "$rpm_signing"; do
+  [[ "$fingerprint" =~ ^[0-9A-F]{40}$ ]] || { echo "fingerprints must be complete 40-hex values" >&2; exit 64; }
+done
+[[ "$minimum_valid_days" =~ ^[0-9]+$ && "$minimum_valid_days" -le 3650 ]] || {
+  echo "minimum-valid-days must be an integer from 0 through 3650" >&2
+  exit 64
+}
+if [[ "$minimum_valid_days" == 0 && "$allow_test_only" != true ]]; then
+  echo "a zero-day validity floor requires --allow-test-only" >&2
+  exit 64
+fi
+for path in "$apt_release" "$rpm_repository"; do
+  [[ "$path" != /* && "$path" != ".." && "$path" != ../* && "$path" != */../* && "$path" != */.. ]] || {
+    echo "repository paths must be relative and must not contain '..': $path" >&2
+    exit 64
+  }
+done
+for tool in date gpg gpgv python3 rpm rpmkeys sha256sum stat zstd; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "$tool is required" >&2; exit 69; }
+done
+unsafe_repository_entry="$(find "$repository" ! -type d ! -type f -print -quit)"
+if [[ -n "$unsafe_repository_entry" ]]; then
+  echo "repository may contain only regular files and directories: $unsafe_repository_entry" >&2
+  exit 65
+fi
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+metadata_verifier="$script_dir/verify-native-package-metadata.py"
+[[ -f "$metadata_verifier" && ! -L "$metadata_verifier" ]] || {
+  echo "native-package metadata verifier is missing or unsafe" >&2
+  exit 66
+}
+
+temporary_dir="$(mktemp -d)"
+cleanup() { rm -rf -- "$temporary_dir"; }
+trap cleanup EXIT HUP INT TERM
+chmod 0700 "$temporary_dir"
+
+import_public_key() {
+  local role="$1" source="$2" primary="$3" signing="$4" keyring="$5"
+  local home="$temporary_dir/${role,,}-gnupg" listing primary_count minimum_expiry
+  minimum_expiry="$(( $(date +%s) + minimum_valid_days * 86400 ))"
+  mkdir -m 0700 "$home"
+  gpg --homedir "$home" --batch --quiet --no-default-keyring --keyring "$keyring" --import "$source"
+  listing="$(gpg --homedir "$home" --batch --no-default-keyring --keyring "$keyring" \
+    --with-colons --fingerprint --fingerprint)"
+  primary_count="$(awk -F: '$1 == "pub" { count++ } END { print count + 0 }' <<<"$listing")"
+  [[ "$primary_count" == 1 ]] || {
+    echo "$role public key must contain exactly one primary certificate" >&2
+    exit 65
+  }
+  awk -F: -v wanted="$primary" -v minimum_expiry="$minimum_expiry" '
+    $1 == "pub" { valid = $2; expiry = $7; capabilities = $12; want_fpr = 1; next }
+    want_fpr && $1 == "fpr" {
+      exit !($10 == wanted && valid !~ /[re]/ &&
+        capabilities ~ /c/ && capabilities !~ /[sea]/ &&
+        (expiry == 0 || expiry >= minimum_expiry))
+    }
+    END { if (NR == 0) exit 1 }
+  ' <<<"$listing" || {
+    echo "$role primary certificate must match exactly, remain valid, and be certify-only" >&2
+    exit 65
+  }
+  awk -F: -v wanted="$signing" -v minimum_expiry="$minimum_expiry" '
+    $1 == "sub" { valid = $2; expiry = $7; capabilities = $12; want_fpr = 1; next }
+    want_fpr && $1 == "fpr" {
+      if (capabilities ~ /s/) {
+        signing_count++
+        if ($10 == wanted && valid !~ /[re]/ && capabilities !~ /[eca]/ &&
+            (expiry == 0 || expiry >= minimum_expiry)) found = 1
+      }
+      want_fpr = 0
+    }
+    END { exit !(signing_count == 1 && found) }
+  ' <<<"$listing" || {
+    echo "$role public key must contain exactly the requested valid sign-only subkey" >&2
+    exit 65
+  }
+  if [[ "$allow_test_only" != true ]]; then
+    awk -F: '$1 == "uid" && toupper($10) ~ /TEST ONLY/ { found = 1 } END { exit found ? 0 : 1 }' <<<"$listing" && {
+      echo "$role test-only certificate is forbidden without --allow-test-only" >&2
+      exit 65
+    }
+  fi
+}
+
+apt_keyring="$temporary_dir/apt-keyring.gpg"
+rpm_keyring="$temporary_dir/rpm-keyring.gpg"
+import_public_key APT "$apt_public_key" "$apt_primary" "$apt_signing" "$apt_keyring"
+import_public_key RPM "$rpm_public_key" "$rpm_primary" "$rpm_signing" "$rpm_keyring"
+
+signing_manifest="$repository/signing-manifest.txt"
+[[ -f "$signing_manifest" ]] || { echo "signed repository manifest is required" >&2; exit 66; }
+for exact_line in \
+  "APT_PRIMARY_FINGERPRINT=$apt_primary" \
+  "APT_SIGNING_FINGERPRINT=$apt_signing" \
+  "RPM_PRIMARY_FINGERPRINT=$rpm_primary" \
+  "RPM_SIGNING_FINGERPRINT=$rpm_signing" \
+  "APT_RELEASE=$apt_release" \
+  "RPM_REPOSITORY=$rpm_repository"; do
+  grep -Fxq "$exact_line" "$signing_manifest" || {
+    echo "signed repository manifest does not match verification arguments" >&2
+    exit 65
+  }
+done
+if grep -Fxq 'TEST_ONLY=true' "$signing_manifest"; then
+  [[ "$allow_test_only" == true ]] || { echo "test-only signed repository is forbidden" >&2; exit 65; }
+elif ! grep -Fxq 'TEST_ONLY=false' "$signing_manifest"; then
+  echo "signed repository manifest has an invalid TEST_ONLY value" >&2
+  exit 65
+fi
+
+apt_release_path="$repository/$apt_release"
+apt_directory="${apt_release_path%/*}"
+rpm_repository_path="$repository/$rpm_repository"
+[[ -f "$apt_release_path" && -f "$apt_directory/InRelease" && -f "$apt_release_path.gpg" ]] || {
+  echo "APT Release, InRelease, and Release.gpg are all required" >&2
+  exit 66
+}
+[[ -f "$rpm_repository_path/repodata/repomd.xml" && -f "$rpm_repository_path/repodata/repomd.xml.asc" ]] || {
+  echo "RPM repomd.xml and repomd.xml.asc are required" >&2
+  exit 66
+}
+
+verify_gpgv_signer() {
+  local keyring="$1" expected="$2" status="$3"
+  shift 3
+  gpgv --status-fd 1 --keyring "$keyring" "$@" >"$status"
+  grep -Eq "^\[GNUPG:\] VALIDSIG $expected( |$)" "$status" || {
+    echo "signature did not use expected subkey $expected" >&2
+    exit 65
+  }
+}
+
+verify_gpgv_signer "$apt_keyring" "$apt_signing" "$temporary_dir/inrelease.status" \
+  --output "$temporary_dir/inrelease-release" "$apt_directory/InRelease"
+cmp -s "$temporary_dir/inrelease-release" "$apt_release_path" || {
+  echo "InRelease cleartext differs from Release" >&2
+  exit 65
+}
+grep -Fxq 'Acquire-By-Hash: yes' "$apt_release_path" || {
+  echo "APT Release must enable Acquire-By-Hash" >&2
+  exit 65
+}
+verify_gpgv_signer "$apt_keyring" "$apt_signing" "$temporary_dir/release-gpg.status" \
+  "$apt_release_path.gpg" "$apt_release_path"
+
+sha256_entries=0
+while read -r expected_hash expected_size relative_path; do
+  sha256_entries="$((sha256_entries + 1))"
+  [[ "$expected_hash" =~ ^[0-9a-fA-F]{64}$ && "$expected_size" =~ ^[0-9]+$ ]] || {
+    echo "invalid SHA256 entry in APT Release" >&2
+    exit 65
+  }
+  [[ "$relative_path" != /* && "$relative_path" != ".." && "$relative_path" != ../* && "$relative_path" != */../* && "$relative_path" != */.. ]] || {
+    echo "unsafe path in APT Release: $relative_path" >&2
+    exit 65
+  }
+  target="$apt_directory/$relative_path"
+  [[ -f "$target" ]] || { echo "APT Release target is missing: $relative_path" >&2; exit 65; }
+  actual_hash="$(sha256sum "$target" | awk '{print $1}')"
+  actual_size="$(stat -c %s "$target")"
+  [[ "$actual_hash" == "${expected_hash,,}" && "$actual_size" == "$expected_size" ]] || {
+    echo "APT Release digest mismatch: $relative_path" >&2
+    exit 65
+  }
+  case "$relative_path" in
+    */Packages|*/Packages.gz)
+      by_hash="${target%/*}/by-hash/SHA256/${expected_hash,,}"
+      [[ -f "$by_hash" ]] || { echo "APT by-hash target is missing: $relative_path" >&2; exit 65; }
+      cmp -s "$target" "$by_hash" || { echo "APT by-hash target differs: $relative_path" >&2; exit 65; }
+      ;;
+  esac
+done < <(awk '
+  /^SHA256:$/ { in_sha256 = 1; next }
+  /^[A-Za-z0-9-]+:$/ { in_sha256 = 0 }
+  in_sha256 && NF == 3 { print $1, $2, $3 }
+' "$apt_release_path")
+((sha256_entries > 0)) || { echo "APT Release contains no SHA256 entries" >&2; exit 65; }
+
+rpm_db="$temporary_dir/rpmdb"
+mkdir -p "$rpm_db"
+rpm --dbpath "$rpm_db" --initdb
+rpm --dbpath "$rpm_db" --import "$rpm_public_key"
+mapfile -d '' rpm_packages < <(find "$rpm_repository_path/Packages" -type f -name '*.rpm' -print0)
+((${#rpm_packages[@]} > 0)) || { echo "no RPM packages found in repository" >&2; exit 66; }
+for package in "${rpm_packages[@]}"; do
+  rpmkeys --dbpath "$rpm_db" --checksig "$package" >/dev/null
+  signature_file="$temporary_dir/rpm-signature.asc"
+  rpm --dbpath "$rpm_db" -qp --queryformat '%{RSAHEADER:armor}\n' "$package" >"$signature_file"
+  packet_listing="$(gpg --homedir "$temporary_dir/rpm-gnupg" --batch --list-packets "$signature_file" 2>&1)"
+  grep -Fqi "issuer fpr v4 $rpm_signing" <<<"$packet_listing" || {
+    echo "RPM package was not signed by exact subkey $rpm_signing: $package" >&2
+    exit 65
+  }
+done
+verify_gpgv_signer "$rpm_keyring" "$rpm_signing" "$temporary_dir/repomd.status" \
+  "$rpm_repository_path/repodata/repomd.xml.asc" "$rpm_repository_path/repodata/repomd.xml"
+
+python3 "$metadata_verifier" \
+  --repository "$repository" \
+  --apt-release "$apt_release" \
+  --rpm-repository "$rpm_repository"
+
+echo "native-package repository signatures and metadata closure validated"


### PR DESCRIPTION
## Summary

- add safe `wukongim version`, `config init`, and `config validate` commands
- build amd64 deb/rpm previews with hardened systemd lifecycle contracts
- validate temporary TEST ONLY signed APT/RPM repositories and metadata-to-package closure
- add credential-free four-distribution package preview CI
- make binary Releases compatible with immutable Releases through numeric-ID draft creation, exact asset verification, and one-time publication
- document the fail-closed `packages.githubim.com` bootstrap

## Safety

This PR does not contain signing credentials and does not publish APT/YUM indexes. Preview artifacts remain unsigned and expire after 14 days. Temporary repository keys are generated outside the repository and are never uploaded.

The binary publishing workflow must not be triggered until the remote `binary-publish` Environment restrictions are configured and verified.

## Validation

- `GOWORK=off go test ./cmd/wukongim ./internal/config ./internal/app -count=1`
- `GOWORK=off go test ./scripts -run Test(NativePackage|BinaryRelease|GitHubWorkflow) -count=1`
- actionlint 1.7.9 on both changed workflows
- `bun test lib/native-deployment-contract.test.ts`
- signed repository positive/negative container matrix and deb/rpm reinstall lifecycle checks
- `git diff --check`