### PR TITLE
docs: track C++ SDK submission to the vcpkg catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ move those entries into a version section named for that exact tag.
 
 ### 🔧 Improvements / 改进
 
+- Clarify the pending C++ EasySDK submission to the default vcpkg catalog and retain the working custom-registry setup in both languages. / 补充 C++ EasySDK 申请进入 vcpkg 默认目录的待收录状态，中英文接入说明继续保留可用的自定义 registry 配置。
+
 - Document WuKongEasySDK-Python 0.1.0 PyPI installation, matching examples, and published-package verification. / 更新 WuKongEasySDK-Python 0.1.0 的 PyPI 安装、配套示例与正式包验证说明。
 
 - Document Rust EasySDK 0.1.0 public-package WSS recovery acceptance and stabilize the ready-key scheduler regression test with deterministic synchronization. / 补充 Rust EasySDK 0.1.0 正式包 WSS 恢复验收，并使用确定性同步稳定调度器就绪 Key 回归测试。

--- a/docs-site/content/docs/sdk/easy/cpp/getting-started.en.mdx
+++ b/docs-site/content/docs/sdk/easy/cpp/getting-started.en.mdx
@@ -84,6 +84,8 @@ the dependency manifest. SDK source is pinned to
 Commit both JSON files to reproduce dependency selection. Existing projects
 should merge these entries into their manifests instead of overwriting them.
 
+As of 2026-09-08, the curated-catalog submission is [microsoft/vcpkg#53837](https://github.com/microsoft/vcpkg/pull/53837) and has not been merged. The proposed port builds the official `v0.1.0` tag; the instructions above still use the WuKongIM custom registry and require `vcpkg-configuration.json`.
+
 [Independent consumer example](https://github.com/WuKongIM/WuKongEasySDK-CPP/tree/main/examples/vcpkg-consumer) · [Registry maintenance](https://github.com/WuKongIM/WuKongEasySDK-CPP/blob/main/docs/VCPKG.md)
 
 ## Alternative: download and extract a prebuilt SDK

--- a/docs-site/content/docs/sdk/easy/cpp/getting-started.mdx
+++ b/docs-site/content/docs/sdk/easy/cpp/getting-started.mdx
@@ -80,6 +80,8 @@ SDK port 为静态库；Windows 使用 `x64-windows` 时，分发应用需要携
 `3e367a908f42385ab9306f9708b7456399cace7d`，与 registry baseline 分别固定。
 将两个 JSON 文件提交到应用仓库；已有 manifest 的项目应合并字段，不要覆盖原有依赖。
 
+截至 2026-09-08，微软默认目录的收录申请已提交到 [microsoft/vcpkg#53837](https://github.com/microsoft/vcpkg/pull/53837)，尚未合并。申请中的 port 从正式 `v0.1.0` 标签构建；上面的安装方式仍使用 WuKongIM 自定义 registry，当前不能省略 `vcpkg-configuration.json`。
+
 [独立消费端示例](https://github.com/WuKongIM/WuKongEasySDK-CPP/tree/main/examples/vcpkg-consumer) · [Registry 维护说明](https://github.com/WuKongIM/WuKongEasySDK-CPP/blob/main/docs/VCPKG.md)
 
 ## 备选：下载预编译包，解压接入


### PR DESCRIPTION
The C++ EasySDK application to Microsoft’s default vcpkg catalog is now tracked in microsoft/vcpkg#53837. Both quickstarts link to that submission and state that it is not yet merged, so users continue to include the existing custom-registry configuration.

Validation: `bun run verify` passed (196 tests, 8,006 assertions; lint, types, 94 bilingual OpenAPI pages, production build and static output checks). Documentation-only change; runtime code and dependency pins are unchanged.
