### PR TITLE
docs: use package repository bootstrap packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+### 🚀 New Features / 新功能
+
+- 签名 Linux Preview 软件源新增 `wukongim-archive-keyring` 与 `wukongim-release` 引导包，首次配置后可直接通过 APT 或 DNF/YUM 安装和升级 WuKongIM，并由包管理器自动接收后续公开签名证书更新。
+
 ### 🐛 Bug Fixes / 问题修复
 
 - 文档 Pages 自定义域名迁移与回滚现在会先暂存已验证产物，在域名绑定变化后立即重新部署，并以绕过 CDN 的根路径、双语首页、深层页面及搜索真实 GET 作为内容就绪门禁；证书批准或 API `204` 不再被误当作站点可用。
@@ -58,6 +62,7 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Linux 服务端部署文档改为优先使用 APT/RPM 软件源引导包，保留首次 HTTPS 信任边界并说明引导包不会运行脚本、访问网络或关闭签名检查。
 - Linux 服务端部署文档现提供 `v3.0.0-beta.6` 签名 Preview 软件源的 APT 与 DNF/YUM 安装流程，并在写入专用 keyring 前固定核对仓库主密钥指纹。
 - 中英文 v3 文档站现由仓库内 GitHub Pages 工作流执行完整静态验收后发布到 `docs.githubim.com`，发布产物与通过验收的 `docs-site/out` 保持一致。
 - WuKongEasySDK 中英文文档现固定 Web `2.0.4`、Android `1.0.5`、iOS `1.1.1` 与 Flutter `1.1.0` 正式包，并补充四端 example 与正式包的独立验收回执及可复现流程。

--- a/docs-site/content/docs/server/deployment/linux.en.mdx
+++ b/docs-site/content/docs/server/deployment/linux.en.mdx
@@ -11,45 +11,27 @@ Preview is a prerelease channel, not the stable channel. Validate configuration,
 
 ### Debian / Ubuntu (APT)
 
-These commands keep the repository certificate in a dedicated keyring and verify its primary fingerprint before installing it. They do not add global trust or bypass signature checks:
+Install the repository bootstrap package once. WuKongIM can then be installed and upgraded through APT like a package from a distribution repository:
 
 ```bash
 set -euo pipefail
 
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl gpg
-
-apt_key="$(mktemp)"
-trap 'rm -f "$apt_key"' EXIT
+sudo apt-get install -y ca-certificates curl
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --output "$apt_key" \
-  https://packages.githubim.com/keys/apt-preview.asc
-
-apt_fingerprints="$(
-  gpg --batch --show-keys --with-colons "$apt_key" |
-    awk -F: '
-      $1 == "pub" { primary = 1; next }
-      primary && $1 == "fpr" { print $10; primary = 0 }
-    '
-)"
-test "$apt_fingerprints" = 'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1'
-
-sudo install -d -m 0755 /etc/apt/keyrings
-sudo install -o root -g root -m 0644 "$apt_key" /etc/apt/keyrings/wukongim-preview.asc
-rm -f "$apt_key"
-trap - EXIT
-
-printf '%s\n' \
-  'deb [arch=amd64 signed-by=/etc/apt/keyrings/wukongim-preview.asc] https://packages.githubim.com/apt preview main' |
-  sudo tee /etc/apt/sources.list.d/wukongim-preview.list >/dev/null
+  --location --output /tmp/wukongim-archive-keyring_1.0.0_all.deb \
+  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb
+sudo apt-get install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
 
 sudo apt-get update
 sudo apt-get install -y wukongim=3.0.0~beta.6
 ```
 
+`wukongim-archive-keyring` installs only a dedicated binary keyring and Deb822 source file. It does not use global `apt-key` trust, disable signature checks, access the network, or run maintainer scripts. The first download relies on the HTTPS identity of `packages.githubim.com`. After installation, APT authenticates the repository with WuKongIM primary key `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1`, and upgrades the keyring through that same signed repository.
+
 ### RHEL / Rocky / AlmaLinux 9 (DNF/YUM)
 
-Use this dedicated repository configuration on EL9 to verify both package signatures and repository metadata signatures. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum` in every command:
+EL9 likewise needs its repository bootstrap package only once. It installs a dedicated repo definition with package signatures, repository-metadata signatures, and TLS verification enabled. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum` in every command:
 
 ```bash
 set -euo pipefail
@@ -59,42 +41,16 @@ if ! command -v curl >/dev/null; then
   sudo dnf install -y curl-minimal
 fi
 
-rpm_key="$(mktemp)"
-trap 'rm -f "$rpm_key"' EXIT
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --output "$rpm_key" \
-  https://packages.githubim.com/keys/rpm-preview.asc
-
-rpm_fingerprints="$(
-  gpg --batch --show-keys --with-colons "$rpm_key" |
-    awk -F: '
-      $1 == "pub" { primary = 1; next }
-      primary && $1 == "fpr" { print $10; primary = 0 }
-    '
-)"
-test "$rpm_fingerprints" = 'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459'
-
-sudo install -d -m 0755 /etc/pki/rpm-gpg
-sudo install -o root -g root -m 0644 "$rpm_key" /etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
-rm -f "$rpm_key"
-trap - EXIT
-
-sudo tee /etc/yum.repos.d/wukongim-preview.repo >/dev/null <<'EOF'
-[wukongim-preview]
-name=WuKongIM preview
-baseurl=https://packages.githubim.com/rpm/preview/el/9/x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
-sslverify=1
-metadata_expire=300
-skip_if_unavailable=0
-EOF
+  --location --output /tmp/wukongim-release-1.0.0-1.noarch.rpm \
+  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm
+sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
 
 sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
 sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64
 ```
