### PR TITLE
ci: publish unsigned native package assets

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,7 +40,7 @@ authorization and the applicable budget.
 | `cloud-sim-cleanup.yml` | `Safety Automation - Reconcile Cloud Simulation Resources` | Destroys expired cloud leases and supports exact cleanup |
 | `cloud-sim-monitor.yml` | `Safety Automation - Patrol Cloud Simulation Runs` | Patrols retained live runs and records bounded health evidence |
 | `docker-image-publish.yml` | `Safety Automation - Publish Docker Images` | Builds one immutable multi-platform GHCR image, mirrors its digest to Docker Hub and Alibaba Cloud, then advances eligible stable aliases |
-| `binary-release-publish.yml` | `Safety Automation - Publish WuKongIM Binaries` | Builds immutable Linux/macOS release archives for four architectures and publishes them to the exact tag's GitHub Release |
+| `binary-release-publish.yml` | `Safety Automation - Publish WuKongIM Binaries` | Builds immutable Linux/macOS archives plus unsigned Linux amd64 DEB/RPM assets and publishes the exact set to the tag's GitHub Release |
 
 ## Native package preview
 
@@ -68,10 +68,11 @@ Pages bootstrap at the verified HTTPS endpoint `packages.githubim.com`; it
 currently publishes only a `signing_not_provisioned` status and no package
 indexes. Both repositories enforce immutable Releases, and the custom-domain
 DNS and certificate are provisioned. Reviewed public fingerprints, signing
-custody, exact tagged source package assets, cross-repository dispatch, and the
-production publisher remain intentionally outside this credential-free
-workflow. They must be provisioned and reviewed before package indexes are
-enabled.
+custody, cross-repository dispatch, and the production publisher remain
+intentionally outside this credential-free workflow. Exact unsigned source
+package assets are supplied by the tag-bound binary Release described below,
+but they must not enter package indexes until the remaining production controls
+are provisioned and reviewed.
 
 ## Docker image publishing
 
