### PR TITLE
Harden binary release provenance identity

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -149,9 +149,14 @@ failure, a digest mismatch, or a missing platform fails the complete release.
 `binary-release-publish.yml` publishes downloadable WuKongIM executables from
 the same strict SemVer `v*` source identity used by the container publisher. A
 new tag starts the workflow automatically; the manual `version` input accepts
-one existing tag for first publication or incomplete-draft recovery. The tag
-must resolve to a commit reachable from `origin/main` and may not contain
-SemVer build metadata.
+one existing tag for first publication or incomplete-draft recovery. A manual
+run must itself be dispatched from that exact tag, for example
+`gh workflow run binary-release-publish.yml --repo WuKongIM/WuKongIM --ref "$tag" -f version="$tag"`;
+a run dispatched from `main` fails before building because GitHub provenance
+inherits the run ref and Workflow commit. The tag must contain this Workflow,
+resolve to a commit reachable from `origin/main`, and may not contain SemVer
+build metadata. A historical tag without the Workflow needs a new SemVer tag
+rather than provenance synthesized from current `main`.
 
 Each run builds deterministic `.tar.gz` archives for `linux/amd64`,
 `linux/arm64`, `darwin/amd64`, and `darwin/arm64`. Windows is not advertised
@@ -209,11 +214,12 @@ facts. It never falls back to GitHub-generated notes, a commit log, or an empty
 body. Every discovered, created, pre-publication, and published numeric Release
 ID must carry the exact rendered body.
 
-For manual recovery of a tag created before the release-note extractor was
-added, the Workflow fetches that extractor from the exact
-`github.workflow_sha` commit while continuing to read `CHANGELOG.md` and every
-release artifact from the immutable tag. Automatic tag publication fails if
-the tagged source itself omits the extractor.
+For manual recovery, the release-note extractor may come only from the exact
+`github.workflow_sha` commit, which the identity gate requires to resolve to
+the tagged source. It can never be borrowed from current `main`. A historical
+tag missing either this Workflow or the extractor needs a new SemVer tag;
+automatic tag publication likewise fails when the tagged source omits the
+extractor.
 
 The binary publisher waits for a successful Docker publisher run for the same
 tag, then verifies that GHCR, Docker Hub, and Alibaba Cloud expose one identical
@@ -225,12 +231,12 @@ incremental from the previous pre-release in the same version line; stable
 entries summarize user-visible changes since the previous stable release.
 
 Repository administrators must configure a `binary-publish` Environment,
-allow protected `main` for manual recovery and trusted version tags for
-automatic publication, and avoid a reviewer gate for tag-triggered runs. The
-workflow uses only its job-scoped `GITHUB_TOKEN`; it requires no standing
-release credential. Until those Environment deployment restrictions have been
-configured and verified remotely, administrators must not push a release tag
-or manually dispatch this workflow.
+allow only trusted version tags for both automatic publication and manual
+recovery, and avoid a reviewer gate for tag-triggered runs. The workflow uses
+only its job-scoped `GITHUB_TOKEN`; it requires no standing release credential.
+Until those Environment deployment restrictions have been configured and
+verified remotely, administrators must not push a release tag or manually
+dispatch this workflow.
 
 Immediately before pushing a release tag or starting manual recovery, an
 administrator must also verify that repository-level immutable Releases remain

--- a/.github/workflows/binary-release-publish.yml
+++ b/.github/workflows/binary-release-publish.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Existing SemVer tag to publish or recover, for example v3.1.0 or v3.2.0-rc.1
+        description: Existing SemVer tag; dispatch with --ref set to this same tag
         required: true
         type: string
 
@@ -46,6 +46,8 @@ jobs:
       - name: Validate release identity and tag policy
         id: identity
         shell: bash
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           export LC_ALL=C
@@ -106,10 +108,21 @@ jobs:
           }
           source_sha="$(git rev-parse HEAD)"
           test "$(git rev-parse "refs/tags/$version^{commit}")" = "$source_sha"
