### PR TITLE
docs: require automatic wkcli release acceptance

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -184,6 +184,12 @@ applies separate protected APT and RPM signatures, seals the complete snapshot
 and receipt in an immutable audit Release, and only then deploys the `preview`
 APT suite and EL9 RPM repository to GitHub Pages. Every deployed snapshot is
 download-validated on clean Ubuntu, Debian, Rocky Linux, and AlmaLinux clients.
+New-release publication then requires installed `wkcli` functional acceptance
+in separate credential-free containers on those four distributions. Exact
+snapshot identities, valid and invalid offline command behavior, and unchanged
+fixture data must all pass; a deployed snapshot alone is not release completion.
+The package repository's `native-package-cli-acceptance.yml` can repeat this
+public check without signing or deployment, using its exact current control SHA.
 Both repositories enforce immutable Releases, and the custom-domain DNS and
 certificate are provisioned. Exact unsigned source package assets still come
 only from the tag-bound binary Release described below; this credential-free

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+### 🔧 Improvements / 改进
+
+- Require automatic installed `wkcli` identity and offline functional acceptance on all four signed-package client distributions before a new release is complete. / 新版本签名包发布增加四种 Linux 系统的 wkcli 安装身份与离线功能自动验收，全部通过后才算交付完成。
+
 ### 📚 Documentation / 文档
 
 - Document released wkcli installation, paired server/CLI version checks, and installed-command examples in both languages; complete the migration tool navigation. / 补齐中英文 wkcli 发布版安装、服务端与工具版本核对、已安装命令示例及迁移工具导航。

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -217,6 +217,13 @@
   cluster runtime, the multi-reactor channel runtime, and the new business
   kernel are canonical under `pkg/controller`, `pkg/cluster`, `pkg/channel`,
   and `internal`; the former v1 server runtime tree has been removed.
+- New signed native releases require the package repository's installed CLI
+  acceptance gate on all four public-client distributions. Snapshot-bound
+  version/commit/build source, offline benchmark planning, a known-user query,
+  migration diagnosis, negative inputs and unchanged source data must pass.
+  Product binaries run only in separate credential-free installation containers,
+  never in signing or download-only sandboxes. The read-only repeat workflow is
+  `native-package-cli-acceptance.yml`; see `RELEASING.md` for its exact control fence.
 - Release completion includes the signed native package channel and public
   exact-version APT/RPM client verification, as required by
   `docs/development/RELEASING.md`. Tag-triggered Docker, binary, and docs

--- a/docs/development/RELEASING.md
+++ b/docs/development/RELEASING.md
@@ -59,7 +59,8 @@ as part of the same release task:
 6. Wait for the entire publisher, including public clean-client verification,
    to succeed. It signs APT and RPM separately, seals one immutable audit
    snapshot, deploys the complete repository, and verifies target-version
-   downloads on Ubuntu, Debian, Rocky Linux, and AlmaLinux.
+   downloads on Ubuntu, Debian, Rocky Linux, and AlmaLinux. New-release
+   publication also requires installed CLI acceptance on all four distributions.
 
 Never copy signing credentials into the source repository or bypass signed
 metadata verification. Recover only the exact matching draft or immutable
@@ -86,8 +87,26 @@ sudo apt install -y wukongim
 For releases containing the unified operator CLI, each clean native client
 also checks that `wkcli version --output json` matches
 `wukongim version --output json` in version, full commit, and build source.
-Verify `wkcli bench --help`, `wkcli db --help`, and `wkcli migrate --help`
-from the installed package. Official Linux/macOS archives contain both binaries.
+Both identities must also match the reviewed snapshot's exact source SHA and
+version, with build source `release`; two equally wrong binaries cannot pass.
+The public package validator's `--verify-installed-cli` gate installs only
+snapshot-verified downloads in separate credential-free containers. In addition
+to help commands, it runs `bench validate`, queries a known synthetic offline
+user, and completes `migrate diagnose` on a fixed stopped-v2 fixture. Invalid
+inputs must fail, source bytes must remain unchanged, and diagnosis must not
+create a target. Every command and container has a bounded deadline.
+
+All four distributions must return `installed_cli_verified=true` with per-client
+functional receipts. Any failure keeps release delivery incomplete, even after
+Pages deployment. Signing and pre-publication download-only sandboxes never
+execute product payloads. Official Linux/macOS archives contain both binaries.
+
+To repeat this gate for the currently reviewed public snapshot without signing
+or publishing, dispatch `native-package-cli-acceptance.yml` in `WuKongIM/packages`
+from `main`, setting `expected_control_sha` to its exact current protected SHA.
+The workflow derives the audit and version from reviewed control, validates the
+immutable archive and public identities, and retains receipts for 90 days. Do
+not advance package main or run a competing publication while it executes.
 
 The repository bootstrap keyring has its own version. It is not the server
 version. Package upgrades do not restart the running server; service restart


### PR DESCRIPTION
Release completion now requires automatic installed wkcli acceptance in the package repository's final public-client stage. Document the exact source identity, bounded offline functional and negative-input checks, four-distribution evidence, and the read-only repeat workflow. Keep product execution outside signing/download-only sandboxes and explicitly retain incomplete status after a failed post-deployment gate.

Implementation: companion WuKongIM/packages change on codex/wkcli-release-acceptance. Validation: focused binary-release/native-package script contracts pass; package implementation has 313 passing Python tests (one existing skip), workflow syntax checks, and successful actual-binary fixture acceptance.
