### PR TITLE
fix: load cold replicas for Channel migration proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
-- Channel repair scans evaluate current Controller health so expired node reports do not remain healthy in a cached node snapshot.
+- Channel migration probes load cold local replicas from authoritative metadata before checking runtime proof, allowing quorum-replicated followers to participate in dead-leader recovery.
 
 ### 🔧 Improvements / 改进
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+- Channel repair scans evaluate current Controller health so expired node reports do not remain healthy in a cached node snapshot.
+
 ### 🔧 Improvements / 改进
 
 - Document independent Python EasySDK three-node WSS fault recovery and bounded stability acceptance. / 补充 Python EasySDK 三节点 WSS 故障恢复与限时稳定性验收说明。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
-- Channel migration probes load cold local replicas from authoritative metadata before checking runtime proof, allowing quorum-replicated followers to participate in dead-leader recovery.
+- Channel migration probes load cold local replicas from authoritative metadata before checking runtime proof, allowing quorum-replicated followers to participate in dead-leader recovery. Fenced leader metadata can finish loading while writes remain closed; clearing the fence still requires quorum recovery before appends.
 
 ### 🔧 Improvements / 改进
 

--- a/docs/development/FLOW_INDEX.md
+++ b/docs/development/FLOW_INDEX.md
@@ -72,7 +72,7 @@ Regenerate with `GOWORK=off go run ./scripts/flowcheck --mode render --write-ind
 | [pkg/backup/FLOW.md](../../pkg/backup/FLOW.md) | `package` | Defines the portable full-backup repository format, strict manifests, compressed chunks, publication markers, and verification. | 52 | ok |
 | [pkg/bench/model/FLOW.md](../../pkg/bench/model/FLOW.md) | `package` | Defines shared wkbench configuration, deterministic plans, reports, rates, scenario digests, and bench target API DTOs. | 66 | ok |
 | [pkg/channel/FLOW.md](../../pkg/channel/FLOW.md) | `subtree` | Implements the reusable multi-reactor Channel log runtime, replication, persistence ports, transport, services, and bounded workers. | 91 | ok |
-| [pkg/channel/reactor/FLOW.md](../../pkg/channel/reactor/FLOW.md) | `package` | Owns Channel-keyed reactor state, event scheduling, replication progress, lifecycle transitions, and fenced worker completion. | 80 | ok |
+| [pkg/channel/reactor/FLOW.md](../../pkg/channel/reactor/FLOW.md) | `package` | Owns Channel-keyed reactor state, event scheduling, replication progress, lifecycle transitions, and fenced worker completion. | 82 | ok |
 | [pkg/channel/worker/FLOW.md](../../pkg/channel/worker/FLOW.md) | `package` | Runs bounded typed Channel store and RPC tasks with fenced completions, class-aware batching, lease cleanup, and observations. | 68 | ok |
 | [pkg/client/FLOW.md](../../pkg/client/FLOW.md) | `package` | Provides a tooling-grade WKProto TCP client with session crypto, bounded SEND/RECV queues, exact ACK matching, and pooling. | 65 | ok |
 | [pkg/cluster/FLOW.md](../../pkg/cluster/FLOW.md) | `subtree` | Composes Controller state, Slot Multi-Raft metadata, typed node RPC, routing, and replicated Channel runtimes behind Node. | 102 | warning |

--- a/docs/development/FLOW_INDEX.md
+++ b/docs/development/FLOW_INDEX.md
@@ -75,7 +75,7 @@ Regenerate with `GOWORK=off go run ./scripts/flowcheck --mode render --write-ind
 | [pkg/channel/reactor/FLOW.md](../../pkg/channel/reactor/FLOW.md) | `package` | Owns Channel-keyed reactor state, event scheduling, replication progress, lifecycle transitions, and fenced worker completion. | 80 | ok |
 | [pkg/channel/worker/FLOW.md](../../pkg/channel/worker/FLOW.md) | `package` | Runs bounded typed Channel store and RPC tasks with fenced completions, class-aware batching, lease cleanup, and observations. | 68 | ok |
 | [pkg/client/FLOW.md](../../pkg/client/FLOW.md) | `package` | Provides a tooling-grade WKProto TCP client with session crypto, bounded SEND/RECV queues, exact ACK matching, and pooling. | 65 | ok |
