### PR TITLE
fix(release): verify each platform by immutable child manifest

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -212,7 +212,9 @@ missing mirror. Each candidate must also pass the bounded
 `scripts/verify-docker-prometheus.sh` probe: offline non-root startup with
 managed Prometheus enabled, an actual scrape, historical queries after container
 recreation on the same volume, and graceful stop. The canonical digest passes
-that probe again before mirroring, including recovery runs. Extracted Prometheus
+that probe again before mirroring, including recovery runs. Each platform is
+pulled by its unique child manifest from the verified canonical index, so classic
+Docker stores never load both architectures under one index reference. Extracted Prometheus
 executables pass a separate Trivy `rootfs` scan that requires exactly one
 `gobinary` result, preventing an empty scan from passing. Their components and
 dependency edges are included in the corresponding platform SBOM. After the

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -482,8 +482,16 @@ jobs:
         run: |
           set -euo pipefail
           for arch in amd64 arm64; do
-            docker pull --platform "linux/$arch" "$CANONICAL_IMAGE@$CANONICAL_DIGEST"
-            bash scripts/verify-docker-prometheus.sh "$CANONICAL_IMAGE@$CANONICAL_DIGEST" "linux/$arch"
+            # Classic Docker stores cannot load two platforms at one index ref.
+            # Select a unique child from the index verified in the previous step.
+            platform_digest="$(jq -er --arg arch "$arch" '
+              [.manifest.manifests[] | select(.platform.os == "linux" and .platform.architecture == $arch)]
+              | if length == 1 then .[0].digest else error("expected one platform manifest") end
+            ' canonical-manifest.json)"
+            [[ "$platform_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            platform_image="$CANONICAL_IMAGE@$platform_digest"
+            docker pull --platform "linux/$arch" "$platform_image"
+            bash scripts/verify-docker-prometheus.sh "$platform_image" "linux/$arch"
             scan="${{ runner.temp }}/prometheus-canonical-$arch.scan.json"
             trivy rootfs --scanners vuln --severity CRITICAL,HIGH --exit-code 1 --no-progress \
               --format json --output "$scan" "$WK_DOCKER_PROMETHEUS_ARTIFACT_DIR/$arch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes / 问题修复
+
+- Fix dual-architecture Docker release verification and recovery by pulling each platform through its immutable child manifest. / 修复 Docker 双架构发布校验与恢复流程，按不可变子清单分别拉取各架构镜像。
+
 ## [v3.0.0-beta.12] - 2026-09-09
 
 ### 🔧 Improvements / 改进

--- a/scripts/docker_platform_verification_test.go
+++ b/scripts/docker_platform_verification_test.go
@@ -1,0 +1,66 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+// Exercise the actual publication shell with a classic Docker store that
+// rejects pulling an index digest under two different platform identities.
+func TestDockerCanonicalProbeSelectsUniquePlatformManifests(t *testing.T) {
+	var workflow struct {
+		Jobs map[string]struct{ Steps []struct{ Name, Run string } }
+	}
+	require.NoError(t, yaml.Unmarshal(readWorkflow(t, "docker-image-publish.yml"), &workflow))
+	var script string
+	for _, step := range workflow.Jobs["publish"].Steps {
+		if step.Name == "Verify canonical embedded Prometheus" {
+			script = step.Run
+		}
+	}
+	require.NotEmpty(t, script)
+	amd := "sha256:" + strings.Repeat("a", 64)
+	arm := "sha256:" + strings.Repeat("b", 64)
+	index := "sha256:" + strings.Repeat("c", 64)
+	for _, tc := range []struct {
+		name, entries string
+		ok            bool
+	}{
+		{"both platforms", `{"digest":"` + amd + `","platform":{"os":"linux","architecture":"amd64"}},{"digest":"` + arm + `","platform":{"os":"linux","architecture":"arm64"}}`, true},
+		{"missing arm64", `{"digest":"` + amd + `","platform":{"os":"linux","architecture":"amd64"}}`, false},
+		{"ambiguous amd64", `{"digest":"` + amd + `","platform":{"os":"linux","architecture":"amd64"}},{"digest":"` + arm + `","platform":{"os":"linux","architecture":"amd64"}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bin := filepath.Join(dir, "bin")
+			require.NoError(t, os.Mkdir(bin, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "canonical-manifest.json"), []byte(`{"manifest":{"manifests":[`+tc.entries+`]}}`), 0644))
+			stubs := map[string]string{
+				"docker": "#!/bin/sh\ncase \"$*\" in *\"$CANONICAL_DIGEST\"*) echo 'cannot overwrite index digest' >&2; exit 1;; esac\nprintf 'docker %s\\n' \"$*\" >>\"$CALLS\"\n",
+				"bash":   "#!/bin/sh\nprintf 'probe %s\\n' \"$*\" >>\"$CALLS\"\n",
+				"trivy":  "#!/bin/sh\nwhile [ \"$#\" -gt 0 ]; do if [ \"$1\" = --output ]; then printf '{\"Results\":[{\"Type\":\"gobinary\"}]}' >\"$2\"; exit; fi; shift; done\nexit 1\n",
+			}
+			for name, body := range stubs {
+				require.NoError(t, os.WriteFile(filepath.Join(bin, name), []byte(body), 0755))
+			}
+			cmd := exec.Command("bash", "-c", strings.ReplaceAll(script, "${{ runner.temp }}", dir))
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"), "CANONICAL_IMAGE=registry.example/wukongim", "CANONICAL_DIGEST="+index, "WK_DOCKER_PROMETHEUS_ARTIFACT_DIR="+dir, "CALLS="+filepath.Join(dir, "calls"))
+			out, err := cmd.CombinedOutput()
+			if !tc.ok {
+				require.Error(t, err, string(out))
+				return
+			}
+			require.NoError(t, err, string(out))
+			calls, err := os.ReadFile(filepath.Join(dir, "calls"))
+			require.NoError(t, err)
+			require.Equal(t, "docker pull --platform linux/amd64 registry.example/wukongim@"+amd+"\nprobe scripts/verify-docker-prometheus.sh registry.example/wukongim@"+amd+" linux/amd64\ndocker pull --platform linux/arm64 registry.example/wukongim@"+arm+"\nprobe scripts/verify-docker-prometheus.sh registry.example/wukongim@"+arm+" linux/arm64\n", string(calls))
+		})
+	}
+}


### PR DESCRIPTION
## Summary / 变更摘要

Docker's classic image store rejects loading amd64 and arm64 under the same multi-platform index digest (`cannot overwrite digest`), stopping release publication after GHCR upload. Resolve each architecture to exactly one immutable child manifest from the already verified canonical index, and use that child reference for pull and the Prometheus runtime probe. This applies to initial publication and manual recovery.

The v3.0.0-beta.12 source tag and existing GHCR index remain unchanged. Once merged, the documented manual recovery can verify that exact image and fill the missing mirrors.

## Release notes / 发布说明

- [x] Added the operator-facing fix under CHANGELOG.md `[Unreleased]`.

## Verification / 验证

- The regression test executes the real workflow shell with dry-run tool adapters. It fails against the original index-reference code and passes with the fix; missing or ambiguous architecture selections fail closed.
- `GOWORK=off go test ./scripts -run 'DockerCanonical|DockerImagePublish|DockerPrometheus|ReleaseNotes|Changelog' -count=1` passed.
- Live failure evidence: https://github.com/WuKongIM/WuKongIM/actions/runs/34329169442
- actionlint v1.7.9 passed.
- Executed the fixed canonical-verification shell against the real GHCR index `sha256:81edd43432512c6ba9f49e3f9049a300d457eff61e5672ee64d2d184457d2657`: both child pulls, offline Prometheus probes and current-database scans passed.
