### PR TITLE
docs: add C# WuKongEasySDK quickstart and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Add bilingual C# WuKongEasySDK integration, console example, async lifecycle, and pinned-source installation guidance for the new `WuKongEasySDK-CSharp` repository. / 新增 C# WuKongEasySDK 中英文接入文档，覆盖固定源码安装、控制台示例、异步生命周期和验证边界。
+
 - Add a directly runnable, standard-library Go before-send Webhook example with allow/replace/reject rules, bilingual setup instructions, and real-process send/history validation. / 新增可直接运行的 Go 发送前 Webhook 示例，支持放行、改写及拒绝，并附中英文接入说明和真实进程验证。
 
 - Add a reproducible local three-node Webhook acceptance guide covering Token authentication, failure policies, overload isolation, recovery, and observable results. / 新增本机三节点 Webhook 验收指南，覆盖 Token 鉴权、失败策略、过载隔离、恢复及观测结果。

--- a/docs-site/FLOW.md
+++ b/docs-site/FLOW.md
@@ -7,10 +7,8 @@ summary: Owns the bilingual static v3 documentation site, shared navigation, pub
 
 ## Responsibility
 
-`docs-site` is the standalone Fumadocs application for public WuKongIM v3 docs
-under `/zh` and `/en`. It owns navigation, MDX, search, SEO, machine-readable
-output, SDK and API references, and runnable JavaScript/Web and Go Webhook
-examples. It documents runtime contracts but does not define them.
+`docs-site` owns the bilingual Fumadocs v3 site, navigation, references, runnable
+examples, search, SEO, and machine-readable output. Runtime contracts are defined elsewhere.
 
 ## Boundaries
 
@@ -41,9 +39,9 @@ examples. It documents runtime contracts but does not define them.
    supported advanced topics, and API lookup. One shared upgrade page replaces
    per-platform upgrade pages.
 4. The separate EasySDK path keeps released package pins distinct from exact
-   repository-example receipts. Its shared runbook starts one server revision,
-   maps host addresses for browser, emulators, and devices, and reproduces the
-   four maintained examples before platform-specific integration.
+   repository-example receipts. Its runbook maps reachable endpoints and
+   reproduces four registry examples plus the C# source console example, each
+   with its recorded server revision, before platform-specific integration.
 5. Removed SDK pages exist only as redirects. UniApp migration lives under the
    JavaScript advanced section; there is no standalone UniApp documentation
    group.

--- a/docs-site/NAVIGATION.md
+++ b/docs-site/NAVIGATION.md
@@ -135,12 +135,13 @@ Route: `/{lang}/sdk`
       - **媒体与历史消息 / Media & History** `/{lang}/sdk/harmonyos/advanced/media-and-history` — 接入图片或语音消息，并在本地数据不足时补齐历史消息。 / Connect image or voice messages and fill history when local data is incomplete.
     - **API 参考 / API Reference** `/{lang}/sdk/harmonyos/api-reference` — 按管理器查找常用入口、监听器、Provider、模型和状态。 / Find common manager entry points, listeners, providers, models, and states.
   - **升级 SDK / Upgrade SDKs** `/{lang}/sdk/wukongim/upgrade` — 用一套简洁流程升级依赖、检查数据兼容并准备回滚。 / Upgrade dependencies, check data compatibility, and prepare rollback with one concise workflow.
-- **WuKongEasySDK / WuKongEasySDK** `/{lang}/sdk/easy` — 选择 iOS、Android、Flutter 或 Web 快速接入，并用已验证的正式发布包与源码 example 完成在线双向消息。 / Choose an iOS, Android, Flutter, or Web quickstart and use verified released packages and source examples for online bidirectional messaging.
+- **WuKongEasySDK / WuKongEasySDK** `/{lang}/sdk/easy` — 选择 iOS、Android、Flutter、Web 或 C# 快速接入，并用已验证的正式发布包或固定源码完成在线双向消息。 / Choose an iOS, Android, Flutter, Web, or C# quickstart and use verified released packages or pinned source for online bidirectional messaging.
   - **运行官方示例 / Run Official Examples** `/{lang}/sdk/easy/examples` — 启动同一版 WuKongIM，复现四端正式包与源码 example 的在线双向消息、断开和清理。 / Start the same WuKongIM revision and reproduce online bidirectional messaging, disconnect, and cleanup with four released packages and source examples.
   - **iOS 快速接入 / iOS quickstart** `/{lang}/sdk/easy/ios/getting-started` — 精确安装 v1.1.1，完成单聊收发、监听清理和已验证的 Alice/Bob 正式包验收。 / Install exactly v1.1.1 for person messaging, listener cleanup, and verified released-package Alice/Bob acceptance.
   - **Android 快速接入 / Android quickstart** `/{lang}/sdk/easy/android/getting-started` — 精确安装 v1.0.5，处理单例、单聊收发、清理和已验证的 Alice/Bob 正式包验收。 / Install exactly v1.0.5 for singleton ownership, person messaging, cleanup, and verified released-package Alice/Bob acceptance.
   - **Flutter 快速接入 / Flutter quickstart** `/{lang}/sdk/easy/flutter/getting-started` — 精确安装并运行已验证的 v1.1.0 example，完成单聊收发、dispose 清理和 Alice/Bob 验收。 / Install and run the verified v1.1.0 example for person messaging, dispose cleanup, and Alice/Bob acceptance.
   - **Web 快速接入 / Web quickstart** `/{lang}/sdk/easy/javascript/getting-started` — 精确安装 easyjssdk v2.0.4，在真实浏览器与正式包对端中完成 Alice/Bob 在线消息。 / Install exactly easyjssdk v2.0.4 for Alice/Bob online messaging in a real browser and released-package peer runs.
+  - **C# 快速接入 / C# quickstart** `/{lang}/sdk/easy/csharp/getting-started` — 使用 1.0.0 固定源码接入 .NET 8，完成异步连接、消息收发、重连和释放。 / Use pinned 1.0.0 source with .NET 8 for async connections, messaging, reconnect, and cleanup.
 
 ## API 与协议 / API & Protocols
 

--- a/docs-site/PHASE_15_SPEC.md
+++ b/docs-site/PHASE_15_SPEC.md
@@ -39,6 +39,12 @@ against WuKongIM PR test merge
 `1c9430f15fc8844e7025df07d54ab6e80e026414`. That proves bounded platform
 execution of the released packages, but not production readiness.
 
+The C# extension adds `WuKongEasySDK-CSharp` source version `1.0.0` and the
+`/sdk/easy/csharp/getting-started` bilingual route. It targets .NET 8, uses pinned
+source/project references or a locally built NuGet package, and does not claim a
+nuget.org release or inherit the four platforms' historical package receipts.
+Its independent source verification is recorded in the C# quickstart.
+
 ## Audience and completion outcome
 
 The primary reader owns an existing application and trusted product backend.