-| [pkg/cluster/FLOW.md](../../pkg/cluster/FLOW.md) | `subtree` | Composes Controller state, Slot Multi-Raft metadata, typed node RPC, routing, and replicated Channel runtimes behind Node. | 100 | ok |
+| [pkg/cluster/FLOW.md](../../pkg/cluster/FLOW.md) | `subtree` | Composes Controller state, Slot Multi-Raft metadata, typed node RPC, routing, and replicated Channel runtimes behind Node. | 102 | warning |
 | [pkg/controller/FLOW.md](../../pkg/controller/FLOW.md) | `subtree` | Implements the canonical Controller Raft runtime, durable cluster state, mirror synchronization, planning, and fenced task transitions. | 82 | ok |
 | [pkg/db/FLOW.md](../../pkg/db/FLOW.md) | `subtree` | Guides node-local storage ownership, root lifecycle, message and metadata domains, snapshots, metrics, and engine isolation. | 55 | ok |
 | [pkg/db/message/FLOW.md](../../pkg/db/message/FLOW.md) | `package` | Stores Channel message logs, indexes, checkpoints, retention state, snapshots, and compatibility leases on the shared DB engine. | 95 | ok |

--- a/pkg/channel/reactor/FLOW.md
+++ b/pkg/channel/reactor/FLOW.md
@@ -48,7 +48,9 @@ typed bounded workers and returns as `EventWorkerResult`.
   leader epoch, and operation ID. Stale results cannot advance or evict a newer
   incarnation.
 - Quorum install remains pending work and keeps append admission closed until
-  recovery plus the current-authority barrier succeeds. Each accepted append
+  recovery plus the current-authority barrier succeeds. Applying a migration
+  fence completes metadata loading with writes closed; clearing it installs
+  the new authority through normal recovery before append admission opens. Each accepted append
   completes directly from its exact quorum-commit receipt, without hot-path
   PullHint or AckOffset signals.
 - One loaded runtime has one lifecycle controller. Hot follower replication

--- a/pkg/channel/reactor/quorum_runtime.go
+++ b/pkg/channel/reactor/quorum_runtime.go
@@ -2,6 +2,7 @@ package reactor
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"time"
 
@@ -117,6 +118,16 @@ func (r *Reactor) handleQuorumInstallResult(result worker.Result) {
 		return
 	}
 	err := result.Err
