### PR TITLE
docs: add concise package repository setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
-- Linux 服务端部署文档将软件源安装明确收敛为“添加软件源、更新索引、按包名安装”三步；首次添加后不再手工下载特定版本的 WuKongIM deb/rpm。
-- Linux 服务端部署文档改为优先使用 APT/RPM 软件源引导包，保留首次 HTTPS 信任边界并说明引导包不会运行脚本、访问网络或关闭签名检查。
+- Linux 服务端部署文档将软件源安装收敛为统一的 `curl -fsSL https://packages.githubim.com/repo | sudo sh` 添加源入口，再显式更新索引并按包名安装；首次添加后不再手工下载特定版本的 WuKongIM deb/rpm。
+- Linux 软件源引导脚本明确只添加签名软件源，不会更新索引、安装 WuKongIM 或启动服务；文档继续保留首次 HTTPS 信任边界、底层 APT/RPM 引导包和固定主密钥指纹说明。
 - Linux 服务端部署文档现提供 `v3.0.0-beta.6` 签名 Preview 软件源的 APT 与 DNF/YUM 安装流程，并在写入专用 keyring 前固定核对仓库主密钥指纹。
 - 中英文 v3 文档站现由仓库内 GitHub Pages 工作流执行完整静态验收后发布到 `docs.githubim.com`，发布产物与通过验收的 `docs-site/out` 保持一致。
 - WuKongEasySDK 中英文文档现固定 Web `2.0.4`、Android `1.0.5`、iOS `1.1.1` 与 Flutter `1.1.0` 正式包，并补充四端 example 与正式包的独立验收回执及可复现流程。

--- a/docs-site/content/docs/server/deployment/linux.en.mdx
+++ b/docs-site/content/docs/server/deployment/linux.en.mdx
@@ -11,23 +11,15 @@ Preview is a prerelease channel, not the stable channel. Validate configuration,
 
 ### Debian / Ubuntu (APT)
 
-The installation flow has three fixed steps: add the repository, refresh the package index, and install the package. Run the first step only once. APT handles subsequent WuKongIM installs and upgrades without manually downloading a WuKongIM deb file.
+The installation flow has three fixed steps: add the repository, refresh the package index, and install the package. Run the first step only once. APT handles subsequent WuKongIM installs and upgrades without manually downloading a WuKongIM deb file. These commands require `curl` to be installed.
 
-On a minimal system without `curl`, install the HTTPS download prerequisite first:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y ca-certificates curl
-```
-
-Step 1: install the repository bootstrap package to add the WuKongIM preview repository:
+Step 1: run the cross-distribution bootstrap script to add the WuKongIM preview repository:
 
 ```bash
-curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --location --output /tmp/wukongim-archive-keyring_1.0.0_all.deb \
-  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb && \
-  sudo apt install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
+curl -fsSL https://packages.githubim.com/repo | sudo sh
 ```
+
+The script only adds the repository. It does not refresh the package index, install WuKongIM, create an active configuration, or start the service. On an APT system, it installs `wukongim-archive-keyring` over HTTPS. That bootstrap package has no maintainer scripts and writes only the dedicated binary keyring and Deb822 source file; it does not use global `apt-key` trust or disable signature checks. To audit it before execution, open the same URL in a browser and review the script body.
 
 Step 2: refresh the package index:
 
@@ -41,29 +33,19 @@ Step 3: install WuKongIM by package name:
 sudo apt install -y wukongim
 ```
 
-`wukongim-archive-keyring` installs only a dedicated binary keyring and Deb822 source file. It does not use global `apt-key` trust, disable signature checks, access the network, or run maintainer scripts. The first download relies on the HTTPS identity of `packages.githubim.com`. After installation, APT authenticates the repository with WuKongIM primary key `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1`, and upgrades the keyring through that same signed repository.
+The initial bootstrap relies on the HTTPS identity of `packages.githubim.com`. After the repository is added, APT authenticates it with WuKongIM primary key `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1`, and upgrades the keyring through that same signed repository.
 
 ### RHEL / Rocky / AlmaLinux 9 (DNF/YUM)
 
