### PR TITLE
ci: suspend idle formal and lease schedules

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,8 +15,8 @@ authorization and the applicable budget.
 | --- | --- | --- |
 | `chat-lifecycle-rehearsal.yml` | `Agent Tool - Start Chat Lifecycle Rehearsal` | Builds, quotes, acquires, deploys, and hands a full-scale two-hour rehearsal to remote systemd |
 | `chat-lifecycle-rehearsal-finalize.yml` | `Safety Automation - Finalize Chat Lifecycle Rehearsals` | While armed, uploads a terminal rehearsal report before Release and reconciles the Lease to zero inventory |
-| `chat-lifecycle-formal.yml` | `Safety Automation - Start Fresh Formal Chat Lifecycle` | Consumes an authenticated released rehearsal transition and starts a fresh 96-hour formal Lease |
-| `chat-lifecycle-formal-finalize.yml` | `Safety Automation - Finalize Formal Chat Lifecycle Runs` | Collects the same-Lease Soak/capacity/recovery result before Release and zero-inventory proof |
+| `chat-lifecycle-formal.yml` | `Safety Automation - Start Fresh Formal Chat Lifecycle` | While armed, consumes an authenticated released rehearsal transition and starts a fresh 96-hour formal Lease |
+| `chat-lifecycle-formal-finalize.yml` | `Safety Automation - Finalize Formal Chat Lifecycle Runs` | While armed, collects the same-Lease Soak/capacity/recovery result before Release and zero-inventory proof |
 | `chat-lifecycle-stop.yml` | `Agent Tool - Stop Chat Lifecycle Request` | Seals one request-level stop marker and requests coordinated cancellation plus bounded operator-stop finalization |
 | `three-node-chat-lifecycle-regression.yml` | `Safety Automation - Three-Node Chat Lifecycle Regression` | Enforces 400 ms p99 on focused 500 SEND/s PR benchmarks, runs a sealed 500 SEND/s three-node correctness/drain smoke, and runs one fresh nightly ten-minute 500 SEND/s regression directly without the diagnostic rate staircase; 1,000 SEND/s remains a dedicated capacity-environment gate |
 | `review-agent-pr-signal.yml` | `Safety Automation - Review Agent PR Signal` | Emits a credential-free lifecycle or exact-command wake-up hint |
@@ -32,7 +32,7 @@ authorization and the applicable budget.
 | `cloud-lease-provision.yml` | `Agent Tool - Provision Cloud Lease` | Quotes or explicitly acquires one generic Alibaba Cloud Lease |
 | `cloud-lease-observe.yml` | `Agent Tool - Inspect Cloud Lease` | Reconstructs exact Lease inventory through the read-only Observer role |
 | `cloud-lease-analyze.yml` | `Agent Tool - Analyze Chat Lifecycle Cloud Lease` | Authenticates one retained chat-lifecycle handoff, proves live Lease inventory, and brokers one bounded Analysis MCP session |
-| `cloud-lease-release.yml` | `Safety Automation - Release Cloud Leases` | Releases one exact Lease and runs the protected 15-minute expired/cleanup-pending repository sweep |
+| `cloud-lease-release.yml` | `Safety Automation - Release Cloud Leases` | While armed, releases one exact Lease and runs the protected 15-minute expired/cleanup-pending repository sweep |
 | `cloud-deployment-bundle.yml` | `Agent Tool - Build Cloud Deployment Bundle` | Builds and seals one procurement-independent offline Ubuntu four-host payload |
 | `cloud-deployment-activate.yml` | `Agent Tool - Activate Cloud Deployment` | Installs and gates one exact offline bundle on an active four-host Lease |
 | `cloud-sim-provision.yml` | `Agent Tool - Provision Cloud Simulation` | Creates a leased Alibaba Cloud Simulation Run |
@@ -485,6 +485,18 @@ short-lived role. Deployment uses `cloud-deployment`, receives no `id-token`
 permission, and has no Alibaba credential. See
 [`docs/superpowers/runbooks/cloud-lease-identity.md`](../../docs/superpowers/runbooks/cloud-lease-identity.md).
 
+Every paid GitHub Acquire enables the generic Release schedule in a separate
+credential-free job before the Provisioner Environment can run. The direct
+local repair laboratory enables the same backstop before Acquire, then waits
+for any older Release pass to become terminal and seals it enabled again after
+the active Receipt exists. A scheduled provider sweep may disable itself only
+when its typed result proves zero examined, released, pending, and failed
+repository inventory and a separate no-provider-credential job proves every
+protected GitHub Lease producer is terminal. Exact cleanup helpers always
+re-enable the Workflow before dispatch. Consequently an idle repository has no
+15-minute Cloud Lease run, while a new paid Lease cannot depend on a disabled
+cleanup backstop.
+
 ## Cloud Deployment offline bundle
 
 `cloud-deployment-bundle.yml` runs before any Cloud Lease Quote or Acquire and
@@ -637,6 +649,17 @@ it does not commit the whole 12-hour rehearsal Quote.
 second public operator surface. It consumes at most one unspent transition,
 refuses procurement if either stage still has active inventory, reuses the
 exact original bundle, and acquires a completely fresh 96-hour formal Lease.
