### PR TITLE
fix: gate docs domain migration on origin content

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,10 +49,19 @@ authorization and the applicable budget.
 
 `docs-pages.yml` is the sole documentation publisher. A merge to `main` that
 changes `docs-site/**` starts it automatically; `workflow_dispatch` is reserved
-for first publication and recovery. The build job has read-only repository
-access, installs the locked Bun dependencies, runs `bun run verify`, and uploads
-only the resulting `docs-site/out` directory. The deploy job receives only the
-Pages and OIDC permissions required by GitHub's deployment API.
+for first publication, recovery, and the bounded custom-domain migration mode.
+The build job has read-only repository access, installs the locked Bun
+dependencies, runs `bun run verify`, and uploads only the resulting
+`docs-site/out` directory. The deploy job receives only the Pages and OIDC
+permissions required by GitHub's deployment API.
+
+A manual migration run may set `expected_pages_domain` to exactly
+`docs.githubim.com` or `origin-docs.githubim.com`. The Workflow finishes the
+build and upload before its deploy job waits for the Pages API to expose that
+exact domain. This lets an operator stage the verified artifact before the
+single external custom-domain mutation. A non-empty migration input suppresses
+CDN refresh for that run. Changing the Pages setting, receiving REST `204`, or
+seeing an approved certificate never counts as content readiness by itself.
 
 The repository Pages source must remain `workflow`, and the unchanged
 `github-pages` Environment is the content-publication boundary. In the planned
@@ -63,12 +72,18 @@ content origin. Alibaba Cloud CDN serves the canonical public
 Pages Settings/API is the sole custom-domain authority. The export retains
 `.nojekyll` but deliberately contains no `CNAME`.
 
-After a successful Pages deployment, an isolated refresh job may assume the
-refresh-only Alibaba Cloud role from the `docs-cdn` Environment. The job is
-skipped unless repository Variable `DOCS_CDN_ENABLED` is exactly `true`. Once
-enabled, a missing or invalid binding fails before OIDC exchange. It refreshes
-a bounded set of stable public URLs; it does not create provider resources,
-change DNS, replace CDN settings, or broadly purge content-addressed assets.
+After every successful Pages deployment, a read-only verification job requires
+the Pages API to report the exact current domain, workflow build, verified
+ownership, HTTPS enforcement, and approved origin certificate. It then bypasses
+public CDN DNS with `curl --connect-to` and performs complete GETs for the root,
+both locale roots, one deep page, and the search index. Only after that direct
+origin gate succeeds may an isolated refresh job assume the refresh-only
+Alibaba Cloud role from the `docs-cdn` Environment. The refresh job is skipped
+unless repository Variable `DOCS_CDN_ENABLED` is exactly `true`, and is also
+skipped for a migration-mode run. Once enabled, a missing or invalid binding
+fails before OIDC exchange. It refreshes a bounded set of stable public URLs;
+it does not create provider resources, change DNS, replace CDN settings, or
+broadly purge content-addressed assets.
 
 `docs-cdn-certificate.yml` is a separate certificate safety automation. Its
 scheduled and manual paths are also inert while `DOCS_CDN_ENABLED` is disabled.

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -11,7 +11,14 @@ on:
       - "docs-site/**"
       - "scripts/docs-cdn/install-aliyun-cli.sh"
       - "scripts/docs-cdn/refresh.sh"
+      - "scripts/docs-cdn/verify-pages-origin.sh"
   workflow_dispatch:
+    inputs:
+      expected_pages_domain:
+        description: "Optional exact Pages domain; build first, then wait for this domain before deploying"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -72,14 +79,66 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Wait for the expected GitHub Pages custom domain
+        if: github.event_name == 'workflow_dispatch' && inputs.expected_pages_domain != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_PAGES_DOMAIN: ${{ inputs.expected_pages_domain }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == refs/heads/main ]]
+          [[ "$EXPECTED_PAGES_DOMAIN" == docs.githubim.com || "$EXPECTED_PAGES_DOMAIN" == origin-docs.githubim.com ]]
+          readonly pages_api="https://api.github.com/repos/${GITHUB_REPOSITORY}/pages"
+          domain_ready=false
+          for attempt in $(seq 1 120); do
+            current_domain="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "$pages_api" --jq '.cname // ""' 2>/dev/null || true)"
+            if [[ "$current_domain" == "$EXPECTED_PAGES_DOMAIN" ]]; then
+              domain_ready=true
+              break
+            fi
+            printf 'Waiting for Pages domain %s (current: %s, attempt: %s/120)\n' \
+              "$EXPECTED_PAGES_DOMAIN" "${current_domain:-missing}" "$attempt"
+            sleep 5
+          done
+          [[ "$domain_ready" == true ]]
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
+  verify_pages_origin:
+    name: Verify the direct GitHub Pages origin
+    needs: deploy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pages: read
+    steps:
+      - name: Checkout the exact source revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Require the Pages API and direct origin data plane to agree
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DOCS_PAGES_REPOSITORY: ${{ github.repository }}
+          DOCS_PAGES_DOMAIN: ${{ inputs.expected_pages_domain }}
+          DOCS_PAGES_CACHE_BUST: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+        run: ./scripts/docs-cdn/verify-pages-origin.sh
+
   refresh_cdn:
     name: Refresh bounded Alibaba CDN URLs
-    needs: deploy
-    if: github.ref == 'refs/heads/main' && vars.DOCS_CDN_ENABLED == 'true'
+    needs: verify_pages_origin
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      vars.DOCS_CDN_ENABLED == 'true' &&
+      (github.event_name != 'workflow_dispatch' || inputs.expected_pages_domain == '')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ move those entries into a version section named for that exact tag.
 
 ### 🐛 Bug Fixes / 问题修复
 
+- 文档 Pages 自定义域名迁移与回滚现在会先暂存已验证产物，在域名绑定变化后立即重新部署，并以绕过 CDN 的根路径、双语首页、深层页面及搜索真实 GET 作为内容就绪门禁；证书批准或 API `204` 不再被误当作站点可用。
 - 文档 CDN 证书检查现在根据显式公网路由模式和多个公共解析器的直接 CNAME 答案决定是否验证阿里云边缘证书，不再将供应商 `DomainCnameStatus` 误当作公网切流证明。
 - 文档 CDN 证书检查现在正确接受“已安装证书且暂无需续期”以及强制初始化时“尚未安装证书”的布尔结果，同时仍会拒绝缺失或类型错误的状态字段。
 - 文档 CDN 证书轮换现在兼容阿里云已启用的手动上传证书省略 `Status` 字段的响应，同时仍会拒绝免费或未知类型的空状态以及尚未生效的证书状态。
@@ -16,7 +17,7 @@ move those entries into a version section named for that exact tag.
 - 插件热重载监视器现在在启动后立即停止时保持完成信号的稳定引用，避免并发清理将其置空后引发 `close of nil channel` 崩溃。
 - Issue Agent 验证器现在会在判定工作目录越界前规范化 checkout 根路径，避免 macOS 上 `/var` 与 `/private/var` 别名导致合法子目录被误拒。
 - JSON-RPC 解码器现在会将未知通知方法统一归类为 `ErrUnknownMethod`，与未知请求的错误分类保持一致，便于调用方稳定识别协议错误。
