### PR TITLE
docs: activate v3.0.0-beta.7 installation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Every category must contain at least one "- " list entry. Release headings use
 the exact form: ## [v3.0.0-beta.5] - 2026-09-01
 -->
 
+### 📚 Documentation / 文档
+
+- 中英文 Linux 部署与配置参考现已将 `v3.0.0-beta.7` 作为签名 Preview 软件源版本，并以 `sudo wukongim init` 作为默认初始化入口，同时保留显式路径兼容命令；Docker 部署示例也同步固定到同一版本。
+
 ## [v3.0.0-beta.7] - 2026-09-03
 
 ### 🚀 New Features / 新功能

--- a/docs-site/content/docs/server/configuration/reference.en.mdx
+++ b/docs-site/content/docs/server/configuration/reference.en.mdx
@@ -13,7 +13,7 @@ This is the quick-reference handbook for WuKongIM's public startup configuration
 - Configuration is loaded at node startup. Restart the node after a change unless the subsystem explicitly documents otherwise.
 
 <Callout type="info" title="Defaults and configuration baselines">
-  Starting with a later release that includes this feature, `wukongim init` creates a security-oriented installation baseline at `/etc/wukongim/wukongim.toml` by default and explicitly disables Diagnostics and Plugin. Continue to use `wukongim config init --config PATH` with the current `v3.0.0-beta.6`; that form will remain supported. `wukongim.toml.example` is a loadable development and tuning baseline. Neither baseline is a complete catalog of runtime defaults. In the table, “omitted” means neither TOML nor an environment value was supplied; it may differ from an explicit `0`, empty string, or `false`.
+  Starting with `v3.0.0-beta.7`, `wukongim init` creates a security-oriented installation baseline at `/etc/wukongim/wukongim.toml` by default and explicitly disables Diagnostics and Plugin. Use `wukongim init --config PATH` to choose another location; the original `wukongim config init --config PATH` compatibility entry point also remains available. `wukongim.toml.example` is a loadable development and tuning baseline. Neither baseline is a complete catalog of runtime defaults. In the table, “omitted” means neither TOML nor an environment value was supplied; it may differ from an explicit `0`, empty string, or `false`.
 </Callout>
 
 `node.id`, `node.data_dir`, and `cluster.listen_addr` are always required. Seed joining additionally requires `cluster.id`, non-empty `cluster.seeds`, a peer-reachable `cluster.advertise_addr`, and a non-empty `cluster.join_token`.

--- a/docs-site/content/docs/server/configuration/reference.mdx
+++ b/docs-site/content/docs/server/configuration/reference.mdx
@@ -13,7 +13,7 @@ description: 可搜索的 WuKongIM 配置手册，逐项说明全部公开 TOML 
 - 配置在节点启动时加载；除非对应子系统明确说明，否则修改后需要重启节点。
 
 <Callout type="info" title="默认值与配置基线">
-  从包含该功能的后续版本起，`wukongim init` 默认在 `/etc/wukongim/wukongim.toml` 生成面向安装场景的安全基线，并显式关闭 Diagnostics 和 Plugin；当前 `v3.0.0-beta.6` 请继续使用 `wukongim config init --config PATH`，该写法后续也会保留。`wukongim.toml.example` 是可加载的开发与调优基线。这两个基线都不是完整的运行时默认值清单。下表中的“省略”指没有提供 TOML 和环境变量；它与显式的 `0`、空字符串或 `false` 可能具有不同含义。
+  从 `v3.0.0-beta.7` 起，`wukongim init` 默认在 `/etc/wukongim/wukongim.toml` 生成面向安装场景的安全基线，并显式关闭 Diagnostics 和 Plugin。需要自定义位置时可使用 `wukongim init --config PATH`，原有的 `wukongim config init --config PATH` 兼容入口也继续保留。`wukongim.toml.example` 是可加载的开发与调优基线。这两个基线都不是完整的运行时默认值清单。下表中的“省略”指没有提供 TOML 和环境变量；它与显式的 `0`、空字符串或 `false` 可能具有不同含义。
 </Callout>
 
 `node.id`、`node.data_dir` 和 `cluster.listen_addr` 始终必填。种子加入还要求 `cluster.id`、非空的 `cluster.seeds`、可被其他节点访问的 `cluster.advertise_addr`，以及非空的 `cluster.join_token`。

