### PR TITLE
docs: publish signed Linux package installation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -110,16 +110,17 @@ the operator-owned configuration and data remain byte-identical. Only the
 unsigned preview packages and checksums are retained as Actions artifacts for
 14 days; this workflow still publishes no APT/YUM repository.
 
-The separate public `WuKongIM/packages` repository owns the fail-closed GitHub
-Pages bootstrap at the verified HTTPS endpoint `packages.githubim.com`; it
-currently publishes only a `signing_not_provisioned` status and no package
-indexes. Both repositories enforce immutable Releases, and the custom-domain
-DNS and certificate are provisioned. Reviewed public fingerprints, signing
-custody, cross-repository dispatch, and the production publisher remain
-intentionally outside this credential-free workflow. Exact unsigned source
-package assets are supplied by the tag-bound binary Release described below,
-but they must not enter package indexes until the remaining production controls
-are provisioned and reviewed.
+The separate public `WuKongIM/packages` repository owns the signed Preview
+channel at the verified HTTPS endpoint `packages.githubim.com`. Its production
+publisher independently verifies one immutable tag-bound source Release,
+applies separate protected APT and RPM signatures, seals the complete snapshot
+and receipt in an immutable audit Release, and only then deploys the `preview`
+APT suite and EL9 RPM repository to GitHub Pages. Every deployed snapshot is
+download-validated on clean Ubuntu, Debian, Rocky Linux, and AlmaLinux clients.
+Both repositories enforce immutable Releases, and the custom-domain DNS and
+certificate are provisioned. Exact unsigned source package assets still come
+only from the tag-bound binary Release described below; this credential-free
+source workflow never receives production signing or package-publisher access.
 
 ## Docker image publishing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Linux 服务端部署文档现提供 `v3.0.0-beta.6` 签名 Preview 软件源的 APT 与 DNF/YUM 安装流程，并在写入专用 keyring 前固定核对仓库主密钥指纹。
 - 中英文 v3 文档站现由仓库内 GitHub Pages 工作流执行完整静态验收后发布到 `docs.githubim.com`，发布产物与通过验收的 `docs-site/out` 保持一致。
 - WuKongEasySDK 中英文文档现固定 Web `2.0.4`、Android `1.0.5`、iOS `1.1.1` 与 Flutter `1.1.0` 正式包，并补充四端 example 与正式包的独立验收回执及可复现流程。
 - Docker 服务端部署现在提供一键安装脚本，只需一条命令即可生成随机凭据、创建持久卷、启动固定摘要镜像并等待单节点集群就绪；未指定版本时自动选择最新 GitHub tag，也可通过 `WK_VERSION` 指定版本，中英文主流程均保持两步。

--- a/docs-site/NAVIGATION.md
+++ b/docs-site/NAVIGATION.md
@@ -47,7 +47,7 @@ Route: `/{lang}/server`
 
 - **部署 / Deployment** `/{lang}/server/deployment` — 选择并实施适合环境的服务端部署方式。 / Choose and implement the server deployment method appropriate for the environment.
   - **Docker 部署 / Docker** `/{lang}/server/deployment/docker` — 构建固定镜像，并用显式配置和持久卷运行节点。 / Builds an immutable image and runs a node with explicit configuration and persistent storage.
-  - **Linux 部署 / Linux** `/{lang}/server/deployment/linux` — 使用二进制、配置文件和 systemd 运行服务。 / Runs the server with a binary, configuration file, and systemd.
+  - **Linux 部署 / Linux** `/{lang}/server/deployment/linux` — 从签名 APT/DNF Preview 软件源安装，并用安全配置和 systemd 运行服务。 / Installs from the signed APT/DNF preview repository and runs the service with secure configuration and systemd.
   - **多节点集群 / Multi-node Cluster** `/{lang}/server/deployment/multi-node` — 规划成员、副本、故障域并验证集群就绪。 / Plans membership, replicas, failure domains, and cluster readiness.
   - **Kubernetes 部署（Beta） / Kubernetes (Beta)** `/{lang}/server/deployment/kubernetes` — 按最短路径适配并验证有状态集群部署。 / Adapts and verifies a stateful cluster deployment through the shortest path.
   - **Kubernetes 资源参考（Beta） / Kubernetes Resource Reference (Beta)** `/{lang}/server/deployment/kubernetes-resources` — 提供 StatefulSet、Service、PVC、探针和 PDB 参考片段。 / Provides StatefulSet, Service, PVC, probe, and PDB reference fragments.