+
+`wukongim-release` installs only a dedicated RPM public key and a `%config(noreplace)` repo file; it contains no scriptlets. Its fixed primary-key fingerprint is `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`. The initial bootstrap still relies on HTTPS. DNF/YUM then verifies and upgrades the public-key package through the signed repository.
 
 Confirm the binary identity after installation. The version should be `3.0.0-beta.6`; `source` in the text output and `build_source` in JSON should be `release`:
 
@@ -105,7 +61,7 @@ wukongim version --output json
 
 The package installs `/usr/bin/wukongim` and a hardened `wukongim.service`, then creates the `wukongim` system account and `/etc/wukongim`, `/var/lib/wukongim`, `/var/log/wukongim`, and `/run/wukongim`. It does not create an active configuration, enable or start the service, or restart it.
 
-The repository does not yet ship a separate keyring package, so repository certificates are not refreshed automatically. Before an announced signing-subkey promotion, download the applicable certificate again and recheck the primary fingerprint above. Never disable package or repository-metadata signature verification.
+Do not delete the keyring, public key, or repository files owned by the bootstrap packages, and never disable package or repository-metadata signature verification. Before a signing-subkey promotion, the project will first distribute the updated public certificate as a bootstrap-package upgrade.
 
 ## 2. Initialize a secure configuration
 

--- a/docs-site/content/docs/server/deployment/linux.mdx
+++ b/docs-site/content/docs/server/deployment/linux.mdx
@@ -11,45 +11,27 @@ Preview 是预发布通道，不等同于稳定通道。请先在非生产环境
 
 ### Debian / Ubuntu（APT）
 
-下面的命令单独保存仓库证书，核对主密钥指纹后才写入系统 keyring；不会使用全局信任或绕过签名检查：
+先安装一次软件源引导包，之后即可像使用发行版软件源一样通过 APT 安装和升级 WuKongIM：
 
 ```bash
 set -euo pipefail
 
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl gpg
-
-apt_key="$(mktemp)"
-trap 'rm -f "$apt_key"' EXIT
+sudo apt-get install -y ca-certificates curl
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --output "$apt_key" \
-  https://packages.githubim.com/keys/apt-preview.asc
-
-apt_fingerprints="$(
-  gpg --batch --show-keys --with-colons "$apt_key" |
-    awk -F: '
-      $1 == "pub" { primary = 1; next }
-      primary && $1 == "fpr" { print $10; primary = 0 }
-    '
-)"
-test "$apt_fingerprints" = 'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1'
-
-sudo install -d -m 0755 /etc/apt/keyrings
-sudo install -o root -g root -m 0644 "$apt_key" /etc/apt/keyrings/wukongim-preview.asc
-rm -f "$apt_key"
-trap - EXIT
-
-printf '%s\n' \
-  'deb [arch=amd64 signed-by=/etc/apt/keyrings/wukongim-preview.asc] https://packages.githubim.com/apt preview main' |
-  sudo tee /etc/apt/sources.list.d/wukongim-preview.list >/dev/null
+  --location --output /tmp/wukongim-archive-keyring_1.0.0_all.deb \
+  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb
+sudo apt-get install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
 
 sudo apt-get update
 sudo apt-get install -y wukongim=3.0.0~beta.6
 ```
 
+`wukongim-archive-keyring` 只安装专用二进制 keyring 和 Deb822 软件源文件；不会使用全局 `apt-key` 信任、关闭签名检查、访问网络或运行维护脚本。首次下载依赖 `packages.githubim.com` 的 HTTPS 身份；安装后，APT 会用固定的 WuKongIM 主密钥 `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1` 验证软件源，keyring 后续也通过同一签名软件源升级。
+
 ### RHEL / Rocky / AlmaLinux 9（DNF/YUM）
 
