### PR TITLE
docs: restore publication after startup TOML API addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Align the Manager and internal transport documentation inventories with the startup TOML route and RPC 88, restoring documentation publication checks. / 补齐启动 TOML 接口与 RPC 88 的文档清单，恢复文档发布检查。
+
 - Add bilingual C# WuKongEasySDK integration, console example, async lifecycle, and pinned-source installation guidance for the new `WuKongEasySDK-CSharp` repository. / 新增 C# WuKongEasySDK 中英文接入文档，覆盖固定源码安装、控制台示例、异步生命周期和验证边界。
 
 - Add a directly runnable, standard-library Go before-send Webhook example with allow/replace/reject rules, bilingual setup instructions, and real-process send/history validation. / 新增可直接运行的 Go 发送前 Webhook 示例，支持放行、改写及拒绝，并附中英文接入说明和真实进程验证。

--- a/docs-site/content/docs/api/interface-inventory.en.mdx
+++ b/docs-site/content/docs/api/interface-inventory.en.mdx
@@ -5,7 +5,7 @@ description: Private Manager, node transport, MCP, Cloud View, plugin, webhook, 
 
 This page answers “what other entry surfaces exist in source?” It inventories boundaries; it does not promote internal interfaces into public compatibility promises.
 
-## Manager: 108 private routes
+## Manager: 109 private routes
 
 The authoritative registrations are `internal/access/manager/server.go`, `backups.go`, and `restore.go`.
 
@@ -15,7 +15,7 @@ The authoritative registrations are `internal/access/manager/server.go`, `backup
 | Login | 1 | Fixed-user login | Not registered |
 | Permissions | 1 | `cluster.permission:r` | Unguarded |
 | MCP read / write | 2 / 5 | `cluster.mcp:r` / `cluster.mcp:w` | Fail closed |
-| Node read / write | 8 / 12 | `cluster.node:r` / `cluster.node:w` | Unguarded |
+| Node read / write | 9 / 12 | `cluster.node:r` / `cluster.node:w` | Unguarded |
 | Slot read / write | 3 / 3 | `cluster.slot:r` / `cluster.slot:w` | Unguarded |
 | Controller read / write | 6 / 3 | `cluster.controller:r` / `cluster.controller:w` | Unguarded |
 | Diagnostics read / write | 4 / 2 | `cluster.diagnostics:r` / `cluster.diagnostics:w` | Unguarded |
@@ -30,9 +30,11 @@ The authoritative registrations are `internal/access/manager/server.go`, `backup
 | Backup read / write | 2 / 7 | `cluster.backup:r` / `cluster.backup:w` | Reads unguarded; writes fail closed |
 | Restore write | 2 | Exact `cluster.restore:w` | Fail closed |
 
-Total: `108`. `POST /manager/slots/leader-transfer-plan` is a planning-only route under read permission. The MCP handler behind `ANY /mcp` accepts only POST and rejects non-empty Origin; all other Manager routes use open CORS. `lib/api-surface-contracts.ts` retains the complete method/path set and a source test checks it.
+Total: `109`. `POST /manager/slots/leader-transfer-plan` is a planning-only route under read permission. The MCP handler behind `ANY /mcp` accepts only POST and rejects non-empty Origin; all other Manager routes use open CORS. `lib/api-surface-contracts.ts` retains the complete method/path set and a source test checks it.
 
-## Node transport: 57 shared IDs
+`GET /manager/nodes/:node_id/config/toml` returns a versioned, redacted startup TOML document under the same `cluster.node:r` read permission.
+
+## Node transport: 58 shared IDs
 
 The audience is **cluster-internal**. The shared TCP transport has no per-call Bearer or TLS identity. Only join validates the Join Token; other calls trust cluster routing and an isolated network.
 
@@ -42,6 +44,7 @@ The audience is **cluster-internal**. The shared TCP transport has no per-call B
 | `32–33` | `msg_slot_raft`, `msg_slot_raft_batch` |
 | `64–86` | `control_write`, `manager_message_retention`, `node_lifecycle`, `slot_status`, `manager_task_audit`, `channel_migration_meta`, `message_event_append`, `manager_node_config`, `manager_latest_messages`, `scheduled_backup_messages`, `scheduled_backup_slot`, `scheduled_backup_probe`, `scheduled_backup_restore`, `operations_mcp`, `manager_goroutines`, `slot_subscriber_metadata`, `slot_channel_metadata`, `channel_conversation_heads`, `channel_committed_reads`, `slot_user_membership`, `slot_runtime_metadata`, `slot_permission_metadata_batch`, `channel_quorum_exchange` |
 | `87` | `slot_identity_metadata` |