--- a/docs-site/content/docs/server/deployment/linux.en.mdx
+++ b/docs-site/content/docs/server/deployment/linux.en.mdx
@@ -1,44 +1,111 @@
 ---
 title: Linux
-description: Install WuKongIM from deb/rpm previews or source, initialize it safely, and supervise a cluster node with systemd.
+description: Install WuKongIM from the signed APT/DNF preview repository or local deb/rpm packages, initialize it safely, and supervise a cluster node with systemd.
 ---
 
-The Linux path fits teams that want direct control over hosts, filesystems, networking, and service lifecycle. The repository can now build deb/rpm preview packages, and the separate `WuKongIM/packages` repository has a fail-closed bootstrap at the verified HTTPS endpoint `packages.githubim.com`. Signing keys and APT/YUM indexes are not enabled yet, however, so that endpoint cannot be used for installation. Do not treat these local previews as a signed production distribution channel.
+The signed WuKongIM Linux preview repository is now available. It currently publishes `v3.0.0-beta.6` for amd64/x86_64 only. The publication pipeline has verified repository metadata, signatures, and exact-version downloads in fresh Ubuntu 24.04, Debian 13, Rocky Linux 9, and AlmaLinux 9 containers. RHEL 9 is a compatible target for the same EL9 repository, but is not part of this automated clean-client matrix.
 
-The first preview targets Linux amd64 and runs installation contract checks on Ubuntu 24.04, Debian 12, Rocky Linux 9, and AlmaLinux 9.
+Preview is a prerelease channel, not the stable channel. Validate configuration, backup, recovery, and upgrade compatibility outside production first.
 
-## 1. Build and install a local preview package
+## 1. Install from the signed preview repository
 
-The repository requires Go `1.25.11`; the package configuration is validated with GoReleaser `v2.18.0`:
+### Debian / Ubuntu (APT)
 
-```bash
-git rev-parse HEAD
-go version
-goreleaser release --snapshot --clean \
-  --config .goreleaser.packages.yaml
-(cd dist && sha256sum --check checksums.txt)
-```
-
-Install the generated `.deb` on Debian or Ubuntu:
+These commands keep the repository certificate in a dedicated keyring and verify its primary fingerprint before installing it. They do not add global trust or bypass signature checks:
 
 ```bash
-sudo apt install ./dist/wukongim_*_linux_amd64.deb
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gpg
+
+apt_key="$(mktemp)"
+trap 'rm -f "$apt_key"' EXIT
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+  --output "$apt_key" \
+  https://packages.githubim.com/keys/apt-preview.asc
+
+apt_fingerprints="$(
+  gpg --batch --show-keys --with-colons "$apt_key" |
+    awk -F: '
+      $1 == "pub" { primary = 1; next }
+      primary && $1 == "fpr" { print $10; primary = 0 }
+    '
+)"
+test "$apt_fingerprints" = 'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1'
+
+sudo install -d -m 0755 /etc/apt/keyrings
+sudo install -o root -g root -m 0644 "$apt_key" /etc/apt/keyrings/wukongim-preview.asc
+rm -f "$apt_key"
+trap - EXIT
+
+printf '%s\n' \
+  'deb [arch=amd64 signed-by=/etc/apt/keyrings/wukongim-preview.asc] https://packages.githubim.com/apt preview main' |
+  sudo tee /etc/apt/sources.list.d/wukongim-preview.list >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y wukongim=3.0.0~beta.6
 ```
 
-Install the generated `.rpm` on Rocky or AlmaLinux:
+### RHEL / Rocky / AlmaLinux 9 (DNF/YUM)
+
+Use this dedicated repository configuration on EL9 to verify both package signatures and repository metadata signatures. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum` in every command:
 
 ```bash