+The rehearsal finalizer enables this continuation before it can publish a
+formal transition. An always-running disarm job disables future continuation
+triggers only after the complete bounded Artifact inventory contains no
+authenticated unconsumed transition and no protected rehearsal finalizer can
+still publish one. Formal transition discovery shares the 20,000-Artifact
+bound used by handoff discovery. Before formal orchestration can Acquire, the
+continuation enables the formal finalizer; that finalizer disables itself only
+after no authenticated formal handoff lacks zero-inventory proof and no
+protected formal producer remains active. Operator stop re-enables the exact
+formal finalizer before dispatch. These state transitions remove idle formal
+schedules without weakening transition or cleanup recovery.
 Remote `wkbench-formal.service` owns the uninterrupted 72-hour Soak, hour-24
 qualification, at-most-eight-hour aged-data capacity staircase, and 30-minute
 2,000-SEND/s recovery in one `wkbench formal-chain` process with the same

--- a/.github/workflows/chat-lifecycle-formal-finalize.yml
+++ b/.github/workflows/chat-lifecycle-formal-finalize.yml
@@ -496,3 +496,19 @@ jobs:
         if: always()
         shell: bash
         run: rm -f "$RUNNER_TEMP/deployment-key" "$RUNNER_TEMP/wrapping-key"
+
+  disarm:
+    name: Disable idle formal finalizer schedule
+    needs: [discover, finalize]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Prove no formal handoff or producer before disabling future schedules
+        shell: bash
+        run: scripts/chat-lifecycle/formal-workflows-state.sh disable-finalizer-if-idle

--- a/.github/workflows/chat-lifecycle-formal.yml
+++ b/.github/workflows/chat-lifecycle-formal.yml
@@ -165,6 +165,9 @@ jobs:
               exit 1
             }
           done
+      - name: Enable formal finalizer safety schedule before paid orchestration
+        shell: bash
+        run: scripts/chat-lifecycle/formal-workflows-state.sh enable-finalizer
       - name: Materialize, quote, acquire, deploy, and hand off remote formal ownership
         shell: bash
         env:
@@ -274,3 +277,19 @@ jobs:
         if: always()
         shell: bash
         run: rm -f "$RUNNER_TEMP/wrapping.pub" "$RUNNER_TEMP/codex-diagnostic.pub"
+
+  disarm:
+    name: Disable idle formal continuation schedule
+    needs: [discover, orchestrate]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Prove no transition or transition producer before disabling future schedules
+        shell: bash
+        run: scripts/chat-lifecycle/formal-workflows-state.sh disable-starter-if-idle

--- a/.github/workflows/chat-lifecycle-rehearsal-finalize.yml
+++ b/.github/workflows/chat-lifecycle-rehearsal-finalize.yml
@@ -361,6 +361,10 @@ jobs:
             echo 'Rehearsal Release emitted neither zero proof nor cleanup continuation.' >&2
             exit 1
           fi
+      - name: Enable formal continuation before transition publication
+        if: steps.cleanup.outputs.zero == 'true' && env.WK_CHAT_OPERATOR_STOP != 'true' && steps.handoff.outputs.mode == 'run' && ((steps.collect.outputs.ready == 'true' && steps.final_upload.outcome == 'success') || steps.existing.outputs.ready == 'true')
+        shell: bash
+        run: scripts/chat-lifecycle/formal-workflows-state.sh enable-starter
       - name: Seal fresh-formal transition after rehearsal evidence and zero inventory
         id: transition
         if: steps.cleanup.outputs.zero == 'true' && env.WK_CHAT_OPERATOR_STOP != 'true' && steps.handoff.outputs.mode == 'run' && ((steps.collect.outputs.ready == 'true' && steps.final_upload.outcome == 'success') || steps.existing.outputs.ready == 'true')

--- a/.github/workflows/chat-lifecycle-stop.yml
+++ b/.github/workflows/chat-lifecycle-stop.yml
@@ -67,6 +67,8 @@ jobs:
           set -euo pipefail
           scripts/chat-lifecycle/rehearsal-finalizer-state.sh enable || \
             echo 'Rehearsal finalizer enable failed; the exact dispatch below remains the authoritative availability check.' >&2
+          scripts/chat-lifecycle/formal-workflows-state.sh enable-finalizer || \
+            echo 'Formal finalizer enable failed; the exact dispatch below remains the authoritative availability check.' >&2
           dispatch_failed=false
           for workflow in chat-lifecycle-rehearsal-finalize.yml chat-lifecycle-formal-finalize.yml; do
             gh workflow run "$workflow" --repo "$GITHUB_REPOSITORY" --ref main \

--- a/.github/workflows/cloud-lease-provision.yml
+++ b/.github/workflows/cloud-lease-provision.yml
@@ -42,9 +42,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  arm_release:
+    name: Arm generic cleanup before paid Acquire
+    if: github.ref == 'refs/heads/main' && inputs.quote_only == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Enable the independent generic release backstop
+        shell: bash
+        run: scripts/chat-lifecycle/cloud-lease-release-state.sh enable
+
   provision:
     name: Quote and optionally acquire one exact Lease
