### PR TITLE
fix(gateway): avoid listener error storms from rejected WebSocket handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ move those entries into a version section named for that exact tag.
 
 ## [Unreleased]
 
+- Sample rejected WebSocket handshakes as informational diagnostics instead of listener-error stack traces; genuine listener faults remain errors. / WebSocket 握手拒绝改为限频 INFO 诊断，避免扫描请求刷出 ERROR 堆栈，真实监听器故障仍完整记录。
+
 - Exclude normal Slot scheduling coalescing and rescheduling from Manager runtime admission errors; show observed zero errors as normal while preserving missing-data status. / Manager 运行时准入错误排除正常 Slot 调度合并及重新调度，有采集且错误为零时显示正常，无数据仍保持未知。
 
 ## [v3.0.0-beta.14] - 2026-09-12

--- a/docs/development/PROJECT_KNOWLEDGE.md
+++ b/docs/development/PROJECT_KNOWLEDGE.md
@@ -1370,3 +1370,9 @@ Recovery barriers compare the complete `(ChannelEpoch, LeaderTerm, FenceVersion)
 - Legacy sync may reread only the latest visible empty-number head after an advanced client cursor, because old clients could advance local sequence bookkeeping while losing that message to an empty-key collision. This read-only replay leaves membership, unread, read and delete boundaries unchanged.
 
 Duplicate-chain resolution reuses only same-pass, randomly namespaced disk proofs; independent conversion/verification passes cannot reuse one another’s cache. Exact direct edges and terminal identities remain in the digest-bound chain sidecar. Disk-sorted terminal/root references avoid archive-wide terminal maps. The 100,000 traversal guard bounds uncached per-root work; verified suffix reuse requires no repeated traversal.
+
+- WebSocket HTTP handshake rejections use `transport.HandshakeRejectionError`:
+  preserve the 4xx response/connection close and redacted diagnostics, but the
+  product gateway logs at INFO at most once per ten seconds across listeners,
+  with a cumulative `rejected_total` since handler creation. Sampling uses fixed
+  state, never peer/path maps. Genuine listener failures remain unsampled ERROR.

--- a/internal/access/gateway/handler.go
+++ b/internal/access/gateway/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/WuKongIM/WuKongIM/internal/usecase/message"
 	"github.com/WuKongIM/WuKongIM/internal/usecase/presence"
 	coregateway "github.com/WuKongIM/WuKongIM/pkg/gateway"
+	"github.com/WuKongIM/WuKongIM/pkg/gateway/transport"
 	"github.com/WuKongIM/WuKongIM/pkg/protocol/frame"
 	"github.com/WuKongIM/WuKongIM/pkg/wklog"
 )
@@ -108,6 +110,11 @@ type Handler struct {
 	traceIDGenerator TraceIDGenerator
 	logger           wklog.Logger
 	plannedShutdown  atomic.Bool
+	// One shared sampling window bounds rejection logging across all listeners;
+	// never allocate per-peer or per-path state for untrusted requests.
+	rejectionMu    sync.Mutex
+	rejectionNext  time.Time
+	rejectionTotal uint64
 }
 
 type terminalFenceBinding struct {
@@ -180,9 +187,35 @@ func (h *Handler) OnListenerError(listener string, err error) {
 	if err == nil {
 		return
 	}
+	var rejection *transport.HandshakeRejectionError
+	if errors.As(err, &rejection) && rejection != nil {
+		h.logHandshakeRejection(listener, err, rejection.StatusCode, time.Now())
+		return
+	}
 	h.connLogger().Error("gateway listener error",
 		wklog.Event("internal.access.gateway.listener_error"),
 		wklog.String("listener", listener),
+		wklog.Error(err),
+	)
+}
+
+// logHandshakeRejection retains a diagnostic sample and cumulative count at
+// most once per ten seconds. Real listener faults bypass this sampling window.
+func (h *Handler) logHandshakeRejection(listener string, err error, status int, now time.Time) {
+	h.rejectionMu.Lock()
+	h.rejectionTotal++
+	total := h.rejectionTotal
+	if now.Before(h.rejectionNext) {
+		h.rejectionMu.Unlock()
+		return
+	}
+	h.rejectionNext = now.Add(10 * time.Second)
+	h.rejectionMu.Unlock()
+	h.connLogger().Info("gateway handshake rejected",
+		wklog.Event("internal.access.gateway.handshake_rejected"),
+		wklog.String("listener", listener),
+		wklog.Int("http_status", status),
+		wklog.Uint64("rejected_total", total),
 		wklog.Error(err),
 	)
 }

--- a/internal/access/gateway/logging_integration_test.go
+++ b/internal/access/gateway/logging_integration_test.go
@@ -74,7 +74,7 @@ func TestWebSocketPathRejectionLogIncludesDiagnostics(t *testing.T) {
 				t.Fatal(err)
 			}
 			logs, err := applog.NewAppLogReader(applog.AppLogReaderOptions{Dir: dir}).Entries(
-				context.Background(), applog.AppLogEntriesRequest{Limit: 10, Levels: []string{"ERROR"}},
+				context.Background(), applog.AppLogEntriesRequest{Limit: 10, Levels: []string{"INFO", "ERROR"}},
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -83,6 +83,12 @@ func TestWebSocketPathRejectionLogIncludesDiagnostics(t *testing.T) {
 				t.Fatalf("error log count = %d, want 1", len(logs.Items))
 			}
 			entry := logs.Items[0]
+			if entry.Level != "INFO" {
+				t.Fatalf("handshake rejection level = %s, want INFO", entry.Level)
+			}
+			if strings.Contains(entry.Raw, "github.com/WuKongIM") {
+				t.Fatal("rejection includes stack trace")
+			}
 			if entry.Fields["listener"] != "ws-gateway" {
 				t.Fatalf("listener field = %v, want ws-gateway", entry.Fields["listener"])
 			}

--- a/internal/access/gateway/logging_test.go
+++ b/internal/access/gateway/logging_test.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 	"errors"
+	"fmt"
+	"github.com/WuKongIM/WuKongIM/pkg/gateway/transport"
 	"testing"
 	"time"
 
@@ -257,4 +259,34 @@ func requireFieldValue[T any](t *testing.T, entry recordedLogEntry, key string) 
 	var zero T
 	t.Fatalf("missing field %q in %#v", key, entry.fields)
 	return zero
+}
+
+func TestHandlerSamplesHandshakeRejectionsWithoutSuppressingListenerFaults(t *testing.T) {
+	logger := newRecordingLogger("internal.access.gateway")
+	h := New(Options{Logger: logger})
+	rejected := &transport.HandshakeRejectionError{StatusCode: 404, Err: errors.New("path mismatch")}
+	h.OnListenerError("ws", fmt.Errorf("wrapped: %w", rejected))
+	// Use a fixed timestamp inside the already opened window, without sleeps.
+	now := h.rejectionNext.Add(-time.Second)
+	for i := 0; i < 1000; i++ {
+		h.logHandshakeRejection("ws", rejected, 404, now)
+	}
+	h.OnListenerError("tcp", errors.New("accept failed"))
+	h.OnListenerError("ws", nil)
+	if got := len(logger.entries()); got != 2 {
+		t.Fatalf("log count = %d, want one sample and one fault", got)
+	}
+	entry := requireLogEntry(t, logger, "INFO", "internal.access.gateway.conn", "internal.access.gateway.handshake_rejected")
+	if got := requireFieldValue[uint64](t, entry, "rejected_total"); got != 1 {
+		t.Fatalf("total = %d", got)
+	}
+	requireLogEntry(t, logger, "ERROR", "internal.access.gateway.conn", "internal.access.gateway.listener_error")
+	h.logHandshakeRejection("ws", rejected, 404, now.Add(time.Second))
+	entries := logger.entries()
+	if len(entries) != 3 {
+		t.Fatalf("next window did not log: %d", len(entries))
+	}
+	if got := requireFieldValue[uint64](t, entries[2], "rejected_total"); got != 1002 {
+		t.Fatalf("total = %d, want 1002", got)
+	}
 }

--- a/pkg/gateway/transport/gnet/group.go
+++ b/pkg/gateway/transport/gnet/group.go
@@ -517,7 +517,7 @@ func (g *engineGroup) handleWSTraffic(c gnetv2.Conn, state *connState) gnetv2.Ac
 				err := fmt.Errorf("websocket handshake rejected: %w (http_status=%d conn_id=%d remote_addr=%q local_addr=%q)",
 					failure.err, failure.statusCode, state.id, state.remoteAddr, state.localAddr)
 				transport.LogConnectFailure(state.runtime.opts, state.id, state.localAddr, state.remoteAddr, err)
-				state.runtime.reportError(err)
+				state.runtime.reportError(&transport.HandshakeRejectionError{StatusCode: failure.statusCode, Err: err})
 				if len(failure.response) == 0 {
 					_ = c.Close()
 					return gnetv2.None

--- a/pkg/gateway/transport/gnet/ws_listener_integration_test.go
+++ b/pkg/gateway/transport/gnet/ws_listener_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -191,6 +192,15 @@ func TestWSHandshakeRejectsInvalidRequestsAndReportsErrors(t *testing.T) {
 	}
 
 	waitUntil(t, time.Second, func() bool { return errs.Count() == len(tests) })
+	errs.mu.Lock()
+	defer errs.mu.Unlock()
+	for i, err := range errs.errs {
+		var rejected *transport.HandshakeRejectionError
+		if !errors.As(err, &rejected) || rejected.StatusCode != tests[i].status {
+			t.Fatalf("%s: rejection classification = %T %v", tests[i].name, err, err)
+		}
+	}
+
 }
 
 func TestWSHandshakeFailureReportsErrorBeforeConnectionCloses(t *testing.T) {

--- a/pkg/gateway/transport/transport.go
+++ b/pkg/gateway/transport/transport.go
@@ -65,3 +65,16 @@ type ListenerSpec struct {
 	Options ListenerOptions
 	Handler ConnHandler
 }
+
+// HandshakeRejectionError identifies an expected client handshake rejection,
+// not a failure of the listener. Transports still return the HTTP rejection
+// and close the connection; observers may sample these diagnostics separately.
+type HandshakeRejectionError struct {
+	// StatusCode is the HTTP response sent to the rejected client.
+	StatusCode int
+	// Err is the non-nil, redacted transport diagnostic cause.
+	Err error
+}
+
+func (e *HandshakeRejectionError) Error() string { return e.Err.Error() }
+func (e *HandshakeRejectionError) Unwrap() error { return e.Err }


### PR DESCRIPTION
External HTTP scans and accidental browser requests to the WebSocket port were rejected correctly but logged as listener ERROR stack traces. Classify expected handshake rejections with a typed transport error and emit sampled INFO diagnostics (at most one per ten seconds per handler, cumulative count). Preserve unsampled listener faults, HTTP rejection responses, connection closure and redacted diagnostics.

Validation: all gateway subtree and access unit tests passed; focused integration tests with race detection passed for actual logger output, invalid requests and typed statuses, rejection close ordering, and valid WebSocket frame exchange. The real console/JSON logging regression failed before repair and passed after. Deterministic burst/next-window tests verify sampling and real-fault visibility.

Local standards and behavior review passed. Review Agent workflows remain disabled as explicitly requested by the maintainer.