-          if [[ "$GITHUB_EVENT_NAME" == push ]]; then
-            test "$GITHUB_REF" = "refs/tags/$version"
-            test "$(git rev-parse "$GITHUB_SHA^{commit}")" = "$source_sha"
-          fi
+          expected_ref="refs/tags/$version"
+          test "$GITHUB_REF" = "$expected_ref" || {
+            echo "release workflow must run from exact tag ref $expected_ref" >&2
+            echo "manual recovery: gh workflow run binary-release-publish.yml --repo WuKongIM/WuKongIM --ref $version -f version=$version" >&2
+            exit 1
+          }
+          test "$(git rev-parse "$GITHUB_SHA^{commit}")" = "$source_sha" || {
+            echo "workflow event SHA does not resolve to release source" >&2
+            exit 1
+          }
+          [[ "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse "$WORKFLOW_SHA^{commit}")" = "$source_sha" || {
+            echo "workflow definition SHA does not resolve to release source" >&2
+            exit 1
+          }
           git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
           git merge-base --is-ancestor "$source_sha" origin/main || {
             echo "release source must be reachable from origin/main" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ move those entries into a version section named for that exact tag.
 
 - Chat Lifecycle 正式演练启动器、正式收尾器和通用 Cloud Lease 回收扫描现在仅在存在 transition、handoff、付费资源生产者或云端库存期间启用；取得完整空闲与零库存证明后会自动停用，并在下一次 transition、停止请求、精确清理或付费 Acquire 前安全恢复；完整 Artifact 盘点会重试短暂的 GitHub API 分页错误。
 
+### 🔒 Security / 安全
+
+- 二进制发布的手动恢复现在必须从目标版本的精确 tag ref 启动，并同时绑定事件提交与 Workflow 提交；从 `main` 为其他 tag 生成无法被软件源信任的 provenance 会在构建前失败。
+
 ### 📚 Documentation / 文档
 
 - 中英文 v3 文档站现由仓库内 GitHub Pages 工作流执行完整静态验收后发布到 `docs.githubim.com`，发布产物与通过验收的 `docs-site/out` 保持一致。

--- a/scripts/binary_release_workflow_test.go
+++ b/scripts/binary_release_workflow_test.go
@@ -35,6 +35,7 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 				If   string            `yaml:"if"`
 				Uses string            `yaml:"uses"`
 				Run  string            `yaml:"run"`
+				Env  map[string]string `yaml:"env"`
 				With map[string]string `yaml:"with"`
 			} `yaml:"steps"`
 		} `yaml:"jobs"`
@@ -177,6 +178,7 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 	stepRuns := make(map[string]string, len(publish.Steps))
 	stepUses := make(map[string]string, len(publish.Steps))
 	stepIfs := make(map[string]string, len(publish.Steps))
+	stepEnvs := make(map[string]map[string]string, len(publish.Steps))
 	stepWith := make(map[string]map[string]string, len(publish.Steps))
 	var packageBuildStep struct {
 		If   string
@@ -187,6 +189,7 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		stepRuns[step.Name] = step.Run
 		stepUses[step.Name] = step.Uses
 		stepIfs[step.Name] = step.If
+		stepEnvs[step.Name] = step.Env
 		stepWith[step.Name] = step.With
 		if step.Name == "Build unsigned amd64 native packages" {
 			packageBuildStep.If = step.If
@@ -201,6 +204,25 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 		"version":      "v2.18.0",
 		"args":         "release --clean --config .goreleaser.packages.yaml",
 	}, packageBuildStep.With)
+
+	identityRun := stepRuns["Validate release identity and tag policy"]
+	require.Equal(t, "${{ github.workflow_sha }}", stepEnvs["Validate release identity and tag policy"]["WORKFLOW_SHA"])
+	require.Contains(t, identityRun, `expected_ref="refs/tags/$version"`)
+	require.Contains(t, identityRun, `test "$GITHUB_REF" = "$expected_ref"`)
+	require.Contains(t, identityRun, `git rev-parse "$GITHUB_SHA^{commit}"`)
+	require.Contains(t, identityRun, `git rev-parse "$WORKFLOW_SHA^{commit}"`)
+	require.Contains(t, identityRun, "gh workflow run binary-release-publish.yml --repo WuKongIM/WuKongIM --ref $version -f version=$version")
+	require.NotContains(t, identityRun, "GITHUB_EVENT_NAME")
+	tagPeel := strings.Index(identityRun, `refs/tags/$version^{commit}`)
+	runRefFence := strings.Index(identityRun, `test "$GITHUB_REF" = "$expected_ref"`)
+	runSHAFence := strings.Index(identityRun, `git rev-parse "$GITHUB_SHA^{commit}"`)
+	workflowSHAFence := strings.Index(identityRun, `git rev-parse "$WORKFLOW_SHA^{commit}"`)
+	mainFetch := strings.Index(identityRun, "git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'")
+	require.GreaterOrEqual(t, tagPeel, 0)
+	require.Greater(t, runRefFence, tagPeel)
+	require.Greater(t, runSHAFence, runRefFence)
+	require.Greater(t, workflowSHAFence, runSHAFence)
+	require.Greater(t, mainFetch, workflowSHAFence)
 
 	finalizeRun := stepRuns["Finalize exact release asset set and checksums"]
 	require.Contains(t, finalizeRun, "find \"$RELEASE_DIR\" -maxdepth 1 -type f")


### PR DESCRIPTION
## Summary
- require manual binary recovery to run from the exact release tag ref
- bind tag, event SHA, and workflow SHA to one release source commit before build
- document tag-only binary-publish Environment policy and historical-tag boundary
- add workflow contract coverage and an Unreleased security note

## Validation
- GOWORK=off go test ./scripts -count=1
- GOWORK=off go test ./cmd/wukongim -count=1
- awk release-note extraction for v3.0.0-beta.6
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/binary-release-publish.yml
- git diff --check

No release workflow, product tag, or Release was created or dispatched.