### PR TITLE
fix(docker): patch embedded Prometheus gRPC for beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
-## [v3.0.0-beta.11] - 2026-09-09
+## [v3.0.0-beta.12] - 2026-09-09
 
 ### 🔧 Improvements / 改进
 
@@ -51,6 +51,8 @@ move those entries into a version section named for that exact tag.
 - Improve Manager node-log troubleshooting with explicit keyword search, a navigable details drawer and copy feedback, reliable retry, and live scrolling that preserves the reading position. / 优化管理台节点日志排查：关键字提交查询、可切换事件的详情抽屉与复制反馈、可靠重试，以及保护阅读位置的实时跟随。
 
 ### 🐛 Bug Fixes / 问题修复
+
+- Update the embedded Prometheus gRPC dependency to v1.83.2 to address CVE-2026-84445. / 将内嵌 Prometheus 的 gRPC 依赖升级至 v1.83.2，修复 CVE-2026-84445。
 
 - Fix release archive validation to include the unified `wkcli` executable, and use the official Go module proxy in hosted image builds. / 修复发布归档校验遗漏统一 `wkcli` 的问题，并在托管镜像构建中使用官方 Go 模块代理。
 

--- a/docker/prometheus/toolchain.env
+++ b/docker/prometheus/toolchain.env
@@ -1,9 +1,9 @@
 # Identifies our dependency-patched build of the fixed upstream 3.14.0 source.
-PROMETHEUS_VERSION=3.14.0-wukongim.1
+PROMETHEUS_VERSION=3.14.0-wukongim.2
 # Upstream v3.14.0 commit and its codeload archive checksum; never follow a branch.
 PROMETHEUS_SOURCE_COMMIT=d7598b7141418fa35be2b5ec5d0fefb634199610
 PROMETHEUS_SOURCE_SHA256=8370fdaecc92d528e181cd263157ecd6950b0b9d965348ddb8e8d62f66a48ca6
-# Fixed dependencies for CVE-2026-56854 and CVE-2026-84304. Keep these explicit
-# until a later upstream release contains the fixes. Go verifies module sums.
+# Fixed dependencies for CVE-2026-56854, CVE-2026-84304, and CVE-2026-84445.
+# Keep these explicit until upstream includes the fixes. Go verifies module sums.
 PROMETHEUS_X_CRYPTO_VERSION=v0.55.0
-PROMETHEUS_GRPC_VERSION=v1.83.1
+PROMETHEUS_GRPC_VERSION=v1.83.2


### PR DESCRIPTION
## Summary / 变更摘要

Patch the embedded Prometheus gRPC dependency from v1.83.1 to v1.83.2 for CVE-2026-84445, and identify the patched build as 3.14.0-wukongim.2. The upstream Prometheus source and all other dependency pins remain fixed.

Prepare v3.0.0-beta.12 with the pending notes since the last published beta.9. The beta.11 image publisher stopped at its security scan before publication; existing tags remain unchanged.

## Release notes / 发布说明

- [x] User-visible security change recorded in CHANGELOG.md and moved into the exact target heading as release preparation requires.

## Verification / 验证

- `GOWORK=off go test ./scripts -run 'ReleaseNotes|Changelog|BinaryRelease|DockerImagePublish|DockerPrometheus' -count=1` passed.
- Upstream advisory identifies v1.83.1 as affected and v1.83.2 as patched: https://github.com/grpc/grpc-go/security/advisories/GHSA-2v4p-qf9q-27wj
- Current Trivy 0.74.0 database (2026-09-09T07:06Z) reproduces exactly one HIGH finding in the old embedded binary: grpc v1.83.1 / CVE-2026-84445. Patched amd64 image and extracted Prometheus both pass the same database; the extracted binary contains grpc v1.83.2. Offline non-root startup, scrape, history after recreation, and graceful shutdown pass. arm64 image and embedded Prometheus also pass the same runtime checks and current-database scans. Local downloads used the host proxy and HTTP/1.1; source, compiler and dependency pins match the committed Docker recipe.
- The first three-node benchmark attempt exceeded the 400 ms limit at the unchanged storage commit seam (append p99 409 ms). Evidence is retained; the second attempt passed all benchmarks and the process-level smoke (append p99 6.539 ms, mixed-send p99 11.69 ms, real TCP send p99 177.6 ms).