-- JSON-RPC subscribe/unsubscribe 请求现在会转换为带正确 action 的协议帧，并将订阅回执关联到原请求，不再在解码成功后被网关拒绝。
+- JSON-RPC subscribe/unsubscribe 请求现在会在协议适配层转换为带正确 action 的 `SUB` 帧，并将可用的 `SUBACK` 关联到原请求；当前 Product Gateway 仍未发布 `SUB` 入站能力。
 - 权限元数据批量读取现在会在进入 Slot 代理前拒绝未知读取类型，并保持其余合法结果的原始对齐，避免无效类型被下游结果覆盖或污染整批授权证据。
 - Controller Slot 副本迁移与 Leader 转移在运行时未启动时现在统一 fail closed 为 `ErrNotStarted`，不再根据空状态返回误导性的业务校验错误。
 - Slot FSM 现在会为确定性的过期元数据提案持久化已应用水位，节点重启后不再重复回放已经判定为无操作的 Raft 日志。

--- a/docs-site/FLOW.md
+++ b/docs-site/FLOW.md
@@ -7,11 +7,10 @@ summary: Owns the bilingual static v3 documentation site, shared navigation, pub
 
 ## Responsibility
 
-`docs-site` is the standalone Fumadocs application for public WuKongIM v3
-documentation under `/zh` and `/en`. It owns navigation, MDX, search and SEO,
-machine-readable output, SDK guidance, API and protocol references, and the
-runnable JavaScript/Web SDK example. It documents runtime contracts but does
-not define them.
+`docs-site` is the standalone Fumadocs application for public WuKongIM v3 docs
+under `/zh` and `/en`. It owns navigation, MDX, search, SEO, machine-readable
+output, SDK and API references, and the runnable JavaScript/Web example. It
+documents runtime contracts but does not define them.
 
 ## Boundaries
 
@@ -21,10 +20,11 @@ not define them.
 - `lib/navigation.ts` is the shared bilingual publication registry.
 - `SDK_DOCUMENTATION_SPEC.md` owns the maintained WuKongIMSDK versions,
   learning order, and reader contract. WuKongEasySDK remains a separate path.
-- `.github/workflows/docs-pages.yml` deploys the exact export to GitHub Pages
-  and may refresh a pre-provisioned CDN only when `DOCS_CDN_ENABLED=true`. It
-  never provisions or reconfigures DNS, CDN topology, RAM, or certificates;
-  its only Alibaba mutation is the four bounded cache invalidations.
+- `.github/workflows/docs-pages.yml` deploys the export, verifies the direct
+  Pages data plane, and may refresh a CDN when `DOCS_CDN_ENABLED=true`. Its
+  migration input stages the export before one exact external domain change.
+  It never reconfigures DNS, CDN topology, RAM, or certificates; its only
+  Alibaba mutation is four bounded cache invalidations.
 - The canonical URL remains `https://docs.githubim.com`. After CDN cutover,
   GitHub Pages serves `https://origin-docs.githubim.com` as the only origin.
   Pages Settings/API is the sole domain authority; the export carries no CNAME.
@@ -54,9 +54,10 @@ not define them.
    machine-artifact checks run before the Workflow uploads that exact directory
    as the GitHub Pages artifact. Hidden files are retained so `.nojekyll` and
    future machine-readable well-known endpoints cannot be dropped silently.
-8. After external CDN setup and enablement, the deploy Workflow refreshes only
-   bounded stable URLs. It never broadly purges content-addressed assets, and
-   refresh failure does not undo a successful Pages deployment.
+8. After deployment, Pages API state and direct root, locale, deep-page, and
+   search GETs gate bounded CDN refreshes. Migration runs skip refresh; a normal
+   follow-up refreshes after the gate. It never broadly purges content-addressed
+   assets, and refresh failure does not undo a successful Pages deployment.
 
 ## Invariants and Failure Semantics
 
@@ -70,22 +71,21 @@ not define them.
 - A trusted application backend supplies identity, tokens, routing, history,
   channel metadata, and media URLs as needed. Untrusted clients never call
   Product HTTP management operations directly.
-- The JavaScript example is a runnable development aid with unit and build
-  checks. It is not a production backend or a substitute for testing on the
-  application's actual browsers, devices, networks, and release configuration.
-- EasySDK example evidence names the exact client and server revisions. When a
-  verified repository revision is ahead of its package release, pages must not
-  attribute that source run to the older npm, Maven, CocoaPods, or Release
-  artifact.
+- The JavaScript example is a tested development aid, not a production backend
+  or a substitute for testing on actual devices, networks, and releases.
+- EasySDK evidence names exact client and server revisions. When verified source
+  is ahead of a package release, pages must not attribute that run to the older
+  npm, Maven, CocoaPods, or Release artifact.
 - The complete Product HTTP contract must match current route registrations.
   Missing authentication, weak validation, legacy behavior, and unbounded
   responses stay explicit rather than being normalized away.
 - The static API reference keeps its playground disabled. Generated examples
   come only from reviewed samples that state the trusted-backend boundary.
-- Production publication uses one non-canceling `github-pages` concurrency
-  group. The deploy job receives only `pages: write` and `id-token: write`; the
-  build job remains read-only. CDN refresh and certificate rotation use the
-  separate `docs-cdn` and `docs-cdn-certificate` Environments and OIDC roles.
+- Publication uses one non-canceling `github-pages` group. Deploy receives only
+  `pages: write` and `id-token: write`; build and origin verification stay
+  read-only. CDN refresh and certificate rotation use separate Environments and
+  OIDC roles. Domain, build, or certificate state never replaces a fresh
+  deployment and the direct content gate.
 
 ## Read First
 

--- a/docs-site/NAVIGATION.md
+++ b/docs-site/NAVIGATION.md
@@ -44,15 +44,9 @@ Route: `/{lang}/server`
 
 部署、配置、运维和理解 WuKongIM 集群。 / Deploy, configure, operate, and understand a WuKongIM cluster.
 
-<<<<<<< HEAD
-- **部署 / Deployment** `/{lang}/server/deployment` — 选择并实施适合环境的服务端部署方式。 / Choose and implement the server deployment method appropriate for the environment.
-  - **Docker 部署 / Docker** `/{lang}/server/deployment/docker` — 构建固定镜像，并用显式配置和持久卷运行节点。 / Builds an immutable image and runs a node with explicit configuration and persistent storage.
-  - **Linux 部署 / Linux** `/{lang}/server/deployment/linux` — 从签名 APT/DNF Preview 软件源安装，并用安全配置和 systemd 运行服务。 / Installs from the signed APT/DNF preview repository and runs the service with secure configuration and systemd.
-=======
 - **部署 / Deployment** `/{lang}/server/deployment` — 从 Docker、Linux 或多节点路径完成服务端部署。 / Deploy the server through the Docker, Linux, or multi-node path.
   - **Docker 部署 / Docker** `/{lang}/server/deployment/docker` — 使用固定的官方镜像、显式配置和持久卷运行节点。 / Runs a node with a pinned official image, explicit configuration, and persistent storage.
-  - **Linux 部署 / Linux** `/{lang}/server/deployment/linux` — 安装经过校验的 Release 二进制，并用 systemd 运行节点。 / Installs a verified release binary and runs the node with systemd.
->>>>>>> a5e302b5f (docs: streamline guides and deployment paths)
+  - **Linux 部署 / Linux** `/{lang}/server/deployment/linux` — 从签名 APT/DNF Preview 软件源安装，并用安全配置和 systemd 运行服务。 / Installs from the signed APT/DNF preview repository and runs the service with secure configuration and systemd.
   - **多节点集群 / Multi-node Cluster** `/{lang}/server/deployment/multi-node` — 规划成员、副本、故障域并验证集群就绪。 / Plans membership, replicas, failure domains, and cluster readiness.
   - **生产检查清单 / Production Checklist** `/{lang}/server/deployment/production-checklist` — 汇总资源、磁盘、安全、监控、备份和容量检查。 / Checks resources, disks, security, monitoring, backups, and capacity.
 - **配置 / Configuration** `/{lang}/server/configuration` — 解释配置来源、覆盖规则和各领域配置。 / Explains configuration sources, override rules, and domain settings.