+| `88` | `manager_node_config_document` |
 
 ID `16` is retired-reserved and ID `20` reserves a removed feature; neither may be reused. The default Slot proxy uses promoted IDs `79/80/83/84/85/87`. The default identity handler accepts only `get_device`; user reads and scans remain outside this runtime surface. Identity metadata uses ID `87`, avoiding the former collision with `channel_pull_hint` at `4`. The generic, non-default Slot Store still declares private IDs `47/53`; these remain catalog debt. Keep these protocols in an unstable internal inventory and never generate fake OpenAPI paths for them.
 

--- a/docs-site/content/docs/api/interface-inventory.mdx
+++ b/docs-site/content/docs/api/interface-inventory.mdx
@@ -5,7 +5,7 @@ description: Manager、Node transport、MCP、Cloud View、插件、Webhook 和 
 
 本页回答“源码里还有哪些入口”。它是边界清单，不把内部接口升级为公共兼容承诺。
 
-## Manager：108 条私有路由
+## Manager：109 条私有路由
 
 权威注册点是 `internal/access/manager/server.go`、`backups.go` 和 `restore.go`。
 
@@ -15,7 +15,7 @@ description: Manager、Node transport、MCP、Cloud View、插件、Webhook 和 
 | Login | 1 | 固定用户登录 | 不注册 |
 | Permissions | 1 | `cluster.permission:r` | 无权限门槛 |
 | MCP read / write | 2 / 5 | `cluster.mcp:r` / `cluster.mcp:w` | 失败关闭 |
-| Node read / write | 8 / 12 | `cluster.node:r` / `cluster.node:w` | 无权限门槛 |
+| Node read / write | 9 / 12 | `cluster.node:r` / `cluster.node:w` | 无权限门槛 |
 | Slot read / write | 3 / 3 | `cluster.slot:r` / `cluster.slot:w` | 无权限门槛 |
 | Controller read / write | 6 / 3 | `cluster.controller:r` / `cluster.controller:w` | 无权限门槛 |
 | Diagnostics read / write | 4 / 2 | `cluster.diagnostics:r` / `cluster.diagnostics:w` | 无权限门槛 |
@@ -30,9 +30,11 @@ description: Manager、Node transport、MCP、Cloud View、插件、Webhook 和 
 | Backup read / write | 2 / 7 | `cluster.backup:r` / `cluster.backup:w` | 读无门槛；写失败关闭 |
 | Restore write | 2 | 精确 `cluster.restore:w` | 失败关闭 |
 
-合计 `108`。`POST /manager/slots/leader-transfer-plan` 是只生成计划的读权限路由。`ANY /mcp` 的 MCP Handler 实际只接受 POST，拒绝非空 Origin；其余 Manager 路由使用开放 CORS。完整 method/path 集合由 `lib/api-surface-contracts.ts` 保存并由源码测试校验。
+合计 `109`。`POST /manager/slots/leader-transfer-plan` 是只生成计划的读权限路由。`ANY /mcp` 的 MCP Handler 实际只接受 POST，拒绝非空 Origin；其余 Manager 路由使用开放 CORS。完整 method/path 集合由 `lib/api-surface-contracts.ts` 保存并由源码测试校验。
 
-## Node transport：57 个共享编号
+`GET /manager/nodes/:node_id/config/toml` 返回版本化、脱敏的启动 TOML 文档，使用相同的 `cluster.node:r` 读取权限。
+
+## Node transport：58 个共享编号
 
 受众是 **cluster-internal**。共享 TCP transport 没有逐调用 Bearer 或 TLS 身份；只有加入流程检查 Join Token，其余调用信任集群路由和隔离网络。
 
