### PR TITLE
chore(release): prepare v3.0.0-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+## [v3.0.0-beta.10] - 2026-09-09
+
 ### 🔧 Improvements / 改进
 
 - Consolidate operator tools into `wkcli bench`, `wkcli db`, and `wkcli migrate`; remove the separate `wkbench`, `wkdb`, and `wkmigrate` executables, migrate repository callers, and include version-matched `wkcli` in binary archives and native packages. External scripts must adopt the new subcommands. / 运维工具统一为 `wkcli bench/db/migrate`，移除旧独立程序并迁移仓库调用；二进制归档与原生安装包包含同版本 `wkcli`，外部脚本需切换新子命令。


### PR DESCRIPTION
## Summary / 变更摘要

Prepare `v3.0.0-beta.10` by moving the existing Unreleased notes into its dated release section. The release includes the unified operator CLI and the changes accumulated since beta.9; note text is preserved.

## Release notes / 发布说明

- [ ] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [x] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

Skip reason / 豁免理由：Release bookkeeping only; existing entries are assigned to the target release without changing runtime behavior.

## Verification / 验证

Exact-version release-note extraction and focused release/changelog/publisher contracts passed. The preceding product PR passed its applicable CI checks. Publication will follow only after this commit is reachable from main, through the existing immutable Docker/binary/docs publishers and signed preview APT/RPM process.