-sudo dnf install ./dist/wukongim_*_linux_amd64.rpm
+set -euo pipefail
+
+sudo dnf install -y ca-certificates gnupg2
+if ! command -v curl >/dev/null; then
+  sudo dnf install -y curl-minimal
+fi
+
+rpm_key="$(mktemp)"
+trap 'rm -f "$rpm_key"' EXIT
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+  --output "$rpm_key" \
+  https://packages.githubim.com/keys/rpm-preview.asc
+
+rpm_fingerprints="$(
+  gpg --batch --show-keys --with-colons "$rpm_key" |
+    awk -F: '
+      $1 == "pub" { primary = 1; next }
+      primary && $1 == "fpr" { print $10; primary = 0 }
+    '
+)"
+test "$rpm_fingerprints" = 'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459'
+
+sudo install -d -m 0755 /etc/pki/rpm-gpg
+sudo install -o root -g root -m 0644 "$rpm_key" /etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
+rm -f "$rpm_key"
+trap - EXIT
+
+sudo tee /etc/yum.repos.d/wukongim-preview.repo >/dev/null <<'EOF'
+[wukongim-preview]
+name=WuKongIM preview
+baseurl=https://packages.githubim.com/rpm/preview/el/9/x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
+sslverify=1
+metadata_expire=300
+skip_if_unavailable=0
+EOF
+
+sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
+sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64
 ```
 
-The package installs `/usr/bin/wukongim` and a hardened `wukongim.service`, then creates the `wukongim` system account and `/etc/wukongim`, `/var/lib/wukongim`, `/var/log/wukongim`, and `/run/wukongim`. It does not create an active configuration, enable or start the service, or restart it.
-
-Confirm the binary identity:
+Confirm the binary identity after installation. The version should be `3.0.0-beta.6`; `source` in the text output and `build_source` in JSON should be `release`:
 
 ```bash
 wukongim version
 wukongim version --output json
 ```
+
+The package installs `/usr/bin/wukongim` and a hardened `wukongim.service`, then creates the `wukongim` system account and `/etc/wukongim`, `/var/lib/wukongim`, `/var/log/wukongim`, and `/run/wukongim`. It does not create an active configuration, enable or start the service, or restart it.
+
+The repository does not yet ship a separate keyring package, so repository certificates are not refreshed automatically. Before an announced signing-subkey promotion, download the applicable certificate again and recheck the primary fingerprint above. Never disable package or repository-metadata signature verification.
 
 ## 2. Initialize a secure configuration
 
@@ -91,9 +158,35 @@ Also verify persistent mounts, directory ownership, and advertised addresses fro
 
 Before an upgrade, validate the target commit, artifact, configuration, backup, and recovery path outside production. Roll one node at a time only when the target release explicitly supports mixed operation with the current version; otherwise use a full maintenance window. See [Upgrade & Migration](/en/server/operations/upgrade-and-migration) for the complete boundary.
 
+## Build a local preview package
+
+To audit package contents or test unpublished code, build a local package from a fixed commit. The repository requires Go `1.25.11`; the package configuration is validated with GoReleaser `v2.18.0`:
+
+```bash
+git rev-parse HEAD
+go version
+goreleaser release --snapshot --clean \
+  --config .goreleaser.packages.yaml
+(cd dist && sha256sum --check checksums.txt)
+```
+
+Install the generated `.deb` on Debian or Ubuntu:
+
+```bash
+sudo apt install ./dist/wukongim_*_linux_amd64.deb
+```
+
+Install the generated `.rpm` on Rocky or AlmaLinux:
+
+```bash
+sudo dnf install ./dist/wukongim_*_linux_amd64.rpm
+```
+
+A local snapshot does not carry the public preview repository's signatures or immutable publication audit and must not be presented as a public-channel artifact.
+
 ## Install from source
 
-Until the public repository is enabled, you can also build the binary directly:
+If a source deployment is genuinely required, build the binary from a fixed commit:
 
 ```bash
 GOWORK=off go build -trimpath -o ./bin/wukongim ./cmd/wukongim

--- a/docs-site/content/docs/server/deployment/linux.mdx
+++ b/docs-site/content/docs/server/deployment/linux.mdx
@@ -1,44 +1,111 @@
 ---
 title: Linux 部署
-description: 用 deb/rpm 预览包或源码安装 WuKongIM，并通过安全初始化和 systemd 托管集群节点。
+description: 从签名 APT/DNF Preview 软件源或本地 deb/rpm 安装 WuKongIM，并通过安全初始化和 systemd 托管集群节点。
 ---
 
