### PR TITLE
ci: validate native package systemd lifecycle

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,7 +27,7 @@ authorization and the applicable budget.
 | `issue-agent-engineer.yml` | `Agent Tool - Issue Engineer` | Runs one exact Context Builder, Codex Engineer, and clean Verifier chain |
 | `manager-browser-smoke.yml` | `Safety Automation - Manager Browser Smoke` | Builds the production Manager bundle and runs the desktop/mobile Chromium matrix against a real three-node cluster |
 | `easysdk-release-acceptance.yml` | `Safety Automation - EasySDK Released Package Acceptance` | Resolves the pinned Android, iOS, and Flutter registry releases and proves bidirectional messaging against the current Product Gateway on hosted simulators/emulators |
-| `native-package-preview.yml` | `Safety Automation - Validate Native Package Preview` | Builds unsigned amd64 deb/rpm previews and checks non-activating installs on the four supported Linux distributions |
+| `native-package-preview.yml` | `Safety Automation - Validate Native Package Preview` | Builds unsigned amd64 deb/rpm previews and checks non-activating transactions plus the explicit systemd lifecycle on four Linux distributions |
 | `cloud-lease-oidc-setup.yml` | `Agent Tool - Configure Cloud Lease OIDC Roles` | Reconciles and live-verifies the three workflow-conditioned Cloud Lease roles |
 | `cloud-lease-provision.yml` | `Agent Tool - Provision Cloud Lease` | Quotes or explicitly acquires one generic Alibaba Cloud Lease |
 | `cloud-lease-observe.yml` | `Agent Tool - Inspect Cloud Lease` | Reconstructs exact Lease inventory through the read-only Observer role |
@@ -124,6 +124,28 @@ upgrade. The upgrade check records every `systemctl` request and verifies that
 the operator-owned configuration and data remain byte-identical. Only the
 unsigned preview packages and checksums are retained as Actions artifacts for
 14 days; this workflow still publishes no APT/YUM repository.
+
+A separate checksum-bound matrix downloads that exact run Artifact and boots
+each distribution with a real systemd PID 1. The container mounts only its one
+candidate package read-only; it receives no credential, Docker socket, or
+writable repository checkout. Bootstrap installs the candidate package before
+executing systemd because the minimal base images do not contain PID 1; every
+live service action, package-manager reinstall, active removal, and subsequent
+install then runs against that real systemd instance. The test follows the
+operator-owned boundary:
+initialize and validate configuration, explicitly enable and start the unit,
+require `/healthz` and `/readyz`, prove a package-manager reinstall does not
+replace the live process, explicitly restart and stop it, remove the active
+package while retaining configuration/data/log state, reinstall without
+implicit activation, and explicitly start it again. Every bootstrap,
+readiness, and cleanup wait is bounded. Failure cleanup emits bounded available
+Docker logs and, when the live container exposes systemctl, attempts bounded
+unit status and journal evidence.
+
+Debian 12 is deliberately retained as the source-preview compatibility target
+already used by this workflow. The public repository publisher owns its
+separate clean-client publication matrix, so this source gate does not redefine
+that downstream support policy.
 
 The separate public `WuKongIM/packages` repository owns the signed Preview
 channel at the verified HTTPS endpoint `packages.githubim.com`. Its production

--- a/.github/workflows/native-package-preview.yml
+++ b/.github/workflows/native-package-preview.yml
@@ -4,17 +4,23 @@ on:
   pull_request:
     paths:
       - ".goreleaser.packages.yaml"
+      - "go.mod"
+      - "go.sum"
       - "cmd/wukongim/**"
-      - "internal/app/**"
-      - "internal/config/**"
+      - "internal/**"
+      - "pkg/**"
       - "packaging/**"
       - "scripts/native_package_contract_test.go"
+      - "scripts/native_package_lifecycle_integration_test.go"
       - "scripts/native_package_repository_integration_test.go"
+      - "scripts/script_test_helpers_test.go"
+      - "scripts/script_test_helpers_integration_test.go"
       - "scripts/build-native-package-repositories.sh"
       - "scripts/generate-native-package-test-keyring.sh"
       - "scripts/sign-native-package-repositories.sh"
       - "scripts/validate-native-package.sh"
       - "scripts/validate-native-package-container.sh"
+      - "scripts/validate-native-package-lifecycle-container.sh"
       - "scripts/validate-native-package-repositories-container.sh"
       - "scripts/verify-native-package-metadata.py"
       - "scripts/verify-native-package-repositories.sh"
@@ -99,3 +105,76 @@ jobs:
             dist/checksums.txt
           if-no-files-found: error
           retention-days: 14