-    if: github.ref == 'refs/heads/main'
+    needs: arm_release
+    if: always() && github.ref == 'refs/heads/main' && (inputs.quote_only == true || needs.arm_release.result == 'success')
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     environment: cloud-lease-provision

--- a/.github/workflows/cloud-lease-release.yml
+++ b/.github/workflows/cloud-lease-release.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     environment: cloud-lease-release
+    outputs:
+      global_idle: ${{ steps.release_result.outputs.global_idle }}
     env:
       GOWORK: "off"
       REQUEST_ID: ${{ github.event_name == 'schedule' && format('scheduled-sweep-{0}', github.run_id) || inputs.request_id }}
@@ -92,6 +94,7 @@ jobs:
           audience: ${{ vars.ALIBABA_CLOUD_LEASE_OIDC_AUDIENCE }}
           role-session-name: wukongim-cloud-lease-release-${{ github.run_id }}
       - name: Release and retain residual evidence
+        id: release_result
         shell: bash
         env:
           WK_ALIBABA_LIFECYCLE_MUTATION_AUTHORIZATION: create-and-delete-paid-cloud-lease
@@ -103,6 +106,18 @@ jobs:
             "$RUNNER_TEMP/wkcloudlease" sweep --provider alibaba --region cn-hangzhou --repository "$GITHUB_REPOSITORY" >"$RUNNER_TEMP/release.json"
           fi
           chmod 0600 "$RUNNER_TEMP/release.json"
+          global_idle=false
+          if [[ "$OPERATION" == sweep ]] && jq -e '
+            .schema == "wukongim.cloud_lease.sweep/v1" and
+            .result.examined == 0 and
+            (.result.revoked_access | type == "array" and length == 0) and
+            (.result.released | type == "array" and length == 0) and
+            (.result.pending | type == "array" and length == 0) and
+            (.result.failed | type == "array" and length == 0)
+          ' "$RUNNER_TEMP/release.json" >/dev/null; then
+            global_idle=true
+          fi
+          echo "global_idle=$global_idle" >>"$GITHUB_OUTPUT"
       - name: Upload release or residual proof
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -111,3 +126,22 @@ jobs:
           path: ${{ runner.temp }}/release.json
           if-no-files-found: warn
           retention-days: 7
+
+  disarm:
+    name: Disable idle generic Cloud Lease sweep
+    needs: release
+    if: always() && needs.release.outputs.global_idle == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Prove every protected producer is idle before disabling future sweeps
+        shell: bash
+        run: scripts/chat-lifecycle/cloud-lease-release-state.sh disable-if-idle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+### 🔧 Improvements / 改进
+
+- Chat Lifecycle 正式演练启动器、正式收尾器和通用 Cloud Lease 回收扫描现在仅在存在 transition、handoff、付费资源生产者或云端库存期间启用；取得完整空闲与零库存证明后会自动停用，并在下一次 transition、停止请求、精确清理或付费 Acquire 前安全恢复。
+
 ### 📚 Documentation / 文档
 
 - 中英文 v3 文档站现由仓库内 GitHub Pages 工作流执行完整静态验收后发布到 `docs.githubim.com`，发布产物与通过验收的 `docs-site/out` 保持一致。