+	// Installing a migration fence invalidates the previous quorum authority but
+	// deliberately cannot open append admission. Metadata application still has
+	// to complete so migration can verify this fenced leader and clear the fence.
+	// The later unfenced authority must finish normal recovery and its barrier.
+	if errors.Is(err, ch.ErrWriteFenced) && pending.authority.WriteFence.Set() {
+		rc.quorumInstall = nil
+		rc.state.CommitReady = false
+		r.completeFutures(pending.futures, Result{})
+		return
+	}
 	if err == nil {
 		if result.QuorumInstall == nil || result.QuorumInstall.Installed.Authority != pending.authority.ID ||
 			result.QuorumInstall.Installed.HW > result.QuorumInstall.Installed.LEO {

--- a/pkg/cluster/FLOW.md
+++ b/pkg/cluster/FLOW.md
@@ -43,6 +43,8 @@ It does not own Manager or product business policy.
 3. Channel append resolves or creates Slot-owned runtime metadata, applies it
    monotonically to the selected runtime, and appends locally or forwards to
    the exact leader while background control/task convergence stays bounded.
+   Internal migration probes load cold local replicas from Slot-authoritative
+   active metadata before reading fenced runtime proof; benchmark probes stay read-only.
 4. Conversation hydration batch-reads lifecycle and runtime routes by physical
    Slot, preserves alignment and item errors, and groups heads by exact Leader;
    a cold quorum Leader with durable HW below LEO recovers before read retry.

--- a/pkg/cluster/channels/service.go
+++ b/pkg/cluster/channels/service.go
@@ -352,6 +352,19 @@ func (s *Service) MigrationStore() *MigrationStore {
 // advances the append cache through the same per-channel ordering boundary.
 func (s *Service) ApplyMeta(meta ch.Meta) error { return s.applyRuntimeMeta(meta, true) }
 
+// ApplyMetaContext bounds a maintenance caller's metadata application wait. It
+// rejects contended metadata admission so repair workers can retry on a later
+// tick instead of waiting behind unrelated Channel work on a shared lock.
+func (s *Service) ApplyMetaContext(ctx context.Context, meta ch.Meta) error {
+	if ctx == nil {
+		return ch.ErrInvalidConfig
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.applyRuntimeMetaWithContext(ctx, meta, true)
+}
+
 // Append appends one message.
 func (s *Service) Append(ctx context.Context, req ch.AppendRequest) (ch.AppendResult, error) {
 	res, err, usedMeta, usedCache := s.appendOnce(ctx, req)
@@ -1474,6 +1487,21 @@ func recoveredAppendError(recovered bool, err error) error {
 }
 
 func (s *Service) applyRuntimeMeta(meta ch.Meta, authoritative bool) error {
+	return s.applyRuntimeMetaWithContext(nil, meta, authoritative)
+}
+
+func (s *Service) applyRuntimeMetaToHost(ctx context.Context, meta ch.Meta) error {
+	if ctx == nil {
+		return s.runtime.ApplyMeta(meta)
+	}
+	applier, ok := s.runtime.(runtimeMetaContextApplier)
+	if !ok {
+		return ch.ErrInvalidConfig
+	}
+	return applier.ApplyMetaContext(ctx, meta)
+}
+
+func (s *Service) applyRuntimeMetaWithContext(ctx context.Context, meta ch.Meta, authoritative bool) error {
 	if s == nil || s.runtime == nil {
 		return ch.ErrNotReady
 	}
@@ -1481,15 +1509,19 @@ func (s *Service) applyRuntimeMeta(meta ch.Meta, authoritative bool) error {
 		meta.Key = ch.ChannelKeyForID(meta.ID)
 	}
 	if !validAppendMetaIdentity(meta.ID, meta) {
-		return s.runtime.ApplyMeta(meta)
+		return s.applyRuntimeMetaToHost(ctx, meta)
 	}
 	lock := &s.metaApplyLocks[channelMetaApplyLockIndex(meta.ID)]
-	lock.Lock()
+	if ctx == nil {
+		lock.Lock()
+	} else if !lock.TryLock() {
+		return ch.ErrBackpressured
+	}
 	defer lock.Unlock()
 
 	candidate := cloneMeta(meta)
 	selected, _ := s.metaCache.preferCurrent(meta.ID, candidate)
-	if err := s.runtime.ApplyMeta(selected); err != nil {
+	if err := s.applyRuntimeMetaToHost(ctx, selected); err != nil {
 		return err
 	}
 	if authoritative {

--- a/pkg/cluster/node_channel_migration_worker.go
+++ b/pkg/cluster/node_channel_migration_worker.go
@@ -403,6 +403,11 @@ func (n *Node) applyChannelMigrationLocalRuntimeMeta(ctx context.Context, meta m
 	if n.channels == nil {
 		return ErrNotStarted
 	}
+	if service, ok := n.channels.(interface {
+		ApplyMetaContext(context.Context, ch.Meta) error
+	}); ok {
+		return service.ApplyMetaContext(ctx, channelwrapper.ProjectRuntimeMeta(meta))
+	}
 	service, ok := n.channels.(interface {
 		ApplyMeta(ch.Meta) error
 	})

--- a/pkg/cluster/node_channel_migration_worker.go
+++ b/pkg/cluster/node_channel_migration_worker.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"slices"
 	"sort"
 
 	ch "github.com/WuKongIM/WuKongIM/pkg/channel"
@@ -288,11 +289,9 @@ func (n *Node) ActiveChannelMigrationInHashSlot(ctx context.Context, hashSlot ui
 	return ok, err
 }
 
-// ControlSnapshot reads current Controller health for repair planning. Node-applied
-// snapshots may retain fresh health after its TTL expires when no control event
-// arrives; repair decisions must evaluate freshness at the time of the scan.
+// ControlSnapshot reads the last node-applied control snapshot for migration planning.
 func (n *Node) ControlSnapshot(ctx context.Context) (control.Snapshot, error) {
-	return n.LocalControllerSnapshot(ctx)
+	return n.LocalControlSnapshot(ctx)
 }
 
 // ProbeChannel reads one local or remote Channel runtime proof.
@@ -362,15 +361,33 @@ func (n *Node) ApplyChannelMeta(ctx context.Context, nodeID uint64, meta metadb.
 	return err
 }
 
+// probeLocalChannelRuntime loads cold replicas through authoritative metadata before
+// collecting migration proof. Quorum replication can persist a follower without
+// loading its Reactor; an absent Reactor is not evidence of an absent replica.
 func (n *Node) probeLocalChannelRuntime(ctx context.Context, channelID string, channelType uint8) (ch.RuntimeProbeChannel, error) {
 	id := ch.ChannelID{ID: channelID, Type: channelType}
-	result, err := n.ChannelRuntimeProbe(ctx, ch.RuntimeSelector{ChannelIDs: []ch.ChannelID{id}})
-	if err != nil {
-		return ch.RuntimeProbeChannel{}, err
-	}
-	for _, probe := range result.Channels {
-		if probe.ChannelID == id {
-			return probe, nil
+	for attempt := 0; attempt < 2; attempt++ {
+		result, err := n.ChannelRuntimeProbe(ctx, ch.RuntimeSelector{ChannelIDs: []ch.ChannelID{id}})
+		if err != nil {
+			return ch.RuntimeProbeChannel{}, err
+		}
+		for _, probe := range result.Channels {
+			if probe.ChannelID == id {
+				return probe, nil
+			}
+		}
+		if attempt == 1 {
+			break
+		}
+		meta, err := n.GetChannelRuntimeMeta(ctx, channelID, int64(channelType))
+		if err != nil {
+			return ch.RuntimeProbeChannel{}, err
+		}
+		if meta.Status != uint8(ch.StatusActive) || !slices.Contains(meta.Replicas, n.cfg.NodeID) {
+			return ch.RuntimeProbeChannel{}, ch.ErrChannelNotFound
+		}
+		if err := n.applyChannelMigrationLocalRuntimeMeta(ctx, meta); err != nil {
+			return ch.RuntimeProbeChannel{}, err
 		}
 	}
 	return ch.RuntimeProbeChannel{}, ch.ErrChannelNotFound

--- a/pkg/cluster/node_channel_migration_worker.go
+++ b/pkg/cluster/node_channel_migration_worker.go
@@ -288,9 +288,11 @@ func (n *Node) ActiveChannelMigrationInHashSlot(ctx context.Context, hashSlot ui
 	return ok, err
 }
 
-// ControlSnapshot adapts LocalControlSnapshot to the repair scanner source contract.
+// ControlSnapshot reads current Controller health for repair planning. Node-applied
+// snapshots may retain fresh health after its TTL expires when no control event
+// arrives; repair decisions must evaluate freshness at the time of the scan.
 func (n *Node) ControlSnapshot(ctx context.Context) (control.Snapshot, error) {
-	return n.LocalControlSnapshot(ctx)
+	return n.LocalControllerSnapshot(ctx)
 }
 
 // ProbeChannel reads one local or remote Channel runtime proof.


### PR DESCRIPTION
**Stopped / unmerged historical investigation.** The maintainer limited this task to SDK work. Server findings are handed off in #927; this experiment is not a complete or approved server fix. Preserve the branch for reproduction, and do not merge or publish it as part of the SDK task.

Quorum replication can persist follower data without loading its Channel Reactor. After leader loss, migration probes previously returned `channel not found` for these cold replicas and could not select a replacement. Private migration probes now load an active local replica from Slot-authoritative metadata before collecting the existing fenced proof; public diagnostic probes remain read-only.

Fenced leader metadata now completes application with append admission closed, allowing migration to verify the leader and clear the fence. The resulting unfenced authority still requires normal recovery and its current-authority barrier. Maintenance metadata application preserves caller cancellation and rejects contended admission for a later repair tick.

Validation: focused `pkg/channel/...` and `pkg/cluster/...` tests pass, including after the cancellation change. `flow-doc-contracts` and the existing real-process `TestChannelThreeNodeLeaderFailoverAfterNodeKill` passed for the preceding fenced recovery source. That source also passed three-node lifecycle CI 34205756640. Manager smoke's browser scenario passed but its tracked bundled-asset guard failed; UI files are outside this diff.

This PR remains a draft: complete C#/JS Linux acceptance still has intermittent post-rejoin delivery failures and second-fault recovery conflicts. Diagnostic run 34211014787 identifies the final frontier check in `recovery_repair.go:148`, a separate unresolved path. Do not remove the safety check or treat local passes as complete acceptance. No server tag, release, or package publication is included.