--- a/docs-site/content/docs/server/deployment/docker.en.mdx
+++ b/docs-site/content/docs/server/deployment/docker.en.mdx
@@ -6,7 +6,7 @@ description: Start a WuKongIM single-node cluster with docker run or Docker Comp
 You only need Docker. This path mounts `wukongim.toml` and a Docker volume directly, with no installer.
 
 <Callout type="warn" title="The default is for a quick local evaluation">
-  The example pins image `3.0.0-beta.6`. To use another release, replace the image tag directly and read that release's upgrade notes first. Before serving production traffic, replace the example credentials and complete the [Production Checklist](/en/server/deployment/production-checklist).
+  The example pins image `3.0.0-beta.7`. To use another release, replace the image tag directly and read that release's upgrade notes first. Before serving production traffic, replace the example credentials and complete the [Production Checklist](/en/server/deployment/production-checklist).
 </Callout>
 
 ## 1. Create the configuration file
@@ -52,7 +52,7 @@ docker run -d --name wukongim --restart unless-stopped \
   -p 127.0.0.1:5001:5001 -p 5100:5100 -p 5200:5200 -p 127.0.0.1:5301:5301 \
   -v "$PWD/wukongim.toml:/etc/wukongim/wukongim.toml:ro" \
   -v wukongim-data:/var/lib/wukongim \
-  ghcr.io/wukongim/wukongim:3.0.0-beta.6
+  ghcr.io/wukongim/wukongim:3.0.0-beta.7
 ```
 
 ### Use Docker Compose
@@ -62,7 +62,7 @@ Create `compose.yaml`:
 ```yaml
 services:
   wukongim:
-    image: ghcr.io/wukongim/wukongim:3.0.0-beta.6
+    image: ghcr.io/wukongim/wukongim:3.0.0-beta.7
     container_name: wukongim
     restart: unless-stopped
     ports: ["127.0.0.1:5001:5001", "5100:5100", "5200:5200", "127.0.0.1:5301:5301"]

--- a/docs-site/content/docs/server/deployment/docker.mdx
+++ b/docs-site/content/docs/server/deployment/docker.mdx
@@ -6,7 +6,7 @@ description: 使用配置文件和数据卷，通过 docker run 或 Docker Compo
 只需要 Docker。下面的流程直接挂载 `wukongim.toml` 和 Docker Volume，不依赖安装脚本。
 
 <Callout type="warn" title="默认用于本机快速体验">
-  示例固定使用 `3.0.0-beta.6` 镜像。使用其他版本时直接替换镜像 tag，并先阅读对应版本的升级说明。承载生产流量前，请更换示例凭据并完成[生产检查清单](/zh/server/deployment/production-checklist)。
+  示例固定使用 `3.0.0-beta.7` 镜像。使用其他版本时直接替换镜像 tag，并先阅读对应版本的升级说明。承载生产流量前，请更换示例凭据并完成[生产检查清单](/zh/server/deployment/production-checklist)。
 </Callout>
 
 ## 1. 创建配置文件
@@ -52,7 +52,7 @@ docker run -d --name wukongim --restart unless-stopped \
   -p 127.0.0.1:5001:5001 -p 5100:5100 -p 5200:5200 -p 127.0.0.1:5301:5301 \
   -v "$PWD/wukongim.toml:/etc/wukongim/wukongim.toml:ro" \
   -v wukongim-data:/var/lib/wukongim \
-  ghcr.io/wukongim/wukongim:3.0.0-beta.6
+  ghcr.io/wukongim/wukongim:3.0.0-beta.7
 ```
 
 ### 使用 Docker Compose
@@ -62,7 +62,7 @@ docker run -d --name wukongim --restart unless-stopped \
 ```yaml
 services:
   wukongim:
-    image: ghcr.io/wukongim/wukongim:3.0.0-beta.6
+    image: ghcr.io/wukongim/wukongim:3.0.0-beta.7
     container_name: wukongim
     restart: unless-stopped
     ports: ["127.0.0.1:5001:5001", "5100:5100", "5200:5200", "127.0.0.1:5301:5301"]

--- a/docs-site/content/docs/server/deployment/linux.en.mdx
+++ b/docs-site/content/docs/server/deployment/linux.en.mdx
@@ -3,7 +3,7 @@ title: Linux
 description: Install WuKongIM from the signed APT/DNF preview repository or local deb/rpm packages, initialize it safely, and supervise a cluster node with systemd.
 ---
 
-The signed WuKongIM Linux preview repository is now available. It currently publishes `v3.0.0-beta.6` for amd64/x86_64 only. The publication pipeline has verified repository metadata, signatures, and exact-version downloads in fresh Ubuntu 24.04, Debian 13, Rocky Linux 9, and AlmaLinux 9 containers. RHEL 9 is a compatible target for the same EL9 repository, but is not part of this automated clean-client matrix.
+The signed WuKongIM Linux preview repository is now available. It currently publishes `v3.0.0-beta.7` for amd64/x86_64 only. The publication pipeline has verified repository metadata, signatures, and exact-version downloads in fresh Ubuntu 24.04, Debian 13, Rocky Linux 9, and AlmaLinux 9 containers. RHEL 9 is a compatible target for the same EL9 repository, but is not part of this automated clean-client matrix.
 
 Preview is a prerelease channel, not the stable channel. Validate configuration, backup, recovery, and upgrade compatibility outside production first.
 
@@ -61,7 +61,7 @@ sudo dnf install -y wukongim
 
 The fixed RPM primary-key fingerprint is `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`. The initial bootstrap still relies on HTTPS. DNF/YUM then verifies and upgrades the public-key package through the signed repository.
 
-Confirm the binary identity after installation. The version should be `3.0.0-beta.6`; `source` in the text output and `build_source` in JSON should be `release`:
+Confirm the binary identity after installation. The version should be `3.0.0-beta.7`; `source` in the text output and `build_source` in JSON should be `release`:
 
 ```bash
 wukongim version
@@ -77,17 +77,15 @@ Do not delete the keyring, public key, or repository files owned by the bootstra
 Interactive initialization creates a single-node cluster configuration with a random Cluster ID, join token, Manager JWT secret, and administrator password. The generated administrator password is shown only once:
 
 ```bash
-sudo wukongim config init \
-  --config /etc/wukongim/wukongim.toml
+sudo wukongim init
 ```
 
-Once a later release includes this feature, the command above can be shortened to `sudo wukongim init`. It writes `/etc/wukongim/wukongim.toml` by default and also accepts `--config PATH`. The `v3.0.0-beta.6` package currently in the repository does not contain the short command, so this page keeps the compatible form as its copyable path.
+`sudo wukongim init` writes `/etc/wukongim/wukongim.toml` by default. Pass `--config PATH` to choose another location explicitly. The original `sudo wukongim config init --config PATH` entry point remains available for existing automation.
 
 Automation must supply an administrator password of at least 12 characters through standard input; the command does not echo it:
 
 ```bash
