### PR TITLE
docs: simplify native package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Linux 服务端部署文档将软件源安装明确收敛为“添加软件源、更新索引、按包名安装”三步；首次添加后不再手工下载特定版本的 WuKongIM deb/rpm。
 - Linux 服务端部署文档改为优先使用 APT/RPM 软件源引导包，保留首次 HTTPS 信任边界并说明引导包不会运行脚本、访问网络或关闭签名检查。
 - Linux 服务端部署文档现提供 `v3.0.0-beta.6` 签名 Preview 软件源的 APT 与 DNF/YUM 安装流程，并在写入专用 keyring 前固定核对仓库主密钥指纹。
 - 中英文 v3 文档站现由仓库内 GitHub Pages 工作流执行完整静态验收后发布到 `docs.githubim.com`，发布产物与通过验收的 `docs-site/out` 保持一致。

--- a/docs-site/content/docs/server/deployment/linux.en.mdx
+++ b/docs-site/content/docs/server/deployment/linux.en.mdx
@@ -11,43 +11,70 @@ Preview is a prerelease channel, not the stable channel. Validate configuration,
 
 ### Debian / Ubuntu (APT)
 
-Install the repository bootstrap package once. WuKongIM can then be installed and upgraded through APT like a package from a distribution repository:
+The installation flow has three fixed steps: add the repository, refresh the package index, and install the package. Run the first step only once. APT handles subsequent WuKongIM installs and upgrades without manually downloading a WuKongIM deb file.
+
+On a minimal system without `curl`, install the HTTPS download prerequisite first:
 
 ```bash
-set -euo pipefail
-
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl
+```
+
+Step 1: install the repository bootstrap package to add the WuKongIM preview repository:
+
+```bash
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
   --location --output /tmp/wukongim-archive-keyring_1.0.0_all.deb \
-  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb
-sudo apt-get install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
+  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb && \
+  sudo apt install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
+```
 
-sudo apt-get update
-sudo apt-get install -y wukongim=3.0.0~beta.6
+Step 2: refresh the package index:
+
+```bash
+sudo apt update
+```
+
+Step 3: install WuKongIM by package name:
+
+```bash
+sudo apt install -y wukongim
 ```
 
 `wukongim-archive-keyring` installs only a dedicated binary keyring and Deb822 source file. It does not use global `apt-key` trust, disable signature checks, access the network, or run maintainer scripts. The first download relies on the HTTPS identity of `packages.githubim.com`. After installation, APT authenticates the repository with WuKongIM primary key `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1`, and upgrades the keyring through that same signed repository.
 
 ### RHEL / Rocky / AlmaLinux 9 (DNF/YUM)
 
-EL9 likewise needs its repository bootstrap package only once. It installs a dedicated repo definition with package signatures, repository-metadata signatures, and TLS verification enabled. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum` in every command:
+EL9 uses the same three steps: add the repository, refresh the package index, and install the package. The bootstrap package installs a dedicated repo definition with package signatures, repository-metadata signatures, and TLS verification enabled. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum`.
+
+On a minimal system without `curl`, install the HTTPS download prerequisite first:
 
 ```bash
-set -euo pipefail
-
 sudo dnf install -y ca-certificates gnupg2
 if ! command -v curl >/dev/null; then
   sudo dnf install -y curl-minimal
 fi
+```
 
+Step 1: install the repository bootstrap package to add the WuKongIM preview repository:
+
+```bash
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
   --location --output /tmp/wukongim-release-1.0.0-1.noarch.rpm \
-  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm
-sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
+  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm && \
+  sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
+```
 
+Step 2: refresh the package index:
+
+```bash
 sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
-sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64
+```
+
+Step 3: install WuKongIM by package name:
+
+```bash
+sudo dnf install -y wukongim
 ```
 
 `wukongim-release` installs only a dedicated RPM public key and a `%config(noreplace)` repo file; it contains no scriptlets. Its fixed primary-key fingerprint is `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`. The initial bootstrap still relies on HTTPS. DNF/YUM then verifies and upgrades the public-key package through the signed repository.

--- a/docs-site/content/docs/server/deployment/linux.mdx
+++ b/docs-site/content/docs/server/deployment/linux.mdx
@@ -11,43 +11,70 @@ Preview 是预发布通道，不等同于稳定通道。请先在非生产环境
 
 ### Debian / Ubuntu（APT）
 
-先安装一次软件源引导包，之后即可像使用发行版软件源一样通过 APT 安装和升级 WuKongIM：
+安装流程固定为“添加软件源、更新索引、安装软件”三步。第一步只需执行一次；以后安装和升级 WuKongIM 都由 APT 完成，不再手工下载 WuKongIM 的 deb 包。
+
+极简系统如果还没有 `curl`，先安装 HTTPS 下载工具：
 
 ```bash
-set -euo pipefail
-
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl
+```
+
+第一步，安装软件源引导包以添加 WuKongIM Preview 软件源：
+
+```bash
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
   --location --output /tmp/wukongim-archive-keyring_1.0.0_all.deb \
-  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb
-sudo apt-get install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
+  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb && \
+  sudo apt install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
+```
 
-sudo apt-get update
-sudo apt-get install -y wukongim=3.0.0~beta.6
+第二步，更新软件包索引：
+
+```bash
+sudo apt update
+```
+
+第三步，按包名安装 WuKongIM：
+
+```bash
+sudo apt install -y wukongim
 ```
 
 `wukongim-archive-keyring` 只安装专用二进制 keyring 和 Deb822 软件源文件；不会使用全局 `apt-key` 信任、关闭签名检查、访问网络或运行维护脚本。首次下载依赖 `packages.githubim.com` 的 HTTPS 身份；安装后，APT 会用固定的 WuKongIM 主密钥 `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1` 验证软件源，keyring 后续也通过同一签名软件源升级。
 
 ### RHEL / Rocky / AlmaLinux 9（DNF/YUM）
 