@@ -42,6 +44,7 @@ description: Manager、Node transport、MCP、Cloud View、插件、Webhook 和 
 | `32–33` | `msg_slot_raft`, `msg_slot_raft_batch` |
 | `64–86` | `control_write`, `manager_message_retention`, `node_lifecycle`, `slot_status`, `manager_task_audit`, `channel_migration_meta`, `message_event_append`, `manager_node_config`, `manager_latest_messages`, `scheduled_backup_messages`, `scheduled_backup_slot`, `scheduled_backup_probe`, `scheduled_backup_restore`, `operations_mcp`, `manager_goroutines`, `slot_subscriber_metadata`, `slot_channel_metadata`, `channel_conversation_heads`, `channel_committed_reads`, `slot_user_membership`, `slot_runtime_metadata`, `slot_permission_metadata_batch`, `channel_quorum_exchange` |
 | `87` | `slot_identity_metadata` |
+| `88` | `manager_node_config_document` |
 
 ID `16` 是退役保留项，ID `20` 是删除功能的保留项，均不得复用。默认 Slot proxy 使用已晋升的 `79/80/83/84/85/87`；默认身份处理器仅接受 `get_device`，不开放用户读取或扫描；身份元数据使用 `87`，避免原来的 `4` 与 `channel_pull_hint` 冲突。通用但非默认的 Slot Store 仍声明私有 `47/53`，这些仍不能视为稳定目录。这些协议只能进入“不稳定内部合同”页，不能生成伪 OpenAPI 路径。
 

--- a/docs-site/content/docs/api/operations-http/stability.en.mdx
+++ b/docs-site/content/docs/api/operations-http/stability.en.mdx
@@ -10,7 +10,7 @@ description: Publication scope for Operations, Debug, Bench, and Manager surface
 | `/top/v1/snapshot` | Operator | Unstable | Published without a stability promise |
 | `/debug/*` | Operator | Unstable, disabled by default | No; internal inventory and exposure risk only |
 | `/bench/v1/*` | Agent / benchmark | Unstable, disabled by default | No; benchmark-private contract only |
-| 108 Manager routes | Operator | Private operations contract | Never merge with Product HTTP |
+| 109 Manager routes | Operator | Private operations contract | Never merge with Product HTTP |
 | Node transport | Cluster internal | Unstable compatibility IDs | Never fake it as HTTP/OpenAPI |
 | MCP / Agent CLI | Operator / Agent | Closed tool contract | Use tool or CLI tables, not OpenAPI |
 

--- a/docs-site/content/docs/api/operations-http/stability.mdx
+++ b/docs-site/content/docs/api/operations-http/stability.mdx
@@ -10,7 +10,7 @@ description: 运维、Debug、Bench 与 Manager 的发布范围。
 | `/top/v1/snapshot` | Operator | 不稳定 | 已发布，但不承诺稳定兼容 |
 | `/debug/*` | Operator | 不稳定、默认关闭 | 否；只列内部接口和暴露风险 |
 | `/bench/v1/*` | Agent / benchmark | 不稳定、默认关闭 | 否；只列 Benchmark 私有合同 |
-| Manager 108 路由 | Operator | 私有运维合同 | 不与 Product HTTP 合并 |
+| Manager 109 路由 | Operator | 私有运维合同 | 不与 Product HTTP 合并 |
 | Node transport | Cluster internal | 不稳定兼容编号 | 绝不伪装成 HTTP/OpenAPI |
 | MCP / Agent CLI | Operator / Agent | 闭集工具合同 | 用工具表或 CLI 表，不用 OpenAPI |
 