--- a/scripts/chat-lifecycle/cloud-lease-release-state.sh
+++ b/scripts/chat-lifecycle/cloud-lease-release-state.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?required}"
+
+[[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+
+operation="${1:-}"
+release_workflow=cloud-lease-release.yml
+producer_workflows=(cloud-lease-provision.yml chat-lifecycle-rehearsal.yml chat-lifecycle-formal.yml)
+api_attempts=4
+
+temporary="$(mktemp -d)"
+trap 'rm -r "$temporary"' EXIT
+
+github_api() {
+  local method="$1" endpoint="$2" output="$3" attempt status delay
+  for ((attempt = 1; attempt <= api_attempts; attempt++)); do
+    status=0
+    gh api --method "$method" "$endpoint" >"$output" || status=$?
+    if (( status == 0 )); then
+      return 0
+    fi
+    if (( attempt == api_attempts )); then
+      return "$status"
+    fi
+    delay=$((1 << (attempt - 1)))
+    echo "workflow state request failed; retrying attempt $((attempt + 1))/${api_attempts} after ${delay}s" >&2
+    sleep "$delay"
+  done
+}
+
+set_release_state() {
+  local state="$1"
+  github_api PUT \
+    "repos/${GITHUB_REPOSITORY}/actions/workflows/${release_workflow}/${state}" \
+    "$temporary/release-${state}.json"
+}
+
+workflow_is_active() {
+  local workflow="$1" status response
+  for status in queued in_progress waiting requested pending; do
+    response="$temporary/${workflow}-${status}.json"
+    github_api GET \
+      "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs?branch=main&status=${status}&per_page=100" \
+      "$response"
+    jq -e '(.total_count | type == "number") and .total_count <= 100 and
+      (.workflow_runs | type == "array")' "$response" >/dev/null
+    if jq -e --arg repository "$GITHUB_REPOSITORY" --arg status "$status" '
+      any(.workflow_runs[];
+        .repository.full_name == $repository and
+        .head_repository.full_name == $repository and
+        (.event == "schedule" or .event == "workflow_dispatch") and
+        .head_branch == "main" and .status == $status)
+    ' "$response" >/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+release_workflow_is_active() {
+  workflow_is_active "$release_workflow"
+}
+
+enable_release() {
+  set_release_state enable
+  echo 'Generic Cloud Lease release schedule is enabled.'
+}
+
+enable_after_provision() {
+  local deadline
+  enable_release
+  deadline=$(( $(date -u +%s) + 2700 ))
+  while release_workflow_is_active; do
+    [[ "$(date -u +%s)" -lt "$deadline" ]] || {
+      echo 'Timed out waiting for an older generic Cloud Lease release pass before sealing the enabled backstop.' >&2
+      return 1
+    }
+    sleep 5
+  done
+  set_release_state enable
+  echo 'Generic Cloud Lease release schedule is enabled after all older release passes became terminal.'
+}
+
+disable_if_idle() {
+  local workflow
+  for workflow in "${producer_workflows[@]}"; do
+    if workflow_is_active "$workflow"; then
+      echo "Generic Cloud Lease release schedule remains enabled: protected producer ${workflow} is active."
+      return 0
+    fi
+  done
+  set_release_state disable
+  echo 'Generic Cloud Lease release schedule is disabled after provider zero-inventory and producer-idle proof.'
+}
+
+case "$operation" in
+  enable) enable_release ;;
+  enable-after-provision) enable_after_provision ;;
+  disable-if-idle) disable_if_idle ;;
+  *)
+    echo "usage: $0 <enable|enable-after-provision|disable-if-idle>" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/chat-lifecycle/direct-lab.sh
+++ b/scripts/chat-lifecycle/direct-lab.sh
@@ -330,6 +330,17 @@ ensure_control_tools() {
   fi
 }
 
