### PR TITLE
Document C# EasySDK NuGet 1.0.0 installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Document the public WuKongEasySDK C# NuGet 1.0.0 installation and its independent package verification in both languages. / 更新 C# WuKongEasySDK 中英文文档，提供 NuGet 1.0.0 正式包安装与独立发布验证记录。
+
 - Align the Manager and internal transport documentation inventories with the startup TOML route and RPC 88, restoring documentation publication checks. / 补齐启动 TOML 接口与 RPC 88 的文档清单，恢复文档发布检查。
 
 - Add bilingual C# WuKongEasySDK integration, console example, async lifecycle, and pinned-source installation guidance for the new `WuKongEasySDK-CSharp` repository. / 新增 C# WuKongEasySDK 中英文接入文档，覆盖固定源码安装、控制台示例、异步生命周期和验证边界。

--- a/docs-site/PHASE_15_SPEC.md
+++ b/docs-site/PHASE_15_SPEC.md
@@ -39,11 +39,12 @@ against WuKongIM PR test merge
 `1c9430f15fc8844e7025df07d54ab6e80e026414`. That proves bounded platform
 execution of the released packages, but not production readiness.
 
-The C# extension adds `WuKongEasySDK-CSharp` source version `1.0.0` and the
-`/sdk/easy/csharp/getting-started` bilingual route. It targets .NET 8, uses pinned
-source/project references or a locally built NuGet package, and does not claim a
-nuget.org release or inherit the four platforms' historical package receipts.
-Its independent source verification is recorded in the C# quickstart.
+The C# extension adds `WuKongEasySDK-CSharp` and the bilingual
+`/sdk/easy/csharp/getting-started` route. It targets .NET 8 and installs
+`WuKongEasySDK` `1.0.0` from nuget.org, with pinned source builds as an option.
+Its exact public package installation receipt and original real-server source
+receipt are recorded separately; neither inherits the other four platforms'
+historical package receipts.
 
 ## Audience and completion outcome
 

--- a/docs-site/content/docs/sdk/easy/csharp/getting-started.en.mdx
+++ b/docs-site/content/docs/sdk/easy/csharp/getting-started.en.mdx
@@ -1,12 +1,12 @@
 ---
 title: C# quickstart
-description: Integrate pinned WuKongEasySDK-CSharp source with .NET 8 for authentication, online messaging, automatic reconnect, and async cleanup.
+description: Integrate the WuKongEasySDK-CSharp NuGet release with .NET 8 for authentication, online messaging, automatic reconnect, and async cleanup.
 ---
 
 [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) follows the JavaScript EasySDK WebSocket JSON-RPC protocol with idiomatic async C# APIs and typed events. It has no third-party runtime dependencies.
 