--- a/docs-site/content/docs/api/client-protocols/json-rpc.en.mdx
+++ b/docs-site/content/docs/api/client-protocols/json-rpc.en.mdx
@@ -21,7 +21,7 @@ WebSocket `wsmux` selects JSON-RPC when the first non-whitespace byte is `{` or 
 | request | `send` | → `SEND` | handled only on an authenticated session; returns same-ID SENDACK result/error |
 | request | `ping` | → `PING` | returns the same ID with explicit `result: null` |
 | request | `disconnect` | → `DISCONNECT` | unsupported by the product handler; closes |
-| request | `subscribe` / `unsubscribe` | decoded only | frame bridge missing |
+| request | `subscribe` / `unsubscribe` | → `SUB` (`action` is `0` / `1`) | the Product Gateway handler does not support `SUB`; the default handler-error policy closes the session, so the current product path cannot emit `SUBACK` |
 | notification | `recvack` | → `RECVACK` | confirms online delivery on an authenticated session; iOS `v1.1.1` sends both camelCase `messageId` and `messageSeq` |
 | notification | `recv` / `disconnect` / `event` | decoded only | frame bridge missing |
 | response | any structurally valid response | decoded to a generic response | frame bridge missing |

--- a/docs-site/content/docs/api/client-protocols/json-rpc.mdx
+++ b/docs-site/content/docs/api/client-protocols/json-rpc.mdx
@@ -21,7 +21,7 @@ WebSocket `wsmux` 在首个非空白字节为 `{` 或 `[` 时选择 JSON-RPC，�
 | request | `send` | → `SEND` | 仅在已认证会话处理；按请求 ID 返回 `SENDACK` result/error |
 | request | `ping` | → `PING` | 返回同 ID 且显式包含 `result: null` |
 | request | `disconnect` | → `DISCONNECT` | 产品处理器不支持并关闭 |
-| request | `subscribe` / `unsubscribe` | 仅解码 | 缺少 frame bridge |
+| request | `subscribe` / `unsubscribe` | → `SUB`（`action` 分别为 `0` / `1`） | Product Gateway handler 尚不支持 `SUB`；默认以 handler error 关闭连接，当前产品路径不会产生 `SUBACK` |
 | notification | `recvack` | → `RECVACK` | 已认证会话中确认在线投递；iOS `v1.1.1` 同时发送 camelCase `messageId` 与 `messageSeq` |
 | notification | `recv` / `disconnect` / `event` | 仅解码 | 缺少 frame bridge |
 | response | 任意合法 response | 仅解码为 generic response | 缺少 frame bridge |

--- a/docs-site/content/docs/api/specifications/json-rpc-schema.en.mdx
+++ b/docs-site/content/docs/api/specifications/json-rpc-schema.en.mdx
@@ -14,7 +14,7 @@ The schema's `x-wukongim-stability` is `experimental-easysdk-core-supported`. Cu
 - `connect` is the first request and returns a correlated result/error after authentication and activation;
 - `send` and `ping` correlate SENDACK/PONG through the request ID;
 - `recv` notifications and `recvack` complete online-delivery acknowledgement;
-- `subscribe`, `unsubscribe`, and several notifications are codec-only or lack a frame bridge;
+- `subscribe` and `unsubscribe` map to `SUB` at the codec boundary, and `SUBACK` has a response mapping; the Product Gateway handler still rejects `SUB`, so the current product path cannot use them;
 - `[` selects JSON mode, but batch arrays are unimplemented; request IDs must be strings, and SEND payload may be an object, Base64, or `null`.
 
 Schema entries outside the EasySDK core path remain non-promises. See [WebSocket JSON-RPC](/en/api/client-protocols/json-rpc) for the full matrix, pinned versions, and evidence boundary.

--- a/docs-site/content/docs/api/specifications/json-rpc-schema.mdx
+++ b/docs-site/content/docs/api/specifications/json-rpc-schema.mdx
@@ -14,7 +14,7 @@ Schema 的 `x-wukongim-stability` 为 `experimental-easysdk-core-supported`。�
 - `connect` 是首个请求，并在鉴权、激活后返回关联 result/error；
 - `send`、`ping` 使用请求 ID 关联 SENDACK/PONG；
 - `recv` notification 与 `recvack` 完成在线投递确认；
-- `subscribe`、`unsubscribe` 及多种 notification 只有 codec 结构或缺少 frame bridge；
+- `subscribe`、`unsubscribe` 会在 codec 层转换为 `SUB`，`SUBACK` 也有对应 response 映射；Product Gateway handler 仍拒绝 `SUB`，因此当前产品路径不可用；
 - `[` 会选择 JSON 模式，但 batch 数组未实现；请求 ID 必须是字符串，SEND Payload 可为对象、Base64 或 `null`。
 
 Schema 中不属于 EasySDK 核心路径的结构仍不产生运行时承诺。完整矩阵、四端固定版本和证据边界见 [WebSocket JSON-RPC](/zh/api/client-protocols/json-rpc)。

--- a/docs-site/contracts/json-rpc.experimental.schema.json
+++ b/docs-site/contracts/json-rpc.experimental.schema.json
@@ -17,6 +17,7 @@
     { "$ref": "#/$defs/DisconnectNotification" },
     { "$ref": "#/$defs/ConnectResponse" },
     { "$ref": "#/$defs/SendResponse" },
+    { "$ref": "#/$defs/SubscriptionResponse" },
     { "$ref": "#/$defs/PongResponse" },
     { "$ref": "#/$defs/ErrorResponse" },
     { "$ref": "#/$defs/GenericResponse" }
@@ -213,7 +214,7 @@
           }
         }
       ],
-      "x-wukongim-product-status": "decoder-only-bridge-missing"
+      "x-wukongim-product-status": "decoded-to-sub-frame-but-product-handler-rejects"
     },
     "UnsubscribeParams": {
       "type": "object",
@@ -235,7 +236,7 @@
           }
         }
       ],
-      "x-wukongim-product-status": "decoder-only-bridge-missing"
+      "x-wukongim-product-status": "decoded-to-sub-frame-but-product-handler-rejects"
     },
     "RecvAckParams": {
       "type": "object",
@@ -311,6 +312,30 @@
           "not": { "required": ["error"] }
         }
       ]