+
+      - name: Reject tracked-tree mutation
+        if: always()
+        run: |
+          git diff --exit-code
+          git diff --cached --exit-code
+
+  lifecycle:
+    name: Exercise ${{ matrix.label }} package lifecycle
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Ubuntu 24.04
+            image: ubuntu:24.04
+            format: deb
+          - label: Debian 12
+            image: debian:12
+            format: deb
+          - label: Rocky Linux 9
+            image: rockylinux:9
+            format: rpm
+          - label: AlmaLinux 9
+            image: almalinux:9
+            format: rpm
+    env:
+      GOWORK: "off"
+      WK_NATIVE_PACKAGE_LIFECYCLE_INTEGRATION: "1"
+      WK_NATIVE_PACKAGE_LIFECYCLE_IMAGE: ${{ matrix.image }}
+      WK_NATIVE_PACKAGE_LIFECYCLE_FORMAT: ${{ matrix.format }}
+      WK_NATIVE_PACKAGE_DIST_DIR: ${{ github.workspace }}/dist
+    steps:
+      - name: Check out exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up repository Go toolchain
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download the exact preview packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wukongim-native-package-preview-${{ github.run_id }}
+          path: dist
+
+      - name: Verify the downloaded package set
+        env:
+          FORMAT: ${{ matrix.format }}
+        run: |
+          shopt -s nullglob
+          packages=(dist/wukongim*."$FORMAT")
+          test "${#packages[@]}" -eq 1
+          (cd dist && sha256sum --check checksums.txt)
+
+      - name: Exercise the operator-owned lifecycle
+        run: >-
+          go test -tags=integration ./scripts
+          -run '^TestNativePackageLifecycle$'
+          -count=1 -timeout=20m
+
+      - name: Reject tracked-tree mutation
+        if: always()
+        run: |
+          git diff --exit-code
+          git diff --cached --exit-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ move those entries into a version section named for that exact tag.
 
 ### 🔧 Improvements / 改进
 
+- 原生 Linux 包 CI 现在会在 Ubuntu 24.04、Debian 12、Rocky Linux 9 与 AlmaLinux 9 的真实 systemd 环境中验证配置初始化、健康检查、显式启停/重启、活动卸载、状态保留及重装不自动激活。
 - 文档发布新增默认关闭的阿里云 CDN 定点刷新与 Let's Encrypt DNS-01 边缘证书轮换支持；两条路径使用独立的 GitHub OIDC 角色，不在仓库保存长期阿里云凭据，且在完成外部配置和切流前不会改变现有 GitHub Pages 服务。
 - Chat Lifecycle 正式演练启动器、正式收尾器和通用 Cloud Lease 回收扫描现在仅在存在 transition、handoff、付费资源生产者或云端库存期间启用；取得完整空闲与零库存证明后会自动停用，并在下一次 transition、停止请求、精确清理或付费 Acquire 前安全恢复；完整 Artifact 盘点会重试短暂的 GitHub API 分页错误。
 

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -105,6 +105,17 @@
   starts/restarts the node.
   Operators initialize atomically with `wukongim config init`, validate with
   `wukongim config validate`, and own enablement plus upgrade restart timing.
+  Source CI also boots the exact checksum-bound candidate Artifact under a real
+  systemd PID 1 on Ubuntu 24.04, Debian 12, Rocky Linux 9, and AlmaLinux 9. It
+  proves the explicit initialize/start/health/restart/stop/remove/reinstall
+  lifecycle, preservation of operator-owned configuration/data/log state, and
+  the absence of implicit activation after reinstall. Those credential-free
+  containers mount only the one candidate package read-only and publish no
+  package repository. Minimal base-image bootstrap installs the candidate before
+  execing systemd; the live reinstall, active removal, later reinstall, and all
+  operator-owned service actions run against PID 1. Debian 12 is the existing
+  source-preview compatibility target and is independent of the public
+  publisher's clean-client support matrix.
 - Runnable `wukongim` helper-script configs live under `scripts/wukongim/` as `.toml`; `.toml.example` files are samples only and should not be script defaults.
 - `wukongim` bottleneck attribution uses Prometheus `/metrics` when `WK_METRICS_ENABLE=true`; compare gateway async SEND, Channel runtime reactor/worker queue plus in-flight peak, and storage commit request-vs-batch metrics split by `leader_append` / `follower_apply` lane. `/bench/v1/snapshot` remains a benchmark setup counter surface.
 - Default Slot Raft timing is a 50-millisecond tick, two-tick heartbeat, and 40-tick election floor: heartbeats run every 100 milliseconds and elections start after at least two seconds. Chat-lifecycle cloud templates pin the same values. This keeps sub-second storage or transport tails from creating avoidable terms while proposal replication remains event-driven; override all three values together when a deployment proves a different failure-detection budget.

--- a/scripts/native_package_contract_test.go
+++ b/scripts/native_package_contract_test.go
@@ -102,6 +102,58 @@ func TestNativePackageDoesNotActivateAnUnconfiguredService(t *testing.T) {
 	}
 }
 