-<Callout type="info" title="Current installation: pinned source or a local NuGet package">
-  The initial source version is `1.0.0`, pinned here to `d365a354f5e0f25fbd7f83bb59aa365ba43e899f`. It has not been published to nuget.org. Use the project reference or locally packed feed below. Source tests and a local `.nupkg` do not prove a public NuGet release.
+<Callout type="info" title="NuGet release 1.0.0">
+  [WuKongEasySDK 1.0.0](https://www.nuget.org/packages/WuKongEasySDK/1.0.0) is published on nuget.org from source `02ea7d60cd94feef1996f41bca35ffc3b8e18ea6`. The default installation below uses public NuGet; project references and local packing remain available for source builds.
 </Callout>
 
 ## Before you begin
@@ -18,11 +18,18 @@ description: Integrate pinned WuKongEasySDK-CSharp source with .NET 8 for authen
 
 Read [Identity & Token](/en/guide/integration/authentication) first. Production uses HTTPS/WSS with certificate validation. Tokens do not belong in URLs, logs, or source code.
 
-## 1. Install pinned source
+## 1. Install the NuGet release
+
+```bash
+dotnet new console -n MyChat --framework net8.0
+dotnet add MyChat/MyChat.csproj package WuKongEasySDK --version 1.0.0 --source https://api.nuget.org/v3/index.json
+```
+
+### Optional: build from pinned source
 
 ```bash
 git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git
-git -C WuKongEasySDK-CSharp checkout d365a354f5e0f25fbd7f83bb59aa365ba43e899f
+git -C WuKongEasySDK-CSharp checkout 02ea7d60cd94feef1996f41bca35ffc3b8e18ea6
 dotnet new console -n MyChat --framework net8.0
 dotnet add MyChat/MyChat.csproj reference WuKongEasySDK-CSharp/src/WuKongEasySDK/WuKongEasySDK.csproj
 ```
@@ -37,7 +44,7 @@ dotnet pack src/WuKongEasySDK -c Release -o artifacts
 dotnet add ../MyChat/MyChat.csproj package WuKongEasySDK --version 1.0.0 --source ./artifacts
 ```
 
-Choose either the project reference or the local package. Do not reference both. Here, `--source ./artifacts` is the local feed you just built.
+Choose one of the public package, project reference, or local package. Do not combine them. Here, `--source ./artifacts` is the local feed you just built.
 
 ## 2. Obtain connection material from your backend
 
@@ -168,7 +175,9 @@ WUKONGIM_BINARY=/absolute/path/to/wukongim python3 scripts/smoke.py
 
 The script starts and cleans up only its own loopback single-node cluster with 256 hash slots and Token authentication. It prepares two test identities and verifies matching SENDACK/RECV for bidirectional Unicode messages, reconnect, heartbeat, and invalid-token rejection.
 
-This source passed 35 tests, Release builds, and local NuGet packing on macOS arm64 with .NET SDK `8.0.424` / runtime `8.0.30`. It also passed the real-process fixture against WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d`. Loopback WebSocket tests cover custom events and reconnect failures. This receipt excludes public NuGet downloads, production WSS, offline recovery, multi-node capacity, and long-duration stability.
+The original implementation `d365a354f5e0f25fbd7f83bb59aa365ba43e899f` passed 35 tests, Release builds, and local NuGet packing on macOS arm64 with .NET SDK `8.0.424` / runtime `8.0.30`. It also passed the real-process fixture against WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d`. Loopback WebSocket tests cover custom events and reconnect failures. This receipt excludes public NuGet downloads, production WSS, offline recovery, multi-node capacity, and long-duration stability.
+
+The independent [NuGet `1.0.0` release verification](https://github.com/WuKongIM/WuKongEasySDK-CSharp/actions/runs/34188740990) covers builds, 35 SDK tests, seven release guard tests, and clean local package installation on Windows, Linux, and macOS. After publication it downloads the exact version from nuget.org, compares every entry except NuGet’s signature with the tested artifact, and restores, compiles, loads, and disposes the client in an isolated project with an empty package cache and only the public feed. This public installation receipt is separate from the real-server messaging receipt above.
 
 ## Next
 

--- a/docs-site/content/docs/sdk/easy/csharp/getting-started.mdx
+++ b/docs-site/content/docs/sdk/easy/csharp/getting-started.mdx
@@ -1,12 +1,12 @@
 ---
 title: C# 快速接入
-description: 使用 WuKongEasySDK-CSharp 固定源码接入 .NET 8，完成认证、在线消息、自动重连和异步释放。
+description: 使用 WuKongEasySDK-CSharp NuGet 正式包接入 .NET 8，完成认证、在线消息、自动重连和异步释放。
 ---
 
 [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 参考 JavaScript EasySDK 的 WebSocket JSON-RPC 协议，提供符合 C# 习惯的异步 API 和强类型事件。运行时不依赖第三方包。
 
-<Callout type="info" title="当前安装方式：固定源码或本地 NuGet 包">
-  初始源码版本为 `1.0.0`，本页固定到 `d365a354f5e0f25fbd7f83bb59aa365ba43e899f`。尚未发布到 nuget.org，请使用下文的项目引用或自行打包后的本地源。源码测试和本地 `.nupkg` 验证不等于公共 NuGet 发布。
+<Callout type="info" title="NuGet 正式版 1.0.0">
+  [WuKongEasySDK 1.0.0](https://www.nuget.org/packages/WuKongEasySDK/1.0.0) 已发布到 nuget.org，对应源码 `02ea7d60cd94feef1996f41bca35ffc3b8e18ea6`。下文默认使用公共 NuGet 安装；源码引用与本地打包用于需要自行构建的场景。
 </Callout>
 
 ## 开始前
@@ -18,11 +18,18 @@ description: 使用 WuKongEasySDK-CSharp 固定源码接入 .NET 8，完成认�
 
 先阅读 [身份与 Token](/zh/guide/integration/authentication)。生产环境使用 HTTPS/WSS，不关闭证书验证，不把 Token 放入 URL、日志或源码。
 
-## 1. 安装固定源码
+## 1. 安装 NuGet 正式包
+
+```bash
+dotnet new console -n MyChat --framework net8.0
+dotnet add MyChat/MyChat.csproj package WuKongEasySDK --version 1.0.0 --source https://api.nuget.org/v3/index.json
+```
+
+### 可选：从固定源码构建
 
 ```bash
 git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git
-git -C WuKongEasySDK-CSharp checkout d365a354f5e0f25fbd7f83bb59aa365ba43e899f
+git -C WuKongEasySDK-CSharp checkout 02ea7d60cd94feef1996f41bca35ffc3b8e18ea6
 dotnet new console -n MyChat --framework net8.0
 dotnet add MyChat/MyChat.csproj reference WuKongEasySDK-CSharp/src/WuKongEasySDK/WuKongEasySDK.csproj
 ```
@@ -37,7 +44,7 @@ dotnet pack src/WuKongEasySDK -c Release -o artifacts
 dotnet add ../MyChat/MyChat.csproj package WuKongEasySDK --version 1.0.0 --source ./artifacts
 ```
 
-项目引用和本地包二选一，不要同时引用。此处的 `--source ./artifacts` 指向你刚生成的本地源。
+公共包、项目引用和本地包三选一，不要同时引用。此处的 `--source ./artifacts` 指向你刚生成的本地源。
 
 ## 2. 由业务后端提供连接材料
 
@@ -168,7 +175,9 @@ WUKONGIM_BINARY=/absolute/path/to/wukongim python3 scripts/smoke.py
 
 该脚本只启动和清理自己拥有的回环地址单节点集群，使用 256 Hash Slots 并启用 Token 认证。它自动准备两个测试账号，检查双向 Unicode 消息的 SENDACK/RECV 一致性、重连、心跳和错误 Token 拒绝。
 
-本页源码在 macOS arm64、.NET SDK `8.0.424` / runtime `8.0.30` 通过 35 项测试、Release 构建与本地 NuGet 打包，并对 WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d` 完成上述真实进程验证。自定义事件与故障重连由回环 WebSocket 测试覆盖。此记录不包含公共 NuGet 下载、生产 WSS、离线恢复、多节点容量或长期稳定性验证。
+原始实现 `d365a354f5e0f25fbd7f83bb59aa365ba43e899f` 在 macOS arm64、.NET SDK `8.0.424` / runtime `8.0.30` 通过 35 项测试、Release 构建与本地 NuGet 打包，并对 WuKongIM `132e46209d98fa0425cc0f88e7a97080cdad044d` 完成上述真实进程验证。自定义事件与故障重连由回环 WebSocket 测试覆盖。此记录不包含公共 NuGet 下载、生产 WSS、离线恢复、多节点容量或长期稳定性验证。
+
+NuGet `1.0.0` 的[独立发布验证](https://github.com/WuKongIM/WuKongEasySDK-CSharp/actions/runs/34188740990)覆盖 Windows、Linux、macOS 构建、35 项 SDK 测试、7 项发布校验测试与全新项目本地包安装。发布后从 nuget.org 下载精确版本，比较除 NuGet 签名外的全部包内容与测试产物，并在空包缓存、仅公共源的独立项目中完成还原、编译、加载和释放。此公共安装记录与上述真实服务端通信记录分别保留。
 
 ## 下一步
 

--- a/docs-site/content/docs/sdk/easy/examples.en.mdx
+++ b/docs-site/content/docs/sdk/easy/examples.en.mdx
@@ -154,7 +154,7 @@ The current Web, Android, and iOS release commits change only version, changelog
 
 ### C# / .NET source example
 
-The new [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) targets .NET 8 at source version `1.0.0` and has not been published to nuget.org. It is separate from the four historical released-package receipts above.
+The new [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) targets .NET 8 and is released as [WuKongEasySDK 1.0.0](https://www.nuget.org/packages/WuKongEasySDK/1.0.0) on NuGet. It is separate from the four historical released-package receipts above.
 
 ```bash
 git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git

--- a/docs-site/content/docs/sdk/easy/examples.mdx
+++ b/docs-site/content/docs/sdk/easy/examples.mdx
@@ -154,7 +154,7 @@ flutter run -d <device-id>
 
 ### C# / .NET 源码示例
 
-新增的 [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 使用 .NET 8，源码版本为 `1.0.0`，尚未发布到 nuget.org。它不属于上面四端的历史正式包记录。
+新增的 [WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 使用 .NET 8，NuGet 正式包为 [WuKongEasySDK 1.0.0](https://www.nuget.org/packages/WuKongEasySDK/1.0.0)。它不属于上面四端的历史正式包记录。
 
 ```bash
 git clone https://github.com/WuKongIM/WuKongEasySDK-CSharp.git

--- a/docs-site/content/docs/sdk/easy/index.en.mdx
+++ b/docs-site/content/docs/sdk/easy/index.en.mdx
@@ -131,11 +131,11 @@ Application dependencies use only these exact versions—never `latest` or a bro
 
 The task sequence was calibrated from the legacy [EasySDK overview](https://wukong.mintlify.app/en/sdk/easy/overview), [iOS](https://wukong.mintlify.app/en/sdk/easy/ios/getting-started), [Android](https://wukong.mintlify.app/en/sdk/easy/android/getting-started), [Flutter](https://wukong.mintlify.app/en/sdk/easy/flutter/getting-started), and [Web](https://wukong.mintlify.app/en/sdk/easy/javascript/getting-started) pages. The released source and distributions above remain authoritative for APIs, versions, and security boundaries.
 
-## C# source integration
+## C# / NuGet integration
 
-[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) provides an independent .NET 8+ client at source version `1.0.0`. Create it with `new WKIM` / `WKIM.Init`, authenticate with `ConnectAsync`, send with `SendAsync`, manage events with `+=` / `-=`, and await `DisposeAsync` or use `await using` on exit. Its default device category is PC `2`.
+[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) provides an independent .NET 8+ client through the `WuKongEasySDK` `1.0.0` NuGet package. Create it with `new WKIM` / `WKIM.Init`, authenticate with `ConnectAsync`, send with `SendAsync`, manage events with `+=` / `-=`, and await `DisposeAsync` or use `await using` on exit. Its default device category is PC `2`.
 
-C# has not been published to nuget.org. Follow the [C# quickstart](/en/sdk/easy/csharp/getting-started) for a pinned project reference or local NuGet package. Its real-process verification uses WuKongIM `132e46209` and remains separate from the four historical registry-package receipts above.
+C# is available on [nuget.org](https://www.nuget.org/packages/WuKongEasySDK/1.0.0). Follow the [C# quickstart](/en/sdk/easy/csharp/getting-started) to install exact version `1.0.0`, or build a pinned project reference or local NuGet package. Its real-process verification uses WuKongIM `132e46209` and remains separate from the four historical registry-package receipts above.
 
 ## Next
 

--- a/docs-site/content/docs/sdk/easy/index.mdx
+++ b/docs-site/content/docs/sdk/easy/index.mdx
@@ -131,11 +131,11 @@ EasySDK 不是聊天 UI，也不是完整产品后端。`send` 成功表示服�
 
 当前教程的任务顺序校准自旧版 [EasySDK 概览](https://wukong.mintlify.app/zh/sdk/easy/overview)、[iOS](https://wukong.mintlify.app/zh/sdk/easy/ios/getting-started)、[Android](https://wukong.mintlify.app/zh/sdk/easy/android/getting-started)、[Flutter](https://wukong.mintlify.app/zh/sdk/easy/flutter/getting-started)和 [Web](https://wukong.mintlify.app/zh/sdk/easy/javascript/getting-started) 页面；API、版本与安全边界以上表的正式源码和分发产物为准。
 
-## C# 源码接入
+## C# / NuGet 接入
 
-[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 提供 .NET 8+ 的独立客户端，源码版本为 `1.0.0`。使用 `new WKIM` / `WKIM.Init` 创建实例，`ConnectAsync` 认证后调用 `SendAsync`，通过 `+=` / `-=` 管理事件，退出时等待 `DisposeAsync` 或使用 `await using`。默认设备类别为 PC `2`。
+[WuKongEasySDK-CSharp](https://github.com/WuKongIM/WuKongEasySDK-CSharp) 提供 .NET 8+ 的独立客户端，NuGet 包为 `WuKongEasySDK` `1.0.0`。使用 `new WKIM` / `WKIM.Init` 创建实例，`ConnectAsync` 认证后调用 `SendAsync`，通过 `+=` / `-=` 管理事件，退出时等待 `DisposeAsync` 或使用 `await using`。默认设备类别为 PC `2`。
 
-C# 尚未发布到 nuget.org，请按 [C# 快速接入](/zh/sdk/easy/csharp/getting-started) 使用固定 commit 的项目引用或本地 NuGet 包。它的真实进程验证使用 WuKongIM `132e46209`，与上面的四端历史正式包记录分别保留。
+C# 已发布到 [nuget.org](https://www.nuget.org/packages/WuKongEasySDK/1.0.0)，请按 [C# 快速接入](/zh/sdk/easy/csharp/getting-started) 安装精确版本 `1.0.0`；也可使用固定 commit 的项目引用或本地 NuGet 包。它的真实进程验证使用 WuKongIM `132e46209`，与上面的四端历史正式包记录分别保留。
 
 ## 下一步
 

--- a/docs-site/lib/easy-sdk-tutorial-contract.test.ts
+++ b/docs-site/lib/easy-sdk-tutorial-contract.test.ts
@@ -423,9 +423,9 @@ describe('EasySDK tutorial content contract', () => {
   });
 });
 
-// The new C# source path must never inherit the older platforms' registry receipts.
-describe('C# EasySDK source integration', () => {
-  test('keeps source installation, ownership, and evidence explicit in both locales', async () => {
+// C# public installation and historical server receipts must remain separate.
+describe('C# EasySDK NuGet integration', () => {
+  test('pins public installation while preserving independent source evidence in both locales', async () => {
     for (const [locale, suffix] of [['zh', ''], ['en', '.en']]) {
       const page = await content(`csharp/getting-started${suffix}.mdx`);
       const overview = await content(`index${suffix}.mdx`);
@@ -436,7 +436,11 @@ describe('C# EasySDK source integration', () => {
       }
       expect(overview).toContain(`/${locale}/sdk/easy/csharp/getting-started`);
       expect(examples).toContain(`/${locale}/sdk/easy/csharp/getting-started`);
-      expect(page).toMatch(/尚未发布到 nuget\.org|has not been published to nuget\.org/u);
+      expect(page).not.toMatch(/尚未发布到 nuget\.org|has not been published to nuget\.org/u);
+      expect(page).toContain('https://www.nuget.org/packages/WuKongEasySDK/1.0.0');
+      expect(page).toContain('package WuKongEasySDK --version 1.0.0 --source https://api.nuget.org/v3/index.json');
+      expect(page).toContain('02ea7d60cd94feef1996f41bca35ffc3b8e18ea6');
+      expect(page).toContain('https://github.com/WuKongIM/WuKongEasySDK-CSharp/actions/runs/34188740990');
       expect(page).toContain('d365a354f5e0f25fbd7f83bb59aa365ba43e899f');
       expect(page).toContain('132e46209d98fa0425cc0f88e7a97080cdad044d');
       expect(page).toContain('DeviceFlag.Desktop');

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -2,7 +2,7 @@
 
 ## Internal
 
-- `WuKongIM/WuKongEasySDK-CSharp` is the independent .NET 8+ EasySDK repository. Its initial source version is `1.0.0`, uses PC device category `2` by default, and is documented at `/sdk/easy/csharp/getting-started` in both locales. Until a public NuGet release exists, installation uses a pinned project reference or local `.nupkg`; source validation must not inherit the other platforms' registry receipts.
+- `WuKongIM/WuKongEasySDK-CSharp` is the independent .NET 8+ EasySDK repository. Its initial source version is `1.0.0`, uses PC device category `2` by default, and is documented at `/sdk/easy/csharp/getting-started` in both locales. NuGet package `WuKongEasySDK` `1.0.0` is pinned to source `02ea7d60cd94feef1996f41bca35ffc3b8e18ea6`; public installation is verified against the tested artifact with an empty consumer cache. Retain the original source messaging receipt separately, without inheriting the other platforms' registry receipts.
 
 - `docs-site/examples/go-webhook` is a separate standard-library business callback example. Its pure marker rules handle raw UTF-8 and SDK `type=1` text JSON without storing idempotency state. Explicit denial returns HTTP 200 with a business reason; HTTP errors remain transport failures governed by the sender policy. The documentation `verify` gate runs its fast Go tests.
 


### PR DESCRIPTION
Make the C# EasySDK quickstart install the public WuKongEasySDK 1.0.0 NuGet package by default, while preserving pinned source builds and the original messaging validation receipt. Update both languages, the platform overview, examples, and content contracts.

Publication source: 02ea7d60cd94feef1996f41bca35ffc3b8e18ea6. The package receipt verifies exact public contents and a clean consumer installation independently of historical server tests.

Validation: docs-site verify passes, including 194 tests, example checks, lint/types, build, and static export contracts. The focused EasySDK contracts also pass after final wording edits.