+cloud_release_state_tool() {
+  printf '%s\n' "${WK_CHAT_LAB_CLOUD_RELEASE_STATE:-$(repository_root)/scripts/chat-lifecycle/cloud-lease-release-state.sh}"
+}
+
+set_cloud_release_backstop_state() {
+  local operation="$1" tool
+  tool="$(cloud_release_state_tool)"
+  require_executable "$tool"
+  GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-WuKongIM/WuKongIM}" "$tool" "$operation"
+}
+
 initialize_request_state() {
   local request_id="$1" directory source_sha root
   validate_request_id "$request_id"
@@ -462,6 +473,10 @@ start_request() {
   chmod 0600 "$temporary"
   mv -f -- "$temporary" "$directory/release-selector.json"
 
+  set_cloud_release_backstop_state enable || {
+    finalize_not_acquired "$directory" release_backstop_enable_failed_before_acquire
+    die 'generic Cloud Lease release backstop could not be enabled before paid Acquire'
+  }
   if ! "$cloud" acquire --plan "$directory/lease-plan.json" --quote "$directory/quote.json" \
     --bootstrap-access "$directory/bootstrap-access.json" >"$directory/receipt.json"; then
     jq '.state="cleanup_required" | .failure="acquire_failed"' "$directory/state.json" >"$directory/.state.next.$$"
@@ -473,6 +488,13 @@ start_request() {
     .schema == "wukongim.cloud_lease.receipt/v1" and .receipt.request_id == $request and
     .receipt.state == "active"
   ' "$directory/receipt.json" >/dev/null || die 'Acquire returned no active typed Receipt'
+  if ! set_cloud_release_backstop_state enable-after-provision; then
+    jq '.state="cleanup_required" | .failure="release_backstop_rearm_failed_after_acquire"' \
+      "$directory/state.json" >"$directory/.state.next.$$"
+    chmod 0600 "$directory/.state.next.$$"
+    mv -f -- "$directory/.state.next.$$" "$directory/state.json"
+    die 'generic Cloud Lease release backstop could not be sealed active after paid Acquire'
+  fi
   "$chat" selector --receipt "$directory/receipt.json" >"$directory/receipt-selector.json"
   cmp -s <(jq -S -c .selector "$directory/release-selector.json") \
     <(jq -S -c .selector "$directory/receipt-selector.json") || die 'Receipt selector differs from the pre-Acquire release selector'

--- a/scripts/chat-lifecycle/discover-formal-transitions.sh
+++ b/scripts/chat-lifecycle/discover-formal-transitions.sh
@@ -14,7 +14,7 @@ fi
 temporary="$(mktemp -d)"
 trap 'rm -r "$temporary"' EXIT
 : >"$temporary/pages.json"
-max_pages=50
+max_pages=200
 inventory_complete=false
 for ((page = 1; page <= max_pages; page++)); do
   page_file="$temporary/page-${page}.json"

--- a/scripts/chat-lifecycle/formal-workflows-state.sh
+++ b/scripts/chat-lifecycle/formal-workflows-state.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?required}"
+: "${GITHUB_REPOSITORY:?required}"
+
+[[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+
+operation="${1:-}"
+starter_workflow=chat-lifecycle-formal.yml
+finalizer_workflow=chat-lifecycle-formal-finalize.yml
+transition_producer_workflow=chat-lifecycle-rehearsal-finalize.yml
+formal_producer_workflow=chat-lifecycle-formal.yml
+api_attempts=4
+
+temporary="$(mktemp -d)"
+trap 'rm -r "$temporary"' EXIT
+
+github_api() {
+  local method="$1" endpoint="$2" output="$3" attempt status delay
+  for ((attempt = 1; attempt <= api_attempts; attempt++)); do
+    status=0
+    gh api --method "$method" "$endpoint" >"$output" || status=$?
+    if (( status == 0 )); then
+      return 0
+    fi
+    if (( attempt == api_attempts )); then
+      return "$status"
+    fi
+    delay=$((1 << (attempt - 1)))
+    echo "workflow state request failed; retrying attempt $((attempt + 1))/${api_attempts} after ${delay}s" >&2
+    sleep "$delay"
+  done
+}
+
+set_workflow_state() {
+  local workflow="$1" state="$2"
+  github_api PUT \
+    "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/${state}" \
+    "$temporary/${workflow}-${state}.json"
+}
+
+workflow_is_active() {
+  local workflow="$1" status response
+  for status in queued in_progress waiting requested pending; do
+    response="$temporary/${workflow}-${status}.json"
+    github_api GET \
+      "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs?branch=main&status=${status}&per_page=100" \
+      "$response"
+    jq -e '(.total_count | type == "number") and .total_count <= 100 and
+      (.workflow_runs | type == "array")' "$response" >/dev/null
+    if jq -e --arg repository "$GITHUB_REPOSITORY" --arg status "$status" '
+      any(.workflow_runs[];
+        .repository.full_name == $repository and
+        .head_repository.full_name == $repository and
+        (.event == "schedule" or .event == "workflow_dispatch") and
+        .head_branch == "main" and .status == $status)
+    ' "$response" >/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+enable_starter() {
+  set_workflow_state "$starter_workflow" enable
+  echo 'Formal continuation schedule is enabled.'
+}
+
+enable_finalizer() {
+  set_workflow_state "$finalizer_workflow" enable
+  echo 'Formal finalizer schedule is enabled.'
+}
+
+disable_starter_if_idle() {
+  local matrix="$temporary/formal-transitions.json"
+  scripts/chat-lifecycle/discover-formal-transitions.sh '' "$matrix"
+  if jq -e '.include | length > 0' "$matrix" >/dev/null; then
+    echo 'Formal continuation schedule remains enabled: an authenticated transition is awaiting consumption.'
+    return 0
+  fi
+  if workflow_is_active "$transition_producer_workflow"; then
+    echo 'Formal continuation schedule remains enabled: a protected rehearsal finalizer may still publish a transition.'
+    return 0
+  fi
+  set_workflow_state "$starter_workflow" disable
+  echo 'Formal continuation schedule is disabled after authenticated global idle proof.'
+}
+
+disable_finalizer_if_idle() {
+  local matrix="$temporary/active-formal-handoffs.json"
+  WK_CHAT_STAGE=formal scripts/chat-lifecycle/discover-active-handoffs.sh '' "$matrix"
+  if jq -e '.include | length > 0' "$matrix" >/dev/null; then
+    echo 'Formal finalizer schedule remains enabled: an authenticated handoff still lacks zero-inventory proof.'
+    return 0
+  fi
+  if workflow_is_active "$formal_producer_workflow"; then
+    echo 'Formal finalizer schedule remains enabled: a protected formal producer may still publish a handoff.'
+    return 0
+  fi
+  set_workflow_state "$finalizer_workflow" disable
+  echo 'Formal finalizer schedule is disabled after authenticated global idle proof.'
+}
+
+case "$operation" in
+  enable-starter) enable_starter ;;
+  enable-finalizer) enable_finalizer ;;
+  disable-starter-if-idle) disable_starter_if_idle ;;
+  disable-finalizer-if-idle) disable_finalizer_if_idle ;;
+  *)
+    echo "usage: $0 <enable-starter|enable-finalizer|disable-starter-if-idle|disable-finalizer-if-idle>" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/chat-lifecycle/release-until-zero.sh
+++ b/scripts/chat-lifecycle/release-until-zero.sh
@@ -17,6 +17,8 @@ max_run_id() {
     --limit 50 --json databaseId --jq 'map(.databaseId) | max // 0'
 }
 
+scripts/chat-lifecycle/cloud-lease-release-state.sh enable
+
 for attempt in 1; do
   before="$(max_run_id)"
   gh workflow run cloud-lease-release.yml --repo "$GITHUB_REPOSITORY" --ref main \