-EL9 uses the same three steps: add the repository, refresh the package index, and install the package. The bootstrap package installs a dedicated repo definition with package signatures, repository-metadata signatures, and TLS verification enabled. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum`.
+EL9 uses the same three steps: add the repository, refresh the package index, and install the package. The bootstrap package installs a dedicated repo definition with package signatures, repository-metadata signatures, and TLS verification enabled. These commands require `curl` to be installed. On a compatible system that still uses the `yum` command name, replace `dnf` with `yum` in steps two and three.
 
-On a minimal system without `curl`, install the HTTPS download prerequisite first:
-
-```bash
-sudo dnf install -y ca-certificates gnupg2
-if ! command -v curl >/dev/null; then
-  sudo dnf install -y curl-minimal
-fi
-```
-
-Step 1: install the repository bootstrap package to add the WuKongIM preview repository:
+Step 1: run the same cross-distribution bootstrap script to add the WuKongIM preview repository:
 
 ```bash
-curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --location --output /tmp/wukongim-release-1.0.0-1.noarch.rpm \
-  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm && \
-  sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
+curl -fsSL https://packages.githubim.com/repo | sudo sh
 ```
+
+The script only adds the repository. It does not refresh the package index or install WuKongIM. On an EL9 system, it installs `wukongim-release` over HTTPS; that scriptlet-free bootstrap package contains only the dedicated RPM public key and `%config(noreplace)` repo file.
 
 Step 2: refresh the package index:
 
@@ -77,7 +59,7 @@ Step 3: install WuKongIM by package name:
 sudo dnf install -y wukongim
 ```
 
-`wukongim-release` installs only a dedicated RPM public key and a `%config(noreplace)` repo file; it contains no scriptlets. Its fixed primary-key fingerprint is `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`. The initial bootstrap still relies on HTTPS. DNF/YUM then verifies and upgrades the public-key package through the signed repository.
+The fixed RPM primary-key fingerprint is `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`. The initial bootstrap still relies on HTTPS. DNF/YUM then verifies and upgrades the public-key package through the signed repository.
 
 Confirm the binary identity after installation. The version should be `3.0.0-beta.6`; `source` in the text output and `build_source` in JSON should be `release`:
 

--- a/docs-site/content/docs/server/deployment/linux.mdx
+++ b/docs-site/content/docs/server/deployment/linux.mdx
@@ -11,23 +11,15 @@ Preview 是预发布通道，不等同于稳定通道。请先在非生产环境
 
 ### Debian / Ubuntu（APT）
 
-安装流程固定为“添加软件源、更新索引、安装软件”三步。第一步只需执行一次；以后安装和升级 WuKongIM 都由 APT 完成，不再手工下载 WuKongIM 的 deb 包。
+安装流程固定为“添加软件源、更新索引、安装软件”三步。第一步只需执行一次；以后安装和升级 WuKongIM 都由 APT 完成，不再手工下载 WuKongIM 的 deb 包。以下命令要求系统已经安装 `curl`。
 
-极简系统如果还没有 `curl`，先安装 HTTPS 下载工具：
-
-```bash
-sudo apt-get update
-sudo apt-get install -y ca-certificates curl
-```
-
-第一步，安装软件源引导包以添加 WuKongIM Preview 软件源：
+第一步，运行跨发行版引导脚本以添加 WuKongIM Preview 软件源：
 
 ```bash
-curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --location --output /tmp/wukongim-archive-keyring_1.0.0_all.deb \
-  https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb && \
-  sudo apt install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb
+curl -fsSL https://packages.githubim.com/repo | sudo sh
 ```
+
+该脚本只添加软件源，不会更新软件包索引、安装 WuKongIM、创建活动配置或启动服务。在 APT 系统上，它通过 HTTPS 安装 `wukongim-archive-keyring`，由这个无维护脚本的引导包写入专用二进制 keyring 和 Deb822 软件源文件；它不会使用全局 `apt-key` 信任或关闭签名检查。需要审计再执行时，可以先在浏览器中打开同一 URL 查看脚本正文。
 
 第二步，更新软件包索引：
 