--- a/docs-site/content/docs/sdk/easy/csharp/getting-started.en.mdx
+++ b/docs-site/content/docs/sdk/easy/csharp/getting-started.en.mdx
@@ -1,0 +1,175 @@
+---
+title: C# quickstart
+description: Integrate pinned WuKongEasySDK-CSharp source with .NET 8 for authentication, online messaging, automatic reconnect, and async cleanup.
+---
+
+[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) follows the JavaScript EasySDK WebSocket JSON-RPC protocol with idiomatic async C# APIs and typed events. It has no third-party runtime dependencies.
+
+<Callout type="info" title="Current installation: pinned source or a local NuGet package">
+  The initial source version is `1.0.0`, pinned here to `d365a354f5e0f25fbd7f83bb59aa365ba43e899f`. It has not been published to nuget.org. Use the project reference or locally packed feed below. Source tests and a local `.nupkg` do not prove a public NuGet release.
+</Callout>
+
+## Before you begin
+
+- Prepare .NET 8 or later on Windows, Linux, or macOS. The target framework is `net8.0`; Unity, .NET Framework, and browser WebAssembly are not currently supported.
+- Start a WuKongIM single-node cluster or multi-node cluster with a healthy `/readyz` and a reachable WebSocket Gateway. A single-node cluster still follows cluster semantics and defaults to 256 hash slots.
+- Have your trusted backend supply separate `uid`, `token`, and `websocketUrl` values for Alice and Bob. Clients do not call Product HTTP management routes such as `/user/token` or `/route`.
+- C# defaults to PC/Desktop `2`. The backend token's `device_flag` must match the client; APP is `0` and Web is `1`.
+
+Read [Identity & Token](/en/guide/integration/authentication) first. Production uses HTTPS/WSS with certificate validation. Tokens do not belong in URLs, logs, or source code.
+
+## 1. Install pinned source
+
+```bash
+git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git
+git -C WuKongEasySDK-CSharp checkout d365a354f5e0f25fbd7f83bb59aa365ba43e899f
+dotnet new console -n MyChat --framework net8.0
+dotnet add MyChat/MyChat.csproj reference WuKongEasySDK-CSharp/src/WuKongEasySDK/WuKongEasySDK.csproj
+```
+
+The two directories are siblings. Record the exact source revision in your build configuration or maintain the reference through a submodule pinned to that commit.
+
+For a local NuGet installation, build the package from that pinned checkout:
+
+```bash
+cd WuKongEasySDK-CSharp
+dotnet pack src/WuKongEasySDK -c Release -o artifacts
+dotnet add ../MyChat/MyChat.csproj package WuKongEasySDK --version 1.0.0 --source ./artifacts
+```
+
+Choose either the project reference or the local package. Do not reference both. Here, `--source ./artifacts` is the local feed you just built.
+
+## 2. Obtain connection material from your backend
+
+After product login, retrieve this minimal response through a protected product route:
+
+```json
+{
+  "uid": "alice",
+  "token": "backend-issued-desktop-token",
+  "websocketUrl": "wss://im.example.com/ws"
+}
+```
+
+The console example reads these values from `WUKONGIM_WS_URL`, `WUKONGIM_UID`, and `WUKONGIM_TOKEN`. A desktop application can consume the login response directly. These variables belong to the example; they are not the server's `WK_` configuration keys.
+
+## 3. Connect, subscribe, and send
+
+Replace `MyChat/Program.cs` with the following. Set the three environment variables for the current identity and supply the other user's UID as a command-line argument.
+
+```csharp
+using WuKongEasySDK;
+
+static string Required(string name) =>
+    Environment.GetEnvironmentVariable(name)
+    ?? throw new InvalidOperationException($"Missing {name}");
+
+if (args.Length != 1)
+    throw new ArgumentException("Pass the peer UID as the first argument.");
+
+await using var im = new WKIM(Required("WUKONGIM_WS_URL"), new AuthOptions
+{
+    Uid = Required("WUKONGIM_UID"),
+    Token = Required("WUKONGIM_TOKEN"),
+    DeviceFlag = DeviceFlag.Desktop
+}, new WKIMOptions
+{
+    ConnectTimeout = TimeSpan.FromSeconds(10),
+    RequestTimeout = TimeSpan.FromSeconds(15)
+});
+
+Action<RecvMessage> onMessage = message =>
+{
+    // Deduplicate by MessageId and pass Payload to application state.
+    // Marshal WinForms/WPF updates to the UI thread; do not log full messages.
+    Console.WriteLine("Message received.");
+};
+im.Message += onMessage;
+im.Connected += _ => Console.WriteLine("Connected.");
+im.Disconnected += _ => Console.WriteLine("Disconnected.");
+im.Error += _ => Console.WriteLine("SDK operation failed.");
+im.CustomEvent += notification =>
+{
+    // Route notification.Data using notification.Type.
+};
+
+try
+{
+    await im.ConnectAsync();
+    Console.WriteLine("Start the peer, then press Enter to send.");
+    Console.ReadLine();
+    var result = await im.SendAsync(args[0], ChannelType.Person,
+        new { type = 1, content = "Hello from C# 👋" });
+    if (!result.IsSuccess)
+        Console.WriteLine($"SEND rejected: {(int)result.ReasonCode}");
+    else
+        Console.WriteLine("Server accepted SEND.");
+    Console.WriteLine("Press Enter after checking both directions to exit.");
+    Console.ReadLine();
+}
+finally
+{
+    im.Message -= onMessage;
+    await im.DisconnectAsync();
+}
+```
+
+In separate terminals using Alice and Bob's connection material, run `dotnet run --project MyChat -- bob` and `dotnet run --project MyChat -- alice`. Async methods return exceptions to their callers and background failures also raise `Error`; provide application handling for authentication failures, timeouts, and business rejections.
+
+SDK logging is disabled by default. Setting `WKIMOptions.DebugLogger` enables only fixed operational strings, excluding tokens, payloads, raw frames, and server error bodies.
+
+## 4. Groups, send results, and received data
+
+Use `ChannelType.Group` with a backend-managed group ID for group messages. Membership and permissions remain server decisions. `SendOptions` provides `ClientMsgNo`, `Header`, `Setting`, and `Topic`. The default header sets `RedDot = true`; an explicitly supplied header is respected.
+
+`ReasonCode.Success` is **1**. `SendResult.IsSuccess` means the server accepted SEND, not that Bob received, displayed, or read it. Business rejection codes such as `128–255` remain in the result. JSON-RPC errors throw `WKIMRpcException` with a numeric `Code`.
+
+Message IDs use `string`; numeric wire IDs never pass through floating-point conversion. `MessageSeq` and `NodeId` use `ulong`. Message `Timestamp` is Unix **seconds**; custom event `Timestamp` is Unix **milliseconds**.
+
+`RecvMessage.Payload` and `EventNotification.Data` are independently owned `JsonElement` values. Receive payloads accept JSON objects or Base64 JSON; undecodable strings remain unchanged. Custom event JSON strings become JSON values, while plain strings remain strings.
+
+## 5. Reconnect, cancellation, and cleanup
+
+| Behavior | C# SDK contract |
+| --- | --- |
+| Instance ownership | `new WKIM` / `WKIM.Init` creates an independent instance; no implicit global singleton |
+| Concurrent connects | `ConnectAsync` callers share the attempt; canceling one cancels only its wait |
+| Stop shared connection | Await `DisconnectAsync` before connecting again |
+| Initial failure | WebSocket open and authentication share a 10-second budget; failure returns directly |
+| Loss after connection | Up to five retries by default, at 1, 2, 4, 8, and 16 seconds; success resets the budget |
+| Stop automatic retry | Authentication rejection, server disconnect/kick, manual disconnect, or disposal |
+| Final cleanup | Await `DisposeAsync` from lifecycle code, or use `await using` |
+
+For token rotation or account switching, dispose the old instance and create one with fresh backend-issued credentials. Set `AuthOptions.DeviceId` explicitly when the device identifier should persist across processes.
+
+Events run serially in the background. Keep handlers short; do not synchronously wait for SDK async operations or wait for disposal inside a callback. A throwing handler does not prevent other listeners or automatic ACK. Already queued callbacks may finish after listener removal or disconnect; `DisposeAsync` waits for them to drain.
+
+RECVACK means admission to the SDK receive queue, not successful business processing. Defaults are 256 pending requests, 128 queued events, and 1 MiB per complete JSON-RPC envelope. Excess requests throw `WKIMBackpressureException`; a full event queue closes the connection without ACKing the unaccepted message. Configure these bounds through `WKIMOptions`.
+
+The SDK does not queue offline messages or automatically resend SEND. A timeout, cancellation, or disconnect may leave the send outcome uncertain. Reconcile business state first; reuse `SendOptions.ClientMsgNo` when retrying the same logical message. Your application owns offline recovery, conversations, unread counts, push, and business receipts.
+
+## 6. Run the official example and acceptance
+
+From the pinned checkout:
+
+```bash
+dotnet build -c Release
+dotnet test -c Release
+dotnet run --project examples/ConsoleChat -- bob
+```
+
+The console example uses the same environment variables. Type text to send, and use `/quit` or Ctrl+C to exit. It displays message text as chat UI without printing complete protocol objects.
+
+With a prebuilt server binary, run the automated real-process fixture:
+
+```bash
+WUKONGIM_BINARY=/absolute/path/to/wukongim python3 scripts/smoke.py
+```
+
+The script starts and cleans up only its own loopback single-node cluster with 256 hash slots and Token authentication. It prepares two test identities and verifies matching SENDACK/RECV for bidirectional Unicode messages, reconnect, heartbeat, and invalid-token rejection.
+
+This source passed 35 tests, Release builds, and local NuGet packing on macOS arm64 with .NET SDK `8.0.424` / runtime `8.0.30`. It also passed the real-process fixture against WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d`. Loopback WebSocket tests cover custom events and reconnect failures. This receipt excludes public NuGet downloads, production WSS, offline recovery, multi-node capacity, and long-duration stability.
+
+## Next
+
+See [Run the Official Examples](/en/sdk/easy/examples) and the [SDK validation record](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/d365a354f5e0f25fbd7f83bb59aa365ba43e899f/docs/validation.md), or return to [WuKongEasySDK](/en/sdk/easy) to compare platforms. Continue production integration with [Messaging](/en/guide/integration/messaging) and [Integration Acceptance](/en/guide/integration/acceptance).

--- a/docs-site/content/docs/sdk/easy/csharp/getting-started.mdx
+++ b/docs-site/content/docs/sdk/easy/csharp/getting-started.mdx
@@ -1,0 +1,175 @@
+---
+title: C# 快速接入
+description: 使用 WuKongEasySDK-CSharp 固定源码接入 .NET 8，完成认证、在线消息、自动重连和异步释放。
+---
+
+[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 参考 JavaScript EasySDK 的 WebSocket JSON-RPC 协议，提供符合 C# 习惯的异步 API 和强类型事件。运行时不依赖第三方包。
+
+<Callout type="info" title="当前安装方式：固定源码或本地 NuGet 包">
+  初始源码版本为 `1.0.0`，本页固定到 `d365a354f5e0f25fbd7f83bb59aa365ba43e899f`。尚未发布到 nuget.org，请使用下文的项目引用或自行打包后的本地源。源码测试和本地 `.nupkg` 验证不等于公共 NuGet 发布。
+</Callout>
+
+## 开始前
+
+- 准备 .NET 8 或更新版本，以及 Windows、Linux 或 macOS 开发环境。当前目标框架为 `net8.0`，不包含 Unity、.NET Framework 和浏览器 WebAssembly 支持。
+- 启动 `/readyz` 健康的 WuKongIM 单节点集群或多节点集群，确认客户端可以访问 WebSocket Gateway。单节点集群同样遵循集群语义，默认使用 256 Hash Slots。
+- 业务后端为 Alice 和 Bob 分别返回 `uid`、`token` 和 `websocketUrl`。客户端不调用 `/user/token` 或 `/route` 等 Product HTTP 管理接口。
+- C# 默认使用 PC/Desktop `2`。后端签发 Token 的 `device_flag` 必须与客户端一致；APP 为 `0`，Web 为 `1`。
+
+先阅读 [身份与 Token](/zh/guide/integration/authentication)。生产环境使用 HTTPS/WSS，不关闭证书验证，不把 Token 放入 URL、日志或源码。
+
+## 1. 安装固定源码
+
+```bash
+git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git
+git -C WuKongEasySDK-CSharp checkout d365a354f5e0f25fbd7f83bb59aa365ba43e899f
+dotnet new console -n MyChat --framework net8.0
+dotnet add MyChat/MyChat.csproj reference WuKongEasySDK-CSharp/src/WuKongEasySDK/WuKongEasySDK.csproj
+```
+
+两个目录处于同一级。将确切源码 revision 记录到构建配置，或通过固定 commit 的子模块维护引用。
+
+如需本地 NuGet 安装，先在这个固定 checkout 中生成包：
+
+```bash
+cd WuKongEasySDK-CSharp
+dotnet pack src/WuKongEasySDK -c Release -o artifacts
+dotnet add ../MyChat/MyChat.csproj package WuKongEasySDK --version 1.0.0 --source ./artifacts
+```
+
+项目引用和本地包二选一，不要同时引用。此处的 `--source ./artifacts` 指向你刚生成的本地源。
+
+## 2. 由业务后端提供连接材料
+
+登录业务系统后，通过受保护的业务接口取得：
+
+```json
+{
+  "uid": "alice",
+  "token": "backend-issued-desktop-token",
+  "websocketUrl": "wss://im.example.com/ws"
+}
+```
+
+下面的控制台示例从 `WUKONGIM_WS_URL`、`WUKONGIM_UID`、`WUKONGIM_TOKEN` 环境变量读取这些值；桌面应用可以改为读取登录响应。它们是本示例的变量，不是服务端的 `WK_` 配置项。
+
+## 3. 连接、监听并发送
+
+用下面代码替换 `MyChat/Program.cs`。启动前设置当前账号的三个环境变量，通过命令行参数传入对方 UID。
+
+```csharp
+using WuKongEasySDK;
+
+static string Required(string name) =>
+    Environment.GetEnvironmentVariable(name)
+    ?? throw new InvalidOperationException($"Missing {name}");
+
+if (args.Length != 1)
+    throw new ArgumentException("Pass the peer UID as the first argument.");
+
+await using var im = new WKIM(Required("WUKONGIM_WS_URL"), new AuthOptions
+{
+    Uid = Required("WUKONGIM_UID"),
+    Token = Required("WUKONGIM_TOKEN"),
+    DeviceFlag = DeviceFlag.Desktop
+}, new WKIMOptions
+{
+    ConnectTimeout = TimeSpan.FromSeconds(10),
+    RequestTimeout = TimeSpan.FromSeconds(15)
+});
+
+Action<RecvMessage> onMessage = message =>
+{
+    // 按 MessageId 去重，并把 Payload 交给应用状态。
+    // WinForms/WPF 等 UI 需切回 UI 线程；不要打印完整消息。
+    Console.WriteLine("Message received.");
+};
+im.Message += onMessage;
+im.Connected += _ => Console.WriteLine("Connected.");
+im.Disconnected += _ => Console.WriteLine("Disconnected.");
+im.Error += _ => Console.WriteLine("SDK operation failed.");
+im.CustomEvent += notification =>
+{
+    // 按 notification.Type 分发 notification.Data。
+};
+
+try
+{
+    await im.ConnectAsync();
+    Console.WriteLine("Start the peer, then press Enter to send.");
+    Console.ReadLine();
+    var result = await im.SendAsync(args[0], ChannelType.Person,
+        new { type = 1, content = "Hello from C# 👋" });
+    if (!result.IsSuccess)
+        Console.WriteLine($"SEND rejected: {(int)result.ReasonCode}");
+    else
+        Console.WriteLine("Server accepted SEND.");
+    Console.WriteLine("Press Enter after checking both directions to exit.");
+    Console.ReadLine();
+}
+finally
+{
+    im.Message -= onMessage;
+    await im.DisconnectAsync();
+}
+```
+
+两个终端分别使用 Alice/Bob 的连接材料，运行 `dotnet run --project MyChat -- bob` 和 `dotnet run --project MyChat -- alice`。异常会通过异步方法返回给调用者，后台错误也会触发 `Error`；应用应为认证失败、超时和业务拒绝分别提供处理界面。
+
+库默认没有日志。只有显式设置 `WKIMOptions.DebugLogger` 才输出固定运行状态文本，不包含 Token、Payload、原始帧或服务端错误正文。
+
+## 4. 群聊、发送结果与接收数据
+
+群聊使用 `ChannelType.Group` 和业务后端管理的群 ID；成员关系和权限仍由服务端判定。可传入 `SendOptions` 设置 `ClientMsgNo`、`Header`、`Setting` 和 `Topic`。默认 Header 为 `RedDot = true`，显式传入的 Header 不会被 SDK 覆盖。
+
+`ReasonCode.Success` 为 **1**。`SendResult.IsSuccess` 表示服务端接受了发送，不代表 Bob 已收到、已展示或已读。`128–255` 等业务拒绝码保留在结果中；JSON-RPC 错误抛出 `WKIMRpcException`，通过数字 `Code` 判定。
+
+消息 ID 使用 `string`，数字形式的 ID 不经过浮点转换。`MessageSeq` 与 `NodeId` 为 `ulong`。消息 `Timestamp` 单位为 Unix **秒**，自定义事件 `Timestamp` 为 Unix **毫秒**。
+
+`RecvMessage.Payload` 和 `EventNotification.Data` 为拥有独立生命周期的 `JsonElement`。接收 Payload 支持 JSON 对象和 Base64 JSON；无法解码的字符串保留原值。自定义事件的 JSON 字符串会解析为 JSON 值，普通字符串保持不变。
+
+## 5. 重连、取消与释放
+
+| 行为 | C# SDK 约定 |
+| --- | --- |
+| 实例所有权 | `new WKIM` / `WKIM.Init` 创建独立实例，无隐式全局单例 |
+| 并发连接 | 多个 `ConnectAsync` 共享尝试；取消某个调用只停止其等待 |
+| 停止共享连接 | 等待 `DisconnectAsync` 后才再次连接 |
+| 初次失败 | 建连与认证共用 10 秒预算，失败直接返回 |
+| 已连接后断线 | 默认最多重试 5 次，间隔 1、2、4、8、16 秒；成功后重置 |
+| 停止自动重连 | 认证拒绝、服务端断开/踢下线、主动断开或释放 |
+| 最终清理 | 在应用生命周期代码中等待 `DisposeAsync`，或使用 `await using` |
+
+Token 更新或账号切换时，释放旧实例，再使用新的业务凭据创建客户端。需要跨进程保留设备 ID 时显式设置 `AuthOptions.DeviceId`。
+
+事件在后台按顺序派发，回调必须尽快返回，不应阻塞等待 SDK 的异步操作或在回调内等待释放。单个监听器抛异常不会中断其他监听器和自动 ACK。已经入队的回调可能在移除监听或断开后继续执行；`DisposeAsync` 会等待它们结束。
+
+RECVACK 表示消息进入 SDK 接收队列，不是业务处理确认。默认最多保留 256 个待完成请求、128 个待派发事件，单个完整 JSON-RPC 帧上限为 1 MiB。请求超限抛出 `WKIMBackpressureException`；事件队列满会关闭连接，不确认无法入队的消息。应用可以通过 `WKIMOptions` 调整这些边界。
+
+SDK 不缓存离线消息，也不自动重发 SEND。请求超时、取消或断线时，发送可能已经成功。应用应先核对业务状态，需要重试同一条逻辑消息时复用 `SendOptions.ClientMsgNo`。离线恢复、会话、未读数、推送与业务回执由应用自行维护。
+
+## 6. 运行官方示例和验收
+
+在固定源码目录执行：
+
+```bash
+dotnet build -c Release
+dotnet test -c Release
+dotnet run --project examples/ConsoleChat -- bob
+```
+
+控制台示例使用同样的环境变量，输入文本发送，`/quit` 或 Ctrl+C 退出。它把正文显示为聊天界面内容，不输出完整协议对象。
+
+已有服务端二进制时，还可运行自动化真实进程测试：
+
+```bash
+WUKONGIM_BINARY=/absolute/path/to/wukongim python3 scripts/smoke.py
+```
+
+该脚本只启动和清理自己拥有的回环地址单节点集群，使用 256 Hash Slots 并启用 Token 认证。它自动准备两个测试账号，检查双向 Unicode 消息的 SENDACK/RECV 一致性、重连、心跳和错误 Token 拒绝。
+
+本页源码在 macOS arm64、.NET SDK `8.0.424` / runtime `8.0.30` 通过 35 项测试、Release 构建与本地 NuGet 打包，并对 WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d` 完成上述真实进程验证。自定义事件与故障重连由回环 WebSocket 测试覆盖。此记录不包含公共 NuGet 下载、生产 WSS、离线恢复、多节点容量或长期稳定性验证。
+
+## 下一步
+
+查看 [运行官方示例](/zh/sdk/easy/examples) 和 [SDK 验证记录](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/d365a354f5e0f25fbd7f83bb59aa365ba43e899f/docs/validation.md)，或回到 [WuKongEasySDK](/zh/sdk/easy) 比较平台。生产接入继续参考 [消息收发](/zh/guide/integration/messaging) 与 [集成验收](/zh/guide/integration/acceptance)。