-EL9 使用下面的独立 repo 配置，同时验证软件包签名与仓库元数据签名。仍使用 `yum` 命令名的兼容系统可以把每一条 `dnf` 命令替换为 `yum`：
+EL9 同样只需安装一次软件源引导包。它会写入独立 repo 配置，同时启用软件包签名、仓库元数据签名和 TLS 验证。仍使用 `yum` 命令名的兼容系统可以把每一条 `dnf` 命令替换为 `yum`：
 
 ```bash
 set -euo pipefail
@@ -59,42 +41,16 @@ if ! command -v curl >/dev/null; then
   sudo dnf install -y curl-minimal
 fi
 
-rpm_key="$(mktemp)"
-trap 'rm -f "$rpm_key"' EXIT
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --output "$rpm_key" \
-  https://packages.githubim.com/keys/rpm-preview.asc
-
-rpm_fingerprints="$(
-  gpg --batch --show-keys --with-colons "$rpm_key" |
-    awk -F: '
-      $1 == "pub" { primary = 1; next }
-      primary && $1 == "fpr" { print $10; primary = 0 }
-    '
-)"
-test "$rpm_fingerprints" = 'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459'
-
-sudo install -d -m 0755 /etc/pki/rpm-gpg
-sudo install -o root -g root -m 0644 "$rpm_key" /etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
-rm -f "$rpm_key"
-trap - EXIT
-
-sudo tee /etc/yum.repos.d/wukongim-preview.repo >/dev/null <<'EOF'
-[wukongim-preview]
-name=WuKongIM preview
-baseurl=https://packages.githubim.com/rpm/preview/el/9/x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-wukongim-preview
-sslverify=1
-metadata_expire=300
-skip_if_unavailable=0
-EOF
+  --location --output /tmp/wukongim-release-1.0.0-1.noarch.rpm \
+  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm
+sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
 
 sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
 sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64
 ```
+
+`wukongim-release` 只安装专用 RPM 公钥和 `%config(noreplace)` repo 文件，不包含脚本；固定主密钥指纹为 `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`。首次引导仍依赖 HTTPS，之后 DNF/YUM 会从签名软件源验证并升级公钥包。
 
 安装后确认二进制身份；版本应为 `3.0.0-beta.6`，文本输出的 `source` 和 JSON 输出的 `build_source` 应为 `release`：
 
@@ -105,7 +61,7 @@ wukongim version --output json
 
 安装包会安装 `/usr/bin/wukongim` 和加固的 `wukongim.service`，创建 `wukongim` 系统账号以及 `/etc/wukongim`、`/var/lib/wukongim`、`/var/log/wukongim`、`/run/wukongim`。它不会生成活动配置，也不会启用、启动或重启服务。
 
-当前软件源还没有单独的 keyring 软件包，因此仓库证书不会随包自动刷新。在官方宣布切换签名子密钥前，重新下载对应证书并再次核对上面的主密钥指纹；不要关闭软件包或仓库元数据签名检查。
+不要删除引导包管理的 keyring、公钥或软件源文件，也不要关闭软件包或仓库元数据签名检查。官方在切换签名子密钥前会先通过引导包升级分发新的公开证书。
 
 ## 2. 安全初始化配置
 

--- a/docs-site/lib/native-deployment-contract.test.ts
+++ b/docs-site/lib/native-deployment-contract.test.ts
@@ -100,21 +100,18 @@ describe('native deployment publication contract', () => {
     for (const content of pages) {
       for (const contract of [
         '3.0.0-beta.6',
-        'https://packages.githubim.com/keys/apt-preview.asc',
-        'https://packages.githubim.com/keys/rpm-preview.asc',
+        'https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb',
+        'https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm',
         'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1',
         'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459',
-        'deb [arch=amd64 signed-by=/etc/apt/keyrings/wukongim-preview.asc] https://packages.githubim.com/apt preview main',
+        'wukongim-archive-keyring',
+        'wukongim-release',
+        'Deb822',
+        '%config(noreplace)',
         'sudo apt-get install -y wukongim=3.0.0~beta.6',
-        'baseurl=https://packages.githubim.com/rpm/preview/el/9/x86_64',
         "sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh",
         'sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64',
-        'gpgcheck=1',
-        'repo_gpgcheck=1',
-        'sslverify=1',
-        'skip_if_unavailable=0',
         'set -euo pipefail',
-        'primary && $1 == "fpr"',
         'sudo dnf install -y curl-minimal',
         'RHEL',
         'build_source',
@@ -131,8 +128,9 @@ describe('native deployment publication contract', () => {
         expect(content).toContain(contract);
       }
       for (const unsafe of [
-        'apt-key',
+        'apt-key add',
         'trusted=yes',
+        'Trusted: yes',
         'gpgcheck=0',
         'repo_gpgcheck=0',
         'curl | sudo',


### PR DESCRIPTION
## Summary / 变更摘要

- Replace the manual APT/RPM repository setup with the signed `wukongim-archive-keyring` and `wukongim-release` bootstrap packages.
- Keep the Preview channel pinned to `v3.0.0-beta.6` and document the initial HTTPS trust boundary, dedicated key storage, enabled signature checks, and no-script package behavior in Chinese and English.
- Update the native deployment publication contract for the new public bootstrap URLs.
- The production repository and four-distribution client verification succeeded in https://github.com/WuKongIM/packages/actions/runs/33712860131.

## Release notes / 发布说明

- [x] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [ ] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

Skip reason / 豁免理由：

N/A

## Verification / 验证

- `bun run test` — 172 passed, 0 failed
- `bun run navigation:check`
- `bun run lint`
- `bun run types:check`
- `bun run build` — 815/815 static pages
- `bun run test:output`
- `git diff --check origin/main...HEAD`