+    },
+    "SubscriptionResult": {
+      "type": "object",
+      "required": ["subNo", "channelId", "channelType", "action", "reasonCode"],
+      "properties": {
+        "header": { "$ref": "#/$defs/Header" },
+        "subNo": { "type": "string" },
+        "channelId": { "type": "string" },
+        "channelType": { "type": "integer" },
+        "action": { "type": "integer", "enum": [0, 1] },
+        "reasonCode": { "type": "integer" }
+      }
+    },
+    "SubscriptionResponse": {
+      "allOf": [
+        { "$ref": "#/$defs/ResponseBase" },
+        {
+          "type": "object",
+          "required": ["result"],
+          "properties": { "result": { "$ref": "#/$defs/SubscriptionResult" } },
+          "not": { "required": ["error"] }
+        }
+      ],
+      "x-wukongim-product-status": "codec-mapping-only-product-handler-rejects-sub"
     },
     "PongResponse": {
       "allOf": [

--- a/docs-site/lib/json-rpc-schema.test.ts
+++ b/docs-site/lib/json-rpc-schema.test.ts
@@ -19,8 +19,14 @@ describe('experimental JSON-RPC schema', () => {
     expect(schema.$defs.ConnectRequest['x-wukongim-product-status']).toContain('supported');
     expect(schema.$defs.SendRequest['x-wukongim-product-status']).toContain('supported');
     expect(schema.$defs.RecvAckNotification['x-wukongim-product-status']).toContain('supported');
-    expect(schema.$defs.SubscribeRequest['x-wukongim-product-status']).toContain(
-      'bridge-missing',
+    expect(schema.$defs.SubscribeRequest['x-wukongim-product-status']).toBe(
+      'decoded-to-sub-frame-but-product-handler-rejects',
+    );
+    expect(schema.$defs.UnsubscribeRequest['x-wukongim-product-status']).toBe(
+      'decoded-to-sub-frame-but-product-handler-rejects',
+    );
+    expect(schema.$defs.SubscriptionResponse['x-wukongim-product-status']).toContain(
+      'product-handler-rejects-sub',
     );
   });
 
@@ -45,6 +51,7 @@ describe('experimental JSON-RPC schema', () => {
     const outboundDefinitionByFrame = {
       CONNACK: 'ConnectResponse',
       SENDACK: 'SendResponse',
+      SUBACK: 'SubscriptionResponse',
       RECV: 'RecvNotification',
       EVENT: 'EventNotification',
       DISCONNECT: 'DisconnectNotification',

--- a/docs-site/lib/protocol-surface-contracts.test.ts
+++ b/docs-site/lib/protocol-surface-contracts.test.ts
@@ -325,8 +325,8 @@ describe('protocol surface contracts', () => {
       { kind: 'request', method: 'send', decoded: true, bridgedFrame: 'SEND', productStatus: 'works' },
       { kind: 'request', method: 'ping', decoded: true, bridgedFrame: 'PING', productStatus: 'works' },
       { kind: 'request', method: 'disconnect', decoded: true, bridgedFrame: 'DISCONNECT', productStatus: 'rejected' },
-      { kind: 'request', method: 'subscribe', decoded: true, productStatus: 'bridge-missing' },
-      { kind: 'request', method: 'unsubscribe', decoded: true, productStatus: 'bridge-missing' },
+      { kind: 'request', method: 'subscribe', decoded: true, bridgedFrame: 'SUB', productStatus: 'rejected' },
+      { kind: 'request', method: 'unsubscribe', decoded: true, bridgedFrame: 'SUB', productStatus: 'rejected' },
       { kind: 'notification', method: 'recvack', decoded: true, bridgedFrame: 'RECVACK', productStatus: 'works' },
       { kind: 'notification', method: 'recv', decoded: true, productStatus: 'bridge-missing' },
       { kind: 'notification', method: 'disconnect', decoded: true, productStatus: 'bridge-missing' },
@@ -335,6 +335,7 @@ describe('protocol surface contracts', () => {
     expect(jsonRPCOutboundSurface.map((item) => item.frame)).toEqual([
       'CONNACK',
       'SENDACK',
+      'SUBACK',
       'RECV',
       'EVENT',
       'DISCONNECT',
@@ -356,6 +357,8 @@ describe('protocol surface contracts', () => {
       'PingRequest',
       'DisconnectRequest',
       'RecvAckNotification',
+      'SubscribeRequest',
+      'UnsubscribeRequest',
     ]);
     expect([...fromFrame.matchAll(/case frame\.([A-Z]+):/gu)].map((match) => match[1])).toEqual(
       jsonRPCOutboundSurface.map((item) => item.frame),
@@ -369,7 +372,13 @@ describe('protocol surface contracts', () => {
     expect(server).toContain('state.listener.auth.ConnectAuthenticationRequired(state.session)');
     expect(server).toContain('state.setAuthRequired(false)');
     expect(server).toContain('state.setAuthenticated(true)');
-    expect(handler).toContain('return ErrUnsupportedFrame');
+    const onFrame = functionBody(
+      handler,
+      'func (h *Handler) OnFrame(',
+      'func (h *Handler) handleTerminalFence(',
+    );
+    expect(onFrame).not.toContain('case *frame.SubPacket:');
+    expect(onFrame).toContain('return ErrUnsupportedFrame');
   });
 
   test('keeps the compatibility encryption algorithm and runtime ordering source-aligned', async () => {

--- a/docs-site/lib/protocol-surface-contracts.ts
+++ b/docs-site/lib/protocol-surface-contracts.ts
@@ -186,8 +186,8 @@ export const jsonRPCInboundSurface: readonly JSONRPCInboundSurface[] = [
   { kind: 'request', method: 'send', decoded: true, bridgedFrame: 'SEND', productStatus: 'works' },
   { kind: 'request', method: 'ping', decoded: true, bridgedFrame: 'PING', productStatus: 'works' },
   { kind: 'request', method: 'disconnect', decoded: true, bridgedFrame: 'DISCONNECT', productStatus: 'rejected' },
-  { kind: 'request', method: 'subscribe', decoded: true, productStatus: 'bridge-missing' },
-  { kind: 'request', method: 'unsubscribe', decoded: true, productStatus: 'bridge-missing' },
+  { kind: 'request', method: 'subscribe', decoded: true, bridgedFrame: 'SUB', productStatus: 'rejected' },
+  { kind: 'request', method: 'unsubscribe', decoded: true, bridgedFrame: 'SUB', productStatus: 'rejected' },
   { kind: 'notification', method: 'recvack', decoded: true, bridgedFrame: 'RECVACK', productStatus: 'works' },
   { kind: 'notification', method: 'recv', decoded: true, productStatus: 'bridge-missing' },
   { kind: 'notification', method: 'disconnect', decoded: true, productStatus: 'bridge-missing' },
@@ -204,6 +204,7 @@ export interface JSONRPCOutboundSurface {
 export const jsonRPCOutboundSurface: readonly JSONRPCOutboundSurface[] = [
   { frame: 'CONNACK', shape: 'correlated connect result or error', productBoundary: 'reachable after JSON-RPC CONNECT authentication and activation' },
   { frame: 'SENDACK', shape: 'correlated send result or error', productBoundary: 'reachable on an authenticated JSON-RPC session' },
+  { frame: 'SUBACK', shape: 'correlated subscription result or error', productBoundary: 'codec mapping only; the product Gateway rejects inbound SUB frames' },
   { frame: 'RECV', shape: 'recv notification with header object and object payload', productBoundary: 'online delivery only; offline sync is outside EasySDK' },
   { frame: 'EVENT', shape: 'event notification', productBoundary: 'tooling-only EVENT scope' },
   { frame: 'DISCONNECT', shape: 'disconnect notification', productBoundary: 'no published product emission contract' },

--- a/docs-site/scripts/check-static-output.ts
+++ b/docs-site/scripts/check-static-output.ts
@@ -434,7 +434,7 @@ export async function checkStaticOutput() {
   if (
     jsonRPCSchema.$schema !== 'https://json-schema.org/draft/2020-12/schema' ||
     jsonRPCSchema['x-wukongim-stability'] !== 'experimental-easysdk-core-supported' ||
-    jsonRPCSchema.anyOf?.length !== 15
+    jsonRPCSchema.anyOf?.length !== 16
   ) {
     throw new Error('JSON-RPC codec Schema lost its bounded EasySDK support boundary');
   }

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -424,7 +424,7 @@
 - The public WuKongIM v3 documentation application lives in `docs-site/`; the repository-level `docs/` tree remains the engineering knowledge base.
 - Public documentation uses the canonical bilingual routes `/{zh|en}/{guide|server|sdk|api}`. Both languages share one navigation registry in `docs-site/lib/navigation.ts`.
 - A documentation route is published only when both language variants are ready. Planned routes remain visible with a badge but are `noindex` and excluded from search, sitemap, and LLM outputs. Navigation tests also fail when an existing MDX file is planned or unknown, so disk content cannot silently remain hidden from public indexes.
-- `docs-site` is a Bun-managed Fumadocs/Next.js static export published by the repository's GitHub Pages Workflow. `https://docs.githubim.com` remains the canonical reader URL. The default-disabled Alibaba Cloud CDN integration can refresh only four bounded public URLs and rotate its Let's Encrypt edge certificate through separate OIDC roles; rotation is limited to temporary ACME TXT records in the delegated child zone and the exact CDN certificate, and no Workflow provisions or reconfigures the DNS/CDN topology. After an operator cutover, GitHub Pages remains the sole content origin at `origin-docs.githubim.com`, with Pages Settings/API—not an artifact `CNAME`—owning the origin-domain binding.
+- `docs-site` is a Bun-managed Fumadocs/Next.js static export published by the repository's GitHub Pages Workflow. `https://docs.githubim.com` remains the canonical reader URL. The default-disabled Alibaba Cloud CDN integration can refresh only four bounded public URLs and rotate its Let's Encrypt edge certificate through separate OIDC roles; rotation is limited to temporary ACME TXT records in the delegated child zone and the exact CDN certificate, and no Workflow provisions or reconfigures the DNS/CDN topology. After an operator cutover, GitHub Pages remains the sole content origin at `origin-docs.githubim.com`, with Pages Settings/API—not an artifact `CNAME`—owning the origin-domain binding. A Pages domain mutation does not deploy content: migration and rollback stage the verified artifact before the mutation, then require a fresh Pages deployment plus direct root, locale, deep-page, and search GETs before any CDN refresh or origin convergence.
 - Documentation ACME account bootstrap is account-only: it fixes the Let's Encrypt production directory and an explicitly reviewed terms URL, persists the service response without ordering a certificate, and treats the ACME account `contact` as optional while keeping the bundle email and account URI as strict local identity boundaries.
 - Published v3 Product HTTP reference pages are generated per operation and tag
   from three bounded OpenAPI contracts: the JavaScript/Web golden path,
@@ -436,8 +436,10 @@
   compatibility encryption. JSON-RPC is published as a bounded support matrix:
   Product Gateway supports CONNECT-first authentication, request correlation,
   Ping, and online SEND/SENDACK plus RECV/RECVACK for the four pinned EasySDK
-  wire profiles; batches, subscriptions, offline sync, push, and general-purpose
-  RPC remain experimental or unsupported.
+  wire profiles. Subscribe/unsubscribe and SUBACK have JSON-RPC codec mappings,
+  but the Product Gateway still rejects inbound SUB; batches, subscriptions,
+  offline sync, push, and general-purpose RPC remain experimental or
+  unsupported.
 - Phase 5 configuration reference pages are checked against every public field returned by `internal/config.SchemaFields()` in both locales. `wukongim.toml.example` is a loadable development baseline, not a promise that its explicit values are runtime defaults for omitted fields.
 - Phase 6 public operations guidance treats Manager as a privileged boundary,
   distinguishes `/healthz` liveness from `/readyz` admission, keeps dynamic

--- a/docs/superpowers/runbooks/docs-alibaba-cdn.md
+++ b/docs/superpowers/runbooks/docs-alibaba-cdn.md
@@ -403,6 +403,13 @@ fix the external setup, and repeat preflight. Do not proceed partially.
 Pause documentation publication for the cutover and work during a low-traffic
 window.
 
+Changing the Pages custom domain is a control-plane update, not a content
+deployment. A successful REST `204`, `status: built`, or an approved TLS
+certificate does not prove that the new Host serves the site. GitHub documents
+that changing a routing path does not initiate a rebuild. Every forward or
+rollback custom-domain change must therefore be paired with a fresh deployment
+and a direct content GET gate.
+
 1. While GitHub Pages still owns `docs.githubim.com`, use this temporary CDN
    migration bridge:
 
@@ -429,9 +436,36 @@ window.
    `DOCS_CDN_PUBLIC_ROUTE_MODE=alibaba-cdn` and manually run
    `docs-cdn-certificate.yml` without forced renewal. Require
    `Public edge verification: passed` before continuing.
-6. In repository Settings, change the GitHub Pages custom domain to
-   `origin-docs.githubim.com`. Keep the Pages source as GitHub Actions.
-7. While GitHub issues the origin certificate, use only this bounded temporary
+6. Confirm there is no queued or running `docs-pages.yml` run, fetch protected
+   `main`, and record its exact SHA. Dispatch the migration mode before changing
+   the Pages domain:
+
+   ```bash
+   gh workflow run docs-pages.yml \
+     --repo WuKongIM/WuKongIM \
+     --ref main \
+     -f expected_pages_domain=origin-docs.githubim.com
+   ```
+
+   Record the resulting run ID and confirm its `headSha` equals the recorded
+   protected-`main` SHA. The Workflow verifies and uploads the artifact first;
+   its deploy job then waits for the exact requested Pages domain. A non-empty
+   `expected_pages_domain` also suppresses CDN refresh for this staging run.
+7. Wait until that run's build job is successful and the deploy job is visibly
+   in `Wait for the expected GitHub Pages custom domain`. Do not change the
+   custom domain before the artifact is staged. If the wait step times out,
+   leave the current domain unchanged and start a new staging run.
+8. Keep the Pages source as GitHub Actions, then make the single domain update.
+   The equivalent REST body is exact:
+
+   ```json
+   {"cname":"origin-docs.githubim.com"}
+   ```
+
+   A `204` confirms only that GitHub accepted the setting. The staged run must
+   observe this exact value and immediately deploy its already verified
+   artifact.
+9. While GitHub issues the origin certificate, use only this bounded temporary
    bridge if required:
 
    ```text
@@ -439,10 +473,22 @@ window.
    origin Host:                   origin-docs.githubim.com
    ```
 
-8. After `https://origin-docs.githubim.com` presents a valid GitHub certificate
-   and serves the exact site, switch CDN address, Host, and SNI together to
-   `origin-docs.githubim.com`. Remove all temporary bridge settings.
-9. Observe for at least 60 minutes before resuming documentation publication.
+10. When the Pages API reports an approved certificate containing
+    `origin-docs.githubim.com`, enable Pages HTTPS enforcement. Then wait for the
+    staging run with `gh run watch <run-id> --exit-status`. Its independent
+    `verify_pages_origin` job requires the API state and a **direct origin GET gate**
+    to agree: real GETs for `/`, `/zh/`, `/en/`, a deep page, and
+    `/api/search` must return complete expected content over trusted TLS while
+    `curl --connect-to` bypasses public CDN DNS. Certificate approval alone is
+    never content readiness.
+11. Only after that run is green, switch CDN address, Host, and SNI together to
+    `origin-docs.githubim.com`. Remove all temporary bridge settings. Validate
+    the same paths through both the direct origin and the assigned CDN CNAME.
+12. Dispatch `docs-pages.yml` normally with no `expected_pages_domain` input.
+    This second exact-`main` deployment repeats the direct origin GET gate and,
+    when `DOCS_CDN_ENABLED=true`, performs the bounded four-URL CDN refresh only
+    after that gate succeeds.
+13. Observe for at least 60 minutes before resuming documentation publication.
 
 Never leave a split Host/SNI bridge as permanent configuration.
 
@@ -477,7 +523,7 @@ Stop changing other controls as soon as a rollback condition is met.
 | --- | --- |
 | Before public DNS changes | Disable `DOCS_CDN_ENABLED`; remove or disable only the unadvertised CDN configuration |
 | Public DNS points to CDN, Pages still owns `docs.githubim.com` | Set `DOCS_CDN_PUBLIC_ROUTE_MODE=github-pages-precutover`, restore the captured public DNS record to `wukongim.github.io`, and wait for all three direct CNAME answers to converge |
-| Pages custom domain is migrating | Restore the captured Pages custom domain and the matching temporary origin settings as one tested phase |
+| Pages custom domain is migrating | Stage a migration-mode Workflow for the captured domain, restore the captured Pages custom domain, redeploy the exact known-good Pages artifact, pass the direct origin GET gate, then restore the matching temporary origin settings and perform only the bounded refresh |
 | Final topology, CDN configuration fault | Restore the exported CDN configuration snapshot; leave DNS stable |
 | Alibaba Cloud CDN provider-wide failure | Publish `https://origin-docs.githubim.com` as the direct emergency URL and recover the public domain deliberately; no minute-scale RTO is promised |
 
@@ -485,6 +531,14 @@ Do not attempt final-state rollback by making `docs.githubim.com` a CNAME to
 `origin-docs.githubim.com`. GitHub Pages routes by the HTTP Host, so that record
 alone does not restore the old custom-domain binding and may return a 404 or
 the wrong site.
+
+For a rollback after any Pages-domain mutation, first dispatch
+`docs-pages.yml` with `expected_pages_domain=docs.githubim.com` and wait for its
+build to finish. Restore the captured Pages custom domain only after that
+artifact is staged. The Workflow must then redeploy the exact known-good Pages
+artifact and pass its direct origin GET gate before an operator restores or
+refreshes the old CDN bridge. A REST `204`, `status: built`, certificate
+approval, or a cache refresh cannot replace this deployment-and-GET sequence.
 
 ## Seven-day review
 

--- a/pkg/protocol/jsonrpc/protocol.md
+++ b/pkg/protocol/jsonrpc/protocol.md
@@ -266,7 +266,7 @@
 
 *(注：`recvack` 通常没有特定的响应体，如果需要响应，服务器可能会返回一个空的成功 `result` 或错误)*
 
-### 5. 订阅频道 (Subscribe)
+### 5. 订阅频道 (Subscribe)（Product Gateway 暂不支持）
 
 #### Subscribe Request (`subscribe`)
 
@@ -297,7 +297,7 @@
 }
 ```
 
-### 6. 取消订阅频道 (Unsubscribe)
+### 6. 取消订阅频道 (Unsubscribe)（Product Gateway 暂不支持）
 
 #### Unsubscribe Request (`unsubscribe`)
 
@@ -327,9 +327,11 @@
 }
 ```
 
-#### 协议帧桥接
+#### 协议帧桥接与产品边界
 
-`subscribe` 和 `unsubscribe` 请求都会转换为 WKProto `SUB` 帧，`action` 分别为 `0` (Subscribe) 和 `1` (Unsubscribe)。服务器收到 `SUBACK` 后，使用原请求的 `id` 返回下述 Subscription Response：成功原因码写入 `result`，非成功原因码写入 `error`。
+JSON-RPC codec 会把 `subscribe` 和 `unsubscribe` 请求转换为 WKProto `SUB` 帧，`action` 分别为 `0` (Subscribe) 和 `1` (Unsubscribe)。如果上层提供 `SUBACK`，codec 会使用原请求的 `id` 返回下述 Subscription Response：成功原因码写入 `result`，非成功原因码写入 `error`。
+
+当前 Product Gateway handler 尚未处理 `SUB`，默认会以 handler error 关闭连接。因此上述映射只是 codec 合同，不表示产品入口已经支持订阅，也不会在当前产品路径产生 `SUBACK`。
 
 #### Subscription Response
 

--- a/scripts/docs-cdn/verify-pages-origin.sh
+++ b/scripts/docs-cdn/verify-pages-origin.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  printf 'docs Pages origin verification failed: %s\n' "$*" >&2
+  exit 1
+}
+
+readonly expected_repository="WuKongIM/WuKongIM"
+readonly github_pages_origin="wukongim.github.io"
+readonly repository="${DOCS_PAGES_REPOSITORY:-}"
+readonly configured_domain="${DOCS_PAGES_DOMAIN:-}"
+readonly cache_bust="${DOCS_PAGES_CACHE_BUST:-}"
+readonly attempts="${DOCS_PAGES_VERIFY_ATTEMPTS:-60}"
+readonly retry_seconds="${DOCS_PAGES_VERIFY_RETRY_SECONDS:-5}"
+
+[[ "$repository" == "$expected_repository" ]] || \
+  fail "DOCS_PAGES_REPOSITORY must be exactly ${expected_repository}"
+if [[ -n "$configured_domain" ]]; then
+  [[ "$configured_domain" == docs.githubim.com || "$configured_domain" == origin-docs.githubim.com ]] || \
+    fail "DOCS_PAGES_DOMAIN must be docs.githubim.com or origin-docs.githubim.com"
+fi
+[[ "$cache_bust" =~ ^[A-Za-z0-9._-]{1,160}$ ]] || \
+  fail "DOCS_PAGES_CACHE_BUST must contain 1-160 safe characters"
+[[ "$attempts" =~ ^[0-9]+$ && "$attempts" -ge 1 && "$attempts" -le 60 ]] || \
+  fail "DOCS_PAGES_VERIFY_ATTEMPTS must be between 1 and 60"
+[[ "$retry_seconds" =~ ^[0-9]+$ && "$retry_seconds" -ge 1 && "$retry_seconds" -le 30 ]] || \
+  fail "DOCS_PAGES_VERIFY_RETRY_SECONDS must be between 1 and 30"
+
+for dependency in gh jq curl mktemp grep; do
+  command -v "$dependency" >/dev/null 2>&1 || fail "missing dependency: ${dependency}"
+done
+
+work_directory="$(mktemp -d)"
+cleanup() {
+  [[ -n "${work_directory:-}" && -d "$work_directory" && "$work_directory" != / ]] || return
+  rm -rf -- "$work_directory"
+}
+trap cleanup EXIT
+
+readonly -a paths=(
+  "/"
+  "/zh/"
+  "/en/"
+  "/zh/guide/quick-start/first-message/"
+  "/api/search"
+)
+
+verify_path() {
+  local domain="$1"
+  local path="$2"
+  local attempt="$3"
+
+  local slug="${path//\//_}"
+  local body="${work_directory}/${attempt}-${slug}.body"
+  local metadata="${work_directory}/${attempt}-${slug}.metadata"
+  local url="https://${domain}${path}?__wk_pages_origin_verification=${cache_bust}-${attempt}"
+
+  if ! curl \
+    --silent \
+    --show-error \
+    --fail-with-body \
+    --compressed \
+    --proto '=https' \
+    --tlsv1.2 \
+    --connect-timeout 15 \
+    --max-time 90 \
+    --connect-to "${domain}:443:${github_pages_origin}:443" \
+    --output "$body" \
+    --write-out '%{http_code}\t%{content_type}\t%{size_download}\n' \
+    "$url" >"$metadata"; then
+    printf 'content_not_ready domain=%s path=%s attempt=%s transport_or_http_failure=true\n' \
+      "$domain" "$path" "$attempt" >&2
+    return 1
+  fi
+
+  local status content_type downloaded_bytes
+  IFS=$'\t' read -r status content_type downloaded_bytes <"$metadata"
+  content_type_ready=false
+  if [[ "$path" == /api/search ]]; then
+    if [[ "$content_type" == application/json* || "$content_type" == application/octet-stream* ]]; then
+      content_type_ready=true
+    fi
+  elif [[ "$content_type" == text/html* ]]; then
+    content_type_ready=true
+  fi
+  if [[ "$status" != 200 || "$content_type_ready" != true || ! -s "$body" ]]; then
+    printf 'content_not_ready domain=%s path=%s attempt=%s status=%s content_type=%s bytes=%s\n' \
+      "$domain" "$path" "$attempt" "${status:-missing}" "${content_type:-missing}" "${downloaded_bytes:-missing}" >&2
+    return 1
+  fi
+  if [[ ! "$downloaded_bytes" =~ ^[0-9]+$ ]] || ((downloaded_bytes <= 0)); then
+    printf 'content_not_ready domain=%s path=%s attempt=%s invalid_download_size=%s\n' \
+      "$domain" "$path" "$attempt" "${downloaded_bytes:-missing}" >&2
+    return 1
+  fi
+
+  if [[ "$path" != /api/search ]]; then
+    grep -Eqi '<html([ >])' "$body" && grep -Eqi '</html>' "$body" || {
+      printf 'content_not_ready domain=%s path=%s attempt=%s invalid_html=true\n' \
+        "$domain" "$path" "$attempt" >&2
+      return 1
+    }
+  else
+    jq -e '.type == "i18n" and (.data | type == "object" and has("zh") and has("en"))' \
+      "$body" >/dev/null || {
+      printf 'content_not_ready domain=%s path=%s attempt=%s invalid_search_payload=true\n' \
+        "$domain" "$path" "$attempt" >&2
+      return 1
+    }
+  fi
+}
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  pages_json=""
+  if ! pages_json="$(gh api \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2026-03-10' \
+    "/repos/${repository}/pages")"; then
+    printf 'api_not_ready attempt=%s reason=request_failed\n' "$attempt" >&2
+  else
+    current_domain="$(jq -r '.cname // ""' <<<"$pages_json")"
+    domain="$configured_domain"
+    if [[ -z "$domain" ]]; then
+      domain="$current_domain"
+    fi
+
+    if [[ "$domain" != docs.githubim.com && "$domain" != origin-docs.githubim.com ]]; then
+      printf 'api_not_ready attempt=%s reason=unexpected_domain domain=%s\n' \
+        "$attempt" "${domain:-missing}" >&2
+    elif ! jq -e --arg domain "$domain" '
+      .cname == $domain and
+      .build_type == "workflow" and
+      .protected_domain_state == "verified" and
+      .https_enforced == true and
+      .https_certificate.state == "approved" and
+      ((.https_certificate.domains // []) | index($domain) != null)
+    ' <<<"$pages_json" >/dev/null; then
+      printf 'api_not_ready attempt=%s domain=%s build_type=%s certificate=%s https_enforced=%s\n' \
+        "$attempt" "$domain" \
+        "$(jq -r '.build_type // "missing"' <<<"$pages_json")" \
+        "$(jq -r '.https_certificate.state // "missing"' <<<"$pages_json")" \
+        "$(jq -r '.https_enforced // "missing"' <<<"$pages_json")" >&2
+    else
+      all_paths_ready=true
+      for path in "${paths[@]}"; do
+        if ! verify_path "$domain" "$path" "$attempt"; then
+          all_paths_ready=false
+          break
+        fi
+      done
+      if [[ "$all_paths_ready" == true ]]; then
+        printf 'origin_ready domain=%s attempt=%s paths=%s bypass=%s\n' \
+          "$domain" "$attempt" "${#paths[@]}" "$github_pages_origin"
+        exit 0
+      fi
+    fi
+  fi
+
+  if ((attempt < attempts)); then
+    sleep "$retry_seconds"
+  fi
+done
+
+fail "origin did not become ready after ${attempts} attempts"

--- a/scripts/docs_cdn_workflow_test.go
+++ b/scripts/docs_cdn_workflow_test.go
@@ -18,8 +18,10 @@ func TestDocsCDNRefreshRunsOnlyAfterSuccessfulPagesDeployment(t *testing.T) {
 
 	for _, want := range []string{
 		"refresh_cdn:",
-		"needs: deploy",
-		"if: github.ref == 'refs/heads/main' && vars.DOCS_CDN_ENABLED == 'true'",
+		"needs: verify_pages_origin",
+		"github.ref == 'refs/heads/main' &&",
+		"vars.DOCS_CDN_ENABLED == 'true' &&",
+		"(github.event_name != 'workflow_dispatch' || inputs.expected_pages_domain == '')",
 		"name: docs-cdn",
 		"contents: read",
 		"id-token: write",
@@ -64,6 +66,77 @@ func TestDocsCDNRefreshRunsOnlyAfterSuccessfulPagesDeployment(t *testing.T) {
 	authStart := strings.Index(workflow, "- name: Exchange the exact CDN refresh OIDC identity")
 	require.NotEqual(t, -1, preflightStart)
 	require.Greater(t, authStart, preflightStart, "binding validation must happen before OIDC exchange")
+}
+
+func TestDocsPagesDomainMigrationDeploysOnlyAfterTheStagedDomainSwitch(t *testing.T) {
+	workflow := readFile(
+		t,
+		filepath.Join(repoRoot(t), ".github", "workflows", "docs-pages.yml"),
+	)
+
+	for _, want := range []string{
+		"expected_pages_domain:",
+		"Wait for the expected GitHub Pages custom domain",
+		"EXPECTED_PAGES_DOMAIN: ${{ inputs.expected_pages_domain }}",
+		`[[ "$EXPECTED_PAGES_DOMAIN" == docs.githubim.com || "$EXPECTED_PAGES_DOMAIN" == origin-docs.githubim.com ]]`,
+		`https://api.github.com/repos/${GITHUB_REPOSITORY}/pages`,
+		"verify_pages_origin:",
+		"needs: deploy",
+		"pages: read",
+		"scripts/docs-cdn/verify-pages-origin.sh",
+		"needs: verify_pages_origin",
+	} {
+		require.Contains(t, workflow, want)
+	}
+
+	waitStart := strings.Index(workflow, "- name: Wait for the expected GitHub Pages custom domain")
+	deployAction := strings.Index(workflow, "uses: actions/deploy-pages@")
+	verifyStart := strings.Index(workflow, "\n  verify_pages_origin:")
+	refreshStart := strings.Index(workflow, "\n  refresh_cdn:")
+	require.NotEqual(t, -1, waitStart)
+	require.Greater(t, deployAction, waitStart, "the artifact must already be built and wait for the domain switch before deployment")
+	require.Greater(t, verifyStart, deployAction, "origin verification must run after Pages deployment")
+	require.Greater(t, refreshStart, verifyStart, "CDN refresh must wait for direct Pages content readiness")
+
+	verifyJob := workflow[verifyStart:refreshStart]
+	require.NotContains(t, verifyJob, "id-token: write")
+	require.NotContains(t, verifyJob, "ALIBABA_CLOUD_")
+	require.NotContains(t, verifyJob, "configure-aliyun-credentials-action")
+}
+
+func TestDocsCDNRunbookRequiresRedeployForMigrationAndRollback(t *testing.T) {
+	runbook := readFile(
+		t,
+		filepath.Join(repoRoot(t), "docs", "superpowers", "runbooks", "docs-alibaba-cdn.md"),
+	)
+
+	stagedStart := strings.Index(runbook, "## Staged cutover")
+	acceptanceStart := strings.Index(runbook, "## Acceptance gate")
+	require.NotEqual(t, -1, stagedStart)
+	require.Greater(t, acceptanceStart, stagedStart)
+	staged := runbook[stagedStart:acceptanceStart]
+
+	stageWorkflow := strings.Index(staged, "expected_pages_domain=origin-docs.githubim.com")
+	domainSwitch := strings.Index(staged, `"cname":"origin-docs.githubim.com"`)
+	deployGate := strings.Index(staged, "direct origin GET gate")
+	cdnConvergence := strings.Index(staged, "switch CDN address, Host, and SNI together")
+	require.NotEqual(t, -1, stageWorkflow)
+	require.Greater(t, domainSwitch, stageWorkflow, "the verified artifact must be staged before changing the Pages domain")
+	require.Greater(t, deployGate, domainSwitch, "a fresh Pages deployment and direct GET gate must follow the domain switch")
+	require.Greater(t, cdnConvergence, deployGate, "CDN origin settings must remain unchanged until Pages content is ready")
+
+	rollbackStart := strings.Index(runbook, "## Rollback")
+	sevenDayStart := strings.Index(runbook, "## Seven-day review")
+	require.NotEqual(t, -1, rollbackStart)
+	require.Greater(t, sevenDayStart, rollbackStart)
+	rollback := runbook[rollbackStart:sevenDayStart]
+	for _, want := range []string{
+		"restore the captured Pages custom domain",
+		"redeploy the exact known-good Pages artifact",
+		"direct origin GET gate",
+	} {
+		require.Contains(t, rollback, want)
+	}
 }
 
 func TestDocsCDNRefreshHelperHasAnExactBoundedMutationSurface(t *testing.T) {

--- a/scripts/docs_pages_origin_integration_test.go
+++ b/scripts/docs_pages_origin_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocsPagesOriginVerifierRejectsCertificateReady404UntilContentDeploys(t *testing.T) {
+	root := repoRoot(t)
+	fakeBin := t.TempDir()
+	deployMarker := filepath.Join(t.TempDir(), "deployed")
+	installDocsPagesOriginVerifierFakes(t, fakeBin)
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "docs-cdn", "verify-pages-origin.sh"))
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOCS_PAGES_DOMAIN=origin-docs.githubim.com",
+		"DOCS_PAGES_REPOSITORY=WuKongIM/WuKongIM",
+		"DOCS_PAGES_CACHE_BUST=test-run-1",
+		"DOCS_PAGES_VERIFY_ATTEMPTS=2",
+		"DOCS_PAGES_VERIFY_RETRY_SECONDS=1",
+		"DOCS_PAGES_TEST_DEPLOY_MARKER="+deployMarker,
+	)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Contains(t, string(output), "content_not_ready")
+	require.Contains(t, string(output), "origin_ready")
+	require.FileExists(t, deployMarker)
+}
+
+func TestDocsPagesOriginVerifierNeverAcceptsCertificateReadyPermanent404(t *testing.T) {
+	root := repoRoot(t)
+	fakeBin := t.TempDir()
+	installDocsPagesOriginVerifierFakes(t, fakeBin)
+
+	command := exec.Command("bash", filepath.Join(root, "scripts", "docs-cdn", "verify-pages-origin.sh"))
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOCS_PAGES_DOMAIN=origin-docs.githubim.com",
+		"DOCS_PAGES_REPOSITORY=WuKongIM/WuKongIM",
+		"DOCS_PAGES_CACHE_BUST=test-run-2",
+		"DOCS_PAGES_VERIFY_ATTEMPTS=2",
+		"DOCS_PAGES_VERIFY_RETRY_SECONDS=1",
+		"DOCS_PAGES_TEST_PERMANENT_404=true",
+		"DOCS_PAGES_TEST_DEPLOY_MARKER="+filepath.Join(t.TempDir(), "never-deployed"),
+	)
+	output, err := command.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(output), "content_not_ready")
+	require.Contains(t, string(output), "origin did not become ready")
+	require.NotContains(t, string(output), "origin_ready")
+}
+
+func installDocsPagesOriginVerifierFakes(t *testing.T, fakeBin string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "gh"), []byte(`#!/usr/bin/env bash
+set -euo pipefail
+cat <<'JSON'
+{"cname":"origin-docs.githubim.com","build_type":"workflow","protected_domain_state":"verified","https_enforced":true,"https_certificate":{"state":"approved","domains":["origin-docs.githubim.com"]}}
+JSON
+`), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "sleep"), []byte(`#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${DOCS_PAGES_TEST_PERMANENT_404:-}" != true ]]; then
+  : >"$DOCS_PAGES_TEST_DEPLOY_MARKER"
+fi
+`), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "curl"), []byte(`#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --write-out|--connect-to|--connect-timeout|--max-time|--proto)
+      shift 2
+      ;;
+    --compressed|--fail-with-body|--silent|--show-error|--tlsv1.2)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+[[ -n "$output" && -n "$url" ]]
+if [[ ! -e "$DOCS_PAGES_TEST_DEPLOY_MARKER" ]]; then
+  printf '<html>GitHub Pages 404</html>' >"$output"
+  printf '404\ttext/html\t29\n'
+  exit 22
+fi
+case "$url" in
+  *'/api/search?'*)
+    printf '{"type":"i18n","data":{"zh":{},"en":{}}}' >"$output"
+    printf '200\tapplication/octet-stream\t42\n'
+    ;;
+  *)
+    printf '<!doctype html><html><body>WuKongIM</body></html>' >"$output"
+    printf '200\ttext/html; charset=utf-8\t52\n'
+    ;;
+esac
+`), 0o700))
+}


### PR DESCRIPTION
## Summary / 变更摘要

- Fix the GitHub Pages custom-domain migration race: a migration run now builds and uploads first, waits for the exact externally changed Pages domain, deploys the staged artifact, and verifies the direct Pages data plane before CDN convergence.
- Add a fail-closed origin verifier that bypasses public CDN DNS and validates `/`, `/zh/`, `/en/`, a deep page, and `/api/search`; certificate approval and Pages API `204` no longer count as content readiness.
- Make rollback symmetric and suppress CDN refresh during migration-mode runs.
- Repair the pre-existing JSON-RPC documentation contract drift that blocked the only Pages publisher, including the real SUB/SUBACK codec boundary while retaining the Product Gateway rejection boundary.
- Regenerate `NAVIGATION.md`, removing stale conflict markers that also blocked `bun run verify`.

Root cause: changing the Pages custom domain updates control-plane routing but does not publish the site artifact. The prior runbook treated the accepted domain update and certificate state as readiness, so the new Host could be TLS-valid while returning GitHub Pages 404. The same missing deployment existed in rollback.

## Release notes / 发布说明

- [x] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [ ] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

Skip reason / 豁免理由：N/A

## Verification / 验证

- `cd docs-site && bun run verify` (24 quickstart tests, 172 docs tests, 815-page static export)
- `GOWORK=off go test ./scripts/... -count=1`
- `GOWORK=off go test -tags=integration ./scripts/... -run 'TestDocsPagesOriginVerifier' -count=1`
- `GOWORK=off go test ./pkg/protocol/jsonrpc ./pkg/gateway/protocol/jsonrpc -run 'Subscription|AdapterBridgesSubscription' -count=1`
- `GOWORK=off go run ./scripts/flowcheck --mode check`
- `GOWORK=off go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/docs-pages.yml`
- Live read-only direct-origin probe: current `docs.githubim.com` topology passed all five paths while bypassing Alibaba CDN.