-Linux 路径适合希望直接控制主机、文件系统、网络和服务生命周期的团队。仓库现在能够构建 deb/rpm 预览包，独立的 `WuKongIM/packages` 仓库也已在完成验证的 HTTPS 地址 `packages.githubim.com` 建立 fail-closed bootstrap；但签名密钥和 APT/YUM 索引尚未启用，因此该地址还不能用于安装。不要把下面的本地预览包当作已签名的正式发布渠道。
+WuKongIM 的签名 Linux Preview 软件源已经启用，当前发布 `v3.0.0-beta.6`，仅支持 amd64/x86_64。发布流程已在 Ubuntu 24.04、Debian 13、Rocky Linux 9 和 AlmaLinux 9 的全新容器中验证软件源元数据、签名和精确版本下载；RHEL 9 是同一 EL9 软件源的兼容目标，但不在本次自动化清洁客户端矩阵中。
 
-首批预览支持 Linux amd64，并在 Ubuntu 24.04、Debian 12、Rocky Linux 9 和 AlmaLinux 9 上执行安装契约检查。
+Preview 是预发布通道，不等同于稳定通道。请先在非生产环境验证配置、备份、恢复和升级兼容性。
 
-## 1. 构建并安装本地预览包
+## 1. 从签名 Preview 软件源安装
 
-仓库要求 Go `1.25.11`，打包配置固定按 GoReleaser `v2.18.0` 校验：
+### Debian / Ubuntu（APT）
 
-```bash
-git rev-parse HEAD
-go version
-goreleaser release --snapshot --clean \
-  --config .goreleaser.packages.yaml
-(cd dist && sha256sum --check checksums.txt)
-```
-
-Debian/Ubuntu 安装生成的 `.deb`：
+下面的命令单独保存仓库证书，核对主密钥指纹后才写入系统 keyring；不会使用全局信任或绕过签名检查：
 
 ```bash
-sudo apt install ./dist/wukongim_*_linux_amd64.deb
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gpg
+
+apt_key="$(mktemp)"
+trap 'rm -f "$apt_key"' EXIT
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+  --output "$apt_key" \
+  https://packages.githubim.com/keys/apt-preview.asc
+
+apt_fingerprints="$(
+  gpg --batch --show-keys --with-colons "$apt_key" |
+    awk -F: '
+      $1 == "pub" { primary = 1; next }
+      primary && $1 == "fpr" { print $10; primary = 0 }
+    '
+)"
+test "$apt_fingerprints" = 'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1'
+
+sudo install -d -m 0755 /etc/apt/keyrings
+sudo install -o root -g root -m 0644 "$apt_key" /etc/apt/keyrings/wukongim-preview.asc
+rm -f "$apt_key"
+trap - EXIT
+
+printf '%s\n' \
+  'deb [arch=amd64 signed-by=/etc/apt/keyrings/wukongim-preview.asc] https://packages.githubim.com/apt preview main' |
+  sudo tee /etc/apt/sources.list.d/wukongim-preview.list >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y wukongim=3.0.0~beta.6
 ```
 
-Rocky/AlmaLinux 安装生成的 `.rpm`：
+### RHEL / Rocky / AlmaLinux 9（DNF/YUM）
+
+EL9 使用下面的独立 repo 配置，同时验证软件包签名与仓库元数据签名。仍使用 `yum` 命令名的兼容系统可以把每一条 `dnf` 命令替换为 `yum`：
 
 ```bash
-sudo dnf install ./dist/wukongim_*_linux_amd64.rpm
+set -euo pipefail
+
+sudo dnf install -y ca-certificates gnupg2
+if ! command -v curl >/dev/null; then
+  sudo dnf install -y curl-minimal
+fi
+
+rpm_key="$(mktemp)"
+trap 'rm -f "$rpm_key"' EXIT
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+  --output "$rpm_key" \
+  https://packages.githubim.com/keys/rpm-preview.asc
+
+rpm_fingerprints="$(
+  gpg --batch --show-keys --with-colons "$rpm_key" |
+    awk -F: '
+      $1 == "pub" { primary = 1; next }
+      primary && $1 == "fpr" { print $10; primary = 0 }
+    '
+)"
+test "$rpm_fingerprints" = 'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459'
+
+sudo install -d -m 0755 /etc/pki/rpm-gpg
+sudo install -o root -g root -m 0644 "$rpm_key" /etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
+rm -f "$rpm_key"
+trap - EXIT
+
+sudo tee /etc/yum.repos.d/wukongim-preview.repo >/dev/null <<'EOF'
+[wukongim-preview]
+name=WuKongIM preview
+baseurl=https://packages.githubim.com/rpm/preview/el/9/x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
+sslverify=1
+metadata_expire=300
+skip_if_unavailable=0
+EOF
+
+sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
+sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64
 ```
 