--- a/docs-site/content/docs/sdk/easy/examples.en.mdx
+++ b/docs-site/content/docs/sdk/easy/examples.en.mdx
@@ -152,6 +152,23 @@ Run every target you intend to ship. An iOS Simulator result cannot stand in for
 
 The current Web, Android, and iOS release commits change only version, changelog, or release-documentation metadata above the verified sources; their example behavior source is unchanged. Flutter's release source is the previously verified revision. Use the “Official source examples” table above when reproducing the exact August 31 source receipts.
 
+### C# / .NET source example
+
+The new [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) targets .NET 8 at source version `1.0.0` and has not been published to nuget.org. It is separate from the four historical released-package receipts above.
+
+```bash
+git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git
+cd WuKongEasySDK-CSharp
+git checkout d365a354f5e0f25fbd7f83bb59aa365ba43e899f
+dotnet build -c Release
+dotnet test -c Release
+dotnet run --project examples/ConsoleChat -- bob
+```
+
+Set `WUKONGIM_WS_URL`, `WUKONGIM_UID`, and `WUKONGIM_TOKEN` first, using Alice and Bob's own credentials in separate terminals. Prepare backend tokens with `device_flag` set to `2`, matching the C# default `DeviceFlag.Desktop`. See the complete [C# quickstart](/en/sdk/easy/csharp/getting-started).
+
+The C# source passed 35 tests and local NuGet packing on macOS arm64 / .NET `8.0.424`. Against WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d`, a token-authenticated single-node cluster passed bidirectional messaging, reconnect, heartbeat, invalid-token rejection, and cleanup. Reproduce with `WUKONGIM_BINARY=/absolute/path/to/wukongim python3 scripts/smoke.py`; the script owns only its loopback test processes. This is not public NuGet download or production WSS evidence.
+
 ## 4. Rerun released-package automation
 
 `Safety Automation - EasySDK Released Package Acceptance` resolves the exact four registry versions, builds the current WuKongIM, then uses the released npm package as Bob while Android API 34 and two iOS Simulator jobs complete bidirectional messaging. Trigger a rerun with:

