### PR TITLE
fix(docs): unblock publication after legacy message lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+- Align static documentation publication checks with the source-backed Product HTTP operation registry, including legacy message lookup. / 文档发布产物检查以源码对应的 Product HTTP 接口注册表为准，包含旧版消息查询接口。
+
 - Reuse verified duplicate-chain suffixes within each offline migration pass and count terminals on disk, avoiding quadratic history lookups while retaining original edge proofs. / 离线迁移在每次重建内复用已核实的去重链后缀，以磁盘索引统计终点，避免重复遍历，保留完整原始替代证据。
 
 - Refresh old empty-number conversation previews even when a legacy client cursor has advanced, preserving unread and visibility boundaries. / 旧客户端游标已前移时仍可刷新空编号历史会话摘要，保留未读和可见范围边界。

--- a/docs-site/content/docs/api/compatibility.en.mdx
+++ b/docs-site/content/docs/api/compatibility.en.mdx
@@ -17,7 +17,7 @@ The snapshot's verification status covers only this basic integration flow:
 | `GET /route` | Discover WebSocket ingress |
 | `POST /channel/messagesync` | Recover committed messages after reconnect |
 
-The complete [Product HTTP OpenAPI](/contracts/product-http.openapi.json) covers all 42 current registrations; Operations and Webhooks have separate contracts. Three narrow profiles remain available for controlled adoption, but the end-to-end status above covers only the three basic-integration operations. Source alignment, Schema checks, and protocol pages do not expand that runtime evidence.
+The complete [Product HTTP OpenAPI](/contracts/product-http.openapi.json) covers all 43 current registrations; Operations and Webhooks have separate contracts. Three narrow profiles remain available for controlled adoption, but the end-to-end status above covers only the three basic-integration operations. Source alignment, Schema checks, and protocol pages do not expand that runtime evidence.
 
 ## Version rules
 

--- a/docs-site/content/docs/api/compatibility.mdx
+++ b/docs-site/content/docs/api/compatibility.mdx
@@ -17,7 +17,7 @@ API 页面描述当前构建对应的合同。URL 不变不代表不同服务端
 | `GET /route` | 发现 WebSocket 入口 |
 | `POST /channel/messagesync` | 重连后恢复已提交消息 |
 
-完整 [Product HTTP OpenAPI](/contracts/product-http.openapi.json) 覆盖当前 42 条注册，Operations 与 Webhook 各有独立合同。三份窄 Profile 继续用于受控采用，但上方端到端状态只覆盖基础接入三条操作。源码对齐、Schema 校验和协议页都不会扩大该运行时验收结论。
+完整 [Product HTTP OpenAPI](/contracts/product-http.openapi.json) 覆盖当前 43 条注册，Operations 与 Webhook 各有独立合同。三份窄 Profile 继续用于受控采用，但上方端到端状态只覆盖基础接入三条操作。源码对齐、Schema 校验和协议页都不会扩大该运行时验收结论。
 
 ## 版本规则
 

--- a/docs-site/content/docs/api/index.en.mdx
+++ b/docs-site/content/docs/api/index.en.mdx
@@ -10,7 +10,7 @@ This section classifies every current source interface by audience and protocol.
 <Cards>
   <Card title="Conventions" description="Base URL, JSON, identifiers, cursors, and retry rules." href="/en/api/conventions" />
   <Card title="Authentication & Security" description="Trust boundaries for Product HTTP and Gateway." href="/en/api/authentication" />
-  <Card title="Product HTTP API" description="All 42 business HTTP operations registered by the current source." href="/en/api/product-http" />
+  <Card title="Product HTTP API" description="All 43 business HTTP operations registered by the current source." href="/en/api/product-http" />
   <Card title="Operations HTTP API" description="Health, readiness, metrics, Top, Debug, and Bench boundaries." href="/en/api/operations-http" />
   <Card title="Webhooks" description="Three outbound events, payloads, and reliability semantics." href="/en/api/webhooks" />
   <Card title="Client Protocols" description="WKProto frames, lifecycle, encryption, and the EasySDK JSON-RPC core path." href="/en/api/client-protocols" />

--- a/docs-site/content/docs/api/index.mdx
+++ b/docs-site/content/docs/api/index.mdx
@@ -10,7 +10,7 @@ description: 查阅 Product HTTP、运维 HTTP、Webhook、WKProto 与内部接�
 <Cards>
   <Card title="通用约定" description="Base URL、JSON、标识、游标和重试规则。" href="/zh/api/conventions" />
   <Card title="认证与安全" description="Product HTTP 与 Gateway 的信任边界。" href="/zh/api/authentication" />
-  <Card title="Product HTTP API" description="当前源码注册的 42 条业务 HTTP 操作。" href="/zh/api/product-http" />
+  <Card title="Product HTTP API" description="当前源码注册的 43 条业务 HTTP 操作。" href="/zh/api/product-http" />
   <Card title="运维 HTTP API" description="健康、就绪、指标、Top、Debug 与 Bench 边界。" href="/zh/api/operations-http" />
   <Card title="Webhook" description="三个出站事件、负载和可靠性语义。" href="/zh/api/webhooks" />
   <Card title="客户端协议" description="WKProto 帧、连接、加密与 EasySDK JSON-RPC 核心路径。" href="/zh/api/client-protocols" />

--- a/docs-site/content/docs/api/specifications/openapi.en.mdx
+++ b/docs-site/content/docs/api/specifications/openapi.en.mdx
@@ -9,7 +9,7 @@ Every file uses OpenAPI 3.1. Complete contracts describe the current source surf
 
 | Contract | Scope | Trust boundary | Download |
 | --- | --- | --- | --- |