--- a/scripts/chat_lifecycle_direct_lab_test.go
+++ b/scripts/chat_lifecycle_direct_lab_test.go
@@ -25,7 +25,6 @@ set -euo pipefail
 : >"$WK_TEST_PROVIDER_MARKER"
 exit 99
 `)
-
 	command := exec.Command("bash", filepath.Join(root, "scripts", "chat-lifecycle", "direct-lab.sh"), "preflight")
 	command.Dir = root
 	command.Env = append(os.Environ(),
@@ -338,12 +337,18 @@ case "$1" in
   *) exit 97 ;;
 esac
 `)
+	releaseState := filepath.Join(directory, "cloud-lease-release-state")
+	writeDirectLabExecutable(t, releaseState, `#!/usr/bin/env bash
+set -euo pipefail
+printf 'release-%s\n' "$1" >>"$WK_TEST_CALL_LOG"
+`)
 
 	command := exec.Command("bash", filepath.Join(root, "scripts", "chat-lifecycle", "direct-lab.sh"), "start", requestID)
 	command.Dir = root
 	command.Env = append(os.Environ(),
 		"WK_CHAT_LAB_STATE_ROOT="+directory,
 		"WK_CHAT_LAB_CLOUD_TOOL="+cloudTool,
+		"WK_CHAT_LAB_CLOUD_RELEASE_STATE="+releaseState,
 		"WK_CHAT_LAB_CHAT_TOOL="+chatTool,
 		"WK_CHAT_LAB_BUNDLE_BUILDER="+bundleBuilder,
 		"WK_CHAT_LAB_PAID_AUTHORIZATION=create-paid-cloud-lease",
@@ -362,7 +367,7 @@ esac
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(calls), "build\nmaterialize\nquote\nselector-from-plan\nacquire\nselector\n"; got != want {
+	if got, want := string(calls), "build\nmaterialize\nquote\nselector-from-plan\nrelease-enable\nacquire\nrelease-enable-after-provision\nselector\n"; got != want {
 		t.Fatalf("operation order = %q, want %q", got, want)
 	}
 	requestDirectory := filepath.Join(directory, requestID)

--- a/scripts/chat_lifecycle_workflows_test.go
+++ b/scripts/chat_lifecycle_workflows_test.go
@@ -661,6 +661,231 @@ esac
 	}
 }
 