@@ -41,29 +33,19 @@ sudo apt update
 sudo apt install -y wukongim
 ```
 
-`wukongim-archive-keyring` 只安装专用二进制 keyring 和 Deb822 软件源文件；不会使用全局 `apt-key` 信任、关闭签名检查、访问网络或运行维护脚本。首次下载依赖 `packages.githubim.com` 的 HTTPS 身份；安装后，APT 会用固定的 WuKongIM 主密钥 `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1` 验证软件源，keyring 后续也通过同一签名软件源升级。
+首次引导依赖 `packages.githubim.com` 的 HTTPS 身份；添加软件源后，APT 会用固定的 WuKongIM 主密钥 `D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1` 验证软件源，keyring 后续也通过同一签名软件源升级。
 
 ### RHEL / Rocky / AlmaLinux 9（DNF/YUM）
 
-EL9 同样使用“添加软件源、更新索引、安装软件”三步。软件源引导包会写入独立 repo 配置，同时启用软件包签名、仓库元数据签名和 TLS 验证。仍使用 `yum` 命令名的兼容系统可以把 `dnf` 替换为 `yum`。
+EL9 同样使用“添加软件源、更新索引、安装软件”三步。软件源引导包会写入独立 repo 配置，同时启用软件包签名、仓库元数据签名和 TLS 验证。以下命令要求系统已经安装 `curl`；仍使用 `yum` 命令名的兼容系统可以把第二、三步中的 `dnf` 替换为 `yum`。
 
-极简系统如果还没有 `curl`，先安装 HTTPS 下载工具：
-
-```bash
-sudo dnf install -y ca-certificates gnupg2
-if ! command -v curl >/dev/null; then
-  sudo dnf install -y curl-minimal
-fi
-```
-
-第一步，安装软件源引导包以添加 WuKongIM Preview 软件源：
+第一步，运行同一个跨发行版引导脚本以添加 WuKongIM Preview 软件源：
 
 ```bash
-curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
-  --location --output /tmp/wukongim-release-1.0.0-1.noarch.rpm \
-  https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm && \
-  sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm
+curl -fsSL https://packages.githubim.com/repo | sudo sh
 ```
+
+该脚本只添加软件源，不会更新软件包索引或安装 WuKongIM。在 EL9 系统上，它通过 HTTPS 安装 `wukongim-release`；这个无脚本的引导包只提供专用 RPM 公钥和 `%config(noreplace)` repo 文件。
 
 第二步，更新软件包索引：
 
@@ -77,7 +59,7 @@ sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh
 sudo dnf install -y wukongim
 ```
 
-`wukongim-release` 只安装专用 RPM 公钥和 `%config(noreplace)` repo 文件，不包含脚本；固定主密钥指纹为 `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`。首次引导仍依赖 HTTPS，之后 DNF/YUM 会从签名软件源验证并升级公钥包。
+RPM 固定主密钥指纹为 `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`。首次引导仍依赖 HTTPS，之后 DNF/YUM 会从签名软件源验证并升级公钥包。
 
 安装后确认二进制身份；版本应为 `3.0.0-beta.6`，文本输出的 `source` 和 JSON 输出的 `build_source` 应为 `release`：
 

