### PR TITLE
docs: add C# Chromium WSS acceptance evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ move those entries into a version section named for that exact tag.
 
 ### 📚 Documentation / 文档
 
+- Document C#/Chromium WSS acceptance with certificate rejection controls and separately pinned JavaScript native-WebSocket recovery source. / 补充 C#/Chromium WSS 验收、证书拒绝检查与独立固定版本的 JS 原生 WebSocket 恢复修复记录。
+
 - Document C++ SDK 0.1.0 prebuilt archives for Windows x64, macOS arm64 and Linux x64, including offline CMake integration, compatibility, checksums and upgrades. / 补充 C++ SDK 0.1.0 三平台预编译包的离线 CMake 接入、兼容要求、校验和升级说明。
 
 - Add C#/JavaScript EasySDK interoperability evidence for public NuGet and candidate source, including pinned dependencies, recovery scenarios, and Node/ws transport scope. / 补充 C#/JavaScript EasySDK 正式包与源码互通验证记录，明确固定依赖、故障恢复场景和 Node/ws 传输范围。

--- a/docs-site/content/docs/sdk/easy/csharp/getting-started.en.mdx
+++ b/docs-site/content/docs/sdk/easy/csharp/getting-started.en.mdx
@@ -185,7 +185,15 @@ The independent [C#/JS interoperability CI](https://github.com/WuKongIM/WuKongEa
 
 Five scenario groups cover bidirectional Chinese/emoji and nested custom payloads, exact message IDs above JavaScript's safe integer range and matching SENDACK/RECV, invalid Token rejection, automatic network recovery, real server crash/restart, and manual disconnect with rejected offline SEND followed by explicit reconnect. This server omits `clientMsgNo` in SENDACK; RECV must preserve the supplied correlation value.
 
-Each PR and `main` update runs released and candidate lanes on Linux and retains dependency pins and scenario results. [Reproduction and scope](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/1db387c4f794a45bdb6f4e419d68dbe2bfef740f/docs/interoperability.md) explain the server build, dependency locks, and owned-process cleanup. The verified JS scope is Node with `ws`: Node 24.3 native WebSocket stalled during reconnect fault testing, so browsers and native transport are outside this passing scope. This short loopback test does not establish production WSS, multi-node capacity, or long-duration stability.
+The [earlier reproduction record](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/1db387c4f794a45bdb6f4e419d68dbe2bfef740f/docs/interoperability.md) covers Node with `ws`. The native Node reconnect stall observed there is addressed by the separately identified source repair and acceptance below.
+
+### Chromium/WSS and native Node recovery
+
+The [extended interoperability CI](https://github.com/WuKongIM/WuKongEasySDK-CSharp/actions/runs/34195913516) tests both public NuGet `1.0.0` and candidate C# source with Node `24.3.0` native WebSocket and real Chromium driven by Playwright `1.62.1`. It retains server pin `734166e0ec30fc0f6f10fef6f6d1889d079ab636` and pins repaired JS source `5e5dfb727fb0ea08294939962ae799e998b7ca5c`. The repair settles handshake failures that emit `error` without a subsequent `close`, allowing bounded retries to continue. npm `easyjssdk 2.0.4` **does not contain this repair**.
+
+The browser opens a real HTTPS page and connects over WSS; C# uses its existing `ClientWebSocket`. A temporary CA and isolated browser NSS trust database preserve normal certificate validation. Both clients must reject untrusted CA and mismatched-host certificates without forwarding decrypted application requests to the server protocol. These controls precede the five bidirectional messaging, invalid Token, network recovery, server restart, and manual disconnect scenarios.
+
+Each PR and `main` update runs four Linux jobs, producing six released/candidate reports across npm/`ws`, repaired source/native Node, and repaired source/Chromium WSS. Reports retain dependency pins, actual harness commit, Chromium version, and certificate controls. See [reproduction and trust scope](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/0a6d3254ec8dd4e9da9ee36114af96ee2f657dac/docs/interoperability.md). This verifies the temporary CA, loopback TLS proxy, and Chromium; it does not establish every public CA, reverse proxy, Firefox/WebKit, multi-node capacity, or long-duration stability.
 
 ## Next
 

--- a/docs-site/content/docs/sdk/easy/csharp/getting-started.mdx
+++ b/docs-site/content/docs/sdk/easy/csharp/getting-started.mdx
@@ -185,7 +185,15 @@ NuGet `1.0.0` 的[独立发布验证](https://github.com/WuKongIM/WuKongEasySDK-
 
 五组场景覆盖双向中文/emoji 与嵌套自定义 Payload、超出 JavaScript 安全整数范围的消息 ID 及 SENDACK/RECV 一致性、错误 Token 拒绝、断网后自动重连、真实服务端崩溃重启，以及主动断开后拒绝离线 SEND 并允许显式重连。该服务端的 SENDACK 不返回 `clientMsgNo`，测试会校验 RECV 保留原始关联号。
 
-每次 PR 和 `main` 更新都会运行正式包与源码两条 Linux 任务，保留精确版本及场景结果；[复现步骤和验证范围](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/1db387c4f794a45bdb6f4e419d68dbe2bfef740f/docs/interoperability.md)说明服务端构建、依赖锁定和临时进程清理。验证范围为 Node + `ws`；Node 24.3 原生 WebSocket 在故障测试中出现重连停滞，浏览器与原生传输不属于本次通过范围。此短时回环测试不代表生产 WSS、多节点容量或长期稳定性验证。
+上述[早期复现记录](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/1db387c4f794a45bdb6f4e419d68dbe2bfef740f/docs/interoperability.md)的范围为 Node + `ws`。其中发现的 Node 原生 WebSocket 重连停滞，已在下面的独立源码修复与验收中处理。
+
+### Chromium/WSS 与原生 Node 恢复
+
+[扩展互通 CI](https://github.com/WuKongIM/WuKongEasySDK-CSharp/actions/runs/34195913516)分别使用正式 NuGet `1.0.0` 和 C# 候选源码，验证 Node `24.3.0` 原生 WebSocket，以及 Playwright `1.62.1` 驱动的真实 Chromium。服务端仍固定为 `734166e0ec30fc0f6f10fef6f6d1889d079ab636`，JS 固定为修复源码 `5e5dfb727fb0ea08294939962ae799e998b7ca5c`。该修复结束只发出 `error`、没有后续 `close` 的握手失败，让有限次数重连继续执行；npm `easyjssdk 2.0.4` **不包含此修复**。
+
+浏览器从真实 HTTPS 页面建立 WSS 连接，C# 使用原有 `ClientWebSocket`。测试通过临时 CA 和隔离的浏览器 NSS 信任库保留正常证书校验，要求双方拒绝不受信任的 CA 和主机名不匹配的证书，且没有解密后的应用请求进入服务端协议。证书控制通过后，再执行双向消息、错误 Token、断网恢复、服务端重启和主动断开五组场景。
+
+每次 PR 和 `main` 更新运行四条 Linux 任务，产生 npm/`ws`、修复源码/原生 Node、修复源码/Chromium WSS 共六份正式包或候选源码报告。报告记录精确依赖、实际测试提交、Chromium 版本和证书控制结果；[复现与信任范围](https://github.com/WuKongIM/WuKongEasySDK-CSharp/blob/0a6d3254ec8dd4e9da9ee36114af96ee2f657dac/docs/interoperability.md)说明运行方法。这里验证的是临时 CA、回环 TLS 代理和 Chromium，不代表所有公网 CA、反向代理、Firefox/WebKit、多节点容量或长期稳定性。
 
 ## 下一步
 


### PR DESCRIPTION
更新中英文 C# EasySDK 接入页，保留早期 npm/ws 互通记录，新增已通过的原生 Node 与 Chromium/WSS 验收。明确正式 NuGet 1.0.0、C# 候选源码、JS 修复提交、固定服务端和浏览器版本的边界，说明错误 CA/主机名证书拒绝检查，以及 npm easyjssdk 2.0.4 不包含该 JS 修复。

验证：C# SDK PR #4 的四条 Linux 任务均通过，六份报告覆盖各传输的正式包与候选源码；浏览器为 Chromium 151.0.7922.34 / Playwright 1.62.1，正常证书校验开启。JS PR #10 已合并且三组 Node CI 通过。本文档完整 `bun run verify`（样例、内容/导航/API 合约、lint、类型、静态构建和输出检查）通过，包含根 Changelog 的 Unreleased 条目。