-| Product HTTP | 42 current business HTTP operations | No built-in business authentication; trusted backends only | [JSON](/contracts/product-http.openapi.json) |
+| Product HTTP | 43 current business HTTP operations | No built-in business authentication; trusted backends only | [JSON](/contracts/product-http.openapi.json) |
 | Operations HTTP | `/healthz`, `/readyz`, `/metrics`, `/top/v1/snapshot` | No built-in authentication; operations network only | [JSON](/contracts/operations-http.openapi.json) |
 | Webhooks | `msg.notify`, `msg.offline`, `user.onlinestatus` | Outbound POST JSON; unsigned and best effort | [JSON](/contracts/webhooks.openapi.json) |
 

--- a/docs-site/content/docs/api/specifications/openapi.mdx
+++ b/docs-site/content/docs/api/specifications/openapi.mdx
@@ -9,7 +9,7 @@ description: 下载完整 HTTP 合同或一个边界更窄的接入 Profile。
 
 | 合同 | 范围 | 信任边界 | 下载 |
 | --- | --- | --- | --- |
-| Product HTTP | 42 条当前业务 HTTP 操作 | 无内建业务认证；仅可信后端 | [JSON](/contracts/product-http.openapi.json) |
+| Product HTTP | 43 条当前业务 HTTP 操作 | 无内建业务认证；仅可信后端 | [JSON](/contracts/product-http.openapi.json) |
 | Operations HTTP | `/healthz`、`/readyz`、`/metrics`、`/top/v1/snapshot` | 无内建认证；仅运维网络 | [JSON](/contracts/operations-http.openapi.json) |
 | Webhooks | `msg.notify`、`msg.offline`、`user.onlinestatus` | 出站 POST JSON；无签名、best effort | [JSON](/contracts/webhooks.openapi.json) |
 

--- a/docs-site/content/docs/api/specifications/protocol-changelog.en.mdx
+++ b/docs-site/content/docs/api/specifications/protocol-changelog.en.mdx
@@ -7,7 +7,7 @@ description: Current contract snapshot, the WKProto v5→v6 change, and breaking
 
 | Surface | Current contract |
 | --- | --- |
-| Product HTTP | Complete 42-operation OpenAPI plus narrow 3 / 1 / 16-operation profiles |
+| Product HTTP | Complete 43-operation OpenAPI plus narrow 3 / 1 / 16-operation profiles |
 | Operations HTTP | 4-operation OpenAPI |
 | Webhooks | 3 OpenAPI Webhooks |
 | WKProto | Latest protocol version `6` |

--- a/docs-site/content/docs/api/specifications/protocol-changelog.mdx
+++ b/docs-site/content/docs/api/specifications/protocol-changelog.mdx
@@ -7,7 +7,7 @@ description: 当前合同快照、WKProto v5→v6 变化和破坏性变更规则
 
 | Surface | 当前合同 |
 | --- | --- |
-| Product HTTP | 42 条完整 OpenAPI；另有 3 / 1 / 16 条操作的窄 Profile |
+| Product HTTP | 43 条完整 OpenAPI；另有 3 / 1 / 16 条操作的窄 Profile |
 | Operations HTTP | 4 条 OpenAPI |
 | Webhooks | 3 个 OpenAPI Webhook |
 | WKProto | 最新协议版本 `6` |

--- a/docs-site/scripts/check-static-output.ts
+++ b/docs-site/scripts/check-static-output.ts
@@ -457,9 +457,9 @@ export async function checkStaticOutput() {
       'complete-source-aligned-product-http-runtime' ||
     actualCompleteOperations.sort().join('\n') !==
       expectedCompleteOperations.sort().join('\n') ||
-    expectedCompleteOperations.length !== 42
+    expectedCompleteOperations.length === 0
   ) {
-    throw new Error('complete Product HTTP OpenAPI does not match the 42-operation registry');
+    throw new Error('complete Product HTTP OpenAPI does not match the registered operations');
   }
   for (const operation of productHTTPOpenAPIReferenceOperations) {
     const contracted = completeProductOpenAPI.paths?.[operation.path]?.[operation.method];
@@ -1000,7 +1000,7 @@ export async function checkStaticOutput() {
       'operations-http/read-only': ['/top/v1/snapshot', '/bench/v1/'],
       'webhooks/events': ['msg.notify', 'msg.offline', 'user.onlinestatus'],
       'webhooks/payloads': ['message_idstr', 'compress_to_uids'],
-      'specifications/openapi': ['OpenAPI 3.1', '42', 'webhooks'],
+      'specifications/openapi': ['OpenAPI 3.1', String(productHTTPOpenAPIReferenceOperations.length), 'webhooks'],
       'interface-inventory': ['109', '58', 'slot_identity_metadata', 'manager_node_config_document', '/plugin/start'],
     })) {
       const pageId = `/${locale}/api/${page}`;


### PR DESCRIPTION
Documentation publication failed after the legacy `/messages` route increased the complete Product HTTP registry to 43 operations: static-output checks and four bilingual overview pairs still expected 42. Match the nonempty source-backed registry exactly and align the public overview counts; preserve operation membership, trust boundaries, and narrow-profile checks.

Validation correction: the initial local run mixed file states because overview text changed after its test phase; that result did not validate the final commit. Pages run 34622243410 correctly caught the remaining old-count unit assertion. Follow-up #951 aligns the assertion and navigation. Its frozen commit `6a387681a5075596d058d274e581d9aa15ca5b41` passed the full clean-tree verify, and Pages run 34622730488 passed all publication gates. Both public locale migration pages were verified by complete GETs. Independent local Standards and Spec review covered each correction. Failed runs and the initial mixed-snapshot error remain recorded. Review Agent workflows remained disabled as requested.
