### PR TITLE
fix(release): unblock unified CLI publication for beta.11

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -201,6 +201,9 @@ credentials or publishing an image, the Workflow validates that the tagged
 exact tag. It never derives release notes from commits or GitHub-generated
 notes.
 
+Hosted release builds use the official Go module proxy for both the product
+and embedded Prometheus; the Dockerfile default remains available for local builds.
+
 GHCR is the canonical build target. The Workflow builds
 `linux/amd64,linux/arm64` security candidates and blocks publication when
 Trivy reports any Critical or High vulnerability. A recovery run applies the

--- a/.github/workflows/binary-release-publish.yml
+++ b/.github/workflows/binary-release-publish.yml
@@ -374,6 +374,7 @@ jobs:
               "$archive_root/"
               "$archive_root/README.md"
               "$archive_root/README_CN.md"
+              "$archive_root/wkcli"
               "$archive_root/wukongim"
               "$archive_root/wukongim.toml.example"
             )

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -326,6 +326,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            GOPROXY=https://proxy.golang.org,direct
           platforms: linux/amd64
           load: true
           pull: true
@@ -340,6 +342,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            GOPROXY=https://proxy.golang.org,direct
           platforms: linux/arm64
           load: true
           pull: true
@@ -414,6 +418,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            GOPROXY=https://proxy.golang.org,direct
           platforms: linux/amd64,linux/arm64
           push: true
           pull: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
-## [v3.0.0-beta.10] - 2026-09-09
+## [v3.0.0-beta.11] - 2026-09-09
 
 ### 🔧 Improvements / 改进
 
@@ -51,6 +51,8 @@ move those entries into a version section named for that exact tag.
 - Improve Manager node-log troubleshooting with explicit keyword search, a navigable details drawer and copy feedback, reliable retry, and live scrolling that preserves the reading position. / 优化管理台节点日志排查：关键字提交查询、可切换事件的详情抽屉与复制反馈、可靠重试，以及保护阅读位置的实时跟随。
 
 ### 🐛 Bug Fixes / 问题修复
+
+- Fix release archive validation to include the unified `wkcli` executable, and use the official Go module proxy in hosted image builds. / 修复发布归档校验遗漏统一 `wkcli` 的问题，并在托管镜像构建中使用官方 Go 模块代理。
 
 - Fix Channel follower replacement stalling before the spare joins ISR: copy the committed log in bounded pages, refresh durable follower progress, and keep temporary catch-up lag retryable without reducing quorum. / 修复 Channel 副本替换在备用节点加入 ISR 前停滞的问题：分页同步已提交日志、刷新持久化进度，并保留暂时落后任务的重试能力，不降低仲裁要求。
 - Migration verification accepts valid empty-sender messages while checking their existing exact client index; history continuation reads respect the remaining page demand. Recovery rechecks all observed tails, and timed-out migration tasks yield without skipping peers.

--- a/scripts/binary_release_workflow_test.go
+++ b/scripts/binary_release_workflow_test.go
@@ -197,6 +197,8 @@ func TestBinaryReleaseWorkflowContract(t *testing.T) {
 			packageBuildStep.With = step.With
 		}
 	}
+	require.Contains(t, stepRuns["Validate binary identities and archive contents"], `"$archive_root/wkcli"`)
+
 	require.Equal(t, "steps.build.outputs.native_packages == 'true'", packageBuildStep.If)
 	require.Equal(t, "goreleaser/goreleaser-action@4c6ab561adb47e50c45ef534e2155934e91c40c1", packageBuildStep.Uses)
 	require.Equal(t, map[string]string{

--- a/scripts/docker_image_publish_workflow_test.go
+++ b/scripts/docker_image_publish_workflow_test.go
@@ -31,12 +31,24 @@ func TestDockerImagePublishWorkflowContract(t *testing.T) {
 			TimeoutMinutes int    `yaml:"timeout-minutes"`
 			Environment    string `yaml:"environment"`
 			Steps          []struct {
-				Name string `yaml:"name"`
-				Run  string `yaml:"run"`
+				Name string            `yaml:"name"`
+				Run  string            `yaml:"run"`
+				Uses string            `yaml:"uses"`
+				With map[string]string `yaml:"with"`
 			} `yaml:"steps"`
 		} `yaml:"jobs"`
 	}
 	require.NoError(t, yaml.Unmarshal(raw, &workflow))
+	buildSteps := 0
+	for _, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			if strings.HasPrefix(step.Uses, "docker/build-push-action@") {
+				buildSteps++
+				require.Equal(t, "GOPROXY=https://proxy.golang.org,direct", strings.TrimSpace(step.With["build-args"]), step.Name)
+			}
+		}
+	}
+	require.Equal(t, 3, buildSteps)
 	require.Equal(t, []string{"v*"}, workflow.On.Push.Tags)
 	versionInput, ok := workflow.On.WorkflowDispatch.Inputs["version"]
 	require.True(t, ok)


### PR DESCRIPTION
## Summary / 变更摘要

Fix the beta.10 publication blockers: the archive inventory must include `wkcli`, and GitHub-hosted image builds must use the official Go module proxy for both the product and embedded Prometheus. All three Docker build steps now use the same proxy; local Dockerfile defaults remain unchanged.

Prepare beta.11 with the full notes accumulated since the last published beta.9. Beta.10 produced no published Release or image and its existing tag remains unchanged.

## Release notes / 发布说明

- [ ] I added every user-visible change to `CHANGELOG.md` under `[Unreleased]`.
- [x] This pull request has no user-visible change. I explained why below and a maintainer added the `skip-changelog` label.

Skip reason / 豁免理由：Publication infrastructure and version bookkeeping only; no product runtime behavior changes. The publication corrections and pending product changes are recorded in the exact beta.11 release section for this release task.

## Verification / 验证

- Focused release-note, changelog, binary-publisher, and Docker-publisher contract tests pass.
- Executed the exact archive-content validation block in a network-disabled Ubuntu container for all four platform archives: complete unified payload accepted; missing-CLI payload rejected.
- Added archive CLI presence and consistent hosted Go proxy contract assertions.
- actionlint and git diff whitespace checks pass.
- Failure evidence: beta.10 Docker runs received upstream goproxy.cn HTTP 504; its binary publisher stopped at the outdated archive inventory before Release creation. No safety check or immutable identity is bypassed.