--- a/docs-site/lib/native-deployment-contract.test.ts
+++ b/docs-site/lib/native-deployment-contract.test.ts
@@ -100,8 +100,7 @@ describe('native deployment publication contract', () => {
     for (const content of pages) {
       for (const contract of [
         '3.0.0-beta.6',
-        'https://packages.githubim.com/bootstrap/wukongim-archive-keyring_1.0.0_all.deb',
-        'https://packages.githubim.com/bootstrap/wukongim-release-1.0.0-1.noarch.rpm',
+        'curl -fsSL https://packages.githubim.com/repo | sudo sh',
         'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1',
         'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459',
         'wukongim-archive-keyring',
@@ -112,7 +111,6 @@ describe('native deployment publication contract', () => {
         'sudo apt install -y wukongim\n',
         "sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh",
         'sudo dnf install -y wukongim\n',
-        'sudo dnf install -y curl-minimal',
         'RHEL',
         'build_source',
         '.goreleaser.packages.yaml',
@@ -138,18 +136,29 @@ describe('native deployment publication contract', () => {
         'sudo apt-get install -y wukongim=',
         'sudo dnf install -y wukongim-',
         'sudo dnf -y --enablerepo=wukongim-preview install wukongim-',
+        'packages.githubim.com/bootstrap/wukongim-archive-keyring_',
+        'packages.githubim.com/bootstrap/wukongim-release-',
+        '/tmp/wukongim-archive-keyring_',
+        '/tmp/wukongim-release-',
       ]) {
         expect(content).not.toContain(unsafe);
       }
 
-      const aptBootstrap = content.indexOf('sudo apt install -y /tmp/wukongim-archive-keyring_1.0.0_all.deb');
+      expect(
+        content.match(/^curl -fsSL https:\/\/packages\.githubim\.com\/repo \| sudo sh$/gm),
+      ).toHaveLength(2);
+
+      const aptBootstrap = content.indexOf('curl -fsSL https://packages.githubim.com/repo | sudo sh');
       const aptUpdate = content.indexOf('sudo apt update', aptBootstrap);
       const aptInstall = content.indexOf('sudo apt install -y wukongim', aptUpdate);
       expect(aptBootstrap).toBeGreaterThan(-1);
       expect(aptUpdate).toBeGreaterThan(aptBootstrap);
       expect(aptInstall).toBeGreaterThan(aptUpdate);
 
-      const rpmBootstrap = content.indexOf('sudo dnf install -y /tmp/wukongim-release-1.0.0-1.noarch.rpm');
+      const rpmBootstrap = content.indexOf(
+        'curl -fsSL https://packages.githubim.com/repo | sudo sh',
+        aptInstall,
+      );
       const dnfUpdate = content.indexOf(
         "sudo dnf -y --disablerepo='*' --enablerepo=wukongim-preview makecache --refresh",
         rpmBootstrap,
@@ -159,6 +168,11 @@ describe('native deployment publication contract', () => {
       expect(dnfUpdate).toBeGreaterThan(rpmBootstrap);
       expect(dnfInstall).toBeGreaterThan(dnfUpdate);
     }
+
+    expect(pages[0]).toContain('该脚本只添加软件源，不会更新软件包索引、安装 WuKongIM');
+    expect(pages[1]).toContain(
+      'The script only adds the repository. It does not refresh the package index, install WuKongIM',
+    );
   });
 
   test('states the three-node three-replica readiness boundary', async () => {

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -100,10 +100,13 @@
   `packages.githubim.com`. Every public snapshot is download-validated on clean
   Ubuntu, Debian, Rocky Linux, and AlmaLinux clients. Stable publication remains
   disabled until it moves from GitHub Pages to object storage and a CDN. The
-  public client flow installs a signed-repository bootstrap package once, then
-  uses the package manager's normal update and unversioned `wukongim` install;
-  the bootstrap package owns the dedicated trust root and repository definition
-  so later public-certificate updates arrive through that same signed channel.
+  public client flow runs the HTTPS `packages.githubim.com/repo` bootstrap once,
+  then uses the package manager's normal update and unversioned `wukongim`
+  install. The script only adds the repository; it never refreshes package
+  indexes, installs WuKongIM, or starts the service. It selects the applicable
+  signed-repository bootstrap package, which owns the dedicated trust root and
+  repository definition so later public-certificate updates arrive through
+  that same signed channel.
   The product package installs the binary, hardened systemd unit, service
   identity, and persistent directories, but never creates an active
   configuration or starts/restarts the node.


### PR DESCRIPTION
## Summary

- replace versioned bootstrap package download examples with the stable `/repo` setup endpoint
- keep APT and DNF installation as three explicit steps: add repository, refresh indexes, install `wukongim`
- state that step one only configures the signed repository and does not install WuKongIM or start a service
- retain the HTTPS trust boundary and fixed signing-key fingerprints in Chinese and English documentation

## Validation

- `bun run verify`
- 24 JavaScript quickstart tests passed
- 173 documentation contract tests passed
- lint, type checks, production build, and all 815 static pages passed
- `git diff --check`

Review Agent is intentionally not requested, per maintainer direction.