-安装包会安装 `/usr/bin/wukongim` 和加固的 `wukongim.service`，创建 `wukongim` 系统账号以及 `/etc/wukongim`、`/var/lib/wukongim`、`/var/log/wukongim`、`/run/wukongim`。它不会生成活动配置，也不会启用、启动或重启服务。
-
-用下面的命令确认二进制身份：
+安装后确认二进制身份；版本应为 `3.0.0-beta.6`，文本输出的 `source` 和 JSON 输出的 `build_source` 应为 `release`：
 
 ```bash
 wukongim version
 wukongim version --output json
 ```
+
+安装包会安装 `/usr/bin/wukongim` 和加固的 `wukongim.service`，创建 `wukongim` 系统账号以及 `/etc/wukongim`、`/var/lib/wukongim`、`/var/log/wukongim`、`/run/wukongim`。它不会生成活动配置，也不会启用、启动或重启服务。
+
+当前软件源还没有单独的 keyring 软件包，因此仓库证书不会随包自动刷新。在官方宣布切换签名子密钥前，重新下载对应证书并再次核对上面的主密钥指纹；不要关闭软件包或仓库元数据签名检查。
 
 ## 2. 安全初始化配置
 
@@ -91,9 +158,35 @@ curl --fail http://127.0.0.1:5001/readyz
 
 升级前先在非生产环境验证目标提交、制品、配置、备份和恢复路径。只有目标版本明确声明支持与当前版本混跑时，才能逐节点滚动升级；否则使用全体维护窗口。完整边界见[升级与迁移](/zh/server/operations/upgrade-and-migration)。
 
+## 本地构建预览包
+
+需要审计打包内容或测试未发布代码时，可以在固定提交上构建本地包。仓库要求 Go `1.25.11`，打包配置固定按 GoReleaser `v2.18.0` 校验：
+
+```bash
+git rev-parse HEAD
+go version
+goreleaser release --snapshot --clean \
+  --config .goreleaser.packages.yaml
+(cd dist && sha256sum --check checksums.txt)
+```
+
+Debian/Ubuntu 安装生成的 `.deb`：
+
+```bash
+sudo apt install ./dist/wukongim_*_linux_amd64.deb
+```
+
+Rocky/AlmaLinux 安装生成的 `.rpm`：
+
+```bash
+sudo dnf install ./dist/wukongim_*_linux_amd64.rpm
+```
+
+本地 snapshot 包没有公共 Preview 软件源的签名与不可变发布审计，不应冒充公开渠道制品。
+
 ## 从源码安装
 