+func TestNativePackageLifecycleUsesRealSystemd(t *testing.T) {
+	root := repoRoot(t)
+	validator := readNativePackageFile(t, root, "scripts/validate-native-package-lifecycle-container.sh")
+	for _, required := range []string{
+		"--privileged",
+		"--cgroupns private",
+		"native package lifecycle validation exceeded its 900-second total deadline",
+		`run_bounded 300 docker pull --platform linux/amd64 "$image"`,
+		"run_bounded 30 docker rm --force --volumes",
+		"package bootstrap and systemd did not reach running or degraded state within 300 seconds",
+		"IFS= read -r -t 2 status",
+		"probe_http /healthz",
+		"probe_http /readyz",
+		"systemctl enable --now wukongim.service",
+		`run_shell_bounded 300 "$reinstall_command"`,
+		"InvocationID",
+		"require_service_identity",
+		"systemctl restart wukongim.service",
+		"ActiveState=$active_state SubState=$sub_state Result=$result MainPID=$main_pid",
+		"readyz remained reachable after explicit stop",
+		"sha256sum --check /tmp/wukongim-lifecycle-state.sha256",
+		"wukongim-lifecycle-state.manifest",
+		"getent passwd wukongim",
+		"require_unit_removed \"$removed_pid\"",
+		"test ! -e /usr/bin/wukongim",
+		"test ! -e /usr/lib/systemd/system/wukongim.service",
+		"journalctl --no-pager -u wukongim.service -n 300",
+		"native package lifecycle validation passed",
+	} {
+		require.Contains(t, validator, required)
+	}
+	for _, forbidden := range []string{
+		"/workspace",
+		"docker.sock",
+		"/sys/fs/cgroup",
+		"--volume $repository_root",
+	} {
+		require.NotContains(t, validator, forbidden)
+	}
+	require.NotContains(t, validator, `run_shell "$reinstall_command"`)
+	require.NotContains(t, validator, `run_shell "$remove_command"`)
+	require.NotContains(t, validator, `run_shell "$install_command"`)
+
+	info, err := os.Stat(filepath.Join(root, "scripts", "validate-native-package-lifecycle-container.sh"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+
+	wrapper := readNativePackageFile(t, root, "scripts/native_package_lifecycle_integration_test.go")
+	require.Contains(t, wrapper, "command.Process.Signal(syscall.SIGTERM)")
+	require.Contains(t, wrapper, "command.WaitDelay = 3 * time.Minute")
+}
+
 func TestNativePackageFilesUseExpectedModes(t *testing.T) {
 	root := repoRoot(t)
 	for _, path := range []string{
@@ -261,7 +313,40 @@ func TestNativePackageRepositorySigningFailsClosed(t *testing.T) {
 func TestNativePackageWorkflowIsCredentialFreeAndBounded(t *testing.T) {
 	root := repoRoot(t)
 	raw := readNativePackageFile(t, root, ".github/workflows/native-package-preview.yml")
-	var document any
+	type matrixEntry struct {
+		Label  string `yaml:"label"`
+		Image  string `yaml:"image"`
+		Format string `yaml:"format"`
+	}
+	type workflowStep struct {
+		Name string            `yaml:"name"`
+		Uses string            `yaml:"uses"`
+		If   string            `yaml:"if"`
+		Run  string            `yaml:"run"`
+		Env  map[string]string `yaml:"env"`
+		With map[string]any    `yaml:"with"`
+	}
+	type workflowJob struct {
+		Needs       string            `yaml:"needs"`
+		Permissions map[string]string `yaml:"permissions"`
+		Strategy    struct {
+			FailFast *bool `yaml:"fail-fast"`
+			Matrix   struct {
+				Include []matrixEntry `yaml:"include"`
+			} `yaml:"matrix"`
+		} `yaml:"strategy"`
+		Env   map[string]string `yaml:"env"`
+		Steps []workflowStep    `yaml:"steps"`
+	}
+	var document struct {
+		On struct {
+			PullRequest struct {
+				Paths []string `yaml:"paths"`
+			} `yaml:"pull_request"`
+		} `yaml:"on"`
+		Permissions map[string]string      `yaml:"permissions"`
+		Jobs        map[string]workflowJob `yaml:"jobs"`
+	}
 	require.NoError(t, yaml.Unmarshal([]byte(raw), &document))
 
 	for _, required := range []string{
@@ -270,15 +355,17 @@ func TestNativePackageWorkflowIsCredentialFreeAndBounded(t *testing.T) {
 		"goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1",
 		"version: v2.18.0",
 		"scripts/native_package_repository_integration_test.go",
+		"scripts/native_package_lifecycle_integration_test.go",
+		"scripts/validate-native-package-lifecycle-container.sh",
 		"scripts/validate-native-package-repositories-container.sh",
 		"scripts/verify-native-package-metadata.py",
 		"WK_NATIVE_PACKAGE_REPOSITORY_INTEGRATION: \"1\"",
 		"go test -tags=integration ./scripts",
 		"-run '^TestNativePackageSignedRepository$'",
-		"ubuntu:24.04 deb",
-		"debian:12 deb",
-		"rockylinux:9 rpm",
-		"almalinux:9 rpm",
+		"WK_NATIVE_PACKAGE_LIFECYCLE_INTEGRATION: \"1\"",
+		"WK_NATIVE_PACKAGE_LIFECYCLE_IMAGE: ${{ matrix.image }}",
+		"WK_NATIVE_PACKAGE_LIFECYCLE_FORMAT: ${{ matrix.format }}",
+		"-run '^TestNativePackageLifecycle$'",
 		"retention-days: 14",
 	} {
 		require.Contains(t, raw, required)
@@ -290,8 +377,79 @@ func TestNativePackageWorkflowIsCredentialFreeAndBounded(t *testing.T) {
 		"secrets.",
 		"packages.githubim.com",
 		"release --clean",
+		"pull_request_target:",
 	} {
 		require.NotContains(t, raw, forbidden)
+	}
+
+	validate, ok := document.Jobs["validate"]
+	require.True(t, ok)
+	lifecycle, ok := document.Jobs["lifecycle"]
+	require.True(t, ok)
+	require.Equal(t, "validate", lifecycle.Needs)
+	require.NotNil(t, lifecycle.Strategy.FailFast)
+	require.False(t, *lifecycle.Strategy.FailFast)
+	require.Equal(t, map[string]string{"contents": "read"}, document.Permissions)
+	for name, job := range document.Jobs {
+		require.Empty(t, job.Permissions, name)
+	}
+	for _, path := range []string{
+		"go.mod",
+		"go.sum",
+		"internal/**",
+		"pkg/**",
+		"scripts/native_package_lifecycle_integration_test.go",
+		"scripts/script_test_helpers_test.go",
+		"scripts/script_test_helpers_integration_test.go",
+		"scripts/validate-native-package-lifecycle-container.sh",
+	} {
+		require.Contains(t, document.On.PullRequest.Paths, path)
+	}
+	require.Equal(t, []matrixEntry{
+		{Label: "Ubuntu 24.04", Image: "ubuntu:24.04", Format: "deb"},
+		{Label: "Debian 12", Image: "debian:12", Format: "deb"},
+		{Label: "Rocky Linux 9", Image: "rockylinux:9", Format: "rpm"},
+		{Label: "AlmaLinux 9", Image: "almalinux:9", Format: "rpm"},
+	}, lifecycle.Strategy.Matrix.Include)
+	require.Equal(t, "1", lifecycle.Env["WK_NATIVE_PACKAGE_LIFECYCLE_INTEGRATION"])
+	require.Equal(t, "${{ matrix.image }}", lifecycle.Env["WK_NATIVE_PACKAGE_LIFECYCLE_IMAGE"])
+	require.Equal(t, "${{ matrix.format }}", lifecycle.Env["WK_NATIVE_PACKAGE_LIFECYCLE_FORMAT"])
+	require.Equal(t, "${{ github.workspace }}/dist", lifecycle.Env["WK_NATIVE_PACKAGE_DIST_DIR"])
+
+	findStep := func(steps []workflowStep, name string) workflowStep {
+		t.Helper()
+		for _, step := range steps {
+			if step.Name == name {
+				return step
+			}
+		}
+		t.Fatalf("workflow step %q is missing", name)
+		return workflowStep{}
+	}
+	for _, job := range []workflowJob{validate, lifecycle} {
+		checkout := findStep(job.Steps, "Check out exact source")
+		require.Equal(t, "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", checkout.Uses)
+		require.Equal(t, false, checkout.With["persist-credentials"])
+	}
+	const artifactName = "wukongim-native-package-preview-${{ github.run_id }}"
+	upload := findStep(validate.Steps, "Upload preview packages")
+	require.Equal(t, "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", upload.Uses)
+	require.Equal(t, artifactName, upload.With["name"])
+	uploadPath, ok := upload.With["path"].(string)
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"dist/*.deb", "dist/*.rpm", "dist/checksums.txt"}, strings.Fields(uploadPath))
+	download := findStep(lifecycle.Steps, "Download the exact preview packages")
+	require.Equal(t, "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", download.Uses)
+	require.Equal(t, artifactName, download.With["name"])
+	require.Equal(t, "dist", download.With["path"])
+	checksum := findStep(lifecycle.Steps, "Verify the downloaded package set")
+	require.Equal(t, "${{ matrix.format }}", checksum.Env["FORMAT"])
+	require.Contains(t, checksum.Run, `packages=(dist/wukongim*."$FORMAT")`)
+	require.Contains(t, checksum.Run, `(cd dist && sha256sum --check checksums.txt)`)
+	for _, job := range []workflowJob{validate, lifecycle} {
+		mutation := findStep(job.Steps, "Reject tracked-tree mutation")
+		require.Equal(t, "always()", mutation.If)
+		require.Equal(t, []string{"git", "diff", "--exit-code", "git", "diff", "--cached", "--exit-code"}, strings.Fields(mutation.Run))
 	}
 }
 

--- a/scripts/native_package_lifecycle_integration_test.go
+++ b/scripts/native_package_lifecycle_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestNativePackageLifecycle(t *testing.T) {
+	if os.Getenv("WK_NATIVE_PACKAGE_LIFECYCLE_INTEGRATION") != "1" {
+		t.Skip("set WK_NATIVE_PACKAGE_LIFECYCLE_INTEGRATION=1 to run the native package lifecycle validation")
+	}
+
+	image := strings.TrimSpace(os.Getenv("WK_NATIVE_PACKAGE_LIFECYCLE_IMAGE"))
+	format := strings.TrimSpace(os.Getenv("WK_NATIVE_PACKAGE_LIFECYCLE_FORMAT"))
+	if image == "" || format == "" {
+		t.Fatal("WK_NATIVE_PACKAGE_LIFECYCLE_IMAGE and WK_NATIVE_PACKAGE_LIFECYCLE_FORMAT are required")
+	}
+
+	runHeavyShellScriptTestInParallel(t)
+	root := repoRoot(t)
+	command := exec.CommandContext(
+		t.Context(),
+		"bash",
+		filepath.Join(root, "scripts", "validate-native-package-lifecycle-container.sh"),
+		image,
+		format,
+	)
+	command.Dir = root
+	command.Env = os.Environ()
+	command.Cancel = func() error {
+		return command.Process.Signal(syscall.SIGTERM)
+	}
+	command.WaitDelay = 3 * time.Minute
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("native package lifecycle validation failed: %v\n%s", err, output)
+	}
+}

--- a/scripts/validate-native-package-lifecycle-container.sh
+++ b/scripts/validate-native-package-lifecycle-container.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <container-image> <deb|rpm>" >&2
+  exit 64
+fi
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_dir="${WK_NATIVE_PACKAGE_DIST_DIR:-$repository_root/dist}"
+[[ -d "$package_dir" && ! -L "$package_dir" ]] || {
+  echo "native package directory is missing or unsafe: $package_dir" >&2
+  exit 66
+}
+package_dir="$(cd "$package_dir" && pwd -P)"
+image="$1"
+format="$2"
+
+case "$image|$format" in
+  ubuntu:24.04\|deb|debian:12\|deb|rockylinux:9\|rpm|almalinux:9\|rpm) ;;
+  *)
+    echo "unsupported native package lifecycle target: $image $format" >&2
+    exit 64
+    ;;
+esac
+
+shopt -s nullglob
+case "$format" in
+  deb)
+    packages=("$package_dir"/wukongim*.deb)
+    mount_target="/opt/wukongim-package.deb"
+    install_command='apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 install --no-install-recommends -y /opt/wukongim-package.deb'
+    reinstall_command='DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 install --no-install-recommends --reinstall -y /opt/wukongim-package.deb'
+    remove_command='DEBIAN_FRONTEND=noninteractive apt-get remove -y wukongim'
+    ;;
+  rpm)
+    packages=("$package_dir"/wukongim*.rpm)
+    mount_target="/opt/wukongim-package.rpm"
+    install_command='dnf install -y /opt/wukongim-package.rpm'
+    reinstall_command='dnf reinstall -y /opt/wukongim-package.rpm'
+    remove_command='dnf remove -y wukongim'
+    ;;
+esac
+[[ "${#packages[@]}" -eq 1 ]] || {
+  echo "expected exactly one $format package in $package_dir, found ${#packages[@]}" >&2
+  exit 65
+}
+package="${packages[0]}"
+
+container_name="wk-native-lifecycle-${format}-$$-${RANDOM}"
+[[ "$container_name" =~ ^wk-native-lifecycle-(deb|rpm)-[0-9]+-[0-9]+$ ]]
+active_command_pid=0
+active_watchdog_pid=0
+active_timeout_marker=""
+total_watchdog_pid=0
+total_timeout_marker=""
+
+run_bounded() {
+  local timeout_seconds="$1"
+  shift
+  local command_pid marker watchdog_pid status
+
+  "$@" &
+  command_pid=$!
+  active_command_pid="$command_pid"
+  marker="$(mktemp "${TMPDIR:-/tmp}/wk-native-lifecycle-timeout.XXXXXX")"
+  active_timeout_marker="$marker"
+  (
+    timer_pid=0
+    trap 'if [[ "$timer_pid" =~ ^[1-9][0-9]*$ ]]; then kill -TERM "$timer_pid" >/dev/null 2>&1 || true; fi; exit 0' TERM INT
+    sleep "$timeout_seconds" &
+    timer_pid=$!
+    wait "$timer_pid" || exit 0
+    if [[ -e "$marker" ]] && kill -0 "$command_pid" >/dev/null 2>&1; then
+      echo "command timed out after ${timeout_seconds}s: $1" >&2
+      kill -TERM "$command_pid" >/dev/null 2>&1 || true
+      sleep 5
+      kill -KILL "$command_pid" >/dev/null 2>&1 || true
+    fi
+    rm -f "$marker"
+  ) &
+  watchdog_pid=$!
+  active_watchdog_pid="$watchdog_pid"
+
+  if wait "$command_pid"; then
+    status=0
+  else
+    status=$?
+  fi
+  rm -f "$marker"
+  kill -TERM "$watchdog_pid" >/dev/null 2>&1 || true
+  active_command_pid=0
+  active_watchdog_pid=0
+  active_timeout_marker=""
+  return "$status"
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if [[ -n "$active_timeout_marker" ]]; then
+    rm -f "$active_timeout_marker"
+  fi
+  if [[ -n "$total_timeout_marker" ]]; then
+    rm -f "$total_timeout_marker"
+  fi
+  for pid in "$active_command_pid" "$active_watchdog_pid" "$total_watchdog_pid"; do
+    if [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
+      kill -TERM "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+  if ((status != 0)) && run_bounded 10 docker inspect "$container_name" >/dev/null 2>&1; then
+    echo "native package lifecycle container logs:" >&2
+    run_bounded 15 docker logs --tail 300 "$container_name" >&2 || true
+    if run_bounded 10 docker exec "$container_name" test -x /usr/bin/systemctl >/dev/null 2>&1; then
+      echo "wukongim service status:" >&2
+      run_bounded 15 docker exec "$container_name" systemctl status --no-pager wukongim.service >&2 || true
+      echo "wukongim service journal:" >&2
+      run_bounded 15 docker exec "$container_name" journalctl --no-pager -u wukongim.service -n 300 >&2 || true
+    fi
+  fi
+  run_bounded 30 docker rm --force --volumes "$container_name" >/dev/null 2>&1 || true
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+total_timeout_marker="$(mktemp "${TMPDIR:-/tmp}/wk-native-lifecycle-total-timeout.XXXXXX")"
+(
+  timer_pid=0
+  trap 'if [[ "$timer_pid" =~ ^[1-9][0-9]*$ ]]; then kill -TERM "$timer_pid" >/dev/null 2>&1 || true; fi; exit 0' TERM INT
+  sleep 900 &
+  timer_pid=$!
+  wait "$timer_pid" || exit 0
+  if [[ -e "$total_timeout_marker" ]]; then
+    echo "native package lifecycle validation exceeded its 900-second total deadline" >&2
+    kill -TERM "$$" >/dev/null 2>&1 || true
+    rm -f "$total_timeout_marker"
+  fi
+) &
+total_watchdog_pid=$!
+
+run_in_container() {
+  run_in_container_bounded 30 "$@"
+}
+
+run_in_container_bounded() {
+  local timeout_seconds="$1"
+  shift
+  run_bounded "$timeout_seconds" docker exec "$container_name" "$@"
+}
+
+run_shell() {
+  run_shell_bounded 30 "$1"
+}
+
+run_shell_bounded() {
+  local timeout_seconds="$1"
+  shift
+  run_in_container_bounded "$timeout_seconds" /bin/sh -ec "$1"
+}
+
+probe_http() {
+  local path="$1"
+  run_in_container_bounded 5 /bin/bash -ec "exec 3<>/dev/tcp/127.0.0.1/5001 2>/dev/null; printf 'GET $path HTTP/1.0\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n' >&3; IFS= read -r -t 2 status <&3; [[ \"\$status\" == *' 200 '* ]]"
+}
+
+wait_for_systemd() {
+  local deadline state
+  deadline=$((SECONDS + 300))
+  while ((SECONDS < deadline)); do
+    state="$(run_in_container systemctl is-system-running 2>/dev/null || true)"
+    case "$state" in
+      running|degraded) return 0 ;;
+    esac
+    if [[ "$(run_bounded 10 docker inspect --format '{{.State.Running}}' "$container_name")" != "true" ]]; then
+      echo "systemd container stopped while booting" >&2
+      return 1
+    fi
+    sleep 1
+  done
+  echo "package bootstrap and systemd did not reach running or degraded state within 300 seconds" >&2
+  return 1
+}
+
+wait_for_ready() {
+  local deadline
+  deadline=$((SECONDS + 90))
+  while ((SECONDS < deadline)); do
+    if probe_http /healthz && probe_http /readyz; then
+      return 0
+    fi
+    if ! run_in_container systemctl is-active --quiet wukongim.service; then
+      echo "wukongim.service stopped before readiness" >&2
+      return 1
+    fi
+    if ((SECONDS < deadline)); then
+      sleep 1
+    fi
+  done
+  echo "wukongim.service did not become ready within 90 seconds" >&2
+  return 1
+}
+
+unit_property() {
+  run_in_container systemctl show wukongim.service --property="$1" --value
+}
+
+require_unit_stopped() {
+  local active_state sub_state result main_pid
+  active_state="$(unit_property ActiveState)"
+  sub_state="$(unit_property SubState)"
+  result="$(unit_property Result)"
+  main_pid="$(unit_property MainPID)"
+  if [[ "$active_state" != "inactive" || "$sub_state" != "dead" || "$result" != "success" || "$main_pid" != "0" ]]; then
+    echo "wukongim.service did not reach a clean inactive/dead state: ActiveState=$active_state SubState=$sub_state Result=$result MainPID=$main_pid" >&2
+    return 1
+  fi
+}
+
+require_inactive_and_disabled() {
+  local load_state unit_file_state
+  load_state="$(unit_property LoadState)"
+  unit_file_state="$(unit_property UnitFileState)"
+  require_unit_stopped
+  if [[ "$load_state" != "loaded" || "$unit_file_state" != "disabled" ]]; then
+    echo "wukongim.service is not installed disabled: LoadState=$load_state UnitFileState=$unit_file_state" >&2
+    return 1
+  fi
+}
+
+wait_for_pid_exit() {
+  local deadline pid state
+  pid="$1"
+  deadline=$((SECONDS + 30))
+  while ((SECONDS < deadline)); do
+    state="$(run_shell "if [ -e /proc/$pid ]; then printf present; else printf absent; fi")"
+    if [[ "$state" == "absent" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "wukongim process $pid survived package removal" >&2
+  return 1
+}
+
+require_unit_removed() {
+  local removed_pid load_state unit_file_state
+  removed_pid="$1"
+  wait_for_pid_exit "$removed_pid"
+  load_state="$(unit_property LoadState)"
+  unit_file_state="$(unit_property UnitFileState)"
+  if [[ "$load_state" != "not-found" || -n "$unit_file_state" ]]; then
+    echo "removed wukongim.service remains registered: LoadState=$load_state UnitFileState=$unit_file_state" >&2
+    return 1
+  fi
+  run_in_container test ! -e /etc/systemd/system/multi-user.target.wants/wukongim.service
+}
+
+service_pid() {
+  unit_property MainPID
+}
+
+service_invocation_id() {
+  unit_property InvocationID
+}
+
+service_start_time() {
+  local pid="$1"
+  run_shell "awk '{print \$22}' /proc/$pid/stat"
+}
+
+require_service_identity() {
+  local expected_pid="$1"
+  local expected_invocation="$2"
+  local expected_start_time="$3"
+  local actual_pid actual_invocation actual_start_time
+  actual_pid="$(service_pid)"
+  actual_invocation="$(service_invocation_id)"
+  actual_start_time="$(service_start_time "$actual_pid")"
+  if [[ "$actual_pid" != "$expected_pid" || "$actual_invocation" != "$expected_invocation" || "$actual_start_time" != "$expected_start_time" ]]; then
+    echo "package-manager reinstall replaced the live service identity" >&2
+    return 1
+  fi
+}
+
+state_manifest_command="cd / && {
+  stat -c '%a %u %g %n' etc/wukongim etc/wukongim/wukongim.toml var/lib/wukongim var/lib/wukongim/package-lifecycle-sentinel var/log/wukongim var/log/wukongim/package-lifecycle-sentinel
+  getent passwd wukongim
+  getent group wukongim
+}"
+
+record_operator_state() {
+  run_shell "printf '%s\\n' package-lifecycle-data >/var/lib/wukongim/package-lifecycle-sentinel && printf '%s\\n' package-lifecycle-log >/var/log/wukongim/package-lifecycle-sentinel && cd / && sha256sum etc/wukongim/wukongim.toml var/lib/wukongim/package-lifecycle-sentinel var/log/wukongim/package-lifecycle-sentinel >/tmp/wukongim-lifecycle-state.sha256 && $state_manifest_command >/tmp/wukongim-lifecycle-state.manifest && cd /tmp && sha256sum wukongim-lifecycle-state.manifest >/tmp/wukongim-lifecycle-state-manifest.sha256"
+}
+
+require_operator_state() {
+  run_shell "cd / && sha256sum --check /tmp/wukongim-lifecycle-state.sha256 && $state_manifest_command >/tmp/wukongim-lifecycle-state.current && test \"\$(sha256sum /tmp/wukongim-lifecycle-state.current | cut -d' ' -f1)\" = \"\$(cut -d' ' -f1 /tmp/wukongim-lifecycle-state-manifest.sha256)\""
+}
+
+bootstrap_command="set -eu
+if [ -n \"\${NATIVE_PACKAGE_TEST_APT_MIRROR:-}\" ] && [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+  sed -i -e \"s#http://archive.ubuntu.com/ubuntu/#\${NATIVE_PACKAGE_TEST_APT_MIRROR}/#\" -e \"s#http://security.ubuntu.com/ubuntu/#\${NATIVE_PACKAGE_TEST_APT_MIRROR}/#\" /etc/apt/sources.list.d/ubuntu.sources
+fi
+if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+  sed -i 's/^Components:.*/Components: main/' /etc/apt/sources.list.d/ubuntu.sources
+fi
+$install_command
+if [ -x /lib/systemd/systemd ]; then exec /lib/systemd/systemd; fi
+if [ -x /usr/lib/systemd/systemd ]; then exec /usr/lib/systemd/systemd; fi
+echo 'systemd executable is missing after package installation' >&2
+exit 1"
+
+run_bounded 300 docker pull --platform linux/amd64 "$image" >/dev/null
+run_bounded 30 docker run --detach \
+  --name "$container_name" \
+  --hostname wk-native-lifecycle \
+  --platform linux/amd64 \
+  --pull never \
+  --privileged \
+  --cgroupns private \
+  --stop-signal SIGRTMIN+3 \
+  --tmpfs /run:rw,nosuid,nodev,mode=755 \
+  --tmpfs /run/lock:rw,nosuid,nodev,mode=755 \
+  --volume "$package:$mount_target:ro" \
+  --env container=docker \
+  --env "NATIVE_PACKAGE_TEST_APT_MIRROR=${WK_NATIVE_PACKAGE_APT_MIRROR:-}" \
+  "$image" \
+  /bin/sh -ec "$bootstrap_command" >/dev/null
+
+wait_for_systemd
+run_in_container test -x /usr/bin/wukongim
+run_in_container test -f /usr/lib/systemd/system/wukongim.service
+run_in_container systemd-analyze verify /usr/lib/systemd/system/wukongim.service
+run_shell "/usr/bin/wukongim version --output json | grep -F '\"build_source\":\"release\"'"
+run_in_container test ! -e /etc/wukongim/wukongim.toml
+require_inactive_and_disabled
+
+run_shell "printf '%s\\n' 'native-package-lifecycle-test' | /usr/bin/wukongim config init --config /etc/wukongim/wukongim.toml --admin-password-stdin"
+run_in_container /usr/bin/wukongim config validate --config /etc/wukongim/wukongim.toml
+run_shell "test \"\$(stat -c '%a %U %G' /etc/wukongim/wukongim.toml)\" = '640 root wukongim'"
+record_operator_state
+
+run_in_container systemctl enable --now wukongim.service
+wait_for_ready
+run_in_container systemctl is-enabled --quiet wukongim.service
+first_pid="$(service_pid)"
+[[ "$first_pid" =~ ^[1-9][0-9]*$ ]]
+run_shell "test \"\$(awk '/^Uid:/ {print \$2}' /proc/$first_pid/status)\" = \"\$(id -u wukongim)\""
+first_invocation="$(service_invocation_id)"
+first_start_time="$(service_start_time "$first_pid")"
+[[ "$first_invocation" =~ ^[0-9a-f]{32}$ && "$first_start_time" =~ ^[1-9][0-9]*$ ]]
+
+run_shell_bounded 300 "$reinstall_command"
+run_in_container systemctl is-active --quiet wukongim.service
+run_in_container systemctl is-enabled --quiet wukongim.service
+wait_for_ready
+require_service_identity "$first_pid" "$first_invocation" "$first_start_time"
+sleep 2
+wait_for_ready
+require_service_identity "$first_pid" "$first_invocation" "$first_start_time"
+require_operator_state
+
+run_in_container systemctl restart wukongim.service
+wait_for_ready
+second_pid="$(service_pid)"
+[[ "$second_pid" =~ ^[1-9][0-9]*$ && "$second_pid" != "$first_pid" ]] || {
+  echo "explicit restart did not replace the wukongim process" >&2
+  exit 1
+}
+
+run_in_container systemctl stop wukongim.service
+require_unit_stopped
+if probe_http /readyz; then
+  echo "readyz remained reachable after explicit stop" >&2
+  exit 1
+fi
+
+run_in_container systemctl start wukongim.service
+wait_for_ready
+removed_pid="$(service_pid)"
+[[ "$removed_pid" =~ ^[1-9][0-9]*$ ]]
+run_shell_bounded 300 "$remove_command"
+require_unit_removed "$removed_pid"
+run_in_container test ! -e /usr/bin/wukongim
+run_in_container test ! -e /usr/lib/systemd/system/wukongim.service
+require_operator_state
+run_shell_bounded 300 "$install_command"
+require_inactive_and_disabled
+require_operator_state
+run_in_container /usr/bin/wukongim config validate --config /etc/wukongim/wukongim.toml
+
+run_in_container systemctl enable --now wukongim.service
+wait_for_ready
+run_in_container systemctl stop wukongim.service
+run_in_container systemctl disable wukongim.service
+require_inactive_and_disabled
+
+echo "native package lifecycle validation passed for $image $format"


### PR DESCRIPTION
## Summary / 变更摘要

- Build the preview deb/rpm once, retain its checksum set, and fan the exact same-run Artifact into a four-distribution lifecycle matrix.
- Exercise operator-owned configuration, real systemd start/health/restart/stop, live package-manager reinstall, active removal, retained state, and reinstall without implicit activation.
- Bound every Docker/package-manager/readiness/cleanup path, retain failure diagnostics when available, and keep lifecycle containers credential-free with only the exact package mounted read-only.
- Expand the workflow trigger to product runtime inputs and add structured contracts for matrix, permissions, artifact closure, checkout credentials, and tracked-tree immutability.

No release tag is created by this change.

## Release notes / 发布说明

- [x] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [ ] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

Skip reason / 豁免理由：

N/A

## Verification / 验证

- `GOWORK=off go test ./cmd/wukongim ./internal/config ./internal/app -count=1`
- `GOWORK=off go test ./scripts -count=1`
- `GOWORK=off go test ./scripts/... -run 'Workflow|NativePackage' -count=1`
- `GOWORK=off go test -tags=integration ./scripts -run '^TestNativePackageLifecycle$' -count=1` (compile/opt-in skip path)
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/native-package-preview.yml`
- `bash -n scripts/validate-native-package-lifecycle-container.sh`
- `git diff --check`
- Real local lifecycle against the immutable `v3.0.0-beta.6` packages: AlmaLinux 9 PASS; Rocky Linux 9 PASS. GitHub Hosted CI owns the final Ubuntu 24.04, Debian 12, Rocky Linux 9, and AlmaLinux 9 matrix evidence for this candidate head.