@@ -131,16 +132,29 @@ Each run builds deterministic `.tar.gz` archives for `linux/amd64`,
 `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. Windows is not advertised
 because the server currently contains Unix-only runtime and filesystem paths.
 Every archive includes the executable, English and Chinese readmes, and
-`wukongim.toml.example`. The workflow publishes a shared SHA-256
-checksum file, creates signed GitHub build provenance, verifies the Linux
-binaries under amd64 and arm64, and retains all archives plus a JSON receipt as
-Actions evidence for 90 days. Tags containing the version command also prove
-the embedded version, full source commit, and `release` build source; older
-tags remain bound by the immutable tag, checksums, and attestation.
+`wukongim.toml.example`. When the tagged source contains
+`.goreleaser.packages.yaml`, the same run also uses the commit-pinned
+GoReleaser action with GoReleaser `v2.18.0` to build unsigned Linux amd64
+packages, normalized to exactly:
+
+- `wukongim_<version>_linux_amd64.deb`;
+- `wukongim_<version>_linux_amd64.rpm`.
+
+All archives and native packages share one SHA-256 checksum file and one signed
+GitHub build-provenance statement. The workflow verifies Linux binaries under
+amd64 and arm64 and retains the complete asset set plus a JSON receipt as
+Actions evidence for 90 days. Native packages remain unsigned source assets;
+the separate package repository must apply and verify its production package
+and repository signatures before publication. Tags containing the version
+command also prove the embedded version, full source commit, and `release`
+build source. Older tags that predate `.goreleaser.packages.yaml` retain their
+original five-asset recovery contract and remain bound by the immutable tag,
+checksums, and attestation.
 
 The workflow creates a draft Release without publishing it, uploads every
-expected asset, downloads and byte-compares the complete exact asset set, and
-only then publishes the verified draft once. Recovery may compare existing
+expected archive, native package, and checksum, downloads and byte-compares the
+complete exact asset set, and only then publishes the verified draft once.
+Recovery may compare existing
 assets and fill missing files only in that same draft. Draft discovery scans
 all Releases for one exact tag match, then binds creation, upload, verification,
 and publication to the resulting numeric Release ID; it never relies on the
@@ -155,8 +169,9 @@ incomplete one must never be reused and requires a new SemVer tag. A
 pre-release SemVer tag must correspond to a GitHub pre-release; stable tags
 must correspond to a normal Release. After publication, the workflow verifies
 that GitHub sealed the same numeric Release ID as immutable, checks every
-asset's API size and SHA-256 digest against the local file, and falls back to
-an ID-bound download and byte comparison when the API omits a digest.
+asset's API size and any available SHA-256 digest against the local file, and
+always performs an ID-bound download and byte comparison. The same ID-bound
+byte comparison is repeated immediately before publication.
 
 Repository administrators must configure a `binary-publish` Environment,
 allow protected `main` for manual recovery and trusted version tags for

--- a/.github/workflows/binary-release-publish.yml
+++ b/.github/workflows/binary-release-publish.yml
@@ -156,6 +156,7 @@ jobs:
           tar --version | grep -F 'GNU tar' >/dev/null
 
           embedded_version=false
+          native_packages=false
           ldflags='-s -w -buildid='
           if [[ -f cmd/wukongim/version.go ]]; then
             embedded_version=true
@@ -207,15 +208,94 @@ jobs:
           done
 
           checksum_name="wukongim_${BINARY_VERSION}_checksums.txt"
-          (
-            cd "$RELEASE_DIR"
-            sha256sum wukongim_*.tar.gz | sort -k2 >"$checksum_name"
-            sha256sum --check "$checksum_name"
-          )
+          [[ ! -f .goreleaser.packages.yaml ]] || native_packages=true
           {
             echo "embedded_version=$embedded_version"
+            echo "native_packages=$native_packages"
             echo "checksum_name=$checksum_name"
           } >>"$GITHUB_OUTPUT"
+
+      - name: Build unsigned amd64 native packages
+        if: steps.build.outputs.native_packages == 'true'
+        uses: goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1 # v7.2.0
+        with:
+          distribution: goreleaser
+          version: v2.18.0
+          args: release --clean --config .goreleaser.packages.yaml
+
+      - name: Normalize unsigned native package assets
+        if: steps.build.outputs.native_packages == 'true'
+        shell: bash
+        env:
+          BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
+          RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+          shopt -s nullglob
+
+          deb_packages=(dist/*.deb)
+          rpm_packages=(dist/*.rpm)
+          ((${#deb_packages[@]} == 1)) || {
+            echo "GoReleaser must produce exactly one unsigned deb asset" >&2
+            exit 1
+          }
+          ((${#rpm_packages[@]} == 1)) || {
+            echo "GoReleaser must produce exactly one unsigned rpm asset" >&2
+            exit 1
+          }
+          [[ -f "${deb_packages[0]}" && ! -L "${deb_packages[0]}" ]]
+          [[ -f "${rpm_packages[0]}" && ! -L "${rpm_packages[0]}" ]]
+
+          deb_name="wukongim_${BINARY_VERSION}_linux_amd64.deb"
+          rpm_name="wukongim_${BINARY_VERSION}_linux_amd64.rpm"
+          install -m 0644 "${deb_packages[0]}" "$RELEASE_DIR/$deb_name"
+          install -m 0644 "${rpm_packages[0]}" "$RELEASE_DIR/$rpm_name"
+          test "$(dpkg-deb --field "$RELEASE_DIR/$deb_name" Package)" = wukongim
+          test "$(dpkg-deb --field "$RELEASE_DIR/$deb_name" Architecture)" = amd64
+
+      - name: Finalize exact release asset set and checksums
+        shell: bash
+        env:
+          BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
+          NATIVE_PACKAGES: ${{ steps.build.outputs.native_packages }}
+          CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
+          RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          release_assets=(
+            "wukongim_${BINARY_VERSION}_linux_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_linux_arm64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_amd64.tar.gz"
+            "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
+          )
+          if [[ "$NATIVE_PACKAGES" == true ]]; then
+            release_assets+=(
+              "wukongim_${BINARY_VERSION}_linux_amd64.deb"
+              "wukongim_${BINARY_VERSION}_linux_amd64.rpm"
+            )
+          fi
+          for asset in "${release_assets[@]}"; do
+            [[ -f "$RELEASE_DIR/$asset" && ! -L "$RELEASE_DIR/$asset" ]] || {
+              echo "missing or unsafe release asset: $asset" >&2
+              exit 1
+            }
+          done
+          mapfile -t actual_assets < <(
+            find "$RELEASE_DIR" -maxdepth 1 -type f -printf '%f\n' | sort
+          )
+          mapfile -t expected_assets < <(printf '%s\n' "${release_assets[@]}" | sort)
+          test "${actual_assets[*]}" = "${expected_assets[*]}" || {
+            echo "local release directory does not contain the exact pre-checksum asset set" >&2
+            exit 1
+          }
+          (
+            cd "$RELEASE_DIR"
+            sha256sum "${release_assets[@]}" | sort -k2 >"$CHECKSUM_NAME"
+            sha256sum --check "$CHECKSUM_NAME"
+          )
 
       - name: Set up QEMU for arm64 validation
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -274,6 +354,7 @@ jobs:
           VERSION: ${{ steps.identity.outputs.version }}
           BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
           STABLE: ${{ steps.identity.outputs.stable }}
+          NATIVE_PACKAGES: ${{ steps.build.outputs.native_packages }}
           CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
           RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
         run: |
@@ -287,6 +368,12 @@ jobs:
             "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
             "$CHECKSUM_NAME"
           )
+          if [[ "$NATIVE_PACKAGES" == true ]]; then
+            expected_assets+=(
+              "wukongim_${BINARY_VERSION}_linux_amd64.deb"
+              "wukongim_${BINARY_VERSION}_linux_amd64.rpm"
+            )
+          fi
           gh api "repos/$GITHUB_REPOSITORY/immutable-releases" \
             | jq -e '.enabled == true' >/dev/null || {
               echo "repository immutable Releases must remain enabled before publication" >&2
@@ -393,6 +480,8 @@ jobs:
         with:
           subject-path: |
             ${{ runner.temp }}/wukongim-binary-release/*.tar.gz
+            ${{ runner.temp }}/wukongim-binary-release/*.deb
+            ${{ runner.temp }}/wukongim-binary-release/*.rpm
             ${{ runner.temp }}/wukongim-binary-release/*_checksums.txt
 
       - name: Create or recover draft GitHub Release
@@ -496,6 +585,7 @@ jobs:
           RELEASE_ID: ${{ steps.draft.outputs.release_id }}
           BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
           STABLE: ${{ steps.identity.outputs.stable }}
+          NATIVE_PACKAGES: ${{ steps.build.outputs.native_packages }}
           CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
           RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
         run: |
@@ -524,6 +614,12 @@ jobs:
             "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
             "$CHECKSUM_NAME"
           )
+          if [[ "$NATIVE_PACKAGES" == true ]]; then
+            expected_assets+=(
+              "wukongim_${BINARY_VERSION}_linux_amd64.deb"
+              "wukongim_${BINARY_VERSION}_linux_amd64.rpm"
+            )
+          fi
           mapfile -t expected_assets < <(printf '%s\n' "${expected_assets[@]}" | sort)
           test "${actual_assets[*]}" = "${expected_assets[*]}" || {
             echo "$VERSION draft does not contain the exact expected asset set" >&2
@@ -531,7 +627,8 @@ jobs:
           }
 
           mkdir -p "$draft_dir"
-          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR/$CHECKSUM_NAME"; do
+          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR"/*.deb "$RELEASE_DIR"/*.rpm "$RELEASE_DIR/$CHECKSUM_NAME"; do
+            [[ -e "$local_asset" ]] || continue
             asset="$(basename "$local_asset")"
             asset_id="$(jq -r --arg name "$asset" \
               '.assets[] | select(.name == $name) | .id' "$draft_json")"
@@ -556,6 +653,7 @@ jobs:
           RELEASE_ID: ${{ steps.draft.outputs.release_id }}
           BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
           STABLE: ${{ steps.identity.outputs.stable }}
+          NATIVE_PACKAGES: ${{ steps.build.outputs.native_packages }}
           CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
           RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
         run: |
@@ -579,8 +677,9 @@ jobs:
             | jq -e '.enabled == true' >/dev/null || {
               echo "repository immutable Releases were disabled before publication" >&2
               exit 1
-            }
+          }
           prepublish_json="$RUNNER_TEMP/prepublish-binary-release.json"
+          prepublish_dir="$RUNNER_TEMP/prepublish-binary-release"
           gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" >"$prepublish_json"
           jq -e --arg version "$VERSION" \
             '.tag_name == $version and .draft == true and (.immutable // false) == false' \
@@ -602,19 +701,29 @@ jobs:
             "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
             "$CHECKSUM_NAME"
           )
+          if [[ "$NATIVE_PACKAGES" == true ]]; then
+            expected_assets+=(
+              "wukongim_${BINARY_VERSION}_linux_amd64.deb"
+              "wukongim_${BINARY_VERSION}_linux_amd64.rpm"
+            )
+          fi
           mapfile -t expected_assets < <(printf '%s\n' "${expected_assets[@]}" | sort)
           test "${actual_assets[*]}" = "${expected_assets[*]}" || {
             echo "$VERSION draft asset set changed immediately before publication" >&2
             exit 1
           }
-          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR/$CHECKSUM_NAME"; do
+          mkdir -p "$prepublish_dir"
+          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR"/*.deb "$RELEASE_DIR"/*.rpm "$RELEASE_DIR/$CHECKSUM_NAME"; do
+            [[ -e "$local_asset" ]] || continue
             asset="$(basename "$local_asset")"
             asset_json="$(jq -c --arg name "$asset" \
               '.assets[] | select(.name == $name)' "$prepublish_json")"
+            asset_id="$(jq -r '.id' <<<"$asset_json")"
             api_size="$(jq -r '.size' <<<"$asset_json")"
             api_digest="$(jq -r '.digest // empty' <<<"$asset_json")"
             local_size="$(stat -c '%s' "$local_asset")"
             local_sha256="$(sha256sum "$local_asset" | awk '{print $1}')"
+            [[ "$asset_id" =~ ^[1-9][0-9]*$ ]]
             [[ "$api_size" =~ ^[0-9]+$ && "$api_size" == "$local_size" ]] || {
               echo "$asset draft size changed immediately before publication" >&2
               exit 1
@@ -623,6 +732,11 @@ jobs:
               echo "$asset draft digest changed immediately before publication" >&2
               exit 1
             }
+            gh api \
+              -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
+              >"$prepublish_dir/$asset"
+            cmp "$local_asset" "$prepublish_dir/$asset"
           done
 
           gh api --method PATCH \
@@ -638,6 +752,7 @@ jobs:
           RELEASE_ID: ${{ steps.draft.outputs.release_id }}
           BINARY_VERSION: ${{ steps.identity.outputs.binary_version }}
           STABLE: ${{ steps.identity.outputs.stable }}
+          NATIVE_PACKAGES: ${{ steps.build.outputs.native_packages }}
           CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
           RELEASE_DIR: ${{ runner.temp }}/wukongim-binary-release
         run: |
@@ -666,6 +781,12 @@ jobs:
             "wukongim_${BINARY_VERSION}_darwin_arm64.tar.gz"
             "$CHECKSUM_NAME"
           )
+          if [[ "$NATIVE_PACKAGES" == true ]]; then
+            expected_assets+=(
+              "wukongim_${BINARY_VERSION}_linux_amd64.deb"
+              "wukongim_${BINARY_VERSION}_linux_amd64.rpm"
+            )
+          fi
           mapfile -t expected_assets < <(printf '%s\n' "${expected_assets[@]}" | sort)
           test "${actual_assets[*]}" = "${expected_assets[*]}" || {
             echo "$VERSION published Release does not contain the exact expected asset set" >&2
@@ -673,7 +794,8 @@ jobs:
           }
 
           mkdir -p "$published_dir"
-          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR/$CHECKSUM_NAME"; do
+          for local_asset in "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR"/*.deb "$RELEASE_DIR"/*.rpm "$RELEASE_DIR/$CHECKSUM_NAME"; do
+            [[ -e "$local_asset" ]] || continue
             asset="$(basename "$local_asset")"
             asset_json="$(jq -c --arg name "$asset" \
               '.assets[] | select(.name == $name)' "$published_json")"
@@ -692,13 +814,12 @@ jobs:
                 echo "$asset published digest conflicts with the verified local asset" >&2
                 exit 1
               }
-            else
-              gh api \
-                -H 'Accept: application/octet-stream' \
-                "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
-                >"$published_dir/$asset"
-              cmp "$local_asset" "$published_dir/$asset"
             fi
+            gh api \
+              -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" \
+              >"$published_dir/$asset"
+            cmp "$local_asset" "$published_dir/$asset"
           done
 
       - name: Write release receipt and summary
@@ -709,6 +830,7 @@ jobs:
           SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
           STABLE: ${{ steps.identity.outputs.stable }}
           EMBEDDED_VERSION: ${{ steps.build.outputs.embedded_version }}
+          NATIVE_PACKAGES: ${{ steps.build.outputs.native_packages }}
           CHECKSUM_NAME: ${{ steps.build.outputs.checksum_name }}
           RECOVERY: ${{ steps.publication.outputs.release_exists }}
           ATTESTATION_URL: ${{ steps.attestation.outputs.attestation-url }}
@@ -730,6 +852,7 @@ jobs:
             --arg source_sha "$SOURCE_SHA" \
             --arg stable "$STABLE" \
             --arg embedded_version "$EMBEDDED_VERSION" \
+            --arg native_packages "$NATIVE_PACKAGES" \
             --arg recovery "$RECOVERY" \
             --arg event "$GITHUB_EVENT_NAME" \
             --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
@@ -746,6 +869,7 @@ jobs:
               source_sha: $source_sha,
               stable: ($stable == "true"),
               embedded_version: ($embedded_version == "true"),
+              unsigned_native_packages: ($native_packages == "true"),
               recovery: ($recovery == "true"),
               trigger: $event,
               run_url: $run_url,
@@ -767,6 +891,7 @@ jobs:
             echo "| Source | \`$SOURCE_SHA\` |"
             echo "| Platforms | \`linux/amd64\`, \`linux/arm64\`, \`darwin/amd64\`, \`darwin/arm64\` |"
             echo "| Embedded version command | \`$EMBEDDED_VERSION\` |"
+            echo "| Unsigned amd64 DEB/RPM | \`$NATIVE_PACKAGES\` |"
             echo "| Recovery | \`$RECOVERY\` |"
             echo "| Release | $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$VERSION |"
             [[ -z "$ATTESTATION_URL" ]] || echo "| Attestation | $ATTESTATION_URL |"
@@ -778,6 +903,8 @@ jobs:
           name: wukongim-binary-release-${{ steps.identity.outputs.binary_version }}
           path: |
             ${{ runner.temp }}/wukongim-binary-release/*.tar.gz
+            ${{ runner.temp }}/wukongim-binary-release/*.deb
+            ${{ runner.temp }}/wukongim-binary-release/*.rpm
             ${{ runner.temp }}/wukongim-binary-release/*_checksums.txt
             ${{ runner.temp }}/wukongim-binary-release/*_release.json
           if-no-files-found: error

--- a/scripts/binary_release_workflow_test.go
+++ b/scripts/binary_release_workflow_test.go
@@ -31,8 +31,11 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 			TimeoutMinutes int    `yaml:"timeout-minutes"`
 			Environment    string `yaml:"environment"`
 			Steps          []struct {
-				Name string `yaml:"name"`
-				Run  string `yaml:"run"`
+				Name string            `yaml:"name"`
+				If   string            `yaml:"if"`
+				Uses string            `yaml:"uses"`
+				Run  string            `yaml:"run"`
+				With map[string]string `yaml:"with"`
 			} `yaml:"steps"`
 		} `yaml:"jobs"`
 	}
@@ -70,6 +73,13 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		"darwin/arm64",
 		"tar --sort=name",
 		"gzip -n -9",
+		"goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1",
+		"version: v2.18.0",
+		"args: release --clean --config .goreleaser.packages.yaml",
+		"wukongim_${BINARY_VERSION}_linux_amd64.deb",
+		"wukongim_${BINARY_VERSION}_linux_amd64.rpm",
+		"dpkg-deb --field",
+		"sha256sum \"${release_assets[@]}\"",
 		"sha256sum --check",
 		"docker/setup-qemu-action@",
 		"actions/attest@",
@@ -104,6 +114,7 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		"local_size=\"$(stat -c '%s'",
 		"$api_digest\" == \"sha256:$local_sha256",
 		"wukongim/binary-release-receipt/v1",
+		"unsigned_native_packages: ($native_packages == \"true\")",
 		"retention-days: 90",
 		"git diff --exit-code HEAD --",
 	} {
@@ -127,6 +138,9 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 	orderedSteps := []string{
 		"- name: Validate release identity and tag policy",
 		"- name: Build deterministic release archives",
+		"- name: Build unsigned amd64 native packages",
+		"- name: Normalize unsigned native package assets",
+		"- name: Finalize exact release asset set and checksums",
 		"- name: Validate binary identities and archive contents",
 		"- name: Classify draft GitHub Release assets",
 		"- name: Create GitHub build provenance",
@@ -144,9 +158,67 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 	}
 
 	stepRuns := make(map[string]string, len(publish.Steps))
+	stepUses := make(map[string]string, len(publish.Steps))
+	stepIfs := make(map[string]string, len(publish.Steps))
+	stepWith := make(map[string]map[string]string, len(publish.Steps))
+	var packageBuildStep struct {
+		If   string
+		Uses string
+		With map[string]string
+	}
 	for _, step := range publish.Steps {
 		stepRuns[step.Name] = step.Run
+		stepUses[step.Name] = step.Uses
+		stepIfs[step.Name] = step.If
+		stepWith[step.Name] = step.With
+		if step.Name == "Build unsigned amd64 native packages" {
+			packageBuildStep.If = step.If
+			packageBuildStep.Uses = step.Uses
+			packageBuildStep.With = step.With
+		}
 	}
+	require.Equal(t, "steps.build.outputs.native_packages == 'true'", packageBuildStep.If)
+	require.Equal(t, "goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1", packageBuildStep.Uses)
+	require.Equal(t, map[string]string{
+		"distribution": "goreleaser",
+		"version":      "v2.18.0",
+		"args":         "release --clean --config .goreleaser.packages.yaml",
+	}, packageBuildStep.With)
+
+	finalizeRun := stepRuns["Finalize exact release asset set and checksums"]
+	require.Contains(t, finalizeRun, "find \"$RELEASE_DIR\" -maxdepth 1 -type f")
+	require.Contains(t, finalizeRun, "sha256sum \"${release_assets[@]}\" | sort -k2")
+	require.Contains(t, finalizeRun, "sha256sum --check \"$CHECKSUM_NAME\"")
+	require.GreaterOrEqual(t, strings.Count(text, "\"wukongim_${BINARY_VERSION}_linux_amd64.deb\""), 5)
+	require.GreaterOrEqual(t, strings.Count(text, "\"wukongim_${BINARY_VERSION}_linux_amd64.rpm\""), 5)
+	require.Equal(t, 3, strings.Count(text, "\"$RELEASE_DIR\"/*.deb"))
+	require.Equal(t, 3, strings.Count(text, "\"$RELEASE_DIR\"/*.rpm"))
+	for _, stepName := range []string{
+		"Classify draft GitHub Release assets",
+		"Verify complete draft Release",
+		"Publish verified draft Release once",
+		"Verify published immutable Release",
+	} {
+		run := stepRuns[stepName]
+		require.Contains(t, run, "wukongim_${BINARY_VERSION}_linux_amd64.deb", stepName)
+		require.Contains(t, run, "wukongim_${BINARY_VERSION}_linux_amd64.rpm", stepName)
+		require.Contains(t, run, "if [[ \"$NATIVE_PACKAGES\" == true ]]", stepName)
+	}
+	for _, stepName := range []string{
+		"Verify complete draft Release",
+		"Publish verified draft Release once",
+		"Verify published immutable Release",
+	} {
+		run := stepRuns[stepName]
+		require.Contains(t, run, "\"$RELEASE_DIR\"/*.deb", stepName)
+		require.Contains(t, run, "\"$RELEASE_DIR\"/*.rpm", stepName)
+	}
+	require.Equal(t, "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6", stepUses["Create GitHub build provenance"])
+	require.Contains(t, stepWith["Create GitHub build provenance"]["subject-path"], "/*.deb")
+	require.Contains(t, stepWith["Create GitHub build provenance"]["subject-path"], "/*.rpm")
+	require.Contains(t, stepWith["Upload binary release evidence"]["path"], "/*.deb")
+	require.Contains(t, stepWith["Upload binary release evidence"]["path"], "/*.rpm")
+	require.Empty(t, stepIfs["Finalize exact release asset set and checksums"])
 	classifyRun := stepRuns["Classify draft GitHub Release assets"]
 	require.Contains(t, classifyRun, "gh api --paginate --slurp")
 	require.Contains(t, classifyRun, "[.[][] | select(.tag_name == $version)]")
@@ -185,6 +257,8 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 	require.Contains(t, publishRun, "releases/$RELEASE_ID")
 	require.Contains(t, publishRun, "stat -c '%s'")
 	require.Contains(t, publishRun, "sha256:$local_sha256")
+	require.Contains(t, publishRun, ">\"$prepublish_dir/$asset\"")
+	require.Contains(t, publishRun, "cmp \"$local_asset\" \"$prepublish_dir/$asset\"")
 
 	verifyPublishedRun := stepRuns["Verify published immutable Release"]
 	require.Contains(t, verifyPublishedRun, "releases/$RELEASE_ID")
@@ -192,5 +266,7 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 	require.Contains(t, verifyPublishedRun, "stat -c '%s'")
 	require.Contains(t, verifyPublishedRun, "sha256:$local_sha256")
 	require.Contains(t, verifyPublishedRun, "releases/assets/$asset_id")
+	require.Contains(t, verifyPublishedRun, ">\"$published_dir/$asset\"")
+	require.Contains(t, verifyPublishedRun, "cmp \"$local_asset\" \"$published_dir/$asset\"")
 	require.NotContains(t, verifyPublishedRun, "releases/tags/")
 }


### PR DESCRIPTION
## Summary
- build unsigned amd64 DEB and RPM assets with pinned GoReleaser
- include packages in the immutable Release checksum and attestation closure
- verify the exact asset set and bytes before and after publication
- retain compatibility with tags created before the package configuration existed

## Validation
- GOWORK=off go test ./scripts/... -count=1
- actionlint v1.7.9 over all workflows
- git diff --check

This PR does not create a tag, Release, signing key, or public package repository.