-公共软件源启用前，也可以直接构建二进制：
+如果确实需要源码部署，可直接构建固定提交的二进制：
 
 ```bash
 GOWORK=off go build -trimpath -o ./bin/wukongim ./cmd/wukongim

--- a/docs-site/lib/native-deployment-contract.test.ts
+++ b/docs-site/lib/native-deployment-contract.test.ts
@@ -76,20 +76,48 @@ describe('native deployment publication contract', () => {
 
     for (const content of pages) {
       for (const contract of [
+        '3.0.0-beta.6',
+        'https://packages.githubim.com/keys/apt-preview.asc',
+        'https://packages.githubim.com/keys/rpm-preview.asc',
+        'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1',
+        'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459',
+        'deb [arch=amd64 signed-by=/etc/apt/keyrings/wukongim-preview.asc] https://packages.githubim.com/apt preview main',
+        'sudo apt-get install -y wukongim=3.0.0~beta.6',
+        'baseurl=https://packages.githubim.com/rpm/preview/el/9/x86_64',
+        "sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh",
+        'sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64',
+        'gpgcheck=1',
+        'repo_gpgcheck=1',
+        'sslverify=1',
+        'skip_if_unavailable=0',
+        'set -euo pipefail',
+        'primary && $1 == "fpr"',
+        'sudo dnf install -y curl-minimal',
+        'RHEL',
+        'build_source',
         '.goreleaser.packages.yaml',
         'wukongim config init',
         '--admin-password-stdin',
         'wukongim config validate',
+        'systemctl enable --now wukongim',
         'RestartPreventExitStatus',
         '/var/lib/wukongim',
         '/var/log/wukongim',
         '/run/wukongim',
-        'packages.githubim.com',
       ]) {
         expect(content).toContain(contract);
       }
-      expect(content).not.toContain('deb [signed-by=');
-      expect(content).not.toContain('baseurl=https://packages.githubim.com');
+      for (const unsafe of [
+        'apt-key',
+        'trusted=yes',
+        'gpgcheck=0',
+        'repo_gpgcheck=0',
+        'curl | sudo',
+        'sudo apt-get install -y wukongim\n',
+        'sudo dnf install -y wukongim\n',
+      ]) {
+        expect(content).not.toContain(unsafe);
+      }
     }
   });
 

--- a/docs-site/lib/navigation.ts
+++ b/docs-site/lib/navigation.ts
@@ -758,8 +758,8 @@ export const domains: DocumentationDomain[] = [
             'linux',
             'Linux 部署',
             'Linux',
-            '使用二进制、配置文件和 systemd 运行服务。',
-            'Runs the server with a binary, configuration file, and systemd.',
+            '从签名 APT/DNF Preview 软件源安装，并用安全配置和 systemd 运行服务。',
+            'Installs from the signed APT/DNF preview repository and runs the service with secure configuration and systemd.',
           ),
           publishedPage(
             'multi-node',

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -88,18 +88,21 @@
   cluster runtime, the multi-reactor channel runtime, and the new business
   kernel are canonical under `pkg/controller`, `pkg/cluster`, `pkg/channel`,
   and `internal`; the former v1 server runtime tree has been removed.
-- Native Linux packages are an unsigned amd64 preview. CI builds temporary
-  signed APT/RPM repositories with one-run, one-day `TEST ONLY` keys outside
-  the repository and verifies their signatures plus the exact APT and RPM
-  metadata-to-package closures in containers; neither those keys nor the
-  signed repositories are published. The separate public `WuKongIM/packages`
-  repository owns a fail-closed GitHub Pages bootstrap at the verified HTTPS
-  endpoint `packages.githubim.com`; both repositories enforce immutable
-  Releases. It publishes no APT/YUM indexes until reviewed public fingerprints,
-  signing custody, exact tagged source package assets, and the production
-  publisher are ready. The package installs the
-  binary, hardened systemd unit, service identity, and persistent directories,
-  but never creates an active configuration or starts/restarts the node.
+- Native Linux package source assets are unsigned amd64 artifacts of an exact
+  immutable tagged binary Release. Source CI also builds temporary signed
+  APT/RPM repositories with one-run, one-day `TEST ONLY` keys outside the
+  repository and verifies their signatures plus the exact metadata-to-package
+  closures; neither those keys nor temporary repositories are published. The
+  separate public `WuKongIM/packages` repository independently verifies the
+  immutable source Release, applies separate production APT and RPM signatures,
+  seals each complete snapshot and receipt in an immutable audit Release, and
+  publishes the signed `preview` APT suite and EL9 RPM repository at
+  `packages.githubim.com`. Every public snapshot is download-validated on clean
+  Ubuntu, Debian, Rocky Linux, and AlmaLinux clients. Stable publication remains
+  disabled until it moves from GitHub Pages to object storage and a CDN. The
+  package installs the binary, hardened systemd unit, service identity, and
+  persistent directories, but never creates an active configuration or
+  starts/restarts the node.
   Operators initialize atomically with `wukongim config init`, validate with
   `wukongim config validate`, and own enablement plus upgrade restart timing.
 - Runnable `wukongim` helper-script configs live under `scripts/wukongim/` as `.toml`; `.toml.example` files are samples only and should not be script defaults.


### PR DESCRIPTION
## Summary

- publish bilingual APT and DNF/YUM preview installation instructions for v3.0.0-beta.6
- verify unique primary signing fingerprints before installing dedicated keyrings
- pin exact DEB/RPM versions and document the non-activating systemd lifecycle
- update navigation and the Unreleased changelog entry

## Validation

- `cd docs-site && bun run verify`
- copied APT flow installed the published package on a fresh Ubuntu 24.04 container
- copied DNF flow verified repository metadata/signatures and resolved the exact package plus BaseOS dependencies on Rocky Linux 9; the canonical remote client run already validates clean Rocky/Alma downloads
- `git diff --check`

Review Agent is intentionally not invoked per operator authorization; this PR is intended for administrator direct merge after the recorded checks.