-sudo wukongim config init \
-  --config /etc/wukongim/wukongim.toml \
+sudo wukongim init \
   --admin-password-stdin < /secure/path/manager-password
 ```
 

--- a/docs-site/content/docs/server/deployment/linux.mdx
+++ b/docs-site/content/docs/server/deployment/linux.mdx
@@ -3,7 +3,7 @@ title: Linux 部署
 description: 从签名 APT/DNF Preview 软件源或本地 deb/rpm 安装 WuKongIM，并通过安全初始化和 systemd 托管集群节点。
 ---
 
-WuKongIM 的签名 Linux Preview 软件源已经启用，当前发布 `v3.0.0-beta.6`，仅支持 amd64/x86_64。发布流程已在 Ubuntu 24.04、Debian 13、Rocky Linux 9 和 AlmaLinux 9 的全新容器中验证软件源元数据、签名和精确版本下载；RHEL 9 是同一 EL9 软件源的兼容目标，但不在本次自动化清洁客户端矩阵中。
+WuKongIM 的签名 Linux Preview 软件源已经启用，当前发布 `v3.0.0-beta.7`，仅支持 amd64/x86_64。发布流程已在 Ubuntu 24.04、Debian 13、Rocky Linux 9 和 AlmaLinux 9 的全新容器中验证软件源元数据、签名和精确版本下载；RHEL 9 是同一 EL9 软件源的兼容目标，但不在本次自动化清洁客户端矩阵中。
 
 Preview 是预发布通道，不等同于稳定通道。请先在非生产环境验证配置、备份、恢复和升级兼容性。
 
@@ -61,7 +61,7 @@ sudo dnf install -y wukongim
 
 RPM 固定主密钥指纹为 `A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459`。首次引导仍依赖 HTTPS，之后 DNF/YUM 会从签名软件源验证并升级公钥包。
 
-安装后确认二进制身份；版本应为 `3.0.0-beta.6`，文本输出的 `source` 和 JSON 输出的 `build_source` 应为 `release`：
+安装后确认二进制身份；版本应为 `3.0.0-beta.7`，文本输出的 `source` 和 JSON 输出的 `build_source` 应为 `release`：
 
 ```bash
 wukongim version
@@ -77,17 +77,15 @@ wukongim version --output json
 交互式初始化会生成单节点集群配置、随机 Cluster ID、Join Token、Manager JWT Secret 和管理员密码；生成的管理员密码只显示一次：
 
 ```bash
-sudo wukongim config init \
-  --config /etc/wukongim/wukongim.toml
+sudo wukongim init
 ```
 
-在包含该功能的后续版本发布后，上述命令可以缩短为 `sudo wukongim init`；它默认写入 `/etc/wukongim/wukongim.toml`，也接受 `--config PATH`。当前软件源中的 `v3.0.0-beta.6` 尚不包含这个短命令，因此本页仍以兼容写法作为可复制的主路径。
+`sudo wukongim init` 默认写入 `/etc/wukongim/wukongim.toml`；如需显式选择其他位置，可传入 `--config PATH`。原有的 `sudo wukongim config init --config PATH` 入口继续保留，便于兼容既有自动化。
 
 自动化环境必须从标准输入提供至少 12 个字符的管理员密码，命令不会回显它：
 
 ```bash
-sudo wukongim config init \
-  --config /etc/wukongim/wukongim.toml \
+sudo wukongim init \
   --admin-password-stdin < /secure/path/manager-password
 ```
 