-EL9 同样只需安装一次软件源引导包。它会写入独立 repo 配置，同时启用软件包签名、仓库元数据签名和 TLS 验证。仍使用 `yum` 命令名的兼容系统可以把每一条 `dnf` 命令替换为 `yum`：
+EL9 同样使用“添加软件源、更新索引、安装软件”三步。软件源引导包会写入独立 repo 配置，同时启用软件包签名、仓库元数据签名和 TLS 验证。仍使用 `yum` 命令名的兼容系统可以把 `dnf` 替换为 `yum`。
+
+极简系统如果还没有 `curl`，先安装 HTTPS 下载工具：
 
 ```bash
-set -euo pipefail
-
 sudo dnf install -y ca-certificates gnupg2
 if ! command -v curl >/dev/null; then
   sudo dnf install -y curl-minimal
 fi
+```
 
+第一步，安装软件源引导包以添加 WuKongIM Preview 软件源：
+
+```bash
 curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
   --location --output /tmp/wukongim-release-1.0.0-1.noarch.rpm \
-  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm
-sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
+  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm && \
+  sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
+```
 
+第二步，更新软件包索引：
+
+```bash
 sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
-sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64
+```
+
+第三步，按包名安装 WuKongIM：
+
+```bash
+sudo dnf install -y wukongim
 ```
 
 `wukongim-release` 只安装专用 RPM 公钥和 `%config(noreplace)` repo 文件，不包含脚本；固定主密钥指纹为 `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`。首次引导仍依赖 HTTPS，之后 DNF/YUM 会从签名软件源验证并升级公钥包。

--- a/docs-site/lib/native-deployment-contract.test.ts
+++ b/docs-site/lib/native-deployment-contract.test.ts
@@ -108,10 +108,10 @@ describe('native deployment publication contract', () => {
         'wukongim-release',
         'Deb822',
         '%config(noreplace)',
-        'sudo apt-get install -y wukongim=3.0.0~beta.6',
+        'sudo apt update',
+        'sudo apt install -y wukongim\n',
         "sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh",
-        'sudo dnf -y --enablerepo=wukongim-preview install wukongim-3.0.0~beta.6-1.x86_64',
-        'set -euo pipefail',
+        'sudo dnf install -y wukongim\n',
         'sudo dnf install -y curl-minimal',
         'RHEL',
         'build_source',
@@ -134,11 +134,30 @@ describe('native deployment publication contract', () => {
         'gpgcheck=0',
         'repo_gpgcheck=0',
         'curl | sudo',
-        'sudo apt-get install -y wukongim\n',
-        'sudo dnf install -y wukongim\n',
+        'sudo apt install -y wukongim=',
+        'sudo apt-get install -y wukongim=',
+        'sudo dnf install -y wukongim-',
+        'sudo dnf -y --enablerepo=wukongim-preview install wukongim-',
       ]) {
         expect(content).not.toContain(unsafe);
       }
+
+      const aptBootstrap = content.indexOf('sudo apt install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb');
+      const aptUpdate = content.indexOf('sudo apt update', aptBootstrap);
+      const aptInstall = content.indexOf('sudo apt install -y wukongim', aptUpdate);
+      expect(aptBootstrap).toBeGreaterThan(-1);
+      expect(aptUpdate).toBeGreaterThan(aptBootstrap);
+      expect(aptInstall).toBeGreaterThan(aptUpdate);
+
+      const rpmBootstrap = content.indexOf('sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm');
+      const dnfUpdate = content.indexOf(
+        "sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh",
+        rpmBootstrap,
+      );
+      const dnfInstall = content.indexOf('sudo dnf install -y wukongim', dnfUpdate);
+      expect(rpmBootstrap).toBeGreaterThan(-1);
+      expect(dnfUpdate).toBeGreaterThan(rpmBootstrap);
+      expect(dnfInstall).toBeGreaterThan(dnfUpdate);
     }
   });
 

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -100,9 +100,13 @@
   `packages.githubim.com`. Every public snapshot is download-validated on clean
   Ubuntu, Debian, Rocky Linux, and AlmaLinux clients. Stable publication remains
   disabled until it moves from GitHub Pages to object storage and a CDN. The
-  package installs the binary, hardened systemd unit, service identity, and
-  persistent directories, but never creates an active configuration or
-  starts/restarts the node.
+  public client flow installs a signed-repository bootstrap package once, then
+  uses the package manager's normal update and unversioned `wukongim` install;
+  the bootstrap package owns the dedicated trust root and repository definition
+  so later public-certificate updates arrive through that same signed channel.
+  The product package installs the binary, hardened systemd unit, service
+  identity, and persistent directories, but never creates an active
+  configuration or starts/restarts the node.
   Operators initialize atomically with `wukongim config init`, validate with
   `wukongim config validate`, and own enablement plus upgrade restart timing.
   Source CI also boots the exact checksum-bound candidate Artifact under a real


### PR DESCRIPTION
## Summary

- present APT and DNF installation as add repository, refresh index, then install by package name
- keep the signed bootstrap packages and automatic certificate-update path
- update bilingual documentation contracts, project knowledge, and changelog

## Validation

- bun test lib/native-deployment-contract.test.ts
- bun run verify
- bun run lint
- bun run types:check
- clean Ubuntu 24.04 resolved the unversioned wukongim package from the preview repository
- clean Rocky Linux 9 imported the repository key, refreshed metadata, and resolved the unversioned wukongim package