### PR TITLE
fix: accept active uploaded CDN certificate state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ move those entries into a version section named for that exact tag.
 
 ### 🐛 Bug Fixes / 问题修复
 
+- 文档 CDN 证书轮换现在兼容阿里云已启用的手动上传证书省略 `Status` 字段的响应，同时仍会拒绝免费或未知类型的空状态以及尚未生效的证书状态。
 - 文档 CDN 的 ACME 账户初始化现在使用固定生产端点和已审阅条款的账户专用流程，不再因合法邮箱或 Let's Encrypt 省略可选联系人字段而失败，也不会在初始化账户时误发起证书申请。
 
 ### 🔧 Improvements / 改进

--- a/scripts/docs-cdn/certificate-helper/main.go
+++ b/scripts/docs-cdn/certificate-helper/main.go
@@ -678,7 +678,10 @@ func inspectCDNCertificate(response cdnResponse, now time.Time, allowMissing boo
 		}, nil
 	}
 	if info.DomainName != expectedDomain || info.ServerCertificateStatus != "on" || !validCDNState(info) {
-		return certificateSummary{}, errors.New("Alibaba CDN certificate is not active on the exact documentation domain")
+		return certificateSummary{}, fmt.Errorf(
+			"Alibaba CDN certificate is not active on the exact documentation domain (%s)",
+			cdnStateDiagnostic(info),
+		)
 	}
 	leaf, _, err := parseCertificateChain([]byte(info.ServerCertificate))
 	if err != nil {
@@ -748,7 +751,10 @@ func verifyCDNDeployment(response cdnResponse, expectedPEM []byte, expectedName 
 	}
 	info := response.CertInfos.CertInfo[0]
 	if info.DomainName != expectedDomain || info.CertDomainName != expectedDomain || info.CertName != expectedName || info.CertType != "upload" || info.ServerCertificateStatus != "on" || !validCDNState(info) {
-		return errors.New("Alibaba CDN has not activated the exact uploaded documentation certificate")
+		return fmt.Errorf(
+			"Alibaba CDN has not activated the exact uploaded documentation certificate (%s)",
+			cdnStateDiagnostic(info),
+		)
 	}
 	actualLeaf, _, err := parseCertificateChain([]byte(info.ServerCertificate))
 	if err != nil {
@@ -766,7 +772,23 @@ func verifyCDNDeployment(response cdnResponse, expectedPEM []byte, expectedName 
 func validCDNState(info cdnCertificateInfo) bool {
 	validCNAMEState := info.DomainCnameStatus == "ok" || info.DomainCnameStatus == "cname_error" || info.DomainCnameStatus == "top_domain_cname_error"
 	validCertificateState := info.Status == "success" || info.Status == "cname_error" || info.Status == "top_domain_cname_error"
+	if info.Status == "" {
+		// DescribeDomainCertificateInfo omits Status for an activated uploaded
+		// certificate. Other certificate types still require an explicit state.
+		validCertificateState = info.CertType == "upload"
+	}
 	return validCNAMEState && validCertificateState
+}
+
+func cdnStateDiagnostic(info cdnCertificateInfo) string {
+	return fmt.Sprintf(
+		"domain=%q https=%q cert_type=%q status=%q cname_status=%q",
+		info.DomainName,
+		info.ServerCertificateStatus,
+		info.CertType,
+		info.Status,
+		info.DomainCnameStatus,
+	)
 }
 
 func verifyReportedExpiry(value string, expected time.Time) error {

--- a/scripts/docs-cdn/certificate-helper/main_test.go
+++ b/scripts/docs-cdn/certificate-helper/main_test.go
@@ -423,6 +423,105 @@ func TestInspectCDNCertificateAllowsPreCutoverState(t *testing.T) {
 	}
 }
 
+func TestValidCDNStateMatrix(t *testing.T) {
+	tests := []struct {
+		name              string
+		certificateType   string
+		certificateStatus string
+		cnameStatus       string
+		want              bool
+	}{
+		{name: "uploaded certificate omits status", certificateType: "upload", certificateStatus: "", cnameStatus: "ok", want: true},
+		{name: "uploaded certificate is successful", certificateType: "upload", certificateStatus: "success", cnameStatus: "ok", want: true},
+		{name: "free certificate is successful", certificateType: "free", certificateStatus: "success", cnameStatus: "ok", want: true},
+		{name: "pre-cutover CNAME error", certificateType: "upload", certificateStatus: "cname_error", cnameStatus: "cname_error", want: true},
+		{name: "pre-cutover top-domain CNAME error", certificateType: "upload", certificateStatus: "top_domain_cname_error", cnameStatus: "top_domain_cname_error", want: true},
+		{name: "free certificate omits status", certificateType: "free", certificateStatus: "", cnameStatus: "ok", want: false},
+		{name: "unknown certificate omits status", certificateType: "unknown", certificateStatus: "", cnameStatus: "ok", want: false},
+		{name: "certificate type omitted with status", certificateType: "", certificateStatus: "", cnameStatus: "ok", want: false},
+		{name: "certificate checking", certificateType: "upload", certificateStatus: "checking", cnameStatus: "ok", want: false},
+		{name: "certificate applying", certificateType: "upload", certificateStatus: "applying", cnameStatus: "ok", want: false},
+		{name: "certificate failed", certificateType: "upload", certificateStatus: "failed", cnameStatus: "ok", want: false},
+		{name: "certificate does not support wildcard", certificateType: "upload", certificateStatus: "unsupport_wildcard", cnameStatus: "ok", want: false},
+		{name: "CNAME status omitted", certificateType: "upload", certificateStatus: "", cnameStatus: "", want: false},
+		{name: "CNAME checking", certificateType: "upload", certificateStatus: "success", cnameStatus: "checking", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			info := cdnCertificateInfo{
+				CertType:          test.certificateType,
+				Status:            test.certificateStatus,
+				DomainCnameStatus: test.cnameStatus,
+			}
+			if got := validCDNState(info); got != test.want {
+				t.Fatalf("validCDNState(%+v) = %t, want %t", info, got, test.want)
+			}
+		})
+	}
+}
+
+func TestInspectCDNCertificateStatusMatrix(t *testing.T) {
+	now := time.Date(2026, time.September, 2, 12, 0, 0, 0, time.UTC)
+	certificatePEM, _ := issueTestCertificate(t, now, []string{expectedDomain}, 31*24*time.Hour)
+	tests := []struct {
+		name              string
+		certificateType   string
+		certificateStatus string
+		cnameStatus       string
+		wantOK            bool
+	}{
+		{name: "uploaded certificate omits status", certificateType: "upload", certificateStatus: "", cnameStatus: "ok", wantOK: true},
+		{name: "free certificate is successful", certificateType: "free", certificateStatus: "success", cnameStatus: "ok", wantOK: true},
+		{name: "free certificate omits status", certificateType: "free", certificateStatus: "", cnameStatus: "ok"},
+		{name: "unknown certificate omits status", certificateType: "unknown", certificateStatus: "", cnameStatus: "ok"},
+		{name: "uploaded certificate is checking", certificateType: "upload", certificateStatus: "checking", cnameStatus: "ok"},
+		{name: "uploaded certificate is applying", certificateType: "upload", certificateStatus: "applying", cnameStatus: "ok"},
+		{name: "uploaded certificate has failed", certificateType: "upload", certificateStatus: "failed", cnameStatus: "ok"},
+		{name: "uploaded certificate does not support wildcard", certificateType: "upload", certificateStatus: "unsupport_wildcard", cnameStatus: "ok"},
+		{name: "uploaded certificate has unknown CNAME state", certificateType: "upload", certificateStatus: "", cnameStatus: "checking"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := responseForCertificate(t, certificatePEM, "existing", test.certificateType)
+			info := &response.CertInfos.CertInfo[0]
+			info.Status = test.certificateStatus
+			info.DomainCnameStatus = test.cnameStatus
+			summary, err := inspectCDNCertificate(response, now, false)
+			if test.wantOK {
+				if err != nil {
+					t.Fatalf("inspectCDNCertificate() error = %v", err)
+				}
+				if !summary.CertificatePresent || summary.DomainCNAMEStatus != test.cnameStatus {
+					t.Fatalf("inspectCDNCertificate() summary = %+v", summary)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("inspectCDNCertificate accepted an invalid Alibaba CDN state")
+			}
+			assertSanitizedCDNStateError(t, err, *info)
+		})
+	}
+}
+
+func TestCDNStateDiagnosticIncludesOnlyApprovedFields(t *testing.T) {
+	info := cdnCertificateInfo{
+		CertDomainName:          "secret-cert-domain",
+		CertExpireTime:          "secret-expiry",
+		CertName:                "secret-name",
+		CertType:                "upload",
+		DomainCnameStatus:       "ok",
+		DomainName:              expectedDomain,
+		ServerCertificate:       "secret-certificate-pem",
+		ServerCertificateStatus: "on",
+		Status:                  "checking",
+	}
+	want := `domain="docs.githubim.com" https="on" cert_type="upload" status="checking" cname_status="ok"`
+	if got := cdnStateDiagnostic(info); got != want {
+		t.Fatalf("cdnStateDiagnostic() = %q, want %q", got, want)
+	}
+}
+
 func TestValidateIssuedCertificateRequiresExactSANAndMatchingKey(t *testing.T) {
 	now := time.Date(2026, time.September, 2, 12, 0, 0, 0, time.UTC)
 	certificatePEM, keyPEM := issueTestCertificate(t, now, []string{expectedDomain}, 89*24*time.Hour)
@@ -472,6 +571,64 @@ func TestVerifyCDNDeploymentRequiresExactUploadedCertificate(t *testing.T) {
 	response.CertInfos.CertInfo[0].CertType = "cas"
 	if err := verifyCDNDeployment(response, certificatePEM, summary.CertificateName); err == nil {
 		t.Fatal("verifyCDNDeployment accepted the wrong certificate type")
+	}
+}
+
+func TestVerifyCDNDeploymentStatusMatrix(t *testing.T) {
+	now := time.Date(2026, time.September, 2, 12, 0, 0, 0, time.UTC)
+	certificatePEM, keyPEM := issueTestCertificate(t, now, []string{expectedDomain}, 89*24*time.Hour)
+	summary, err := validateIssuedCertificate(certificatePEM, keyPEM, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name              string
+		certificateType   string
+		certificateStatus string
+		cnameStatus       string
+		wantOK            bool
+	}{
+		{name: "uploaded certificate omits status", certificateType: "upload", certificateStatus: "", cnameStatus: "ok", wantOK: true},
+		{name: "uploaded certificate is successful", certificateType: "upload", certificateStatus: "success", cnameStatus: "ok", wantOK: true},
+		{name: "pre-cutover CNAME error", certificateType: "upload", certificateStatus: "cname_error", cnameStatus: "cname_error", wantOK: true},
+		{name: "pre-cutover top-domain CNAME error", certificateType: "upload", certificateStatus: "top_domain_cname_error", cnameStatus: "top_domain_cname_error", wantOK: true},
+		{name: "free certificate omits status", certificateType: "free", certificateStatus: "", cnameStatus: "ok"},
+		{name: "unknown certificate omits status", certificateType: "unknown", certificateStatus: "", cnameStatus: "ok"},
+		{name: "uploaded certificate is checking", certificateType: "upload", certificateStatus: "checking", cnameStatus: "ok"},
+		{name: "uploaded certificate is applying", certificateType: "upload", certificateStatus: "applying", cnameStatus: "ok"},
+		{name: "uploaded certificate has failed", certificateType: "upload", certificateStatus: "failed", cnameStatus: "ok"},
+		{name: "uploaded certificate does not support wildcard", certificateType: "upload", certificateStatus: "unsupport_wildcard", cnameStatus: "ok"},
+		{name: "uploaded certificate has unknown CNAME state", certificateType: "upload", certificateStatus: "", cnameStatus: "checking"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := responseForCertificate(t, certificatePEM, summary.CertificateName, test.certificateType)
+			info := &response.CertInfos.CertInfo[0]
+			info.Status = test.certificateStatus
+			info.DomainCnameStatus = test.cnameStatus
+			err := verifyCDNDeployment(response, certificatePEM, summary.CertificateName)
+			if test.wantOK {
+				if err != nil {
+					t.Fatalf("verifyCDNDeployment() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("verifyCDNDeployment accepted an invalid Alibaba CDN state")
+			}
+			assertSanitizedCDNStateError(t, err, *info)
+		})
+	}
+}
+
+func assertSanitizedCDNStateError(t *testing.T, err error, info cdnCertificateInfo) {
+	t.Helper()
+	if !strings.Contains(err.Error(), cdnStateDiagnostic(info)) {
+		t.Fatalf("error %q does not contain sanitized CDN state %q", err, cdnStateDiagnostic(info))
+	}
+	leakedCertificateName := info.CertName != "" && strings.Contains(err.Error(), info.CertName)
+	if strings.Contains(err.Error(), "BEGIN CERTIFICATE") || leakedCertificateName {
+		t.Fatalf("error leaked certificate material or certificate name: %q", err)
 	}
 }
 


### PR DESCRIPTION
## Summary / 变更摘要

- Fix the certificate helper after the first enabled rotation showed that Alibaba CDN returns `Status=""` for an otherwise active `CertType=upload` certificate.
- Accept the empty certificate status only for uploaded certificates, while continuing to reject empty states for free or unknown types and all pending/failed states.
- Apply the same strict rule to pre-rotation inspection and post-upload verification, and add diagnostics limited to domain, HTTPS, certificate type, certificate status, and CNAME status.
- Add focused state matrices and a diagnostic allowlist test so certificate PEM and certificate names cannot enter the new error output.

The live failure was [run 33632250960](https://github.com/WuKongIM/WuKongIM/actions/runs/33632250960). It stopped before lego, ACME, DNS-01, issuance, or CDN mutation. Related alert: #874; keep it open until a successful post-merge recovery run.

## Release notes / 发布说明

- [x] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [ ] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

Skip reason / 豁免理由：

N/A

## Verification / 验证

- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go test -race ./scripts/docs-cdn/certificate-helper -count=1`
- `GOWORK=off go vet ./scripts/docs-cdn/certificate-helper`
- `gofmt -d scripts/docs-cdn/certificate-helper/main.go scripts/docs-cdn/certificate-helper/main_test.go`
- `git diff --check`