--- a/docs-site/lib/native-deployment-contract.test.ts
+++ b/docs-site/lib/native-deployment-contract.test.ts
@@ -47,7 +47,7 @@ describe('native deployment publication contract', () => {
         'docker compose up -d',
         'name: wukongim-data',
         'docker compose down --volumes',
-        'ghcr.io/wukongim/wukongim:3.0.0-beta.6',
+        'ghcr.io/wukongim/wukongim:3.0.0-beta.7',
         'wukongim-data',
         'http://127.0.0.1:5301',
         'http://127.0.0.1:5001/readyz',
@@ -65,6 +65,7 @@ describe('native deployment publication contract', () => {
       expect(content).not.toContain('docker volume create');
       expect(content).not.toContain('--mount');
       expect(content).not.toContain('node1.toml');
+      expect(content).not.toContain('3.0.0-beta.6');
       for (const optional of [
         'cluster.id',
         'nodes =',
@@ -99,7 +100,7 @@ describe('native deployment publication contract', () => {
 
     for (const content of pages) {
       for (const contract of [
-        '3.0.0-beta.6',
+        '3.0.0-beta.7',
         'curl -fsSL https://packages.githubim.com/repo | sudo sh',
         'D4D5F12AD0FDCAE4D85B577E318ABB2BD40B6BB1',
         'A8FB9F660EC3B4F40B853C4A0FB64C9DD0801459',
@@ -114,8 +115,8 @@ describe('native deployment publication contract', () => {
         'RHEL',
         'build_source',
         '.goreleaser.packages.yaml',
-        'sudo wukongim init',
-        'wukongim config init',
+        '```bash\nsudo wukongim init\n```',
+        'wukongim config init --config PATH',
         '--admin-password-stdin',
         'wukongim config validate',
         'systemctl enable --now wukongim',
@@ -144,6 +145,10 @@ describe('native deployment publication contract', () => {
       ]) {
         expect(content).not.toContain(unsafe);
       }
+      expect(content).not.toContain('3.0.0-beta.6');
+      expect(content).toContain(
+        'sudo wukongim init \\\n  --admin-password-stdin < /secure/path/manager-password',
+      );
 
       expect(
         content.match(/^curl -fsSL https:\/\/packages\.githubim\.com\/repo \| sudo sh$/gm),
@@ -171,9 +176,34 @@ describe('native deployment publication contract', () => {
     }
 
     expect(pages[0]).toContain('该脚本只添加软件源，不会更新软件包索引、安装 WuKongIM');
+    expect(pages[0]).not.toContain('后续版本');
     expect(pages[1]).toContain(
       'The script only adds the repository. It does not refresh the package index, install WuKongIM',
     );
+    expect(pages[1]).not.toContain('later release');
+  });
+
+  test('keeps configuration references aligned with the released package initializer', async () => {
+    const pages = await Promise.all([
+      page('../configuration/reference.mdx'),
+      page('../configuration/reference.en.mdx'),
+    ]);
+
+    for (const content of pages) {
+      for (const contract of [
+        'v3.0.0-beta.7',
+        '`wukongim init`',
+        '/etc/wukongim/wukongim.toml',
+        'wukongim init --config PATH',
+        'wukongim config init --config PATH',
+      ]) {
+        expect(content).toContain(contract);
+      }
+      expect(content).not.toContain('v3.0.0-beta.6');
+    }
+
+    expect(pages[0]).not.toContain('后续版本');
+    expect(pages[1]).not.toContain('later release');
   });
 
   test('states the three-node three-replica readiness boundary', async () => {


### PR DESCRIPTION
## Summary

- update the bilingual Linux deployment guide to the publicly verified `v3.0.0-beta.7` signed Preview repository
- make `sudo wukongim init` the primary interactive and automation path while retaining `wukongim config init --config PATH` for compatibility and custom locations
- align the bilingual configuration reference and Docker examples with `v3.0.0-beta.7`
- strengthen the native deployment content contract and record the user-visible documentation change under `Unreleased`

## Validation

- [x] `bun test ./lib/native-deployment-contract.test.ts`
  - 6 passed, 0 failed, 233 assertions
- [x] `bun run verify`
  - JavaScript quickstart: 24 passed
  - documentation library: 178 passed, 5636 assertions
  - navigation, OpenAPI, lint, and TypeScript checks passed
  - 815 static pages built
  - 402 bounded RSC refresh URLs verified
- [x] `git diff --check`

## Public package evidence

- [x] immutable source Release: https://github.com/WuKongIM/WuKongIM/releases/tag/v3.0.0-beta.7
- [x] immutable package audit: https://github.com/WuKongIM/packages/releases/tag/native-package-preview-r381833800
- [x] clean Ubuntu 24.04 client configured `https://packages.githubim.com` with `curl -fsSL https://packages.githubim.com/repo | sudo sh`
- [x] `sudo apt update` selected the signed Preview repository
- [x] `sudo apt install -y wukongim` installed `3.0.0~beta.7`
- [x] `wukongim version --output json` reported `3.0.0-beta.7` with `build_source=release`
- [x] `sudo wukongim init` created `/etc/wukongim/wukongim.toml` with the package contract ownership/mode `root:wukongim 0640`

Review Agent is intentionally not requested; merge after ordinary required checks pass.