--- a/docs-site/lib/api-surface-contracts.test.ts
+++ b/docs-site/lib/api-surface-contracts.test.ts
@@ -97,7 +97,7 @@ describe('operations HTTP surface', () => {
 });
 
 describe('Manager private surface', () => {
-  test('matches all 108 registered method and path pairs', async () => {
+  test('matches all 109 registered method and path pairs', async () => {
     const [server, backups, restore] = await Promise.all([
       source('../../internal/access/manager/server.go'),
       source('../../internal/access/manager/backups.go'),
@@ -133,8 +133,8 @@ describe('Manager private surface', () => {
       ...parseGinCalls(restore, { restore: '/manager/backups' }),
     ].filter((route) => route === 'ANY /mcp' || route.includes(' /manager'));
 
-    expect(managerRoutes).toHaveLength(108);
-    expect(new Set(managerRoutes.map(({ method, path }) => routeKey(method, path))).size).toBe(108);
+    expect(managerRoutes).toHaveLength(109);
+    expect(new Set(managerRoutes.map(({ method, path }) => routeKey(method, path))).size).toBe(109);
     expect(sorted(actual)).toEqual(
       sorted(managerRoutes.map(({ method, path }) => routeKey(method, path))),
     );
@@ -182,7 +182,7 @@ describe('cluster transport catalog', () => {
       }
     }
 
-    expect(nodeTransportServices).toHaveLength(57);
+    expect(nodeTransportServices).toHaveLength(58);
     expect(parsed.sort((a, b) => a.id - b.id)).toEqual(
       nodeTransportServices
         .map(({ id, symbol }) => ({ id, symbol }))

--- a/docs-site/lib/api-surface-contracts.ts
+++ b/docs-site/lib/api-surface-contracts.ts
@@ -162,6 +162,7 @@ export const managerRouteGroups: readonly ManagerRouteGroup[] = [
     ['GET', '/manager/nodes'],
     ['GET', '/manager/nodes/:node_id'],
     ['GET', '/manager/nodes/:node_id/config'],
+    ['GET', '/manager/nodes/:node_id/config/toml'],
     ['GET', '/manager/runtime/workqueues'],
     ['GET', '/manager/realtime-monitor'],
     ['GET', '/manager/nodes/:node_id/onboarding/status'],
@@ -392,6 +393,7 @@ export const nodeTransportServices: readonly NodeTransportService[] = [
   nodeService(85, 'RPCSlotPermissionMetadataBatch', 'slot_permission_metadata_batch'),
   nodeService(86, 'RPCChannelQuorumExchange', 'channel_quorum_exchange'),
   nodeService(87, 'RPCSlotIdentityMetadata', 'slot_identity_metadata'),
+  nodeService(88, 'RPCManagerNodeConfigDocument', 'manager_node_config_document'),
 ];
 
 export const nodeTransportBoundary =

--- a/docs-site/scripts/check-static-output.ts
+++ b/docs-site/scripts/check-static-output.ts
@@ -789,7 +789,7 @@ export async function checkStaticOutput() {
         '/contracts/json-rpc.experimental.schema.json',
         'Experimental',
       ],
-      'interface-inventory': ['108', '57', 'slot_identity_metadata', 'cluster_health', '/plugin/start'],
+      'interface-inventory': ['109', '58', 'slot_identity_metadata', 'manager_node_config_document', '/manager/nodes/:node_id/config/toml', 'cluster_health', '/plugin/start'],
     } as const;
     for (const [page, facts] of Object.entries(alignedSurfaceFacts)) {
       const markdown = await text(`llms.mdx/${locale}/api/${page}/content.md`);
@@ -982,7 +982,7 @@ export async function checkStaticOutput() {
       'webhooks/events': ['msg.notify', 'msg.offline', 'user.onlinestatus'],
       'webhooks/payloads': ['message_idstr', 'compress_to_uids'],
       'specifications/openapi': ['OpenAPI 3.1', '41', 'webhooks'],
-      'interface-inventory': ['108', '57', 'slot_identity_metadata', '/plugin/start'],
+      'interface-inventory': ['109', '58', 'slot_identity_metadata', 'manager_node_config_document', '/plugin/start'],
     })) {
       const pageId = `/${locale}/api/${page}`;
       for (const fact of facts) {


### PR DESCRIPTION
## Summary / 变更摘要

补齐主分支新增的 `GET /manager/nodes/:node_id/config/toml` 和内部 RPC 88 (`manager_node_config_document`) 的文档清单。同步中英文路由数量（109）、Node transport 数量（58）、权限说明和静态导出断言，恢复文档站发布。

这是 C# EasySDK 文档 PR #898 合并后的发布阻塞修复。发布失败在 #898 合并前已存在：[原主分支失败记录](https://github.com/WuKongIM/WuKongIM/actions/runs/34185923794)。所有权限、内部协议边界与服务端实现保持一致。

## Release notes / 发布说明

- [x] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [ ] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

## Verification / 验证

- `bun test ./lib/api-surface-contracts.test.ts`：12 项源码契约测试通过，精确匹配当前服务端注册与传输 ID。
- 文档站 194 项测试、JS/Go 示例检查、导航与 OpenAPI、lint、类型检查、Release 构建通过。
- `bun run test:output`：最终 HTML/Markdown 与 402 条静态 RSC 路径检查通过。
- `git diff --check` 通过。