+func TestChatLifecycleFormalAndCloudSafetySchedulesArmAndDisarmAtSafeLifecycleEdges(t *testing.T) {
+	rehearsalFinalizer := string(readWorkflow(t, "chat-lifecycle-rehearsal-finalize.yml"))
+	formalArm := strings.Index(rehearsalFinalizer, "scripts/chat-lifecycle/formal-workflows-state.sh enable-starter")
+	transitionProducer := strings.Index(rehearsalFinalizer, "Seal fresh-formal transition after rehearsal evidence and zero inventory")
+	if formalArm < 0 || transitionProducer <= formalArm {
+		t.Fatal("rehearsal finalizer does not arm formal continuation before it can publish a transition")
+	}
+
+	formalStart := string(readWorkflow(t, "chat-lifecycle-formal.yml"))
+	finalizerArm := strings.Index(formalStart, "scripts/chat-lifecycle/formal-workflows-state.sh enable-finalizer")
+	formalAcquire := strings.Index(formalStart, "scripts/chat-lifecycle/stage-orchestrate.sh")
+	if finalizerArm < 0 || formalAcquire <= finalizerArm {
+		t.Fatal("formal continuation does not arm its finalizer before paid orchestration")
+	}
+	for _, required := range []string{
+		"name: Disable idle formal continuation schedule",
+		"needs: [discover, orchestrate]",
+		"scripts/chat-lifecycle/formal-workflows-state.sh disable-starter-if-idle",
+	} {
+		if !strings.Contains(formalStart, required) {
+			t.Fatalf("formal continuation idle disarm contract is missing %q", required)
+		}
+	}
+
+	formalFinalizer := string(readWorkflow(t, "chat-lifecycle-formal-finalize.yml"))
+	for _, required := range []string{
+		"name: Disable idle formal finalizer schedule",
+		"needs: [discover, finalize]",
+		"scripts/chat-lifecycle/formal-workflows-state.sh disable-finalizer-if-idle",
+	} {
+		if !strings.Contains(formalFinalizer, required) {
+			t.Fatalf("formal finalizer idle disarm contract is missing %q", required)
+		}
+	}
+
+	stop := string(readWorkflow(t, "chat-lifecycle-stop.yml"))
+	stopArm := strings.Index(stop, "scripts/chat-lifecycle/formal-workflows-state.sh enable-finalizer")
+	stopDispatch := strings.Index(stop, `gh workflow run "$workflow"`)
+	if stopArm < 0 || stopDispatch <= stopArm {
+		t.Fatal("operator stop does not arm the formal finalizer before exact dispatch")
+	}
+
+	provision := string(readWorkflow(t, "cloud-lease-provision.yml"))
+	for _, required := range []string{
+		"name: Arm generic cleanup before paid Acquire",
+		"permissions:\n      contents: read\n      actions: write",
+		"scripts/chat-lifecycle/cloud-lease-release-state.sh enable",
+		"needs: arm_release",
+	} {
+		if !strings.Contains(provision, required) {
+			t.Fatalf("Cloud Lease provision safety arming is missing %q", required)
+		}
+	}
+
+	release := string(readWorkflow(t, "cloud-lease-release.yml"))
+	for _, required := range []string{
+		"global_idle: ${{ steps.release_result.outputs.global_idle }}",
+		`.schema == "wukongim.cloud_lease.sweep/v1"`,
+		"name: Disable idle generic Cloud Lease sweep",
+		"needs.release.outputs.global_idle == 'true'",
+		"scripts/chat-lifecycle/cloud-lease-release-state.sh disable-if-idle",
+	} {
+		if !strings.Contains(release, required) {
+			t.Fatalf("Cloud Lease idle disarm contract is missing %q", required)
+		}
+	}
+
+	releaseUntilZero := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "release-until-zero.sh"))
+	arm := strings.Index(releaseUntilZero, "cloud-lease-release-state.sh enable")
+	dispatch := strings.Index(releaseUntilZero, "gh workflow run cloud-lease-release.yml")
+	if arm < 0 || dispatch <= arm {
+		t.Fatal("exact cleanup does not re-enable the generic release workflow before dispatch")
+	}
+
+	formalState := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "formal-workflows-state.sh"))
+	for _, required := range []string{
+		"discover-formal-transitions.sh", "discover-active-handoffs.sh",
+		"chat-lifecycle-rehearsal-finalize.yml", "chat-lifecycle-formal.yml",
+		"queued in_progress waiting requested pending", "api_attempts=4",
+	} {
+		if !strings.Contains(formalState, required) {
+			t.Fatalf("formal workflow state gate is missing %q", required)
+		}
+	}
+
+	cloudState := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "cloud-lease-release-state.sh"))
+	for _, required := range []string{
+		"cloud-lease-provision.yml", "chat-lifecycle-rehearsal.yml", "chat-lifecycle-formal.yml",
+		"queued in_progress waiting requested pending", "api_attempts=4",
+	} {
+		if !strings.Contains(cloudState, required) {
+			t.Fatalf("Cloud Lease release state gate is missing %q", required)
+		}
+	}
+}
+
+func TestFormalWorkflowStateLeavesSchedulesArmedWhileAProducerIsActive(t *testing.T) {
+	root := repoRoot(t)
+	directory := t.TempDir()
+	calls := filepath.Join(directory, "calls")
+	fakeGH := filepath.Join(directory, "gh")
+	fake := `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *'/actions/artifacts?'*) printf '%s\n' '{"artifacts":[]}' ;;
+  *'/actions/workflows/'*'/runs?'*)
+    if [[ -n "${FAKE_ACTIVE_WORKFLOW:-}" && "$*" == *"/${FAKE_ACTIVE_WORKFLOW}/runs?"* && "$*" == *'status=in_progress'* ]]; then
+      printf '%s\n' '{"total_count":1,"workflow_runs":[{"repository":{"full_name":"WuKongIM/WuKongIM"},"head_repository":{"full_name":"WuKongIM/WuKongIM"},"event":"schedule","head_branch":"main","status":"in_progress"}]}'
+    else
+      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+    fi
+    ;;
+  *'chat-lifecycle-formal.yml/enable'*) printf '%s\n' enable-starter >>"$FAKE_CALLS" ;;
+  *'chat-lifecycle-formal-finalize.yml/enable'*) printf '%s\n' enable-finalizer >>"$FAKE_CALLS" ;;
+  *'chat-lifecycle-formal.yml/disable'*) printf '%s\n' disable-starter >>"$FAKE_CALLS" ;;
+  *'chat-lifecycle-formal-finalize.yml/disable'*) printf '%s\n' disable-finalizer >>"$FAKE_CALLS" ;;
+  *) echo "unexpected gh call: $*" >&2; exit 2 ;;
+esac
+`
+	if err := os.WriteFile(fakeGH, []byte(fake), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := func(operation, activeWorkflow string) string {
+		t.Helper()
+		if err := os.WriteFile(calls, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		command := exec.Command("bash", filepath.Join(root, "scripts", "chat-lifecycle", "formal-workflows-state.sh"), operation)
+		command.Dir = root
+		command.Env = append(os.Environ(),
+			"PATH="+directory+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GH_TOKEN=test-token", "GITHUB_REPOSITORY=WuKongIM/WuKongIM",
+			"FAKE_CALLS="+calls, "FAKE_ACTIVE_WORKFLOW="+activeWorkflow)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s formal workflow state: %v\n%s", operation, err, output)
+		}
+		return string(output)
+	}
+
+	run("enable-starter", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "enable-starter" {
+		t.Fatalf("starter enable calls = %q", got)
+	}
+	run("enable-finalizer", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "enable-finalizer" {
+		t.Fatalf("finalizer enable calls = %q", got)
+	}
+	activeStarter := run("disable-starter-if-idle", "chat-lifecycle-rehearsal-finalize.yml")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "" || !strings.Contains(activeStarter, "may still publish a transition") {
+		t.Fatalf("active transition producer calls = %q, output = %q", got, activeStarter)
+	}
+	run("disable-starter-if-idle", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "disable-starter" {
+		t.Fatalf("starter idle calls = %q", got)
+	}
+	activeFinalizer := run("disable-finalizer-if-idle", "chat-lifecycle-formal.yml")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "" || !strings.Contains(activeFinalizer, "may still publish a handoff") {
+		t.Fatalf("active formal producer calls = %q, output = %q", got, activeFinalizer)
+	}
+	run("disable-finalizer-if-idle", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "disable-finalizer" {
+		t.Fatalf("finalizer idle calls = %q", got)
+	}
+}
+
+func TestCloudLeaseReleaseStateLeavesScheduleArmedWhileAProducerIsActive(t *testing.T) {
+	root := repoRoot(t)
+	directory := t.TempDir()
+	calls := filepath.Join(directory, "calls")
+	fakeGH := filepath.Join(directory, "gh")
+	fake := `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *'/actions/workflows/'*'/runs?'*)
+    if [[ -n "${FAKE_ACTIVE_WORKFLOW:-}" && "$*" == *"/${FAKE_ACTIVE_WORKFLOW}/runs?"* && "$*" == *'status=in_progress'* ]]; then
+      printf '%s\n' '{"total_count":1,"workflow_runs":[{"repository":{"full_name":"WuKongIM/WuKongIM"},"head_repository":{"full_name":"WuKongIM/WuKongIM"},"event":"workflow_dispatch","head_branch":"main","status":"in_progress"}]}'
+    else
+      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+    fi
+    ;;
+  *'cloud-lease-release.yml/enable'*) printf '%s\n' enable >>"$FAKE_CALLS" ;;
+  *'cloud-lease-release.yml/disable'*) printf '%s\n' disable >>"$FAKE_CALLS" ;;
+  *) echo "unexpected gh call: $*" >&2; exit 2 ;;
+esac
+`
+	if err := os.WriteFile(fakeGH, []byte(fake), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := func(operation, activeWorkflow string) string {
+		t.Helper()
+		if err := os.WriteFile(calls, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		command := exec.Command("bash", filepath.Join(root, "scripts", "chat-lifecycle", "cloud-lease-release-state.sh"), operation)
+		command.Dir = root
+		command.Env = append(os.Environ(),
+			"PATH="+directory+string(os.PathListSeparator)+os.Getenv("PATH"),
+			"GH_TOKEN=test-token", "GITHUB_REPOSITORY=WuKongIM/WuKongIM",
+			"FAKE_CALLS="+calls, "FAKE_ACTIVE_WORKFLOW="+activeWorkflow)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s Cloud Lease release state: %v\n%s", operation, err, output)
+		}
+		return string(output)
+	}
+
+	run("enable", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "enable" {
+		t.Fatalf("enable calls = %q", got)
+	}
+	run("enable-after-provision", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "enable\nenable" {
+		t.Fatalf("post-provision enable calls = %q", got)
+	}
+	active := run("disable-if-idle", "chat-lifecycle-formal.yml")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "" || !strings.Contains(active, "protected producer chat-lifecycle-formal.yml is active") {
+		t.Fatalf("active producer calls = %q, output = %q", got, active)
+	}
+	run("disable-if-idle", "")
+	if got := strings.TrimSpace(readFile(t, calls)); got != "disable" {
+		t.Fatalf("idle disarm calls = %q", got)
+	}
+}
+
 func TestOperatorStopDiscoveryAuthenticatesProducerAndFailsClosedAtInventoryBound(t *testing.T) {
 	root := repoRoot(t)
 	directory := t.TempDir()
@@ -1729,7 +1954,7 @@ func TestChatLifecycleFormalStartMatrixConsumesOnlyUnspentTransition(t *testing.
 	}
 	discovery := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "discover-formal-transitions.sh"))
 	authenticator := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "authenticate-operator-stop-producer.sh"))
-	if !strings.Contains(discovery, "max_pages=50") || !strings.Contains(discovery, "inventory_complete=false") ||
+	if !strings.Contains(discovery, "max_pages=200") || !strings.Contains(discovery, "inventory_complete=false") ||
 		!strings.Contains(discovery, "formal transition discovery exceeded") || strings.Contains(discovery, "--paginate") ||
 		!strings.Contains(discovery, "authenticate-operator-stop-producer.sh") ||
 		!strings.Contains(discovery, "chat-lifecycle-rehearsal-finalize.yml") ||


### PR DESCRIPTION
## Summary

- dynamically arm and disarm the formal continuation and formal finalizer around authenticated lifecycle state
- dynamically arm the generic Cloud Lease release sweep before paid Acquire and disable it only after provider zero-inventory plus producer-idle proof
- widen formal transition discovery to the existing 20,000-Artifact bound and cover GitHub/local Acquire edges with regression tests

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/*.yml`
- `git diff --check`

## Changelog

Operator-visible scheduling behavior is recorded under `Unreleased`.