### PR TITLE
ci: retry formal artifact discovery

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -654,7 +654,8 @@ formal transition. An always-running disarm job disables future continuation
 triggers only after the complete bounded Artifact inventory contains no
 authenticated unconsumed transition and no protected rehearsal finalizer can
 still publish one. Formal transition discovery shares the 20,000-Artifact
-bound used by handoff discovery. Before formal orchestration can Acquire, the
+bound and four-attempt per-page retry used by handoff discovery. Before formal
+orchestration can Acquire, the
 continuation enables the formal finalizer; that finalizer disables itself only
 after no authenticated formal handoff lacks zero-inventory proof and no
 protected formal producer remains active. Operator stop re-enables the exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ move those entries into a version section named for that exact tag.
 
 ### 🔧 Improvements / 改进
 
-- Chat Lifecycle 正式演练启动器、正式收尾器和通用 Cloud Lease 回收扫描现在仅在存在 transition、handoff、付费资源生产者或云端库存期间启用；取得完整空闲与零库存证明后会自动停用，并在下一次 transition、停止请求、精确清理或付费 Acquire 前安全恢复。
+- Chat Lifecycle 正式演练启动器、正式收尾器和通用 Cloud Lease 回收扫描现在仅在存在 transition、handoff、付费资源生产者或云端库存期间启用；取得完整空闲与零库存证明后会自动停用，并在下一次 transition、停止请求、精确清理或付费 Acquire 前安全恢复；完整 Artifact 盘点会重试短暂的 GitHub API 分页错误。
 
 ### 📚 Documentation / 文档
 

--- a/scripts/chat-lifecycle/discover-formal-transitions.sh
+++ b/scripts/chat-lifecycle/discover-formal-transitions.sh
@@ -15,10 +15,29 @@ temporary="$(mktemp -d)"
 trap 'rm -r "$temporary"' EXIT
 : >"$temporary/pages.json"
 max_pages=200
+artifact_api_attempts=4
 inventory_complete=false
+
+fetch_artifact_page() {
+  local endpoint="$1" output="$2" attempt status delay
+  for ((attempt = 1; attempt <= artifact_api_attempts; attempt++)); do
+    status=0
+    gh api "$endpoint" >"$output" || status=$?
+    if (( status == 0 )); then
+      return 0
+    fi
+    if (( attempt == artifact_api_attempts )); then
+      return "$status"
+    fi
+    delay=$((1 << (attempt - 1)))
+    echo "artifact inventory request failed; retrying attempt $((attempt + 1))/${artifact_api_attempts} after ${delay}s" >&2
+    sleep "$delay"
+  done
+}
+
 for ((page = 1; page <= max_pages; page++)); do
   page_file="$temporary/page-${page}.json"
-  gh api "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100&page=${page}" >"$page_file"
+  fetch_artifact_page "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100&page=${page}" "$page_file"
   jq -c . "$page_file" >>"$temporary/pages.json"
   if [[ "$(jq -r '.artifacts | length' "$page_file")" != 100 ]]; then
     inventory_complete=true

--- a/scripts/chat_lifecycle_workflows_test.go
+++ b/scripts/chat_lifecycle_workflows_test.go
@@ -1954,12 +1954,66 @@ func TestChatLifecycleFormalStartMatrixConsumesOnlyUnspentTransition(t *testing.
 	}
 	discovery := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "discover-formal-transitions.sh"))
 	authenticator := readFile(t, filepath.Join(repoRoot(t), "scripts", "chat-lifecycle", "authenticate-operator-stop-producer.sh"))
-	if !strings.Contains(discovery, "max_pages=200") || !strings.Contains(discovery, "inventory_complete=false") ||
+	if !strings.Contains(discovery, "max_pages=200") || !strings.Contains(discovery, "artifact_api_attempts=4") ||
+		!strings.Contains(discovery, "fetch_artifact_page") || !strings.Contains(discovery, "inventory_complete=false") ||
 		!strings.Contains(discovery, "formal transition discovery exceeded") || strings.Contains(discovery, "--paginate") ||
 		!strings.Contains(discovery, "authenticate-operator-stop-producer.sh") ||
 		!strings.Contains(discovery, "chat-lifecycle-rehearsal-finalize.yml") ||
 		!strings.Contains(authenticator, "chat-lifecycle-stop.yml") {
 		t.Fatal("formal transition discovery is not bounded and producer-authenticated")
+	}
+}
+
+func TestFormalTransitionDiscoveryRetriesTransientArtifactInventoryFailure(t *testing.T) {
+	root := repoRoot(t)
+	directory := t.TempDir()
+	bin := filepath.Join(directory, "bin")
+	if err := os.Mkdir(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	attemptsPath := filepath.Join(directory, "attempts")
+	if err := os.WriteFile(attemptsPath, []byte("0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gh := `#!/bin/sh
+attempts="$(cat "$FAKE_ATTEMPTS")"
+attempts=$((attempts + 1))
+printf '%s\n' "$attempts" >"$FAKE_ATTEMPTS"
+if [ "$attempts" -lt 3 ]; then
+  printf '%s\n' 'unexpected EOF' >&2
+  exit 1
+fi
+printf '%s\n' '{"artifacts":[]}'
+`
+	for name, content := range map[string]string{
+		"gh":    gh,
+		"sleep": "#!/bin/sh\nexit 0\n",
+	} {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte(content), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	output := filepath.Join(directory, "matrix.json")
+	command := exec.Command("bash", filepath.Join(root, "scripts", "chat-lifecycle", "discover-formal-transitions.sh"), "", output)
+	command.Dir = root
+	command.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"), "FAKE_ATTEMPTS="+attemptsPath,
+		"GH_TOKEN=test-token", "GITHUB_REPOSITORY=WuKongIM/WuKongIM")
+	combined, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("transient formal Artifact inventory failure was not retried: %v\n%s", err, combined)
+	}
+	if attempts := strings.TrimSpace(readFile(t, attemptsPath)); attempts != "3" {
+		t.Fatalf("formal Artifact inventory attempts = %s, want 3", attempts)
+	}
+	var matrix struct {
+		Include []json.RawMessage `json:"include"`
+	}
+	if err := json.Unmarshal([]byte(readFile(t, output)), &matrix); err != nil {
+		t.Fatal(err)
+	}
+	if len(matrix.Include) != 0 {
+		t.Fatalf("formal transition matrix = %#v, want empty", matrix.Include)
 	}
 }
 


### PR DESCRIPTION
## Summary

- retry each formal transition Artifact inventory page up to four times with bounded exponential backoff
- preserve the existing 20,000-Artifact fail-closed inventory bound
- add a regression for transient `unexpected EOF` recovery

## Validation

- `GOWORK=off go test ./scripts/... -count=1`
- focused transient retry and inventory-bound tests
- `git diff --check`

## Changelog

The existing `Unreleased` scheduling entry now records transient pagination recovery.