### PR TITLE
fix(docs): align overview tests and navigation with HTTP contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
-- Align static documentation publication checks with the source-backed Product HTTP operation registry, including legacy message lookup. / 文档发布产物检查以源码对应的 Product HTTP 接口注册表为准，包含旧版消息查询接口。
+- Align static documentation publication checks, navigation counts, and overview tests with the source-backed Product HTTP operation registry, including legacy message lookup. / 文档发布产物检查、导航数量及总览测试以源码对应的 Product HTTP 接口注册表为准，包含旧版消息查询接口。
 
 - Reuse verified duplicate-chain suffixes within each offline migration pass and count terminals on disk, avoiding quadratic history lookups while retaining original edge proofs. / 离线迁移在每次重建内复用已核实的去重链后缀，以磁盘索引统计终点，避免重复遍历，保留完整原始替代证据。
 

--- a/docs-site/NAVIGATION.md
+++ b/docs-site/NAVIGATION.md
@@ -161,7 +161,7 @@ Route: `/{lang}/api`
 
 - **接口清单与信任边界 / Interface Inventory & Trust Boundaries** `/{lang}/api/interface-inventory` — 盘点 Manager、Node transport、MCP、插件与 Agent 私有合同。 / Inventories Manager, node transport, MCP, plugin, and agent-private contracts.
 
-- **Product HTTP API / Product HTTP API** `/{lang}/api/product-http` — 浏览当前源码注册的全部 42 条 Product HTTP 操作。 / Browse all 42 Product HTTP operations registered by the current source.
+- **Product HTTP API / Product HTTP API** `/{lang}/api/product-http` — 浏览当前源码注册的全部 43 条 Product HTTP 操作。 / Browse all 43 Product HTTP operations registered by the current source.
   - **用户 / Users** `/{lang}/api/product-http/users` — 设备 Token、在线状态与系统身份。 / Device tokens, presence, and system identities.
     - **创建或更新设备 Token / Create or update a device token** **POST** `/{lang}/api/product-http/users/setQuickstartUserToken` — 创建缺失的 UID 元数据并更新一个设备 Token；Gateway Token 鉴权默认启用，后续相同 UID 与设备类别的 CONNECT 凭据必须与它匹配。 / Upserts one UID/device token; default Gateway authentication requires later CONNECT credentials for the same UID and device category to match it.
     - **退出用户设备 / Clear a user device token** **POST** `/{lang}/api/product-http/users/quitUserDevice` — 清空一个已存设备 Token 并调度 owner-local Session 关闭；device_flag=-1 选择 APP、Web 与 PC。 / Clears one stored device token and schedules owner-local Session closure; device_flag -1 selects APP, Web, and PC.

--- a/docs-site/lib/api-specifications-contract.test.ts
+++ b/docs-site/lib/api-specifications-contract.test.ts
@@ -87,7 +87,7 @@ describe('API specification pages', () => {
     expect(operationCount(management)).toBe(16);
 
     for (const content of [zh, en]) {
-      for (const count of ['42', '3', '1', '16']) expect(content).toContain(count);
+      for (const count of [String(operationCount(productHTTP)), '3', '1', '16']) expect(content).toContain(count);
       expect(content).toContain('OpenAPI 3.1');
       expect(content).toContain('webhooks');
       expect(content).toContain('/metrics');

--- a/docs-site/lib/navigation.ts
+++ b/docs-site/lib/navigation.ts
@@ -1,6 +1,7 @@
 import { easySdkReleases } from './easy-sdk-version';
 import {
   productHTTPOpenAPIReferenceGroups,
+  productHTTPOpenAPIReferenceOperations,
   type ProductHTTPOpenAPIMethod,
 } from './product-http-openapi';
 
@@ -502,8 +503,8 @@ function publishedProductHTTPGroup(): NavigationGroup {
     'product-http',
     'Product HTTP API',
     'Product HTTP API',
-    '浏览当前源码注册的全部 42 条 Product HTTP 操作。',
-    'Browse all 42 Product HTTP operations registered by the current source.',
+    `浏览当前源码注册的全部 ${productHTTPOpenAPIReferenceOperations.length} 条 Product HTTP 操作。`,
+    `Browse all ${productHTTPOpenAPIReferenceOperations.length} Product HTTP operations registered by the current source.`,
     [
       ...productHTTPOpenAPIReferenceGroups.map((group) =>
         publishedGroup(


### PR DESCRIPTION
The previous publication repair left the API overview test expecting 42 operations and navigation describing 42, while the source-backed contract and overview pages contain 43. Derive the existing test expectation from the loaded contract and the bilingual navigation count from the operation registry; regenerate navigation and update the existing Unreleased note.

Frozen commit `6a387681a5075596d058d274e581d9aa15ca5b41` passed `bun install --frozen-lockfile` and the full `bun run verify`: 208 tests / 8,286 assertions, sample checks, generated API and navigation contracts, lint, types, 839-page build, and final static output contract (414 RSC URLs). The working tree stayed clean throughout verification. Independent local Standards and Spec reviews passed. The failed Pages run 34622243410 is retained; the earlier mixed-snapshot local verification is superseded by this frozen-commit result. Review Agent workflows remain disabled under the user's explicit direction.