--- a/docs-site/content/docs/sdk/easy/examples.mdx
+++ b/docs-site/content/docs/sdk/easy/examples.mdx
@@ -152,6 +152,23 @@ flutter run -d <device-id>
 
 当前 Web、Android 与 iOS 发布提交只在已验证源码之上修改版本、变更日志或发布说明，example 行为源码保持不变；Flutter 发布源码与先前验证 revision 相同。若要核对 8 月 31 日的精确源码凭据，使用上方“官方源码 example”表中的 revision。
 
+### C# / .NET 源码示例
+
+新增的 [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 使用 .NET 8，源码版本为 `1.0.0`，尚未发布到 nuget.org。它不属于上面四端的历史正式包记录。
+
+```bash
+git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git
+cd WuKongEasySDK-CSharp
+git checkout d365a354f5e0f25fbd7f83bb59aa365ba43e899f
+dotnet build -c Release
+dotnet test -c Release
+dotnet run --project examples/ConsoleChat -- bob
+```
+
+运行前设置 `WUKONGIM_WS_URL`、`WUKONGIM_UID`、`WUKONGIM_TOKEN`；两个终端分别使用 Alice/Bob 的凭据。后端准备 Token 时将 `device_flag` 设为 `2`，与 C# 默认 `DeviceFlag.Desktop` 一致。完整示例见 [C# 快速接入](/zh/sdk/easy/csharp/getting-started)。
+
+C# 源码在 macOS arm64 / .NET `8.0.424` 通过 35 项测试和本地 NuGet 打包，并对 WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d` 完成启用 Token 认证的单节点集群双向消息、重连、心跳、错误 Token 拒绝与清理。可使用 `WUKONGIM_BINARY=/absolute/path/to/wukongim python3 scripts/smoke.py` 复现；脚本仅操作自己启动的回环地址测试进程。该记录不代表公共 NuGet 下载或生产 WSS 验证。
+
 ## 4. 重跑正式包自动验收
 
 仓库中的 `Safety Automation - EasySDK Released Package Acceptance` 会从四个 Registry 解析精确版本，构建当前 WuKongIM，再用正式 npm 包作为 Bob，分别在 Android API 34 与两个 iOS Simulator 任务中完成双向消息。需要重跑时可手动触发：

--- a/docs-site/content/docs/sdk/easy/index.en.mdx
+++ b/docs-site/content/docs/sdk/easy/index.en.mdx
@@ -1,6 +1,6 @@
 ---
 title: WuKongEasySDK
-description: Choose an iOS, Android, Flutter, or Web quickstart and use a pinned release to complete an online Alice/Bob messaging loop.
+description: Choose an iOS, Android, Flutter, Web, or C# quickstart and use a pinned release to complete an online Alice/Bob messaging loop.
 ---
 
 WuKongEasySDK uses WebSocket JSON-RPC CONNECT for a lightweight connection and online-messaging API. It fits applications that already have a product backend and own their UI and product state.
@@ -13,6 +13,7 @@ WuKongEasySDK uses WebSocket JSON-RPC CONNECT for a lightweight connection and o
   <Card title="Android quickstart" description="Install exactly 1.0.5 and complete the loop around the process singleton and Activity lifecycle." href="/en/sdk/easy/android/getting-started" />
   <Card title="Flutter quickstart" description="Install exactly 1.1.0, retain listener references, and release them from dispose." href="/en/sdk/easy/flutter/getting-started" />
   <Card title="Web quickstart" description="Install exactly easyjssdk 2.0.4 and obtain connection material through a product BFF." href="/en/sdk/easy/javascript/getting-started" />
+  <Card title="C# quickstart" description="Use pinned .NET 8 source, async APIs, independent clients, and await using for messaging." href="/en/sdk/easy/csharp/getting-started" />
 </Cards>
 
 After the platform tutorial, Alice and Bob will connect separately, exchange a text JSON payload in a person Channel, then remove listeners and connections on exit.
@@ -50,7 +51,7 @@ Complete [Authentication & Tokens](/en/guide/integration/authentication) first. 
 
 ## Alice/Bob acceptance loop
 
-All four platforms follow the same minimal path:
+All five platforms follow the same minimal path:
 
 1. Obtain separate `uid`, short-lived `token`, and `websocketUrl` values for Alice and Bob.
 2. Create the clients in two independent devices, processes, or browser contexts by following the platform quickstart.
@@ -65,12 +66,12 @@ To validate the environment first, follow [Run the Official Examples](/en/sdk/ea
 
 ## Lifecycle differences across platforms
 
-| Task | iOS | Android | Flutter | Web |
-| --- | --- | --- | --- | --- |
-| Create and initialize | Application-owned `WuKongEasySDK` instance | Process singleton via `getInstance()` + `init` | Application-owned singleton + `init` | One `WKIM` instance per identity or browser context |
-| Listener ownership | Retain each `EventListener` token | Retain the same listener object | Retain the same callback reference | Pass the same function reference to `on` and `off` |
-| Allow send | After `onConnect` | After `CONNECT` | After the `connect` event | After the `Connect` event |
-| Account exit | Remove tokens and `disconnect` | Remove listeners and disconnect; account switching must handle the singleton limit | Remove listeners, `disconnect`, then `dispose` | `off`, then `destroy` |
+| Task | iOS | Android | Flutter | Web | C# |
+| --- | --- | --- | --- | --- | --- |
+| Create and initialize | Application-owned `WuKongEasySDK` instance | Process singleton via `getInstance()` + `init` | Application-owned singleton + `init` | One `WKIM` instance per identity or browser context | Independent `WKIM` instance |
+| Listener ownership | Retain each `EventListener` token | Retain the same listener object | Retain the same callback reference | Pass the same function reference to `on` and `off` | Use the same delegate with `+=` / `-=` |
+| Allow send | After `onConnect` | After `CONNECT` | After the `connect` event | After the `Connect` event | After `ConnectAsync` succeeds |
+| Account exit | Remove tokens and `disconnect` | Remove listeners and disconnect; account switching must handle the singleton limit | Remove listeners, `disconnect`, then `dispose` | `off`, then `destroy` | Await `DisposeAsync` / `await using` |
 
 A view may subscribe to connection state, but rebuilding the view must not create a second connection. Each platform's complete minimal example shows the correct owner and cleanup point.
 
@@ -129,6 +130,12 @@ Application dependencies use only these exact versions—never `latest` or a bro
 | Web | [PR #6](https://github.com/WuKongIM/WuKongEasySDK-JS/pull/6) · `3ebf505734c5b6764b30eac011f0b7a5024c89e8` |
 
 The task sequence was calibrated from the legacy [EasySDK overview](https://wukong.mintlify.app/en/sdk/easy/overview), [iOS](https://wukong.mintlify.app/en/sdk/easy/ios/getting-started), [Android](https://wukong.mintlify.app/en/sdk/easy/android/getting-started), [Flutter](https://wukong.mintlify.app/en/sdk/easy/flutter/getting-started), and [Web](https://wukong.mintlify.app/en/sdk/easy/javascript/getting-started) pages. The released source and distributions above remain authoritative for APIs, versions, and security boundaries.
+
+## C# source integration
+
+[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) provides an independent .NET 8+ client at source version `1.0.0`. Create it with `new WKIM` / `WKIM.Init`, authenticate with `ConnectAsync`, send with `SendAsync`, manage events with `+=` / `-=`, and await `DisposeAsync` or use `await using` on exit. Its default device category is PC `2`.
+
+C# has not been published to nuget.org. Follow the [C# quickstart](/en/sdk/easy/csharp/getting-started) for a pinned project reference or local NuGet package. Its real-process verification uses WuKongIM `132e46209` and remains separate from the four historical registry-package receipts above.
 
 ## Next
 

--- a/docs-site/content/docs/sdk/easy/index.mdx
+++ b/docs-site/content/docs/sdk/easy/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: WuKongEasySDK
-description: 选择 iOS、Android、Flutter 或 Web 快速接入，使用固定版本完成 Alice 与 Bob 的在线双向消息闭环。
+description: 选择 iOS、Android、Flutter、Web 或 C# 快速接入，使用固定版本完成 Alice 与 Bob 的在线双向消息闭环。
 ---
 
 WuKongEasySDK 通过 WebSocket JSON-RPC CONNECT 提供轻量连接与在线消息 API。它适合已经拥有业务后端、希望自己维护界面和产品状态的应用。
@@ -13,6 +13,7 @@ WuKongEasySDK 通过 WebSocket JSON-RPC CONNECT 提供轻量连接与在线消�
   <Card title="Android 快速接入" description="精确安装 1.0.5，按进程单例与 Activity 生命周期完成闭环。" href="/zh/sdk/easy/android/getting-started" />
   <Card title="Flutter 快速接入" description="精确安装 1.1.0，保存监听器引用并在 dispose 中释放。" href="/zh/sdk/easy/flutter/getting-started" />
   <Card title="Web 快速接入" description="精确安装 easyjssdk 2.0.4，通过业务 BFF 获取连接材料。" href="/zh/sdk/easy/javascript/getting-started" />
+  <Card title="C# 快速接入" description="从固定源码接入 .NET 8，使用异步 API、独立实例和 await using 完成收发。" href="/zh/sdk/easy/csharp/getting-started" />
 </Cards>
 
 完成对应教程后，你会让 Alice 与 Bob 分别连接，在个人 Channel 中双向发送一个文本 JSON Payload，并在退出时正确移除监听器和连接。
@@ -50,7 +51,7 @@ EasySDK 不是聊天 UI，也不是完整产品后端。`send` 成功表示服�
 
 ## Alice 与 Bob 验收闭环
 
-四个平台遵循同一条最小路径：
+五个平台遵循同一条最小路径：
 
 1. 为 Alice 和 Bob 分别取得自己的 `uid`、短期 `token` 与 `websocketUrl`；
 2. 在两个独立设备、进程或浏览器上下文中按平台教程创建客户端；
@@ -63,14 +64,14 @@ EasySDK 不是聊天 UI，也不是完整产品后端。`send` 成功表示服�
 
 希望先验证环境时，直接按[运行官方示例](/zh/sdk/easy/examples)使用已通过的服务端和客户端 revision，不必先把教学代码移入自己的应用。
 
-## 四端生命周期差异
+## 各平台生命周期差异
 
-| 任务 | iOS | Android | Flutter | Web |
-| --- | --- | --- | --- | --- |
-| 创建与初始化 | 应用级 `WuKongEasySDK` 实例 | 进程单例 `getInstance()` + `init` | 应用级单例 + `init` | 每个身份或浏览器上下文一个 `WKIM` 实例 |
-| 监听器归属 | 保存 `EventListener` token | 保存同一个 listener 对象 | 保存同一个回调引用 | `on` / `off` 使用同一个函数引用 |
-| 允许发送 | `onConnect` 后 | `CONNECT` 后 | `connect` 事件后 | `Connect` 事件后 |
-| 退出账号 | 移除 token 并 `disconnect` | 移除监听并断开；账号切换需处理单例限制 | 移除监听、`disconnect`、`dispose` | `off` 后 `destroy` |
+| 任务 | iOS | Android | Flutter | Web | C# |
+| --- | --- | --- | --- | --- | --- |
+| 创建与初始化 | 应用级 `WuKongEasySDK` 实例 | 进程单例 `getInstance()` + `init` | 应用级单例 + `init` | 每个身份或浏览器上下文一个 `WKIM` 实例 | 独立 `WKIM` 实例 |
+| 监听器归属 | 保存 `EventListener` token | 保存同一个 listener 对象 | 保存同一个回调引用 | `on` / `off` 使用同一个函数引用 | 使用相同委托 `+=` / `-=` |
+| 允许发送 | `onConnect` 后 | `CONNECT` 后 | `connect` 事件后 | `Connect` 事件后 | `ConnectAsync` 成功后 |
+| 退出账号 | 移除 token 并 `disconnect` | 移除监听并断开；账号切换需处理单例限制 | 移除监听、`disconnect`、`dispose` | `off` 后 `destroy` | 等待 `DisposeAsync` / `await using` |
 
 页面可以订阅连接状态，但不应因为页面重建而创建第二条连接。平台教程中的完整最小代码分别展示了正确的 owner 和清理位置。
 
@@ -129,6 +130,12 @@ EasySDK 不是聊天 UI，也不是完整产品后端。`send` 成功表示服�
 | Web | [PR #6](https://github.com/WuKongIM/WuKongEasySDK-JS/pull/6) · `3ebf505734c5b6764b30eac011f0b7a5024c89e8` |
 
 当前教程的任务顺序校准自旧版 [EasySDK 概览](https://wukong.mintlify.app/zh/sdk/easy/overview)、[iOS](https://wukong.mintlify.app/zh/sdk/easy/ios/getting-started)、[Android](https://wukong.mintlify.app/zh/sdk/easy/android/getting-started)、[Flutter](https://wukong.mintlify.app/zh/sdk/easy/flutter/getting-started)和 [Web](https://wukong.mintlify.app/zh/sdk/easy/javascript/getting-started) 页面；API、版本与安全边界以上表的正式源码和分发产物为准。
+
+## C# 源码接入
+
+[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 提供 .NET 8+ 的独立客户端，源码版本为 `1.0.0`。使用 `new WKIM` / `WKIM.Init` 创建实例，`ConnectAsync` 认证后调用 `SendAsync`，通过 `+=` / `-=` 管理事件，退出时等待 `DisposeAsync` 或使用 `await using`。默认设备类别为 PC `2`。
+
+C# 尚未发布到 nuget.org，请按 [C# 快速接入](/zh/sdk/easy/csharp/getting-started) 使用固定 commit 的项目引用或本地 NuGet 包。它的真实进程验证使用 WuKongIM `132e46209`，与上面的四端历史正式包记录分别保留。
 
 ## 下一步
 

--- a/docs-site/lib/easy-sdk-tutorial-contract.test.ts
+++ b/docs-site/lib/easy-sdk-tutorial-contract.test.ts
@@ -422,3 +422,32 @@ describe('EasySDK tutorial content contract', () => {
     }
   });
 });
+
+// The new C# source path must never inherit the older platforms' registry receipts.
+describe('C# EasySDK source integration', () => {
+  test('keeps source installation, ownership, and evidence explicit in both locales', async () => {
+    for (const [locale, suffix] of [['zh', ''], ['en', '.en']]) {
+      const page = await content(`csharp/getting-started${suffix}.mdx`);
+      const overview = await content(`index${suffix}.mdx`);
+      const examples = await content(`examples${suffix}.mdx`);
+      for (const text of [page, overview, examples]) {
+        expect(text).toContain('WuKongEasySDK-CSharp');
+        expect(text).toContain('nuget.org');
+      }
+      expect(overview).toContain(`/${locale}/sdk/easy/csharp/getting-started`);
+      expect(examples).toContain(`/${locale}/sdk/easy/csharp/getting-started`);
+      expect(page).toMatch(/尚未发布到 nuget\.org|has not been published to nuget\.org/u);
+      expect(page).toContain('d365a354f5e0f25fbd7f83bb59aa365ba43e899f');
+      expect(page).toContain('132e46209d98fa0425cc0f88e7a97080cdad044d');
+      expect(page).toContain('DeviceFlag.Desktop');
+      expect(page).toContain('ConnectAsync');
+      expect(page).toContain('SendAsync');
+      expect(page).toContain('DisposeAsync');
+      expect(page).toContain('await using');
+      expect(page).toContain('im.Message -= onMessage');
+      expect(page).toContain('--source ./artifacts');
+      expect(page).toContain('WKIMBackpressureException');
+      expect(page).not.toContain('CSHARP_SOURCE_REVISION');
+    }
+  });
+});

--- a/docs-site/lib/navigation.test.ts
+++ b/docs-site/lib/navigation.test.ts
@@ -230,6 +230,7 @@ describe('documentation navigation contract', () => {
       ['android/getting-started', 'v1.0.5'],
       ['flutter/getting-started', 'v1.1.0'],
       ['javascript/getting-started', 'v2.0.4'],
+      ['csharp/getting-started', '1.0.0'],
     ]);
 
     expect(easy?.status).toBe('published');
@@ -239,6 +240,7 @@ describe('documentation navigation contract', () => {
       ['android/getting-started', 'published'],
       ['flutter/getting-started', 'published'],
       ['javascript/getting-started', 'published'],
+      ['csharp/getting-started', 'published'],
     ]);
     for (const page of easy?.children ?? []) {
       if (page.slug === 'examples') {
@@ -260,6 +262,7 @@ describe('documentation navigation contract', () => {
       '/en/sdk/easy/android/getting-started',
       '/en/sdk/easy/flutter/getting-started',
       '/en/sdk/easy/javascript/getting-started',
+      '/en/sdk/easy/csharp/getting-started',
     ]) {
       expect(published).toContain(url);
     }
@@ -538,6 +541,7 @@ describe('documentation navigation contract', () => {
         `/${locale}/sdk/easy/android/getting-started`,
         `/${locale}/sdk/easy/flutter/getting-started`,
         `/${locale}/sdk/easy/javascript/getting-started`,
+        `/${locale}/sdk/easy/csharp/getting-started`,
         `/${locale}/api`,
         `/${locale}/api/conventions`,
         `/${locale}/api/authentication`,

--- a/docs-site/lib/navigation.ts
+++ b/docs-site/lib/navigation.ts
@@ -392,8 +392,8 @@ function publishedEasySDKGroup(): NavigationGroup {
     'easy',
     'WuKongEasySDK',
     'WuKongEasySDK',
-    '选择 iOS、Android、Flutter 或 Web 快速接入，并用已验证的正式发布包与源码 example 完成在线双向消息。',
-    'Choose an iOS, Android, Flutter, or Web quickstart and use verified released packages and source examples for online bidirectional messaging.',
+    '选择 iOS、Android、Flutter、Web 或 C# 快速接入，并用已验证的正式发布包或固定源码完成在线双向消息。',
+    'Choose an iOS, Android, Flutter, Web, or C# quickstart and use verified released packages or pinned source for online bidirectional messaging.',
     [
       publishedPage(
         'examples',
@@ -429,6 +429,13 @@ function publishedEasySDKGroup(): NavigationGroup {
         'Web quickstart',
         '精确安装 easyjssdk v2.0.4，在真实浏览器与正式包对端中完成 Alice/Bob 在线消息。',
         'Install exactly easyjssdk v2.0.4 for Alice/Bob online messaging in a real browser and released-package peer runs.',
+      ),
+      publishedPage(
+        'csharp/getting-started',
+        'C# 快速接入',
+        'C# quickstart',
+        '使用 1.0.0 固定源码接入 .NET 8，完成异步连接、消息收发、重连和释放。',
+        'Use pinned 1.0.0 source with .NET 8 for async connections, messaging, reconnect, and cleanup.',
       ),
     ],
   );

--- a/docs/development/FLOW_INDEX.md
+++ b/docs/development/FLOW_INDEX.md
@@ -12,7 +12,7 @@ Regenerate with `GOWORK=off go run ./scripts/flowcheck --mode render --write-ind
 | [cmd/wkcloudbundle/FLOW.md](../../cmd/wkcloudbundle/FLOW.md) | `package` | Seals and verifies immutable offline deployment bundles without cloud, credential, build, or service authority. | 50 | ok |
 | [cmd/wkcloudlease/FLOW.md](../../cmd/wkcloudlease/FLOW.md) | `package` | Exposes synchronous provider-neutral Cloud Lease commands while separating read-only inspection from paid mutation authority. | 52 | ok |
 | [cmd/wkcloudleaseoidc/FLOW.md](../../cmd/wkcloudleaseoidc/FLOW.md) | `package` | Creates, verifies, and removes repository-owned Alibaba OIDC identity without Cloud Lease acquisition authority. | 48 | ok |
-| [docs-site/FLOW.md](../../docs-site/FLOW.md) | `subtree` | Owns the bilingual static v3 documentation site, shared navigation, publication state, search, SEO, and machine-readable outputs. | 102 | warning |
+| [docs-site/FLOW.md](../../docs-site/FLOW.md) | `subtree` | Owns the bilingual static v3 documentation site, shared navigation, publication state, search, SEO, and machine-readable outputs. | 100 | ok |
 | [internal/access/api/FLOW.md](../../internal/access/api/FLOW.md) | `package` | Adapts product, benchmark, debug, and compatibility HTTP requests to internal use cases. | 101 | warning |
 | [internal/access/cloudanalysismcp/FLOW.md](../../internal/access/cloudanalysismcp/FLOW.md) | `package` | Adapts authenticated Analysis MCP and token requests to a closed, bounded observation usecase surface. | 53 | ok |
 | [internal/access/cloudview/FLOW.md](../../internal/access/cloudview/FLOW.md) | `package` | Proxies one Simulation Run's public HTTP and WebSocket traffic while preserving health routing and benchmark-purity evidence. | 55 | ok |

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -2,6 +2,8 @@
 
 ## Internal
 
+- `WuKongIM/WuKongEasySDK-CSharp` is the independent .NET 8+ EasySDK repository. Its initial source version is `1.0.0`, uses PC device category `2` by default, and is documented at `/sdk/easy/csharp/getting-started` in both locales. Until a public NuGet release exists, installation uses a pinned project reference or local `.nupkg`; source validation must not inherit the other platforms' registry receipts.
+
 - `docs-site/examples/go-webhook` is a separate standard-library business callback example. Its pure marker rules handle raw UTF-8 and SDK `type=1` text JSON without storing idempotency state. Explicit denial returns HTTP 200 with a business reason; HTTP errors remain transport failures governed by the sender policy. The documentation `verify` gate runs its fast Go tests.
 
 - The product composition deliberately leaves person-directory admission out of synchronous SEND. UID memberships are projected after durable append, so SENDACK does not imply immediate history visibility. The JavaScript quickstart BFF retries an empty latest page within its finite projection budget; normal cursor pages and unrelated errors keep their original behavior.


### PR DESCRIPTION
## Summary / 变更摘要

新增 C# / .NET 的 WuKongEasySDK 中英文接入页，并更新 EasySDK 平台选择、生命周期对照、官方示例和导航。教程固定引用新仓库 [WuKongIM/WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 的 `d365a354f5e0f25fbd7f83bb59aa365ba43e899f`，覆盖源码或本地 NuGet 安装、PC 设备 Token、异步连接、消息收发、重连、取消与释放。

C# 当前为源码版本 1.0.0，尚未发布到 nuget.org。它的真实进程验证记录独立于原有四端的历史正式包证据。

## Release notes / 发布说明

- [x] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [ ] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

## Verification / 验证

- `bun run verify`：194 项文档测试、示例检查、导航、OpenAPI、lint、类型、构建与静态输出检查通过。
- 最终文案调整后重新验证导航/EasySDK 内容契约、lint、构建和静态输出。
- `flow-doc-contracts` 通过（仅保留现有 `internal/access/api/FLOW.md` 行数提示）。
- 两个语言页面中的 C# 示例均单独编译通过，零警告。
- SDK：35 项协议/生命周期测试；本地 NuGet 包的独立安装、编译及加载；启用 Token 认证、256 Hash Slots 的真实单节点集群双向 Unicode 消息、SENDACK/RECV、重连、心跳、错误 Token 拒绝与清理通过。服务端源码为 `132e46209d98fa0425cc0f88e7a97080cdad044d`。
- [SDK 跨平台 CI](https://github.com/WuKongIM/WuKongEasySDK-CSharp/actions/runs/34186181504)。
